### PR TITLE
fix(checker): address Cyclops audit

### DIFF
--- a/crates/checker/src/adapter/tempo/mod.rs
+++ b/crates/checker/src/adapter/tempo/mod.rs
@@ -18,7 +18,7 @@ use crate::{
 };
 
 use super::{AdapterFindingCode, ImportedAdaptation, deposits::ordinary_deposit_event};
-use withdrawals::{WithdrawalAdaptation, parse_withdrawal_events};
+use withdrawals::{WithdrawalAdaptation, parse_withdrawal_events_prefix};
 
 /// Parse imported transaction envelopes into ordered kernel facts and effects.
 pub(super) fn facts(
@@ -30,24 +30,17 @@ pub(super) fn facts(
     let mut operations = Vec::new();
     let mut effects = Vec::new();
     for tx in observation.protocol_transactions() {
-        let events: Vec<_> = tx.outcomes().iter().map(|x| x.event()).collect();
-        let direct_call = tx.direct_call();
-        let is_creation_block = observation.block_hash() == portal_creation_block_hash;
-        let creation_event_index = events
-            .iter()
-            .position(|event| matches!(event, L1ProtocolEvent::FactoryZoneCreated(_)));
-        let is_creation_transaction = creation_event_index.is_some();
-        if let Some(call) = direct_call {
-            if let Some(call) = call.as_submit_batch() {
-                if !matches!(
-                    events.as_slice(),
-                    [L1ProtocolEvent::Portal(
-                        Portal::ZonePortalEvents::BatchSubmitted(_)
-                    )]
-                ) {
+        let all_events: Vec<_> = tx.outcomes().iter().map(|x| x.event()).collect();
+        let mut event_cursor = 0;
+        for direct_call in tx.direct_calls() {
+            if let Some(call) = direct_call.as_submit_batch() {
+                let Some(L1ProtocolEvent::Portal(Portal::ZonePortalEvents::BatchSubmitted(event))) =
+                    all_events.get(event_cursor).copied()
+                else {
                     return Err(AdapterFindingCode::Grammar
-                        .failure("submitBatch requires exactly one BatchSubmitted event"));
-                }
+                        .failure("submitBatch is not followed by BatchSubmitted"));
+                };
+                event_cursor += 1;
                 operations.push(ImportedOperation::SubmitBatch(BatchSubmission {
                     tempo_block: call.tempoBlockNumber,
                     previous_block: call.blockTransition.prevBlockHash,
@@ -63,7 +56,18 @@ pub(super) fn facts(
                     withdrawal_queue_hash: call.withdrawalQueueHash,
                     next_zone_height: call.nextZoneHeight,
                 }));
-            } else if let Some(call) = call.as_process_withdrawals() {
+                effects.push(Effect::BatchSubmitted {
+                    id: crate::kernel::BatchId::new(zone_id, event.withdrawalBatchIndex)
+                        .ok_or_else(|| AdapterFindingCode::Grammar.failure("zero batch index"))?,
+                    queue_index: event.withdrawalQueueIndex,
+                    processed_deposit_hash: event.nextProcessedDepositQueueHash,
+                    final_block_hash: event.nextBlockHash,
+                    queue_hash: event.withdrawalQueueHash,
+                    processed_deposit_number: event.lastProcessedDepositNumber,
+                });
+                continue;
+            }
+            if let Some(call) = direct_call.as_process_withdrawals() {
                 let withdrawals = call
                     .withdrawals
                     .iter()
@@ -79,14 +83,18 @@ pub(super) fn facts(
                         encrypted_sender: w.encryptedSender.clone(),
                     })
                     .collect();
-                let WithdrawalAdaptation {
-                    outcomes,
-                    effects: processing_effects,
-                } = parse_withdrawal_events(
-                    &events,
+                let (
+                    WithdrawalAdaptation {
+                        outcomes,
+                        effects: processing_effects,
+                    },
+                    consumed,
+                ) = parse_withdrawal_events_prefix(
+                    &all_events[event_cursor..],
                     call.withdrawals.len(),
                     observation.portal_address(),
                 )?;
+                event_cursor += consumed;
                 effects.extend(processing_effects);
                 operations.push(ImportedOperation::ProcessWithdrawals(
                     WithdrawalProcessing {
@@ -101,20 +109,28 @@ pub(super) fn facts(
                         outcomes,
                     },
                 ));
-                continue;
             }
-        } else if events.iter().any(|event| {
-            matches!(
-                event,
-                L1ProtocolEvent::Portal(
-                    Portal::ZonePortalEvents::BatchSubmitted(_)
-                        | Portal::ZonePortalEvents::WithdrawalProcessed(_)
-                        | Portal::ZonePortalEvents::WithdrawalBounceBack(_)
-                        | Portal::ZonePortalEvents::DepositBounceBack(_)
-                        | Portal::ZonePortalEvents::DepositBounceBackPending(_)
+        }
+        let events = &all_events[event_cursor..];
+        let is_creation_block = observation.block_hash() == portal_creation_block_hash;
+        let creation_event_index = events
+            .iter()
+            .position(|event| matches!(event, L1ProtocolEvent::FactoryZoneCreated(_)));
+        let is_creation_transaction = creation_event_index.is_some();
+        if tx.direct_calls().is_empty()
+            && events.iter().any(|event| {
+                matches!(
+                    event,
+                    L1ProtocolEvent::Portal(
+                        Portal::ZonePortalEvents::BatchSubmitted(_)
+                            | Portal::ZonePortalEvents::WithdrawalProcessed(_)
+                            | Portal::ZonePortalEvents::WithdrawalBounceBack(_)
+                            | Portal::ZonePortalEvents::DepositBounceBack(_)
+                            | Portal::ZonePortalEvents::DepositBounceBackPending(_)
+                    )
                 )
-            )
-        }) {
+            })
+        {
             return Err(AdapterFindingCode::Grammar
                 .failure("direct-call event occurred outside its transaction envelope"));
         }
@@ -147,7 +163,7 @@ pub(super) fn facts(
             return Err(AdapterFindingCode::Grammar
                 .failure("ZoneCreated occurred outside the configured creation block"));
         }
-        for (event_index, event) in events.into_iter().enumerate() {
+        for (event_index, event) in events.iter().copied().enumerate() {
             match event {
                 L1ProtocolEvent::FactoryZoneCreated(Factory::ZoneCreated {
                     portal,
@@ -179,9 +195,7 @@ pub(super) fn facts(
                 L1ProtocolEvent::Portal(Portal::ZonePortalEvents::BouncebackGasUpdated(e)) => {
                     operations.push(ImportedOperation::UpdateBouncebackGas(e.bouncebackGas))
                 }
-                L1ProtocolEvent::Portal(Portal::ZonePortalEvents::DepositMade(e))
-                    if direct_call.is_none_or(|call| call.as_process_withdrawals().is_none()) =>
-                {
+                L1ProtocolEvent::Portal(Portal::ZonePortalEvents::DepositMade(e)) => {
                     let d = ordinary_deposit_event(e, "deposit")?;
                     operations.push(ImportedOperation::AppendDeposit(d));
                     effects.push(Effect::DepositAppended {
@@ -207,18 +221,6 @@ pub(super) fn facts(
                         amount: e.amount,
                     });
                 }
-                L1ProtocolEvent::Portal(Portal::ZonePortalEvents::BatchSubmitted(e)) => effects
-                    .push(Effect::BatchSubmitted {
-                        id: crate::kernel::BatchId::new(zone_id, e.withdrawalBatchIndex)
-                            .ok_or_else(|| {
-                                AdapterFindingCode::Grammar.failure("zero batch index")
-                            })?,
-                        queue_index: e.withdrawalQueueIndex,
-                        processed_deposit_hash: e.nextProcessedDepositQueueHash,
-                        final_block_hash: e.nextBlockHash,
-                        queue_hash: e.withdrawalQueueHash,
-                        processed_deposit_number: e.lastProcessedDepositNumber,
-                    }),
                 L1ProtocolEvent::Portal(Portal::ZonePortalEvents::TokenEnabled(_)) => {}
                 L1ProtocolEvent::FactoryZoneCreated(_) => {}
                 L1ProtocolEvent::KnownIgnored | L1ProtocolEvent::Portal(_) => {

--- a/crates/checker/src/adapter/tempo/mod.rs
+++ b/crates/checker/src/adapter/tempo/mod.rs
@@ -33,6 +33,10 @@ pub(super) fn facts(
         let events: Vec<_> = tx.outcomes().iter().map(|x| x.event()).collect();
         let direct_call = tx.direct_call();
         let is_creation_block = observation.block_hash() == portal_creation_block_hash;
+        let creation_event_index = events
+            .iter()
+            .position(|event| matches!(event, L1ProtocolEvent::FactoryZoneCreated(_)));
+        let is_creation_transaction = creation_event_index.is_some();
         if let Some(call) = direct_call {
             if let Some(call) = call.as_submit_batch() {
                 if !matches!(
@@ -114,43 +118,36 @@ pub(super) fn facts(
             return Err(AdapterFindingCode::Grammar
                 .failure("direct-call event occurred outside its transaction envelope"));
         }
-        if events
-            .iter()
-            .any(|event| matches!(event, L1ProtocolEvent::FactoryZoneCreated(_)))
-            && !matches!(
-                events.as_slice(),
-                [
-                    L1ProtocolEvent::Portal(Portal::ZonePortalEvents::TokenEnabled(_)),
-                    L1ProtocolEvent::FactoryZoneCreated(_)
-                ]
-            )
-        {
-            return Err(AdapterFindingCode::Grammar
-                .failure("creation requires TokenEnabled followed by ZoneCreated"));
-        }
-        if is_creation_block
-            && events.iter().any(|event| {
-                matches!(
-                    event,
-                    L1ProtocolEvent::Portal(Portal::ZonePortalEvents::TokenEnabled(_))
-                )
+        let creation_token = if let Some(index) = creation_event_index {
+            if index != 1
+                || events
+                    .iter()
+                    .filter(|event| matches!(event, L1ProtocolEvent::FactoryZoneCreated(_)))
+                    .count()
+                    != 1
+            {
+                return Err(AdapterFindingCode::Grammar
+                    .failure("creation requires TokenEnabled followed by one ZoneCreated"));
+            }
+            let L1ProtocolEvent::Portal(Portal::ZonePortalEvents::TokenEnabled(event)) = events[0]
+            else {
+                return Err(AdapterFindingCode::Grammar
+                    .failure("creation requires TokenEnabled followed by one ZoneCreated"));
+            };
+            Some(TokenEnable {
+                token: event.token,
+                name: event.name.clone(),
+                symbol: event.symbol.clone(),
+                currency: event.currency.clone(),
             })
-            && !events
-                .iter()
-                .any(|event| matches!(event, L1ProtocolEvent::FactoryZoneCreated(_)))
-        {
-            return Err(AdapterFindingCode::Grammar
-                .failure("creation-block TokenEnabled must belong to the creation pair"));
-        }
-        if !is_creation_block
-            && events
-                .iter()
-                .any(|event| matches!(event, L1ProtocolEvent::FactoryZoneCreated(_)))
-        {
+        } else {
+            None
+        };
+        if !is_creation_block && is_creation_transaction {
             return Err(AdapterFindingCode::Grammar
                 .failure("ZoneCreated occurred outside the configured creation block"));
         }
-        for event in events {
+        for (event_index, event) in events.into_iter().enumerate() {
             match event {
                 L1ProtocolEvent::FactoryZoneCreated(Factory::ZoneCreated {
                     portal,
@@ -158,34 +155,19 @@ pub(super) fn facts(
                     initialToken,
                     ..
                 }) if is_creation_block => {
-                    let enabled = tx
-                        .outcomes()
-                        .iter()
-                        .find_map(|x| match x.event() {
-                            L1ProtocolEvent::Portal(Portal::ZonePortalEvents::TokenEnabled(e)) => {
-                                Some(TokenEnable {
-                                    token: e.token,
-                                    name: e.name.clone(),
-                                    symbol: e.symbol.clone(),
-                                    currency: e.currency.clone(),
-                                })
-                            }
-                            _ => None,
-                        })
-                        .ok_or_else(|| {
-                            AdapterFindingCode::Grammar.failure("creation missing TokenEnabled")
-                        })?;
                     operations.push(ImportedOperation::Create {
                         identity: PortalIdentity {
                             portal: *portal,
                             zone_id: *zoneId,
                             initial_token: *initialToken,
                         },
-                        initial_token: enabled,
+                        initial_token: creation_token.clone().ok_or_else(|| {
+                            AdapterFindingCode::Grammar.failure("creation missing TokenEnabled")
+                        })?,
                     });
                 }
                 L1ProtocolEvent::Portal(Portal::ZonePortalEvents::TokenEnabled(e))
-                    if !is_creation_block =>
+                    if creation_event_index != Some(event_index + 1) =>
                 {
                     operations.push(ImportedOperation::EnableToken(TokenEnable {
                         token: e.token,
@@ -237,8 +219,7 @@ pub(super) fn facts(
                         queue_hash: e.withdrawalQueueHash,
                         processed_deposit_number: e.lastProcessedDepositNumber,
                     }),
-                L1ProtocolEvent::Portal(Portal::ZonePortalEvents::TokenEnabled(_))
-                    if is_creation_block => {}
+                L1ProtocolEvent::Portal(Portal::ZonePortalEvents::TokenEnabled(_)) => {}
                 L1ProtocolEvent::FactoryZoneCreated(_) => {}
                 L1ProtocolEvent::KnownIgnored | L1ProtocolEvent::Portal(_) => {
                     return Err(AdapterFindingCode::Grammar

--- a/crates/checker/src/adapter/tempo/withdrawals.rs
+++ b/crates/checker/src/adapter/tempo/withdrawals.rs
@@ -17,11 +17,26 @@ pub(crate) struct WithdrawalAdaptation {
 }
 
 /// Parse the exact event sequence produced by `processWithdrawals`.
+#[cfg(test)]
 pub(super) fn parse_withdrawal_events(
     events: &[&L1ProtocolEvent],
     member_count: usize,
     portal: Address,
 ) -> Result<WithdrawalAdaptation, Failure> {
+    let (adaptation, consumed) = parse_withdrawal_events_prefix(events, member_count, portal)?;
+    if consumed != events.len() {
+        return Err(AdapterFindingCode::Grammar
+            .failure("processWithdrawals has extra or out-of-order events"));
+    }
+    Ok(adaptation)
+}
+
+/// Parse one `processWithdrawals` prefix and return the consumed event count.
+pub(super) fn parse_withdrawal_events_prefix(
+    events: &[&L1ProtocolEvent],
+    member_count: usize,
+    portal: Address,
+) -> Result<(WithdrawalAdaptation, usize), Failure> {
     let mut cursor = 0;
     let mut outcomes = Vec::with_capacity(member_count);
     let mut effects = Vec::new();
@@ -126,11 +141,7 @@ pub(super) fn parse_withdrawal_events(
             }
         }
     }
-    if cursor != events.len() {
-        return Err(AdapterFindingCode::Grammar
-            .failure("processWithdrawals has extra or out-of-order events"));
-    }
-    Ok(WithdrawalAdaptation { outcomes, effects })
+    Ok((WithdrawalAdaptation { outcomes, effects }, cursor))
 }
 
 /// Parse one checker-relevant Portal event emitted by a withdrawal callback.

--- a/crates/checker/src/bootstrap/creation.rs
+++ b/crates/checker/src/bootstrap/creation.rs
@@ -94,15 +94,19 @@ fn validate_creation(
     operations: &[ImportedOperation],
     expected: PortalIdentity,
 ) -> eyre::Result<()> {
-    let [
+    let mut creations = operations.iter().filter_map(|operation| match operation {
         ImportedOperation::Create {
             identity,
             initial_token,
-        },
-    ] = operations
-    else {
-        eyre::bail!("creation block must contain one portal creation operation");
+        } => Some((identity, initial_token)),
+        _ => None,
+    });
+    let Some((identity, initial_token)) = creations.next() else {
+        eyre::bail!("creation block is missing the portal creation operation");
     };
+    if creations.next().is_some() {
+        eyre::bail!("creation block contains multiple portal creation operations");
+    }
     if *identity != expected || initial_token.token != expected.initial_token {
         eyre::bail!("creation identity does not match Zone genesis");
     }
@@ -147,5 +151,23 @@ mod tests {
         assert!(validate_creation(&[creation(mismatched)], expected).is_err());
 
         assert!(validate_creation(&[creation(expected), creation(expected)], expected).is_err());
+    }
+
+    #[test]
+    fn creation_allows_later_canonical_portal_operations() {
+        let expected = identity();
+        let additional_token = TokenEnable {
+            token: Address::repeat_byte(3),
+            name: String::new(),
+            symbol: String::new(),
+            currency: String::new(),
+        };
+        let operations = [
+            creation(expected),
+            ImportedOperation::EnableToken(additional_token),
+            ImportedOperation::UpdateBouncebackGas(42),
+        ];
+
+        assert!(validate_creation(&operations, expected).is_ok());
     }
 }

--- a/crates/checker/src/exex.rs
+++ b/crates/checker/src/exex.rs
@@ -212,18 +212,48 @@ fn checkpoint_is_missing(path: &std::path::Path) -> eyre::Result<bool> {
 async fn drain_notifications<Node>(ctx: &mut ExExContext<Node>) -> eyre::Result<()>
 where
     Node: FullNodeComponents,
+    Node::Provider: BlockHashReader + BlockNumReader,
     Node::Types: NodeTypes<Primitives = TempoPrimitives>,
 {
+    let provider = ctx.provider().clone();
+    publish_canonical_finished_height(ctx, &provider)?;
     loop {
         match ctx.notifications.try_next().await {
-            Ok(Some(_)) => {}
+            Ok(Some(_)) => publish_canonical_finished_height(ctx, &provider)?,
             Ok(None) => eyre::bail!("checker notification stream closed"),
             Err(error) => {
                 tracing::error!(target: "zone::checker", %error, "checker notification stream failed; resuming direct delivery");
                 ctx.set_notifications_without_head();
+                publish_canonical_finished_height(ctx, &provider)?;
             }
         }
     }
+}
+
+/// Publish the current canonical head after the checker has stopped semantic processing.
+fn publish_canonical_finished_height<Node, P>(
+    ctx: &ExExContext<Node>,
+    provider: &P,
+) -> eyre::Result<()>
+where
+    Node: FullNodeComponents,
+    Node::Types: NodeTypes<Primitives = TempoPrimitives>,
+    P: BlockHashReader + BlockNumReader + ?Sized,
+{
+    ctx.send_finished_height(canonical_head(provider)?.into())?;
+    Ok(())
+}
+
+/// Read the node's current canonical tip as one coherent ExEx coordinate.
+fn canonical_head<P>(provider: &P) -> eyre::Result<BlockNumHash>
+where
+    P: BlockHashReader + BlockNumReader + ?Sized,
+{
+    let number = provider.best_block_number()?;
+    let hash = provider
+        .block_hash(number)?
+        .ok_or_else(|| eyre::eyre!("canonical Zone block {number} is unavailable"))?;
+    Ok(BlockNumHash { number, hash })
 }
 
 /// Await checker work while consuming notification wakeups from the node.
@@ -832,7 +862,7 @@ mod tests {
     use reth_provider::test_utils::MockEthProvider;
     use tempo_primitives::{TempoHeader, TempoPrimitives};
 
-    use super::{checkpoint_is_missing, refresh_canonical_head, retry_delay};
+    use super::{canonical_head, checkpoint_is_missing, refresh_canonical_head, retry_delay};
     use crate::{
         kernel::{PortalIdentity, State, StateDelta},
         metrics::CheckerMetrics,
@@ -869,6 +899,15 @@ mod tests {
         assert_eq!(retry_delay(4), Duration::from_secs(16));
         assert_eq!(retry_delay(5), Duration::from_secs(30));
         assert_eq!(retry_delay(u32::MAX), Duration::from_secs(30));
+    }
+
+    #[test]
+    fn canonical_head_uses_the_provider_tip() {
+        let provider = MockEthProvider::<TempoPrimitives>::new();
+        add_header(&provider, block(1, 0x11));
+        add_header(&provider, block(2, 0x12));
+
+        assert_eq!(canonical_head(&provider).unwrap(), block(2, 0x12));
     }
 
     #[test]

--- a/crates/checker/src/observe/error.rs
+++ b/crates/checker/src/observe/error.rs
@@ -250,8 +250,6 @@ pub(crate) enum PortalCallError {
         transaction_hash: B256,
         target: Option<Address>,
     },
-    #[error("conflicting portal call families in transaction {transaction_hash}")]
-    ConflictingFamilies { transaction_hash: B256 },
     #[error(
         "portal calldata/event mismatch in transaction {transaction_hash}: expected {expected}, got {actual}"
     )]

--- a/crates/checker/src/observe/events/portal.rs
+++ b/crates/checker/src/observe/events/portal.rs
@@ -52,6 +52,12 @@ pub(super) const DEPOSITS_PAUSED_TOPIC: B256 =
     b256!("eb225a736fbfee3f85ccb72bdf84ff0396ab358b7970e2cc351ab3e3fd92358d");
 pub(super) const DEPOSITS_RESUMED_TOPIC: B256 =
     b256!("22ab73af03f04a21e91c7923327f99279b7f5d07d9551762c39bccdf051f1fe9");
+pub(super) const PORTAL_PAUSED_TOPIC: B256 =
+    b256!("477a1104043ff48a8d2126e5d02d0d4977cb0b2ee7cd4030cb8823007db90f36");
+pub(super) const PORTAL_RESUMED_TOPIC: B256 =
+    b256!("d2c62538708a93d7454226ca65a098ec07211b126fc22bf2accdcae6561fc2aa");
+pub(super) const ABDICATION_SCHEDULED_TOPIC: B256 =
+    b256!("839069134f9aac5b7c48da0389dd17d6579bb89ebdddc7fbd83bf64af2dd2ef2");
 pub(super) const RPC_URL_UPDATED_TOPIC: B256 =
     b256!("f4e00967b25e707df96d88676243b33be84847ef27615af8ef91290b52294fc6");
 
@@ -78,6 +84,9 @@ pub(super) fn decode(log: &Log) -> Result<Option<Portal::ZonePortalEvents>, Prot
         | LEADER_UPDATED_TOPIC
         | DEPOSITS_PAUSED_TOPIC
         | DEPOSITS_RESUMED_TOPIC
+        | PORTAL_PAUSED_TOPIC
+        | PORTAL_RESUMED_TOPIC
+        | ABDICATION_SCHEDULED_TOPIC
         | RPC_URL_UPDATED_TOPIC => {}
         _ => return Err(unsupported(log)),
     }
@@ -91,18 +100,32 @@ pub(super) fn decode(log: &Log) -> Result<Option<Portal::ZonePortalEvents>, Prot
     let decoded = strict_decode_interface::<Portal::ZonePortalEvents>(log, "Portal event")?;
     validate_dynamic_bounds(log, &decoded)?;
 
-    let changes_checker_state = matches!(
-        decoded,
+    let changes_checker_state = match &decoded {
         Portal::ZonePortalEvents::DepositMade(_)
-            | Portal::ZonePortalEvents::TokenEnabled(_)
-            | Portal::ZonePortalEvents::BatchSubmitted(_)
-            | Portal::ZonePortalEvents::WithdrawalProcessed(_)
-            | Portal::ZonePortalEvents::WithdrawalBounceBack(_)
-            | Portal::ZonePortalEvents::DepositBounceBack(_)
-            | Portal::ZonePortalEvents::DepositBounceBackPending(_)
-            | Portal::ZonePortalEvents::RefundClaimed(_)
-            | Portal::ZonePortalEvents::BouncebackGasUpdated(_)
-    );
+        | Portal::ZonePortalEvents::TokenEnabled(_)
+        | Portal::ZonePortalEvents::BatchSubmitted(_)
+        | Portal::ZonePortalEvents::WithdrawalProcessed(_)
+        | Portal::ZonePortalEvents::WithdrawalBounceBack(_)
+        | Portal::ZonePortalEvents::DepositBounceBack(_)
+        | Portal::ZonePortalEvents::DepositBounceBackPending(_)
+        | Portal::ZonePortalEvents::RefundClaimed(_)
+        | Portal::ZonePortalEvents::BouncebackGasUpdated(_) => true,
+        Portal::ZonePortalEvents::DepositsPaused(_)
+        | Portal::ZonePortalEvents::DepositsResumed(_)
+        | Portal::ZonePortalEvents::PortalPaused(_)
+        | Portal::ZonePortalEvents::PortalResumed(_)
+        | Portal::ZonePortalEvents::AbdicationScheduled(_)
+        | Portal::ZonePortalEvents::RpcUrlUpdated(_)
+        | Portal::ZonePortalEvents::SequencerEncryptionKeyUpdated(_)
+        | Portal::ZonePortalEvents::ZoneGasRateUpdated(_)
+        | Portal::ZonePortalEvents::MaxTempoGasRateUpdated(_)
+        | Portal::ZonePortalEvents::AdminTransferStarted(_)
+        | Portal::ZonePortalEvents::AdminTransferred(_)
+        | Portal::ZonePortalEvents::RoleUpdated(_)
+        | Portal::ZonePortalEvents::EnforcementModesUpdated(_)
+        | Portal::ZonePortalEvents::SequencerSetUpdated(_)
+        | Portal::ZonePortalEvents::LeaderUpdated(_) => false,
+    };
     Ok(changes_checker_state.then_some(decoded))
 }
 

--- a/crates/checker/src/observe/events/tests.rs
+++ b/crates/checker/src/observe/events/tests.rs
@@ -87,6 +87,18 @@ fn independent_topics_match_shared_wire_types() {
             ZonePortal::DepositsResumed::SIGNATURE_HASH,
         ),
         (
+            portal::PORTAL_PAUSED_TOPIC,
+            ZonePortal::PortalPaused::SIGNATURE_HASH,
+        ),
+        (
+            portal::PORTAL_RESUMED_TOPIC,
+            ZonePortal::PortalResumed::SIGNATURE_HASH,
+        ),
+        (
+            portal::ABDICATION_SCHEDULED_TOPIC,
+            ZonePortal::AbdicationScheduled::SIGNATURE_HASH,
+        ),
+        (
             portal::RPC_URL_UPDATED_TOPIC,
             ZonePortal::RpcUrlUpdated::SIGNATURE_HASH,
         ),

--- a/crates/checker/src/observe/l1/events.rs
+++ b/crates/checker/src/observe/l1/events.rs
@@ -7,13 +7,13 @@ use tempo_alloy::rpc::TempoTransactionReceipt;
 use crate::observe::events::{L1ProtocolEvent, Portal, classify_l1_protocol_event};
 
 use super::OrderedL1Outcome;
-use crate::observe::error::{ObservationError, PortalCallError, PortalCallFamily, ProtocolChain};
+use crate::observe::error::{ObservationError, PortalCallFamily, ProtocolChain};
 
 /// Protocol outcomes from one successful transaction before its calldata is reconciled.
 pub(super) struct PendingTransaction {
     pub(super) transaction_index: usize,
     pub(super) transaction_hash: B256,
-    pub(super) required_call: Option<PortalCallFamily>,
+    pub(super) required_calls: Vec<PortalCallFamily>,
     pub(super) outcomes: Vec<OrderedL1Outcome>,
 }
 
@@ -34,7 +34,7 @@ pub(super) fn ordered_transactions(
             continue;
         }
 
-        let mut required_call = None;
+        let mut required_calls = Vec::new();
         let mut outcomes = Vec::new();
         for (receipt_log_index, log) in receipt.logs().iter().enumerate() {
             let log_index = block_log_index;
@@ -57,11 +57,11 @@ pub(super) fn ordered_transactions(
                 continue;
             }
 
-            merge_requirement(
-                &mut required_call,
-                call_requirement(&event),
-                *transaction_hash,
-            )?;
+            if let Some(required) = call_requirement(&event)
+                && !required_calls.contains(&required)
+            {
+                required_calls.push(required);
+            }
             outcomes.push(OrderedL1Outcome { event });
         }
 
@@ -69,7 +69,7 @@ pub(super) fn ordered_transactions(
             transactions.push(PendingTransaction {
                 transaction_index,
                 transaction_hash: *transaction_hash,
-                required_call,
+                required_calls,
                 outcomes,
             });
         }
@@ -98,24 +98,5 @@ fn call_requirement(event: &L1ProtocolEvent) -> Option<PortalCallFamily> {
         | L1ProtocolEvent::Portal(_)
         | L1ProtocolEvent::FactoryZoneCreated(_)
         | L1ProtocolEvent::KnownIgnored => None,
-    }
-}
-
-/// Reject a transaction whose outcomes imply incompatible top-level Portal calls.
-fn merge_requirement(
-    current: &mut Option<PortalCallFamily>,
-    next: Option<PortalCallFamily>,
-    transaction_hash: B256,
-) -> Result<(), ObservationError> {
-    let Some(next) = next else {
-        return Ok(());
-    };
-    match *current {
-        None => {
-            *current = Some(next);
-            Ok(())
-        }
-        Some(required) if required == next => Ok(()),
-        Some(_) => Err(PortalCallError::ConflictingFamilies { transaction_hash }.into()),
     }
 }

--- a/crates/checker/src/observe/l1/mod.rs
+++ b/crates/checker/src/observe/l1/mod.rs
@@ -36,17 +36,16 @@ impl OrderedL1Outcome {
     }
 }
 
-/// Authenticated outcomes and any directly decoded Portal input for one
-/// transaction. `direct_call` is absent when no transition needs calldata.
+/// Authenticated outcomes and directly decoded Portal inputs for one transaction.
 #[derive(Debug)]
 pub(crate) struct L1TransactionObservation {
-    direct_call: Option<DecodedPortalCall>,
+    direct_calls: Vec<DecodedPortalCall>,
     outcomes: Vec<OrderedL1Outcome>,
 }
 
 impl L1TransactionObservation {
-    pub(crate) fn direct_call(&self) -> Option<&DecodedPortalCall> {
-        self.direct_call.as_ref()
+    pub(crate) fn direct_calls(&self) -> &[DecodedPortalCall] {
+        &self.direct_calls
     }
 
     pub(crate) fn outcomes(&self) -> &[OrderedL1Outcome] {
@@ -105,22 +104,21 @@ where
 
     let mut protocol_transactions = Vec::with_capacity(pending.len());
     for transaction in pending {
-        let direct_call = match transaction.required_call {
-            Some(required) => {
-                let envelope: &tempo_primitives::TempoTxEnvelope =
-                    block.transactions[transaction.transaction_index].as_ref();
-                Some(portal::decode_direct_portal_call(
-                    envelope,
-                    portal,
-                    transaction.transaction_index,
-                    transaction.transaction_hash,
-                    required,
-                )?)
-            }
-            None => None,
+        let direct_calls = if transaction.required_calls.is_empty() {
+            Vec::new()
+        } else {
+            let envelope: &tempo_primitives::TempoTxEnvelope =
+                block.transactions[transaction.transaction_index].as_ref();
+            portal::decode_direct_portal_calls(
+                envelope,
+                portal,
+                transaction.transaction_index,
+                transaction.transaction_hash,
+                &transaction.required_calls,
+            )?
         };
         protocol_transactions.push(L1TransactionObservation {
-            direct_call,
+            direct_calls,
             outcomes: transaction.outcomes,
         });
     }

--- a/crates/checker/src/observe/l1/portal.rs
+++ b/crates/checker/src/observe/l1/portal.rs
@@ -1,7 +1,9 @@
 //! Direct-Portal calldata decoding from authenticated block envelopes.
 
 use alloy_primitives::{Address, B256, TxKind};
+use alloy_sol_types::SolCall;
 use tempo_primitives::TempoTxEnvelope;
+use tempo_zone_contracts::ZonePortal;
 
 use super::super::{
     abi::{DecodedPortalCall, decode_portal_call},
@@ -11,59 +13,66 @@ use super::super::{
     },
 };
 
-/// Decode and reconcile the sole direct Portal call required by receipt outcomes.
-pub(super) fn decode_direct_portal_call(
+/// Decode relevant direct Portal calls in authenticated top-level execution order.
+pub(super) fn decode_direct_portal_calls(
     envelope: &TempoTxEnvelope,
     portal: Address,
     transaction_index: usize,
     transaction_hash: B256,
-    expected: PortalCallFamily,
-) -> Result<DecodedPortalCall, ObservationError> {
-    let calldata = sole_portal_calldata(envelope, portal, transaction_hash)?;
+    required: &[PortalCallFamily],
+) -> Result<Vec<DecodedPortalCall>, ObservationError> {
     let coordinate =
         AuthenticatedTransaction::new(ProtocolChain::TempoL1, transaction_index, transaction_hash);
-    let decoded = decode_portal_call(calldata, coordinate)?;
-    let actual = decoded.family();
-    if actual != expected {
-        return Err(PortalCallError::FamilyMismatch {
-            transaction_hash,
-            expected,
-            actual,
-        }
-        .into());
-    }
-    if expected == PortalCallFamily::ProcessWithdrawals
-        && !decoded.is_nonempty_process_withdrawals()
-    {
-        return Err(PortalCallError::EmptyProcessWithOutcomes { transaction_hash }.into());
-    }
-    Ok(decoded)
-}
-
-/// Return calldata only when the envelope contains exactly one direct Portal call.
-pub(super) fn sole_portal_calldata(
-    envelope: &TempoTxEnvelope,
-    portal: Address,
-    transaction_hash: B256,
-) -> Result<&[u8], ObservationError> {
-    let mut calls = envelope.calls();
-    let Some((kind, calldata)) = calls.next() else {
-        return Err(PortalCallError::UnsupportedNestedPortalCall {
-            transaction_hash,
-            target: None,
-        }
-        .into());
-    };
-    let target = match kind {
+    let first_target = envelope.calls().next().and_then(|(kind, _)| match kind {
         TxKind::Call(target) => Some(target),
         TxKind::Create => None,
-    };
-    if calls.next().is_some() || target != Some(portal) {
-        return Err(PortalCallError::UnsupportedNestedPortalCall {
-            transaction_hash,
-            target,
+    });
+    let mut calls = Vec::new();
+    let mut other_family = None;
+    let mut saw_empty_required_process = false;
+    for (kind, calldata) in envelope.calls() {
+        if kind != TxKind::Call(portal) {
+            continue;
         }
-        .into());
+        let family = if calldata.starts_with(&ZonePortal::submitBatchCall::SELECTOR) {
+            PortalCallFamily::SubmitBatch
+        } else if calldata.starts_with(&ZonePortal::processWithdrawalsCall::SELECTOR) {
+            PortalCallFamily::ProcessWithdrawals
+        } else {
+            continue;
+        };
+        if !required.contains(&family) {
+            other_family.get_or_insert(family);
+            continue;
+        }
+        let decoded = decode_portal_call(calldata, coordinate)?;
+        if family == PortalCallFamily::ProcessWithdrawals
+            && !decoded.is_nonempty_process_withdrawals()
+        {
+            saw_empty_required_process = true;
+            continue;
+        }
+        calls.push(decoded);
     }
-    Ok(calldata)
+    for expected in required {
+        if !calls.iter().any(|call| call.family() == *expected) {
+            if *expected == PortalCallFamily::ProcessWithdrawals && saw_empty_required_process {
+                return Err(PortalCallError::EmptyProcessWithOutcomes { transaction_hash }.into());
+            }
+            if let Some(actual) = other_family {
+                return Err(PortalCallError::FamilyMismatch {
+                    transaction_hash,
+                    expected: *expected,
+                    actual,
+                }
+                .into());
+            }
+            return Err(PortalCallError::UnsupportedNestedPortalCall {
+                transaction_hash,
+                target: first_target,
+            }
+            .into());
+        }
+    }
+    Ok(calls)
 }

--- a/crates/checker/src/observe/l1/tests/events.rs
+++ b/crates/checker/src/observe/l1/tests/events.rs
@@ -44,8 +44,8 @@ fn authenticated_event_order_uses_receipt_vectors_not_rpc_log_metadata() {
         L1ProtocolEvent::Portal(ZonePortal::ZonePortalEvents::BouncebackGasUpdated(_))
     ));
     assert_eq!(
-        observed[1].required_call,
-        Some(PortalCallFamily::SubmitBatch)
+        observed[1].required_calls,
+        vec![PortalCallFamily::SubmitBatch]
     );
 }
 
@@ -93,8 +93,8 @@ fn authenticated_event_order_preserves_operation_before_config() {
         L1ProtocolEvent::Portal(ZonePortal::ZonePortalEvents::BatchSubmitted(_))
     ));
     assert_eq!(
-        observed[0].required_call,
-        Some(PortalCallFamily::SubmitBatch)
+        observed[0].required_calls,
+        vec![PortalCallFamily::SubmitBatch]
     );
 
     let config = &observed[1].outcomes[0];
@@ -102,7 +102,7 @@ fn authenticated_event_order_preserves_operation_before_config() {
         config.event,
         L1ProtocolEvent::Portal(ZonePortal::ZonePortalEvents::BouncebackGasUpdated(_))
     ));
-    assert_eq!(observed[1].required_call, None);
+    assert!(observed[1].required_calls.is_empty());
 }
 
 #[test]

--- a/crates/checker/src/observe/l1/tests/mod.rs
+++ b/crates/checker/src/observe/l1/tests/mod.rs
@@ -23,7 +23,7 @@ use zone_precompiles::ecies::AUTHENTICATED_WITHDRAWAL_ENCRYPTED_SIZE;
 
 use super::{acquisition, events as l1_events, observe_l1, portal as l1_portal};
 use crate::observe::{
-    abi::{DecodedPortalCall, ImportedTempoHeader, decode_portal_call},
+    abi::{DecodedPortalCall, ImportedTempoHeader},
     error::{
         AcquisitionError, AcquisitionSource, AuthenticatedDataEvidence, AuthenticatedTransaction,
         DataSource, ObservationError, PortalCallError, PortalCallFamily, ProtocolChain,

--- a/crates/checker/src/observe/l1/tests/observation.rs
+++ b/crates/checker/src/observe/l1/tests/observation.rs
@@ -42,8 +42,8 @@ async fn eventful_submit_batch_fetches_once_and_decodes_direct_calldata() {
     assert_eq!(observed.protocol_transactions.len(), 1);
     assert!(
         observed.protocol_transactions[0]
-            .direct_call
-            .as_ref()
+            .direct_calls()
+            .first()
             .and_then(DecodedPortalCall::as_submit_batch)
             .is_some()
     );
@@ -72,7 +72,8 @@ async fn eventful_process_withdrawals_fetches_once_and_retains_input_and_outcome
         panic!("expected one protocol transaction");
     };
     let call = transaction
-        .direct_call()
+        .direct_calls()
+        .first()
         .and_then(DecodedPortalCall::as_process_withdrawals)
         .expect("authenticated processWithdrawals input");
     assert_eq!(call.withdrawals.len(), 1);

--- a/crates/checker/src/observe/l1/tests/portal.rs
+++ b/crates/checker/src/observe/l1/tests/portal.rs
@@ -3,41 +3,46 @@
 use super::*;
 
 #[test]
-fn one_receipt_cannot_imply_two_portal_call_families() {
+fn one_receipt_can_require_two_portal_call_families() {
     let tx_hash = B256::repeat_byte(0x10);
     let batch = batch_submitted_log(0, 0);
     let processed = withdrawal_processed_log(0, 1);
     let (imported, receipts) = anchor(vec![receipt(tx_hash, 0, true, vec![batch, processed])]);
     acquisition::authenticate_receipts(&imported, &[tx_hash], &receipts).unwrap();
-    assert!(matches!(
-        l1_events::ordered_transactions(PORTAL, &[tx_hash], &receipts),
-        Err(ObservationError::PortalCall(PortalCallError::ConflictingFamilies {
-            transaction_hash
-        })) if transaction_hash == tx_hash
-    ));
+    let observed = l1_events::ordered_transactions(PORTAL, &[tx_hash], &receipts).unwrap();
+    assert_eq!(
+        observed[0].required_calls,
+        vec![
+            PortalCallFamily::SubmitBatch,
+            PortalCallFamily::ProcessWithdrawals
+        ]
+    );
 }
 
 #[test]
-fn direct_portal_call_requires_one_top_level_target_for_legacy_and_aa() {
+fn direct_portal_calls_tolerate_unrelated_aa_calls_and_preserve_order() {
     let calldata = submit_batch_calldata();
     let direct = legacy_call(PORTAL, calldata.clone());
-    assert_eq!(
-        l1_portal::sole_portal_calldata(&direct, PORTAL, B256::ZERO).unwrap(),
-        calldata.as_ref()
-    );
-    assert!(
-        decode_portal_call(
-            l1_portal::sole_portal_calldata(&direct, PORTAL, B256::ZERO).unwrap(),
-            AuthenticatedTransaction::new(ProtocolChain::TempoL1, 0, B256::ZERO),
-        )
-        .unwrap()
-        .as_submit_batch()
-        .is_some()
-    );
+    let calls = l1_portal::decode_direct_portal_calls(
+        &direct,
+        PORTAL,
+        0,
+        B256::ZERO,
+        &[PortalCallFamily::SubmitBatch],
+    )
+    .unwrap();
+    assert_eq!(calls.len(), 1);
+    assert!(calls[0].as_submit_batch().is_some());
 
     let wrong_target = legacy_call(EXTERNAL, calldata.clone());
     assert!(matches!(
-        l1_portal::sole_portal_calldata(&wrong_target, PORTAL, B256::ZERO),
+        l1_portal::decode_direct_portal_calls(
+            &wrong_target,
+            PORTAL,
+            0,
+            B256::ZERO,
+            &[PortalCallFamily::SubmitBatch],
+        ),
         Err(ObservationError::PortalCall(
             PortalCallError::UnsupportedNestedPortalCall {
                 target: Some(EXTERNAL),
@@ -58,20 +63,41 @@ fn direct_portal_call_requires_one_top_level_target_for_legacy_and_aa() {
             input: Bytes::new(),
         },
     ]);
-    assert!(matches!(
-        l1_portal::sole_portal_calldata(&multi, PORTAL, B256::ZERO),
-        Err(ObservationError::PortalCall(
-            PortalCallError::UnsupportedNestedPortalCall { .. }
-        ))
-    ));
+    let calls = l1_portal::decode_direct_portal_calls(
+        &multi,
+        PORTAL,
+        0,
+        B256::ZERO,
+        &[PortalCallFamily::SubmitBatch],
+    )
+    .unwrap();
+    assert_eq!(calls.len(), 1);
+    assert!(calls[0].as_submit_batch().is_some());
 
-    let one_aa = aa_calls(vec![Call {
-        to: PORTAL.into(),
-        value: U256::ZERO,
-        input: calldata.clone(),
-    }]);
-    assert_eq!(
-        l1_portal::sole_portal_calldata(&one_aa, PORTAL, B256::ZERO).unwrap(),
-        calldata.as_ref()
-    );
+    let ordered = aa_calls(vec![
+        Call {
+            to: PORTAL.into(),
+            value: U256::ZERO,
+            input: calldata,
+        },
+        Call {
+            to: PORTAL.into(),
+            value: U256::ZERO,
+            input: process_withdrawals_calldata(true),
+        },
+    ]);
+    let calls = l1_portal::decode_direct_portal_calls(
+        &ordered,
+        PORTAL,
+        0,
+        B256::ZERO,
+        &[
+            PortalCallFamily::SubmitBatch,
+            PortalCallFamily::ProcessWithdrawals,
+        ],
+    )
+    .unwrap();
+    assert_eq!(calls.len(), 2);
+    assert_eq!(calls[0].family(), PortalCallFamily::SubmitBatch);
+    assert_eq!(calls[1].family(), PortalCallFamily::ProcessWithdrawals);
 }


### PR DESCRIPTION
## Summary

- recognize Portal pause, resume, and capability-abdication events and strictly classify them as known events that do not change checker bridge state
- make Portal event state classification exhaustive and verify the independent topic literals
- keep publishing the canonical Zone head as Reth's `FinishedHeight` after the checker blocks or becomes unavailable so the ExEx WAL can be finalized
- refresh the terminal `FinishedHeight` as later notifications are drained
- require exactly one matching Portal creation while replaying additional canonical operations from the creation block in transaction and log order
- preserve later creation-transaction calls, including additional token enablements, instead of treating the initial `TokenEnabled`/`ZoneCreated` pair as the whole transaction
- tolerate unrelated Tempo AA top-level calls while decoding authenticated direct Portal calls
- preserve multiple `submitBatch` and `processWithdrawals` calls and partition their authenticated outcomes in execution order

## Cyclops findings

- fixes valid Portal lifecycle events causing a permanent checker coverage gap
- fixes blocked checker state pinning ExEx WAL retention at the last verified height
- fixes valid same-block Portal activity preventing checkpoint construction
- fixes valid Tempo AA multicalls being reported as bridge divergence

## Validation

- `cargo +nightly fmt --all -- --check`
- `cargo test -p zone-checker observe::events`
- `cargo test -p zone-checker exex::tests`
- `cargo test -p zone-checker -- --test-threads=1` *(122 passed)*
- `cargo +nightly clippy -p zone-checker --all-targets` *(passes with three pre-existing `eyre::bail!` future-incompatibility warnings)*

Stacked on #1147.

Prompted by: @grandizzy
