### PR TITLE
Add Zones transaction load generator

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,5 +1,11 @@
 **/.git
-contrib/
+contrib/*
+!contrib/loadtest/
+!contrib/loadtest/**
+!contrib/bench/
+contrib/bench/*
+!contrib/bench/neobank/
+!contrib/bench/neobank/**
 docs/
 localnet/
 scripts/

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -14093,6 +14093,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "zones-load"
+version = "0.1.0"
+dependencies = [
+ "alloy",
+ "clap",
+ "eyre",
+ "rustls",
+ "serde",
+ "serde_json",
+ "serde_yaml",
+ "tempo-alloy",
+ "tempo-zone-contracts",
+ "tokio",
+]
+
+[[package]]
 name = "zstd"
 version = "0.13.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,6 +11,7 @@ members = [
   "bin/prover/vsock-proxy",
   "bin/prover/enclave",
   "bin/tempo-zone",
+  "bin/zones-load",
   "crates/chainspec",
   "crates/contracts",
   "crates/evm",

--- a/bin/zones-load/Cargo.toml
+++ b/bin/zones-load/Cargo.toml
@@ -1,0 +1,36 @@
+[package]
+name = "zones-load"
+description = "Stateful multi-chain load and codepath coverage runner for Tempo Zones"
+default-run = "zones-load"
+
+version.workspace = true
+edition.workspace = true
+license.workspace = true
+rust-version.workspace = true
+publish.workspace = true
+
+[lints]
+workspace = true
+
+[dependencies]
+tempo-alloy.workspace = true
+tempo-zone-contracts = { workspace = true, features = ["std", "serde", "rpc"] }
+
+alloy = { workspace = true, features = [
+  "providers",
+  "reqwest",
+  "reqwest-rustls-tls",
+  "rpc-types",
+] }
+clap = { workspace = true, features = ["env"] }
+eyre.workspace = true
+serde.workspace = true
+serde_json.workspace = true
+serde_yaml.workspace = true
+tokio.workspace = true
+
+rustls = { version = "0.23", features = ["aws-lc-rs"] }
+
+[[bin]]
+name = "zones-load"
+path = "src/main.rs"

--- a/bin/zones-load/src/catalog.rs
+++ b/bin/zones-load/src/catalog.rs
@@ -1,0 +1,622 @@
+use eyre::{Context as _, Result, bail, ensure};
+use serde::{Deserialize, Serialize};
+use std::{
+    cmp::Ordering,
+    collections::{BTreeMap, BTreeSet},
+    fs,
+    path::{Path, PathBuf},
+};
+
+const BUILTIN_CATALOG: &str = include_str!("../../../contrib/loadtest/catalog.yml");
+
+#[derive(Clone, Debug, Deserialize, Serialize)]
+pub(crate) struct Catalog {
+    pub(crate) version: u32,
+    pub(crate) profiles: BTreeMap<String, Profile>,
+    pub(crate) cases: BTreeMap<String, Case>,
+}
+
+#[derive(Clone, Debug, Deserialize, Serialize)]
+pub(crate) struct Profile {
+    pub(crate) description: String,
+    pub(crate) execution: ExecutionMode,
+    pub(crate) default_count: u64,
+    pub(crate) cases: Vec<String>,
+}
+
+#[derive(Clone, Copy, Debug, Deserialize, Serialize, Eq, PartialEq)]
+#[serde(rename_all = "snake_case")]
+pub(crate) enum ExecutionMode {
+    Sequential,
+    Parallel,
+}
+
+#[derive(Clone, Debug, Deserialize, Serialize)]
+pub(crate) struct Case {
+    pub(crate) description: String,
+    #[serde(default)]
+    pub(crate) scenario: Option<PathBuf>,
+    #[serde(default = "default_true")]
+    pub(crate) implemented: bool,
+    #[serde(default)]
+    pub(crate) dangerous: bool,
+    #[serde(default)]
+    pub(crate) mutation_group: Option<String>,
+    #[serde(default = "default_weight")]
+    pub(crate) weight: u64,
+    #[serde(default)]
+    pub(crate) covers: Vec<String>,
+    #[serde(default)]
+    pub(crate) requires: Vec<String>,
+}
+
+const fn default_true() -> bool {
+    true
+}
+
+const fn default_weight() -> u64 {
+    1
+}
+
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub(crate) struct RunPlan {
+    pub(crate) version: u32,
+    pub(crate) profile: String,
+    pub(crate) execution: ExecutionMode,
+    pub(crate) seed: u64,
+    pub(crate) requested_count: Option<u64>,
+    pub(crate) duration: Option<String>,
+    #[serde(default)]
+    pub(crate) forever: bool,
+    pub(crate) starts_per_second: f64,
+    pub(crate) transactions_per_second: u64,
+    pub(crate) max_in_flight: usize,
+    pub(crate) max_rpc_in_flight: usize,
+    pub(crate) cases: Vec<CasePlan>,
+}
+
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub(crate) struct CasePlan {
+    pub(crate) id: String,
+    pub(crate) description: String,
+    pub(crate) scenario: PathBuf,
+    pub(crate) seed: u64,
+    pub(crate) count: Option<u64>,
+    pub(crate) duration: Option<String>,
+    pub(crate) starts_per_second: f64,
+    pub(crate) transactions_per_second: u64,
+    pub(crate) max_in_flight: usize,
+    pub(crate) max_rpc_in_flight: usize,
+    pub(crate) dangerous: bool,
+    pub(crate) mutation_group: Option<String>,
+    pub(crate) covers: Vec<String>,
+    pub(crate) requires: Vec<String>,
+}
+
+pub(crate) struct PlanRequest<'a> {
+    pub(crate) profile: &'a str,
+    pub(crate) selected_cases: &'a [String],
+    pub(crate) scenario_root: &'a Path,
+    pub(crate) seed: u64,
+    pub(crate) count: Option<u64>,
+    pub(crate) duration: Option<String>,
+    pub(crate) forever: bool,
+    pub(crate) starts_per_second: f64,
+    pub(crate) transactions_per_second: u64,
+    pub(crate) max_in_flight: usize,
+    pub(crate) max_rpc_in_flight: usize,
+}
+
+impl Catalog {
+    pub(crate) fn load(path: Option<&Path>) -> Result<Self> {
+        let contents = match path {
+            Some(path) => fs::read_to_string(path)
+                .wrap_err_with(|| format!("failed reading catalog {}", path.display()))?,
+            None => BUILTIN_CATALOG.to_owned(),
+        };
+        let catalog: Self =
+            serde_yaml::from_str(&contents).wrap_err("failed parsing load-test catalog")?;
+        catalog.validate()?;
+        Ok(catalog)
+    }
+
+    fn validate(&self) -> Result<()> {
+        ensure!(
+            self.version == 1,
+            "unsupported catalog version {}",
+            self.version
+        );
+        ensure!(!self.profiles.is_empty(), "catalog has no profiles");
+        ensure!(!self.cases.is_empty(), "catalog has no cases");
+
+        for (name, profile) in &self.profiles {
+            ensure!(!profile.cases.is_empty(), "profile {name} has no cases");
+            ensure!(
+                profile.default_count > 0,
+                "profile {name} has a zero default count"
+            );
+            let mut seen = BTreeSet::new();
+            for case in &profile.cases {
+                ensure!(
+                    self.cases.contains_key(case),
+                    "profile {name} references unknown case {case}"
+                );
+                ensure!(seen.insert(case), "profile {name} repeats case {case}");
+            }
+        }
+
+        for (name, case) in &self.cases {
+            ensure!(
+                !case.covers.is_empty(),
+                "case {name} has no coverage labels"
+            );
+            if case.implemented {
+                ensure!(
+                    case.scenario.is_some(),
+                    "implemented case {name} has no scenario"
+                );
+                ensure!(case.weight > 0, "implemented case {name} has zero weight");
+            }
+        }
+        Ok(())
+    }
+
+    pub(crate) fn plan(&self, request: PlanRequest<'_>) -> Result<RunPlan> {
+        ensure!(
+            request.max_in_flight > 0,
+            "--max-in-flight must be at least 1"
+        );
+        ensure!(
+            request.max_rpc_in_flight > 0,
+            "--max-rpc-in-flight must be at least 1"
+        );
+        ensure!(
+            request.starts_per_second.is_finite() && request.starts_per_second >= 0.0,
+            "--journeys-per-second must be finite and non-negative"
+        );
+        let profile = self
+            .profiles
+            .get(request.profile)
+            .ok_or_else(|| eyre::eyre!("unknown profile {}", request.profile))?;
+        let ids = if request.selected_cases.is_empty() {
+            profile.cases.clone()
+        } else {
+            request.selected_cases.to_vec()
+        };
+        ensure!(!ids.is_empty(), "no cases selected");
+
+        let mut selected = Vec::with_capacity(ids.len());
+        let mut seen = BTreeSet::new();
+        for id in ids {
+            ensure!(seen.insert(id.clone()), "case {id} selected more than once");
+            let case = self
+                .cases
+                .get(&id)
+                .ok_or_else(|| eyre::eyre!("unknown case {id}"))?;
+            if !case.implemented {
+                bail!("case {id} is catalogued but not implemented");
+            }
+            selected.push((id, case));
+        }
+
+        if (request.duration.is_some() || request.forever)
+            && profile.execution == ExecutionMode::Sequential
+            && selected.len() > 1
+        {
+            let option = if request.forever {
+                "--forever"
+            } else {
+                "--duration"
+            };
+            bail!("{option} with multiple cases requires a parallel profile or a single --case");
+        }
+
+        let total_count = if request.duration.is_some() {
+            None
+        } else if request.forever {
+            Some(u64::MAX)
+        } else {
+            Some(request.count.unwrap_or(profile.default_count))
+        };
+        let weights = selected
+            .iter()
+            .map(|(_, case)| case.weight)
+            .collect::<Vec<_>>();
+        let counts = total_count
+            .map(|total| allocate_counts(total, &weights, request.seed))
+            .transpose()?;
+        let starts = allocate_rate(request.starts_per_second, &weights, profile.execution);
+        let transactions = allocate_transaction_rate(
+            request.transactions_per_second,
+            &weights,
+            profile.execution,
+            request.seed ^ 0x7478_5f72_6174_6500,
+        )?;
+        let in_flight = allocate_limit(
+            request.max_in_flight,
+            &weights,
+            profile.execution,
+            request.seed ^ 0x696e_666c_6967_6874,
+        )?;
+        let rpc_in_flight = allocate_limit(
+            request.max_rpc_in_flight,
+            &weights,
+            profile.execution,
+            request.seed ^ 0x7270_635f_6c69_6d69,
+        )?;
+
+        let cases = selected
+            .into_iter()
+            .enumerate()
+            .map(|(index, (id, case))| {
+                let scenario = request.scenario_root.join(
+                    case.scenario
+                        .as_ref()
+                        .expect("implemented cases have scenario paths"),
+                );
+                let mut requires = case.requires.iter().cloned().collect::<BTreeSet<_>>();
+                requires.extend(discover_env_requirements(&scenario)?);
+                Ok(CasePlan {
+                    scenario,
+                    seed: derive_seed(request.seed, &id),
+                    count: counts.as_ref().map(|counts| counts[index]),
+                    duration: request.duration.clone(),
+                    starts_per_second: starts[index],
+                    transactions_per_second: transactions[index],
+                    max_in_flight: in_flight[index],
+                    max_rpc_in_flight: rpc_in_flight[index],
+                    id,
+                    description: case.description.clone(),
+                    dangerous: case.dangerous,
+                    mutation_group: case.mutation_group.clone(),
+                    covers: case.covers.clone(),
+                    requires: requires.into_iter().collect(),
+                })
+            })
+            .collect::<Result<Vec<_>>>()?;
+
+        Ok(RunPlan {
+            version: 1,
+            profile: request.profile.to_owned(),
+            execution: profile.execution,
+            seed: request.seed,
+            requested_count: if request.forever { None } else { total_count },
+            duration: request.duration,
+            forever: request.forever,
+            starts_per_second: request.starts_per_second,
+            transactions_per_second: request.transactions_per_second,
+            max_in_flight: request.max_in_flight,
+            max_rpc_in_flight: request.max_rpc_in_flight,
+            cases,
+        })
+    }
+
+    pub(crate) fn all_coverage_labels(&self) -> BTreeSet<String> {
+        self.cases
+            .values()
+            .flat_map(|case| case.covers.iter().cloned())
+            .collect()
+    }
+
+    pub(crate) fn implemented_coverage_labels(&self) -> BTreeSet<String> {
+        self.cases
+            .values()
+            .filter(|case| case.implemented)
+            .flat_map(|case| case.covers.iter().cloned())
+            .collect()
+    }
+}
+
+fn discover_env_requirements(root: &Path) -> Result<BTreeSet<String>> {
+    fn visit(
+        path: &Path,
+        visited: &mut BTreeSet<PathBuf>,
+        requirements: &mut BTreeSet<String>,
+    ) -> Result<()> {
+        let canonical = path
+            .canonicalize()
+            .wrap_err_with(|| format!("failed resolving scenario dependency {}", path.display()))?;
+        if !visited.insert(canonical.clone()) {
+            return Ok(());
+        }
+        let contents = fs::read_to_string(&canonical).wrap_err_with(|| {
+            format!("failed reading scenario dependency {}", canonical.display())
+        })?;
+        extract_env_names(&contents, requirements);
+
+        let parent = canonical.parent().unwrap_or_else(|| Path::new("."));
+        for dependency in yaml_dependencies(&contents) {
+            visit(&parent.join(dependency), visited, requirements)?;
+        }
+        Ok(())
+    }
+
+    let mut visited = BTreeSet::new();
+    let mut requirements = BTreeSet::new();
+    visit(root, &mut visited, &mut requirements)?;
+    Ok(requirements)
+}
+
+fn yaml_dependencies(contents: &str) -> Vec<String> {
+    let mut dependencies = Vec::new();
+    let mut include_indent = None;
+    for line in contents.lines() {
+        let indent = line.len() - line.trim_start().len();
+        let trimmed = line.trim();
+        if trimmed.is_empty() || trimmed.starts_with('#') {
+            continue;
+        }
+        if trimmed == "include:" {
+            include_indent = Some(indent);
+            continue;
+        }
+        if let Some(base) = include_indent {
+            if indent > base {
+                if let Some(value) = trimmed.strip_prefix("- ") {
+                    dependencies.push(unquote(value).to_owned());
+                }
+                continue;
+            }
+            include_indent = None;
+        }
+        if let Some(value) = trimmed.strip_prefix("workload:") {
+            let value = value.trim();
+            if !value.is_empty() {
+                dependencies.push(unquote(value).to_owned());
+            }
+        }
+    }
+    dependencies
+}
+
+fn unquote(value: &str) -> &str {
+    value
+        .strip_prefix('"')
+        .and_then(|value| value.strip_suffix('"'))
+        .or_else(|| {
+            value
+                .strip_prefix('\'')
+                .and_then(|value| value.strip_suffix('\''))
+        })
+        .unwrap_or(value)
+}
+
+fn extract_env_names(contents: &str, requirements: &mut BTreeSet<String>) {
+    let mut remaining = contents;
+    while let Some(start) = remaining.find("${") {
+        remaining = &remaining[start + 2..];
+        let Some(end) = remaining.find('}') else {
+            break;
+        };
+        let name = &remaining[..end];
+        if !name.is_empty()
+            && name
+                .bytes()
+                .all(|byte| byte == b'_' || byte.is_ascii_alphanumeric())
+        {
+            requirements.insert(name.to_owned());
+        }
+        remaining = &remaining[end + 1..];
+    }
+}
+
+fn allocate_counts(total: u64, weights: &[u64], seed: u64) -> Result<Vec<u64>> {
+    ensure!(!weights.is_empty(), "cannot allocate count to no cases");
+    ensure!(
+        total >= weights.len() as u64,
+        "count {total} is smaller than the {} selected cases; every case must run once",
+        weights.len()
+    );
+    let weight_sum = weights.iter().copied().sum::<u64>();
+    ensure!(weight_sum > 0, "selected cases have zero total weight");
+
+    let remaining = total - weights.len() as u64;
+    let mut counts = vec![1; weights.len()];
+    let mut assigned = 0;
+    let mut remainders = Vec::with_capacity(weights.len());
+    for (index, weight) in weights.iter().copied().enumerate() {
+        let numerator = u128::from(remaining) * u128::from(weight);
+        let share = (numerator / u128::from(weight_sum)) as u64;
+        counts[index] += share;
+        assigned += share;
+        remainders.push((
+            index,
+            numerator % u128::from(weight_sum),
+            splitmix64(seed ^ index as u64),
+        ));
+    }
+
+    remainders.sort_by(|left, right| {
+        right
+            .1
+            .cmp(&left.1)
+            .then_with(|| right.2.cmp(&left.2))
+            .then_with(|| left.0.cmp(&right.0))
+    });
+    for (index, _, _) in remainders.into_iter().take((remaining - assigned) as usize) {
+        counts[index] += 1;
+    }
+    Ok(counts)
+}
+
+fn allocate_rate(total: f64, weights: &[u64], mode: ExecutionMode) -> Vec<f64> {
+    if total == 0.0 || mode == ExecutionMode::Sequential {
+        return vec![total; weights.len()];
+    }
+    let weight_sum = weights.iter().sum::<u64>() as f64;
+    weights
+        .iter()
+        .map(|weight| total * *weight as f64 / weight_sum)
+        .collect()
+}
+
+fn allocate_transaction_rate(
+    total: u64,
+    weights: &[u64],
+    mode: ExecutionMode,
+    seed: u64,
+) -> Result<Vec<u64>> {
+    if total == 0 || mode == ExecutionMode::Sequential {
+        return Ok(vec![total; weights.len()]);
+    }
+    allocate_counts(total, weights, seed).wrap_err_with(|| {
+        format!(
+            "cannot allocate --transactions-per-second {total} across {} parallel cases",
+            weights.len()
+        )
+    })
+}
+
+fn allocate_limit(
+    total: usize,
+    weights: &[u64],
+    mode: ExecutionMode,
+    seed: u64,
+) -> Result<Vec<usize>> {
+    if mode == ExecutionMode::Sequential {
+        return Ok(vec![total; weights.len()]);
+    }
+    allocate_counts(total as u64, weights, seed)
+        .map(|counts| counts.into_iter().map(|count| count as usize).collect())
+}
+
+fn derive_seed(master: u64, id: &str) -> u64 {
+    let hash = id.bytes().fold(0xcbf2_9ce4_8422_2325u64, |hash, byte| {
+        (hash ^ u64::from(byte)).wrapping_mul(0x1000_0000_01b3)
+    });
+    splitmix64(master ^ hash)
+}
+
+fn splitmix64(mut value: u64) -> u64 {
+    value = value.wrapping_add(0x9e37_79b9_7f4a_7c15);
+    value = (value ^ (value >> 30)).wrapping_mul(0xbf58_476d_1ce4_e5b9);
+    value = (value ^ (value >> 27)).wrapping_mul(0x94d0_49bb_1331_11eb);
+    value ^ (value >> 31)
+}
+
+pub(crate) fn compare_coverage_status(left: &str, right: &str) -> Ordering {
+    coverage_status_rank(left)
+        .cmp(&coverage_status_rank(right))
+        .then_with(|| left.cmp(right))
+}
+
+fn coverage_status_rank(status: &str) -> u8 {
+    match status {
+        "failed" => 0,
+        "uncovered" => 1,
+        "covered" => 2,
+        _ => 3,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn builtin_catalog_is_valid() {
+        Catalog::load(None).unwrap();
+    }
+
+    #[test]
+    fn count_allocation_is_complete_and_deterministic() {
+        let first = allocate_counts(101, &[30, 35, 15, 15, 5], 42).unwrap();
+        let second = allocate_counts(101, &[30, 35, 15, 15, 5], 42).unwrap();
+        assert_eq!(first, second);
+        assert_eq!(first.iter().sum::<u64>(), 101);
+        assert!(first.iter().all(|count| *count >= 1));
+    }
+
+    #[test]
+    fn every_selected_case_runs_at_least_once() {
+        assert!(allocate_counts(1, &[1, 1], 1).is_err());
+        assert_eq!(allocate_counts(2, &[100, 1], 1).unwrap(), vec![1, 1]);
+    }
+
+    #[test]
+    fn parallel_transaction_rate_is_integral_and_preserves_the_total() {
+        let rates =
+            allocate_transaction_rate(11, &[30, 30, 40], ExecutionMode::Parallel, 42).unwrap();
+        assert_eq!(rates.iter().sum::<u64>(), 11);
+        assert!(rates.iter().all(|rate| *rate >= 1));
+        assert!(allocate_transaction_rate(2, &[1, 1, 1], ExecutionMode::Parallel, 42).is_err());
+        assert_eq!(
+            allocate_transaction_rate(0, &[1, 1], ExecutionMode::Parallel, 42).unwrap(),
+            vec![0, 0]
+        );
+    }
+
+    #[test]
+    fn forever_plan_uses_parallel_maximum_counts() {
+        let catalog = Catalog::load(None).unwrap();
+        let selected = vec![
+            "encrypted-deposit".to_owned(),
+            "plain-withdrawal".to_owned(),
+        ];
+        let root = Path::new(env!("CARGO_MANIFEST_DIR")).join("../..");
+        let plan = catalog
+            .plan(PlanRequest {
+                profile: "steady",
+                selected_cases: &selected,
+                scenario_root: &root,
+                seed: 42,
+                count: None,
+                duration: None,
+                forever: true,
+                starts_per_second: 5.0,
+                transactions_per_second: 50,
+                max_in_flight: 20,
+                max_rpc_in_flight: 100,
+            })
+            .unwrap();
+
+        assert!(plan.forever);
+        assert_eq!(plan.requested_count, None);
+        assert_eq!(
+            plan.cases
+                .iter()
+                .map(|case| u128::from(case.count.unwrap()))
+                .sum::<u128>(),
+            u128::from(u64::MAX)
+        );
+    }
+
+    #[test]
+    fn forever_rejects_multiple_sequential_cases() {
+        let catalog = Catalog::load(None).unwrap();
+        let root = Path::new(env!("CARGO_MANIFEST_DIR")).join("../..");
+        let error = catalog
+            .plan(PlanRequest {
+                profile: "core",
+                selected_cases: &[],
+                scenario_root: &root,
+                seed: 1,
+                count: None,
+                duration: None,
+                forever: true,
+                starts_per_second: 1.0,
+                transactions_per_second: 10,
+                max_in_flight: 2,
+                max_rpc_in_flight: 2,
+            })
+            .unwrap_err();
+
+        assert!(error.to_string().contains("--forever with multiple cases"));
+    }
+
+    #[test]
+    fn derived_seeds_are_stable_and_case_specific() {
+        assert_eq!(derive_seed(42, "deposit"), derive_seed(42, "deposit"));
+        assert_ne!(derive_seed(42, "deposit"), derive_seed(42, "withdrawal"));
+    }
+
+    #[test]
+    fn discovers_requirements_through_scenario_dependencies() {
+        let root = Path::new(env!("CARGO_MANIFEST_DIR"))
+            .join("../../contrib/bench/neobank/encrypted-deposit-scenario.yml");
+        let requirements = discover_env_requirements(&root).unwrap();
+        assert!(requirements.contains("L1_RPC_URL"));
+        assert!(requirements.contains("ZONES_BENCH_SEQUENCER_ACCOUNT_INDEX"));
+        assert!(requirements.contains("ZONES_BENCH_REWARD_FUND_AMOUNT"));
+    }
+}

--- a/bin/zones-load/src/deployment.rs
+++ b/bin/zones-load/src/deployment.rs
@@ -1,0 +1,466 @@
+use alloy::{
+    primitives::Address,
+    providers::{Provider, ProviderBuilder},
+};
+use eyre::{Context as _, Result, ensure};
+use serde::{Deserialize, Serialize};
+use std::collections::BTreeMap;
+use tempo_alloy::TempoNetwork;
+use tempo_zone_contracts::{ZONE_INBOX_ADDRESS, ZONE_OUTBOX_ADDRESS, ZonePortal};
+
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub(crate) struct DeploymentContext {
+    pub(crate) portal: Address,
+    pub(crate) zone_id: u32,
+    pub(crate) token: Address,
+    pub(crate) l1_rpc_url: String,
+    #[serde(default)]
+    pub(crate) l1_chain_id: Option<u64>,
+    pub(crate) zone_rpc_url: String,
+    #[serde(default)]
+    pub(crate) zone_chain_id: Option<u64>,
+    pub(crate) zone_submit_rpc_url: String,
+}
+
+#[derive(Clone, Debug, Serialize)]
+pub(crate) struct DoctorReport {
+    pub(crate) healthy: bool,
+    pub(crate) deployment: DeploymentContext,
+    pub(crate) checks: Vec<DoctorCheck>,
+    pub(crate) missing_requirements: Vec<String>,
+}
+
+#[derive(Clone, Debug, Serialize)]
+pub(crate) struct DoctorCheck {
+    pub(crate) name: String,
+    pub(crate) passed: bool,
+    pub(crate) detail: String,
+}
+
+impl DeploymentContext {
+    pub(crate) fn new(
+        portal: Option<Address>,
+        zone_id: Option<u32>,
+        token: Option<Address>,
+        l1_rpc_url: Option<String>,
+        zone_rpc_url: Option<String>,
+        zone_submit_rpc_url: Option<String>,
+    ) -> Result<Self> {
+        let portal = portal.ok_or_else(|| {
+            eyre::eyre!(
+                "--portal is required for doctor, run, and replay (or set L1_PORTAL_ADDRESS)"
+            )
+        })?;
+        let zone_id = zone_id.ok_or_else(|| {
+            eyre::eyre!(
+                "--zone-id is required for doctor, run, and replay (or set ZONES_LOAD_ZONE_ID)"
+            )
+        })?;
+        let token = token.ok_or_else(|| {
+            eyre::eyre!("--token is required for doctor, run, and replay (or set ZONES_LOAD_TOKEN)")
+        })?;
+        ensure!(!portal.is_zero(), "--portal must not be the zero address");
+        ensure!(zone_id != 0, "--zone-id must not be zero");
+        ensure!(!token.is_zero(), "--token must not be the zero address");
+
+        let l1_rpc_url = l1_rpc_url.filter(|url| !url.is_empty()).ok_or_else(|| {
+            eyre::eyre!("L1 RPC is required; pass --l1-rpc-url or set L1_RPC_URL")
+        })?;
+        let zone_rpc_url = zone_rpc_url.filter(|url| !url.is_empty()).ok_or_else(|| {
+            eyre::eyre!("Zone RPC is required; pass --zone-rpc-url or set ZONE_RPC_URL")
+        })?;
+        let zone_submit_rpc_url = zone_submit_rpc_url
+            .filter(|url| !url.is_empty())
+            .unwrap_or_else(|| zone_rpc_url.clone());
+
+        Ok(Self {
+            portal,
+            zone_id,
+            token,
+            l1_rpc_url: normalize_http(&l1_rpc_url),
+            l1_chain_id: None,
+            zone_rpc_url: normalize_http(&zone_rpc_url),
+            zone_chain_id: None,
+            zone_submit_rpc_url: normalize_http(&zone_submit_rpc_url),
+        })
+    }
+
+    pub(crate) async fn resolve(mut self) -> Result<Self> {
+        let l1_provider = ProviderBuilder::new_with_network::<TempoNetwork>()
+            .connect(&self.l1_rpc_url)
+            .await
+            .wrap_err("failed connecting to L1 RPC")?;
+        self.l1_chain_id = Some(
+            l1_provider
+                .get_chain_id()
+                .await
+                .wrap_err("failed reading L1 chain ID")?,
+        );
+        let zone_provider = ProviderBuilder::new_with_network::<TempoNetwork>()
+            .connect(&self.zone_rpc_url)
+            .await
+            .wrap_err("failed connecting to Zone RPC")?;
+        self.zone_chain_id = Some(
+            zone_provider
+                .get_chain_id()
+                .await
+                .wrap_err("failed reading Zone chain ID")?,
+        );
+        Ok(self)
+    }
+
+    pub(crate) fn command_env(&self) -> BTreeMap<String, String> {
+        let mut env = BTreeMap::new();
+        env.insert("L1_RPC_URL".to_owned(), self.l1_rpc_url.clone());
+        env.insert(
+            "ZONES_BENCH_L1_QUERY_RPC_URL".to_owned(),
+            self.l1_rpc_url.clone(),
+        );
+        insert_default(&mut env, "L1_WS_RPC_URL", websocket_url(&self.l1_rpc_url));
+        env.insert("ZONE_RPC_URL".to_owned(), self.zone_rpc_url.clone());
+        env.insert(
+            "ZONE_REDACTED_RPC_URL".to_owned(),
+            self.zone_submit_rpc_url.clone(),
+        );
+        insert_default(
+            &mut env,
+            "ZONE_WS_RPC_URL",
+            websocket_url(&self.zone_rpc_url),
+        );
+        env.insert("L1_PORTAL_ADDRESS".to_owned(), self.portal.to_string());
+        env.insert(
+            "ZONES_BENCH_EXPECTED_ZONE_ID".to_owned(),
+            self.zone_id.to_string(),
+        );
+        env.insert("ZONES_LOAD_ZONE_ID".to_owned(), self.zone_id.to_string());
+        if let Some(chain_id) = self.zone_chain_id {
+            env.insert(
+                "ZONES_BENCH_EXPECTED_ZONE_CHAIN_ID".to_owned(),
+                chain_id.to_string(),
+            );
+            env.insert(
+                "ZONES_LOAD_EXPECTED_ZONE_CHAIN_ID".to_owned(),
+                chain_id.to_string(),
+            );
+        }
+        if let Some(chain_id) = self.l1_chain_id {
+            env.insert(
+                "ZONES_BENCH_EXPECTED_L1_CHAIN_ID".to_owned(),
+                chain_id.to_string(),
+            );
+            env.insert(
+                "ZONES_LOAD_EXPECTED_L1_CHAIN_ID".to_owned(),
+                chain_id.to_string(),
+            );
+        }
+        env.insert("ZONES_BENCH_TOKEN".to_owned(), self.token.to_string());
+        env.insert("ZONES_LOAD_TOKEN".to_owned(), self.token.to_string());
+
+        insert_default(&mut env, "ZONES_BENCH_L1_MAX_FEE_PER_GAS", "12000000000");
+        insert_default(&mut env, "ZONES_BENCH_L1_MAX_PRIORITY_FEE_PER_GAS", "0");
+        insert_default(&mut env, "ZONES_BENCH_ZONE_MAX_FEE_PER_GAS", "10000000000");
+        insert_default(&mut env, "ZONES_BENCH_ZONE_MAX_PRIORITY_FEE_PER_GAS", "0");
+        insert_default(&mut env, "ZONES_BENCH_DEPOSIT_AMOUNT", "2000000");
+        insert_default(&mut env, "ZONES_BENCH_WITHDRAWAL_AMOUNT", "1000000");
+        insert_default(&mut env, "ZONES_BENCH_CALLBACK_GAS_LIMIT", "10000000");
+        insert_default(&mut env, "ZONES_LOAD_L1_MAX_FEE_PER_GAS", "12000000000");
+        insert_default(&mut env, "ZONES_LOAD_ZONE_MAX_FEE_PER_GAS", "10000000000");
+        insert_default(&mut env, "ZONES_LOAD_DEPOSIT_AMOUNT", "2000000");
+        insert_default(&mut env, "ZONES_LOAD_WITHDRAWAL_AMOUNT", "1000000");
+        insert_default(&mut env, "ZONES_LOAD_ACCOUNT_START", "16");
+        insert_default(&mut env, "ZONES_LOAD_ACCOUNT_END", "116");
+        env.insert(
+            "ZONES_LOAD_INBOX".to_owned(),
+            ZONE_INBOX_ADDRESS.to_string(),
+        );
+        env.insert(
+            "ZONES_LOAD_OUTBOX".to_owned(),
+            ZONE_OUTBOX_ADDRESS.to_string(),
+        );
+        if std::env::var("ZONES_LOAD_MNEMONIC").is_err()
+            && let Ok(mnemonic) = std::env::var("ZONES_BENCH_MNEMONIC")
+        {
+            env.insert("ZONES_LOAD_MNEMONIC".to_owned(), mnemonic);
+        }
+        env
+    }
+
+    pub(crate) fn sanitized(&self) -> Self {
+        let mut sanitized = self.clone();
+        sanitized.l1_rpc_url = sanitize_url(&sanitized.l1_rpc_url);
+        sanitized.zone_rpc_url = sanitize_url(&sanitized.zone_rpc_url);
+        sanitized.zone_submit_rpc_url = sanitize_url(&sanitized.zone_submit_rpc_url);
+        sanitized
+    }
+
+    pub(crate) fn missing_requirements(&self, requirements: &[String]) -> Vec<String> {
+        let env = self.command_env();
+        requirements
+            .iter()
+            .filter(|name| {
+                let synthesized = env.get(*name).is_some_and(|value| !value.is_empty());
+                let inherited = std::env::var(name).is_ok_and(|value| !value.is_empty());
+                !synthesized && !inherited
+            })
+            .cloned()
+            .collect()
+    }
+
+    pub(crate) async fn doctor(&self, requirements: &[String]) -> DoctorReport {
+        let mut checks = Vec::new();
+
+        match ProviderBuilder::new_with_network::<TempoNetwork>()
+            .connect(&self.l1_rpc_url)
+            .await
+        {
+            Ok(provider) => {
+                match provider.get_chain_id().await {
+                    Ok(chain_id) => checks.push(pass("l1.rpc", format!("chain ID {chain_id}"))),
+                    Err(error) => checks.push(fail("l1.rpc", error.to_string())),
+                }
+                match provider.get_block_number().await {
+                    Ok(block) => checks.push(pass("l1.head", format!("block {block}"))),
+                    Err(error) => checks.push(fail("l1.head", error.to_string())),
+                }
+                match provider.get_code_at(self.portal).await {
+                    Ok(code) if !code.is_empty() => checks.push(pass(
+                        "l1.portal.code",
+                        format!("{} bytes at {}", code.len(), self.portal),
+                    )),
+                    Ok(_) => checks.push(fail(
+                        "l1.portal.code",
+                        format!("no code at {}", self.portal),
+                    )),
+                    Err(error) => checks.push(fail("l1.portal.code", error.to_string())),
+                }
+
+                let portal = ZonePortal::new(self.portal, &provider);
+                match portal.zoneId().call().await {
+                    Ok(zone_id) if zone_id == self.zone_id => {
+                        checks.push(pass("l1.portal.zone_id", format!("zone ID {zone_id}")))
+                    }
+                    Ok(zone_id) => checks.push(fail(
+                        "l1.portal.zone_id",
+                        format!(
+                            "portal reports {zone_id}, configured Zone ID is {}",
+                            self.zone_id
+                        ),
+                    )),
+                    Err(error) => checks.push(fail("l1.portal.zone_id", error.to_string())),
+                }
+                match portal.enabled_tokens().await {
+                    Ok(tokens) if tokens.contains(&self.token) => checks.push(pass(
+                        "l1.portal.enabled_tokens",
+                        format!(
+                            "configured token {} is one of {} enabled token(s)",
+                            self.token,
+                            tokens.len()
+                        ),
+                    )),
+                    Ok(tokens) => checks.push(fail(
+                        "l1.portal.enabled_tokens",
+                        format!(
+                            "configured token {} is not among {} enabled token(s)",
+                            self.token,
+                            tokens.len()
+                        ),
+                    )),
+                    Err(error) => checks.push(fail("l1.portal.enabled_tokens", error.to_string())),
+                }
+                match portal.encryption_key().await {
+                    Ok((_, index)) => checks.push(pass(
+                        "l1.portal.encryption_key",
+                        format!("active key index {index}"),
+                    )),
+                    Err(error) => checks.push(fail("l1.portal.encryption_key", error.to_string())),
+                }
+            }
+            Err(error) => checks.push(fail("l1.connect", error.to_string())),
+        }
+
+        match ProviderBuilder::new_with_network::<TempoNetwork>()
+            .connect(&self.zone_rpc_url)
+            .await
+        {
+            Ok(provider) => {
+                match provider.get_chain_id().await {
+                    Ok(chain_id) if Some(chain_id) == self.zone_chain_id => {
+                        checks.push(pass("zone.rpc", format!("chain ID {chain_id}")))
+                    }
+                    Ok(chain_id) => checks.push(fail(
+                        "zone.rpc",
+                        format!(
+                            "RPC reports chain ID {chain_id}, resolved chain ID is {}",
+                            self.zone_chain_id.map_or_else(
+                                || "unknown".to_owned(),
+                                |expected| expected.to_string()
+                            )
+                        ),
+                    )),
+                    Err(error) => checks.push(fail("zone.rpc", error.to_string())),
+                }
+                match provider.get_block_number().await {
+                    Ok(block) => checks.push(pass("zone.head", format!("block {block}"))),
+                    Err(error) => checks.push(fail("zone.head", error.to_string())),
+                }
+                for (name, address) in [
+                    ("zone.inbox.code", ZONE_INBOX_ADDRESS),
+                    ("zone.outbox.code", ZONE_OUTBOX_ADDRESS),
+                ] {
+                    match provider.get_code_at(address).await {
+                        Ok(code) if !code.is_empty() => {
+                            checks.push(pass(name, format!("{} bytes at {address}", code.len())))
+                        }
+                        Ok(_) => checks.push(fail(name, format!("no code at {address}"))),
+                        Err(error) => checks.push(fail(name, error.to_string())),
+                    }
+                }
+            }
+            Err(error) => checks.push(fail("zone.connect", error.to_string())),
+        }
+
+        let missing_requirements = self.missing_requirements(requirements);
+        if missing_requirements.is_empty() {
+            checks.push(pass("workload.environment", "all required values are set"));
+        } else {
+            checks.push(fail(
+                "workload.environment",
+                format!("missing {} value(s)", missing_requirements.len()),
+            ));
+        }
+
+        DoctorReport {
+            healthy: checks.iter().all(|check| check.passed),
+            deployment: self.sanitized(),
+            checks,
+            missing_requirements,
+        }
+    }
+}
+
+fn normalize_http(url: &str) -> String {
+    url.replace("wss://", "https://")
+        .replace("ws://", "http://")
+}
+
+fn websocket_url(url: &str) -> String {
+    if let Some(rest) = url.strip_prefix("https://") {
+        format!("wss://{rest}")
+    } else if let Some(rest) = url.strip_prefix("http://") {
+        format!("ws://{rest}")
+    } else {
+        url.to_owned()
+    }
+}
+
+fn sanitize_url(url: &str) -> String {
+    let (prefix, rest) = url
+        .split_once("://")
+        .map_or(("", url), |(scheme, rest)| (scheme, rest));
+    let rest = rest.split_once('#').map_or(rest, |(value, _)| value);
+    let had_query = rest.contains('?');
+    let rest = rest.split_once('?').map_or(rest, |(value, _)| value);
+    let (authority, suffix) = rest
+        .split_once('/')
+        .map_or((rest, ""), |(authority, suffix)| (authority, suffix));
+    let authority = authority
+        .rsplit_once('@')
+        .map_or(authority, |(_, host)| host);
+    let suffix = if suffix.is_empty() {
+        if had_query { "?<redacted>" } else { "" }
+    } else if had_query {
+        "/<redacted>?<redacted>"
+    } else {
+        "/<redacted>"
+    };
+    if prefix.is_empty() {
+        format!("{authority}{suffix}")
+    } else {
+        format!("{prefix}://{authority}{suffix}")
+    }
+}
+
+fn insert_default(env: &mut BTreeMap<String, String>, name: &str, default: impl Into<String>) {
+    let value = std::env::var(name)
+        .ok()
+        .filter(|value| !value.is_empty())
+        .unwrap_or_else(|| default.into());
+    env.insert(name.to_owned(), value);
+}
+
+fn pass(name: &str, detail: impl Into<String>) -> DoctorCheck {
+    DoctorCheck {
+        name: name.to_owned(),
+        passed: true,
+        detail: detail.into(),
+    }
+}
+
+fn fail(name: &str, detail: impl Into<String>) -> DoctorCheck {
+    DoctorCheck {
+        name: name.to_owned(),
+        passed: false,
+        detail: detail.into(),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn builds_environment_from_explicit_deployment_inputs() {
+        let portal = Address::repeat_byte(0x11);
+        let token = Address::repeat_byte(0x22);
+        let mut deployment = DeploymentContext::new(
+            Some(portal),
+            Some(7),
+            Some(token),
+            Some("ws://l1.example.test".to_owned()),
+            Some("wss://zone.example.test".to_owned()),
+            None,
+        )
+        .unwrap();
+        deployment.l1_chain_id = Some(42431);
+        deployment.zone_chain_id = Some(424310007);
+
+        let env = deployment.command_env();
+        assert_eq!(deployment.l1_rpc_url, "http://l1.example.test");
+        assert_eq!(deployment.zone_rpc_url, "https://zone.example.test");
+        assert_eq!(deployment.zone_submit_rpc_url, deployment.zone_rpc_url);
+        assert_eq!(env["L1_PORTAL_ADDRESS"], portal.to_string());
+        assert_eq!(env["ZONES_LOAD_ZONE_ID"], "7");
+        assert_eq!(env["ZONES_LOAD_TOKEN"], token.to_string());
+        assert_eq!(env["ZONES_LOAD_EXPECTED_L1_CHAIN_ID"], "42431");
+        assert_eq!(env["ZONES_LOAD_EXPECTED_ZONE_CHAIN_ID"], "424310007");
+    }
+
+    #[test]
+    fn rejects_zero_deployment_identifiers() {
+        let error = DeploymentContext::new(
+            Some(Address::ZERO),
+            Some(7),
+            Some(Address::repeat_byte(0x22)),
+            Some("http://l1.example.test".to_owned()),
+            Some("http://zone.example.test".to_owned()),
+            None,
+        )
+        .unwrap_err();
+
+        assert!(
+            error
+                .to_string()
+                .contains("--portal must not be the zero address")
+        );
+    }
+
+    #[test]
+    fn normalizes_rpc_schemes() {
+        assert_eq!(normalize_http("ws://localhost:1"), "http://localhost:1");
+        assert_eq!(websocket_url("https://example.test"), "wss://example.test");
+        assert_eq!(
+            sanitize_url("https://user:secret@example.test/rpc?token=secret"),
+            "https://example.test/<redacted>?<redacted>"
+        );
+    }
+}

--- a/bin/zones-load/src/main.rs
+++ b/bin/zones-load/src/main.rs
@@ -1,0 +1,641 @@
+//! Stateful multi-chain load and codepath coverage runner for Tempo Zones.
+
+mod catalog;
+mod deployment;
+mod report;
+mod runner;
+
+use crate::{
+    catalog::{Catalog, PlanRequest, RunPlan},
+    deployment::{DeploymentContext, DoctorCheck},
+    report::{CaseStatus, CoverageReport, load_run_report, write_json_atomic},
+    runner::{RunOptions, check_txgen, execute_plan, validate_plan},
+};
+use alloy::primitives::Address;
+use clap::{Args, Parser, Subcommand, ValueEnum};
+use eyre::{Context as _, Result, bail, ensure};
+use serde_json::json;
+use std::{
+    collections::BTreeSet,
+    path::{Path, PathBuf},
+};
+
+#[derive(Debug, Parser)]
+#[command(version, about)]
+struct Cli {
+    /// ZonePortal contract address on Tempo L1.
+    #[arg(long, global = true, env = "L1_PORTAL_ADDRESS")]
+    portal: Option<Address>,
+
+    /// Numeric Zone ID registered by the Portal.
+    #[arg(long, global = true, env = "ZONES_LOAD_ZONE_ID")]
+    zone_id: Option<u32>,
+
+    /// TIP-20 token to use for deposits, withdrawals, and transfers.
+    #[arg(long, global = true, env = "ZONES_LOAD_TOKEN")]
+    token: Option<Address>,
+
+    /// Tempo L1 HTTP RPC URL.
+    #[arg(long, global = true, env = "L1_RPC_URL")]
+    l1_rpc_url: Option<String>,
+
+    /// Unrestricted Zone HTTP RPC used for queries and observations.
+    #[arg(long, global = true, env = "ZONE_RPC_URL")]
+    zone_rpc_url: Option<String>,
+
+    /// Zone submission RPC; defaults to ZONE_REDACTED_RPC_URL, then the query RPC.
+    #[arg(long, global = true, env = "ZONE_REDACTED_RPC_URL")]
+    zone_submit_rpc_url: Option<String>,
+
+    /// txgen Tempo executable.
+    #[arg(
+        long,
+        global = true,
+        env = "TXGEN_TEMPO_BIN",
+        default_value = "txgen-tempo"
+    )]
+    txgen_bin: PathBuf,
+
+    /// Optional custom workload catalog. The built-in catalog is used when omitted.
+    #[arg(long, global = true)]
+    catalog_file: Option<PathBuf>,
+
+    /// Root used to resolve scenario paths from the catalog.
+    #[arg(long, global = true, default_value = ".")]
+    scenario_root: PathBuf,
+
+    #[command(subcommand)]
+    command: Command,
+}
+
+#[derive(Clone, Debug, Subcommand)]
+enum Command {
+    /// Check RPCs, deployment identity, fixtures, workload inputs, and scenario validity.
+    Doctor(DoctorArgs),
+    /// List workload profiles, cases, and stable coverage labels.
+    Catalog(CatalogArgs),
+    /// Resolve and print the exact deterministic execution plan without submitting transactions.
+    Plan(PlanArgs),
+    /// Validate and execute a workload profile.
+    Run(RunArgs),
+    /// Replay one case from a previous run with its original deterministic seed.
+    Replay(ReplayArgs),
+    /// Render codepath coverage from a run report.
+    Coverage(CoverageArgs),
+}
+
+#[derive(Clone, Debug, Args)]
+struct SelectionArgs {
+    /// Built-in or custom profile name.
+    #[arg(long, default_value = "branch-sweep")]
+    profile: String,
+
+    /// Select a particular case; repeat to select multiple cases.
+    #[arg(long = "case")]
+    cases: Vec<String>,
+
+    /// Master deterministic seed.
+    #[arg(long, default_value_t = 1)]
+    seed: u64,
+
+    /// Total journeys across the selected cases. Defaults to the profile setting.
+    #[arg(long, conflicts_with = "duration")]
+    count: Option<u64>,
+
+    /// Run duration, such as 30s or 10m. Supported by parallel profiles or one case.
+    #[arg(long, conflicts_with = "count")]
+    duration: Option<String>,
+
+    /// Keep starting journeys until interrupted. Supported by parallel profiles or one case.
+    #[arg(long, conflicts_with_all = ["count", "duration"])]
+    forever: bool,
+
+    /// Aggregate journey starts per second; zero means unlimited.
+    #[arg(long, default_value_t = 0.0)]
+    journeys_per_second: f64,
+
+    /// Aggregate transaction submissions per second on each chain; zero means unlimited.
+    #[arg(long, default_value_t = 0)]
+    transactions_per_second: u64,
+
+    /// Aggregate active journey limit.
+    #[arg(long, default_value_t = 20)]
+    max_in_flight: usize,
+
+    /// Aggregate in-flight transaction-submission RPC limit.
+    #[arg(long, default_value_t = 100)]
+    max_rpc_in_flight: usize,
+}
+
+#[derive(Clone, Debug, Args)]
+struct DoctorArgs {
+    /// Profile whose scenario files and environment requirements should be checked.
+    #[arg(long, default_value = "smoke")]
+    profile: String,
+
+    /// Select a particular case; repeat to select multiple cases.
+    #[arg(long = "case")]
+    cases: Vec<String>,
+
+    /// Do not invoke txgen's offline scenario validator.
+    #[arg(long)]
+    skip_scenario_validation: bool,
+
+    /// Emit machine-readable JSON.
+    #[arg(long)]
+    json: bool,
+}
+
+#[derive(Clone, Debug, Args)]
+struct CatalogArgs {
+    /// Limit output to cases in one profile.
+    #[arg(long)]
+    profile: Option<String>,
+
+    /// Include catalogued cases that do not yet have executable scenarios.
+    #[arg(long)]
+    include_planned: bool,
+
+    /// Emit machine-readable JSON.
+    #[arg(long)]
+    json: bool,
+}
+
+#[derive(Clone, Debug, Args)]
+struct PlanArgs {
+    #[command(flatten)]
+    selection: SelectionArgs,
+
+    /// Write the JSON plan to this path instead of stdout.
+    #[arg(long)]
+    output: Option<PathBuf>,
+}
+
+#[derive(Clone, Copy, Debug, ValueEnum)]
+enum FailurePolicy {
+    Continue,
+    FailFast,
+}
+
+impl FailurePolicy {
+    const fn as_str(self) -> &'static str {
+        match self {
+            Self::Continue => "continue",
+            Self::FailFast => "fail-fast",
+        }
+    }
+}
+
+#[derive(Clone, Debug, Args)]
+struct RunArgs {
+    #[command(flatten)]
+    selection: SelectionArgs,
+
+    /// Directory for run.json, run.ndjson, and per-case txgen reports.
+    #[arg(long)]
+    report_dir: Option<PathBuf>,
+
+    /// Continue independent cases after a failure, or stop promptly.
+    #[arg(long, value_enum, default_value_t = FailurePolicy::Continue)]
+    failure_policy: FailurePolicy,
+
+    /// Default timeout for an individual scenario step.
+    #[arg(long, default_value = "10m")]
+    step_timeout: String,
+
+    /// Number of sanitized txgen journey lifecycle samples to retain per case.
+    #[arg(long, default_value_t = 10)]
+    sample_instances: usize,
+
+    /// Required before running a case that mutates Portal governance.
+    #[arg(long)]
+    allow_governance: bool,
+
+    /// Fund every L1 workload signer through the devnet tempo_fundAddress RPC before running.
+    #[arg(long)]
+    fund_accounts: bool,
+
+    /// Skip live RPC and deployment preflight checks.
+    #[arg(long)]
+    skip_doctor: bool,
+
+    /// Print the resolved plan and exit without validation or submission.
+    #[arg(long)]
+    dry_run: bool,
+}
+
+#[derive(Clone, Debug, Args)]
+struct ReplayArgs {
+    /// zones-load run.json from a previous execution.
+    report: PathBuf,
+
+    /// Case to replay. Defaults to the first failed case.
+    #[arg(long = "case")]
+    case: Option<String>,
+
+    /// Override the original case journey count.
+    #[arg(long)]
+    count: Option<u64>,
+
+    /// Directory for the replay report.
+    #[arg(long)]
+    report_dir: Option<PathBuf>,
+
+    #[arg(long, value_enum, default_value_t = FailurePolicy::FailFast)]
+    failure_policy: FailurePolicy,
+
+    #[arg(long, default_value = "10m")]
+    step_timeout: String,
+
+    #[arg(long, default_value_t = 10)]
+    sample_instances: usize,
+
+    /// Fund every L1 workload signer through the devnet tempo_fundAddress RPC before replaying.
+    #[arg(long)]
+    fund_accounts: bool,
+}
+
+#[derive(Clone, Debug, Args)]
+struct CoverageArgs {
+    /// zones-load run.json.
+    report: PathBuf,
+
+    /// Include uncovered labels belonging only to not-yet-implemented cases.
+    #[arg(long)]
+    include_planned: bool,
+
+    /// Exit nonzero when selected coverage is below this percentage.
+    #[arg(long)]
+    fail_under: Option<f64>,
+
+    /// Emit machine-readable JSON.
+    #[arg(long)]
+    json: bool,
+}
+
+#[tokio::main]
+async fn main() -> Result<()> {
+    rustls::crypto::aws_lc_rs::default_provider()
+        .install_default()
+        .expect("failed to install rustls CryptoProvider");
+
+    let cli = Cli::parse();
+    let catalog = Catalog::load(cli.catalog_file.as_deref())?;
+    match cli.command.clone() {
+        Command::Catalog(args) => catalog_command(&catalog, args),
+        Command::Plan(args) => plan_command(&catalog, &cli.scenario_root, args),
+        Command::Doctor(args) => doctor_command(&cli, &catalog, args).await,
+        Command::Run(args) => run_command(&cli, &catalog, args).await,
+        Command::Replay(args) => replay_command(&cli, &catalog, args).await,
+        Command::Coverage(args) => coverage_command(&catalog, args),
+    }
+}
+
+fn catalog_command(catalog: &Catalog, args: CatalogArgs) -> Result<()> {
+    let selected = match &args.profile {
+        Some(profile) => Some(
+            catalog
+                .profiles
+                .get(profile)
+                .ok_or_else(|| eyre::eyre!("unknown profile {profile}"))?,
+        ),
+        None => None,
+    };
+    let ids = selected.map(|profile| profile.cases.iter().cloned().collect::<BTreeSet<_>>());
+    let cases = catalog
+        .cases
+        .iter()
+        .filter(|(id, case)| {
+            ids.as_ref().is_none_or(|ids| ids.contains(*id))
+                && (case.implemented || args.include_planned)
+        })
+        .collect::<Vec<_>>();
+
+    if args.json {
+        let profiles = args.profile.as_ref().map_or_else(
+            || serde_json::to_value(&catalog.profiles),
+            |name| serde_json::to_value([(name, selected.expect("profile resolved"))]),
+        )?;
+        let cases = cases
+            .into_iter()
+            .collect::<std::collections::BTreeMap<_, _>>();
+        println!(
+            "{}",
+            serde_json::to_string_pretty(&json!({
+                "version": catalog.version,
+                "profiles": profiles,
+                "cases": cases,
+            }))?
+        );
+        return Ok(());
+    }
+
+    if args.profile.is_none() {
+        println!("Profiles");
+        for (name, profile) in &catalog.profiles {
+            println!(
+                "  {name:<14} {:?}, default {} journeys — {}",
+                profile.execution, profile.default_count, profile.description
+            );
+        }
+        println!();
+    }
+    println!("Cases");
+    for (id, case) in cases {
+        let state = if case.implemented { "ready" } else { "planned" };
+        println!("  {id:<30} [{state}] {}", case.description);
+        for label in &case.covers {
+            println!("    - {label}");
+        }
+    }
+    Ok(())
+}
+
+fn plan_command(catalog: &Catalog, scenario_root: &Path, args: PlanArgs) -> Result<()> {
+    let plan = build_plan(catalog, scenario_root, &args.selection)?;
+    if let Some(output) = args.output {
+        write_json_atomic(&output, &plan)?;
+        println!("Plan written to {}", output.display());
+    } else {
+        println!("{}", serde_json::to_string_pretty(&plan)?);
+    }
+    Ok(())
+}
+
+async fn doctor_command(cli: &Cli, catalog: &Catalog, args: DoctorArgs) -> Result<()> {
+    let selection = SelectionArgs {
+        profile: args.profile,
+        cases: args.cases,
+        seed: 1,
+        count: None,
+        duration: None,
+        forever: false,
+        journeys_per_second: 0.0,
+        transactions_per_second: 0,
+        max_in_flight: 1,
+        max_rpc_in_flight: 1,
+    };
+    let plan = build_plan(catalog, &cli.scenario_root, &selection)?;
+    let deployment = load_deployment(cli).await?;
+    let requirements = plan_requirements(&plan);
+    let mut report = deployment.doctor(&requirements).await;
+
+    let txgen_available = match check_txgen(&cli.txgen_bin).await {
+        Ok(detail) => {
+            report.checks.push(DoctorCheck {
+                name: "txgen.capability".to_owned(),
+                passed: true,
+                detail,
+            });
+            true
+        }
+        Err(error) => {
+            report.checks.push(DoctorCheck {
+                name: "txgen.capability".to_owned(),
+                passed: false,
+                detail: format!("{error:#}"),
+            });
+            false
+        }
+    };
+    if !args.skip_scenario_validation && report.missing_requirements.is_empty() && txgen_available {
+        match validate_plan(&plan, &deployment, &cli.txgen_bin).await {
+            Ok(()) => report.checks.push(DoctorCheck {
+                name: "workload.scenarios".to_owned(),
+                passed: true,
+                detail: format!("{} scenario(s) valid", plan.cases.len()),
+            }),
+            Err(error) => report.checks.push(DoctorCheck {
+                name: "workload.scenarios".to_owned(),
+                passed: false,
+                detail: format!("{error:#}"),
+            }),
+        }
+    }
+    report.healthy = report.checks.iter().all(|check| check.passed);
+
+    if args.json {
+        println!("{}", serde_json::to_string_pretty(&report)?);
+    } else {
+        let zone_chain_id = report
+            .deployment
+            .zone_chain_id
+            .map_or_else(|| "unknown".to_owned(), |chain_id| chain_id.to_string());
+        println!(
+            "Deployment: Zone {} (chain {}) at {}; token {}",
+            report.deployment.zone_id,
+            zone_chain_id,
+            report.deployment.portal,
+            report.deployment.token
+        );
+        for check in &report.checks {
+            println!(
+                "  {} {:<30} {}",
+                if check.passed { "PASS" } else { "FAIL" },
+                check.name,
+                check.detail
+            );
+        }
+        if !report.missing_requirements.is_empty() {
+            println!("Missing workload values:");
+            for name in &report.missing_requirements {
+                println!("  - {name}");
+            }
+        }
+    }
+    ensure!(report.healthy, "doctor found one or more failed checks");
+    Ok(())
+}
+
+async fn run_command(cli: &Cli, catalog: &Catalog, args: RunArgs) -> Result<()> {
+    let plan = build_plan(catalog, &cli.scenario_root, &args.selection)?;
+    if args.dry_run {
+        println!("{}", serde_json::to_string_pretty(&plan)?);
+        return Ok(());
+    }
+    let deployment = load_deployment(cli).await?;
+    if !args.skip_doctor {
+        let doctor = deployment.doctor(&plan_requirements(&plan)).await;
+        if !doctor.healthy {
+            for check in doctor.checks.iter().filter(|check| !check.passed) {
+                eprintln!("doctor failed: {}: {}", check.name, check.detail);
+            }
+            bail!("preflight checks failed; run `zones-load doctor` for details");
+        }
+    }
+
+    let options = RunOptions {
+        txgen_bin: cli.txgen_bin.clone(),
+        report_dir: args.report_dir,
+        failure_policy: args.failure_policy.as_str().to_owned(),
+        step_timeout: args.step_timeout,
+        sample_instances: args.sample_instances,
+        allow_governance: args.allow_governance,
+        fund_accounts: args.fund_accounts,
+        validate_only: false,
+    };
+    let outcome = execute_plan(catalog, deployment, plan, options).await?;
+    print_run_summary(&outcome.report, &outcome.report_path);
+    ensure!(
+        outcome.succeeded(),
+        "one or more workload cases failed; report: {}",
+        outcome.report_path.display()
+    );
+    Ok(())
+}
+
+async fn replay_command(cli: &Cli, catalog: &Catalog, args: ReplayArgs) -> Result<()> {
+    let previous = load_run_report(&args.report)?;
+    let selected = if let Some(id) = &args.case {
+        previous
+            .cases
+            .iter()
+            .find(|result| &result.plan.id == id)
+            .ok_or_else(|| eyre::eyre!("case {id} is not present in {}", args.report.display()))?
+    } else {
+        previous
+            .cases
+            .iter()
+            .find(|result| result.status != CaseStatus::Passed)
+            .ok_or_else(|| eyre::eyre!("report has no failed case; pass --case to replay one"))?
+    };
+    let mut case = selected.plan.clone();
+    if let Some(count) = args.count {
+        ensure!(count > 0, "--count must be at least 1");
+        case.count = Some(count);
+        case.duration = None;
+    }
+    let replay_forever = previous.plan.forever && args.count.is_none();
+    let plan = RunPlan {
+        version: 1,
+        profile: format!("replay:{}", case.id),
+        execution: catalog::ExecutionMode::Sequential,
+        seed: previous.seed,
+        requested_count: if replay_forever { None } else { case.count },
+        duration: case.duration.clone(),
+        forever: replay_forever,
+        starts_per_second: case.starts_per_second,
+        transactions_per_second: case.transactions_per_second,
+        max_in_flight: case.max_in_flight,
+        max_rpc_in_flight: case.max_rpc_in_flight,
+        cases: vec![case],
+    };
+    let deployment = load_deployment(cli).await.wrap_err(
+        "failed resolving the current deployment for replay; pass --portal, --zone-id, --token, and RPC options explicitly (the report stores only sanitized endpoints)",
+    )?;
+    let options = RunOptions {
+        txgen_bin: cli.txgen_bin.clone(),
+        report_dir: args.report_dir,
+        failure_policy: args.failure_policy.as_str().to_owned(),
+        step_timeout: args.step_timeout,
+        sample_instances: args.sample_instances,
+        allow_governance: false,
+        fund_accounts: args.fund_accounts,
+        validate_only: false,
+    };
+    let outcome = execute_plan(catalog, deployment, plan, options).await?;
+    print_run_summary(&outcome.report, &outcome.report_path);
+    ensure!(
+        outcome.succeeded(),
+        "replayed case failed; report: {}",
+        outcome.report_path.display()
+    );
+    Ok(())
+}
+
+fn coverage_command(catalog: &Catalog, args: CoverageArgs) -> Result<()> {
+    let report = load_run_report(&args.report)?;
+    let coverage = CoverageReport::build(catalog, &report.plan, &report.cases);
+    if args.json {
+        println!("{}", serde_json::to_string_pretty(&coverage)?);
+    } else {
+        println!(
+            "Selected coverage:    {}/{} ({:.1}%)",
+            coverage.selected_covered, coverage.selected_total, coverage.selected_percent
+        );
+        println!(
+            "Implemented catalog:  {}/{} ({:.1}%)",
+            coverage.implemented_covered, coverage.implemented_total, coverage.implemented_percent
+        );
+        println!("Catalog labels:       {}", coverage.catalog_total);
+        println!();
+        for entry in coverage.entries.iter().filter(|entry| {
+            entry.status != "covered" && (entry.implemented || args.include_planned)
+        }) {
+            println!(
+                "  {:<10} {} ({})",
+                entry.status,
+                entry.label,
+                entry.cases.join(", ")
+            );
+        }
+    }
+    if let Some(minimum) = args.fail_under {
+        ensure!(
+            minimum.is_finite() && (0.0..=100.0).contains(&minimum),
+            "--fail-under must be between 0 and 100"
+        );
+        ensure!(
+            coverage.selected_percent >= minimum,
+            "selected coverage {:.1}% is below required {:.1}%",
+            coverage.selected_percent,
+            minimum
+        );
+    }
+    Ok(())
+}
+
+fn build_plan(catalog: &Catalog, scenario_root: &Path, args: &SelectionArgs) -> Result<RunPlan> {
+    catalog.plan(PlanRequest {
+        profile: &args.profile,
+        selected_cases: &args.cases,
+        scenario_root,
+        seed: args.seed,
+        count: args.count,
+        duration: args.duration.clone(),
+        forever: args.forever,
+        starts_per_second: args.journeys_per_second,
+        transactions_per_second: args.transactions_per_second,
+        max_in_flight: args.max_in_flight,
+        max_rpc_in_flight: args.max_rpc_in_flight,
+    })
+}
+
+async fn load_deployment(cli: &Cli) -> Result<DeploymentContext> {
+    let deployment = DeploymentContext::new(
+        cli.portal,
+        cli.zone_id,
+        cli.token,
+        cli.l1_rpc_url.clone(),
+        cli.zone_rpc_url.clone(),
+        cli.zone_submit_rpc_url.clone(),
+    )?;
+    deployment.resolve().await
+}
+
+fn plan_requirements(plan: &RunPlan) -> Vec<String> {
+    plan.cases
+        .iter()
+        .flat_map(|case| case.requires.iter().cloned())
+        .collect::<BTreeSet<_>>()
+        .into_iter()
+        .collect()
+}
+
+fn print_run_summary(report: &report::RunReport, path: &Path) {
+    let passed = report
+        .cases
+        .iter()
+        .filter(|case| case.status == CaseStatus::Passed)
+        .count();
+    println!();
+    println!("Run {}", report.run_id);
+    println!("  Cases:     {passed}/{} passed", report.plan.cases.len());
+    println!(
+        "  Coverage:  {}/{} selected labels ({:.1}%)",
+        report.coverage.selected_covered,
+        report.coverage.selected_total,
+        report.coverage.selected_percent
+    );
+    println!("  Report:    {}", path.display());
+}

--- a/bin/zones-load/src/report.rs
+++ b/bin/zones-load/src/report.rs
@@ -1,0 +1,317 @@
+use crate::{
+    catalog::{CasePlan, Catalog, RunPlan, compare_coverage_status},
+    deployment::DeploymentContext,
+};
+use eyre::{Context as _, Result};
+use serde::{Deserialize, Serialize};
+use serde_json::Value;
+use std::{
+    collections::{BTreeMap, BTreeSet},
+    fs::{self, File, OpenOptions},
+    io::{BufWriter, Write as _},
+    path::{Path, PathBuf},
+    time::{Duration, SystemTime, UNIX_EPOCH},
+};
+
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub(crate) struct RunReport {
+    pub(crate) version: u32,
+    pub(crate) run_id: String,
+    pub(crate) profile: String,
+    pub(crate) seed: u64,
+    pub(crate) started_at_unix_ms: u128,
+    pub(crate) elapsed_ms: u128,
+    pub(crate) cancelled: bool,
+    pub(crate) txgen_bin: String,
+    pub(crate) failure_policy: String,
+    pub(crate) step_timeout: String,
+    #[serde(default)]
+    pub(crate) funded_accounts: usize,
+    pub(crate) deployment: DeploymentContext,
+    pub(crate) plan: RunPlan,
+    pub(crate) cases: Vec<CaseResult>,
+    pub(crate) coverage: CoverageReport,
+}
+
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub(crate) struct CaseResult {
+    pub(crate) plan: CasePlan,
+    pub(crate) status: CaseStatus,
+    pub(crate) exit_code: Option<i32>,
+    pub(crate) elapsed_ms: u128,
+    pub(crate) txgen_report: PathBuf,
+    #[serde(default)]
+    pub(crate) txgen: Option<TxgenSummary>,
+    #[serde(default)]
+    pub(crate) error: Option<String>,
+}
+
+#[derive(Clone, Copy, Debug, Deserialize, Serialize, Eq, PartialEq)]
+#[serde(rename_all = "snake_case")]
+pub(crate) enum CaseStatus {
+    Passed,
+    Failed,
+    Cancelled,
+}
+
+#[derive(Clone, Debug, Default, Deserialize, Serialize)]
+pub(crate) struct TxgenSummary {
+    #[serde(default)]
+    pub(crate) scenario: String,
+    #[serde(default)]
+    pub(crate) elapsed_ms: u64,
+    #[serde(default)]
+    pub(crate) started: u64,
+    #[serde(default)]
+    pub(crate) completed: u64,
+    #[serde(default)]
+    pub(crate) failed: u64,
+    #[serde(default)]
+    pub(crate) timed_out: u64,
+    #[serde(default)]
+    pub(crate) completed_scenarios_per_second: f64,
+}
+
+#[derive(Clone, Debug, Deserialize, Serialize)]
+pub(crate) struct CoverageReport {
+    pub(crate) selected_total: usize,
+    pub(crate) selected_covered: usize,
+    pub(crate) selected_percent: f64,
+    pub(crate) implemented_total: usize,
+    pub(crate) implemented_covered: usize,
+    pub(crate) implemented_percent: f64,
+    pub(crate) catalog_total: usize,
+    pub(crate) entries: Vec<CoverageEntry>,
+}
+
+#[derive(Clone, Debug, Deserialize, Serialize)]
+pub(crate) struct CoverageEntry {
+    pub(crate) label: String,
+    pub(crate) status: String,
+    pub(crate) implemented: bool,
+    pub(crate) cases: Vec<String>,
+}
+
+#[derive(Debug, Serialize)]
+struct JournalEvent<'a> {
+    timestamp_unix_ms: u128,
+    event: &'a str,
+    run_id: &'a str,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    case: Option<&'a str>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    detail: Option<Value>,
+}
+
+pub(crate) struct Journal {
+    writer: BufWriter<File>,
+    run_id: String,
+}
+
+impl Journal {
+    pub(crate) fn create(path: &Path, run_id: &str) -> Result<Self> {
+        if let Some(parent) = path.parent() {
+            fs::create_dir_all(parent).wrap_err_with(|| {
+                format!("failed creating journal directory {}", parent.display())
+            })?;
+        }
+        let file = OpenOptions::new()
+            .create(true)
+            .append(true)
+            .open(path)
+            .wrap_err_with(|| format!("failed opening journal {}", path.display()))?;
+        Ok(Self {
+            writer: BufWriter::new(file),
+            run_id: run_id.to_owned(),
+        })
+    }
+
+    pub(crate) fn record(
+        &mut self,
+        event: &str,
+        case: Option<&str>,
+        detail: Option<Value>,
+    ) -> Result<()> {
+        let entry = JournalEvent {
+            timestamp_unix_ms: unix_ms(),
+            event,
+            run_id: &self.run_id,
+            case,
+            detail,
+        };
+        serde_json::to_writer(&mut self.writer, &entry)
+            .wrap_err("failed encoding journal event")?;
+        self.writer.write_all(b"\n")?;
+        self.writer.flush()?;
+        Ok(())
+    }
+}
+
+impl CoverageReport {
+    pub(crate) fn build(catalog: &Catalog, plan: &RunPlan, results: &[CaseResult]) -> Self {
+        let selected = plan
+            .cases
+            .iter()
+            .flat_map(|case| case.covers.iter().cloned())
+            .collect::<BTreeSet<_>>();
+        let covered = results
+            .iter()
+            .filter(|result| result.status == CaseStatus::Passed)
+            .flat_map(|result| result.plan.covers.iter().cloned())
+            .collect::<BTreeSet<_>>();
+        let failed = results
+            .iter()
+            .filter(|result| result.status != CaseStatus::Passed)
+            .flat_map(|result| result.plan.covers.iter().cloned())
+            .collect::<BTreeSet<_>>();
+        let implemented = catalog.implemented_coverage_labels();
+        let all = catalog.all_coverage_labels();
+
+        let mut owners = BTreeMap::<String, Vec<String>>::new();
+        for (id, case) in &catalog.cases {
+            for label in &case.covers {
+                owners.entry(label.clone()).or_default().push(id.clone());
+            }
+        }
+
+        let mut entries = all
+            .iter()
+            .map(|label| CoverageEntry {
+                status: if covered.contains(label) {
+                    "covered"
+                } else if failed.contains(label) {
+                    "failed"
+                } else {
+                    "uncovered"
+                }
+                .to_owned(),
+                implemented: implemented.contains(label),
+                cases: owners.remove(label).unwrap_or_default(),
+                label: label.clone(),
+            })
+            .collect::<Vec<_>>();
+        entries.sort_by(|left, right| {
+            compare_coverage_status(&left.status, &right.status)
+                .then_with(|| left.label.cmp(&right.label))
+        });
+
+        let selected_covered = selected.intersection(&covered).count();
+        let implemented_covered = implemented.intersection(&covered).count();
+        Self {
+            selected_total: selected.len(),
+            selected_covered,
+            selected_percent: percent(selected_covered, selected.len()),
+            implemented_total: implemented.len(),
+            implemented_covered,
+            implemented_percent: percent(implemented_covered, implemented.len()),
+            catalog_total: all.len(),
+            entries,
+        }
+    }
+}
+
+pub(crate) fn load_txgen_summary(path: &Path) -> Result<TxgenSummary> {
+    let contents = fs::read_to_string(path)
+        .wrap_err_with(|| format!("failed reading txgen report {}", path.display()))?;
+    serde_json::from_str(&contents)
+        .wrap_err_with(|| format!("failed parsing txgen report {}", path.display()))
+}
+
+pub(crate) fn load_run_report(path: &Path) -> Result<RunReport> {
+    let contents = fs::read_to_string(path)
+        .wrap_err_with(|| format!("failed reading run report {}", path.display()))?;
+    serde_json::from_str(&contents)
+        .wrap_err_with(|| format!("failed parsing run report {}", path.display()))
+}
+
+pub(crate) fn write_json_atomic<T: Serialize>(path: &Path, value: &T) -> Result<()> {
+    if let Some(parent) = path.parent() {
+        fs::create_dir_all(parent)
+            .wrap_err_with(|| format!("failed creating report directory {}", parent.display()))?;
+    }
+    let file_name = path
+        .file_name()
+        .and_then(|name| name.to_str())
+        .unwrap_or("report.json");
+    let temporary = path.with_file_name(format!(".{file_name}.{}.tmp", std::process::id()));
+    let contents = serde_json::to_vec_pretty(value).wrap_err("failed encoding JSON report")?;
+    fs::write(&temporary, contents)
+        .wrap_err_with(|| format!("failed writing temporary report {}", temporary.display()))?;
+    fs::rename(&temporary, path)
+        .wrap_err_with(|| format!("failed publishing report {}", path.display()))?;
+    Ok(())
+}
+
+pub(crate) fn unix_ms() -> u128 {
+    SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .unwrap_or(Duration::ZERO)
+        .as_millis()
+}
+
+fn percent(numerator: usize, denominator: usize) -> f64 {
+    if denominator == 0 {
+        100.0
+    } else {
+        numerator as f64 * 100.0 / denominator as f64
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::catalog::{ExecutionMode, RunPlan};
+
+    #[test]
+    fn failed_case_does_not_claim_coverage() {
+        let catalog = Catalog::load(None).unwrap();
+        let case = catalog.cases.get("encrypted-deposit").unwrap();
+        let plan_case = CasePlan {
+            id: "encrypted-deposit".to_owned(),
+            description: case.description.clone(),
+            scenario: PathBuf::from("scenario.yml"),
+            seed: 1,
+            count: Some(1),
+            duration: None,
+            starts_per_second: 0.0,
+            transactions_per_second: 0,
+            max_in_flight: 1,
+            max_rpc_in_flight: 1,
+            dangerous: false,
+            mutation_group: None,
+            covers: case.covers.clone(),
+            requires: case.requires.clone(),
+        };
+        let plan = RunPlan {
+            version: 1,
+            profile: "test".to_owned(),
+            execution: ExecutionMode::Sequential,
+            seed: 1,
+            requested_count: Some(1),
+            duration: None,
+            forever: false,
+            starts_per_second: 0.0,
+            transactions_per_second: 0,
+            max_in_flight: 1,
+            max_rpc_in_flight: 1,
+            cases: vec![plan_case.clone()],
+        };
+        let result = CaseResult {
+            plan: plan_case,
+            status: CaseStatus::Failed,
+            exit_code: Some(1),
+            elapsed_ms: 1,
+            txgen_report: PathBuf::from("missing.json"),
+            txgen: None,
+            error: Some("test".to_owned()),
+        };
+        let coverage = CoverageReport::build(&catalog, &plan, &[result]);
+        assert_eq!(coverage.selected_covered, 0);
+        assert!(
+            coverage
+                .entries
+                .iter()
+                .any(|entry| entry.status == "failed")
+        );
+    }
+}

--- a/bin/zones-load/src/runner.rs
+++ b/bin/zones-load/src/runner.rs
@@ -1,0 +1,685 @@
+use crate::{
+    catalog::{CasePlan, Catalog, ExecutionMode, RunPlan},
+    deployment::DeploymentContext,
+    report::{
+        CaseResult, CaseStatus, CoverageReport, Journal, RunReport, load_txgen_summary, unix_ms,
+        write_json_atomic,
+    },
+};
+use alloy::{
+    network::ReceiptResponse,
+    primitives::{Address, B256},
+    providers::{PendingTransactionBuilder, Provider, ProviderBuilder},
+};
+use eyre::{Context as _, Result, bail, ensure};
+use serde::Deserialize;
+use serde_json::json;
+use std::{
+    collections::{BTreeMap, BTreeSet},
+    path::{Path, PathBuf},
+    process::Stdio,
+    sync::Arc,
+    time::Instant,
+};
+use tempo_alloy::TempoNetwork;
+use tokio::{process::Command, sync::Mutex, task::JoinSet};
+
+async fn shutdown_signal() {
+    #[cfg(unix)]
+    {
+        let mut terminate =
+            tokio::signal::unix::signal(tokio::signal::unix::SignalKind::terminate())
+                .expect("failed installing SIGTERM handler");
+        tokio::select! {
+            _ = tokio::signal::ctrl_c() => {}
+            _ = terminate.recv() => {}
+        }
+    }
+
+    #[cfg(not(unix))]
+    {
+        let _ = tokio::signal::ctrl_c().await;
+    }
+}
+
+#[derive(Clone, Debug)]
+pub(crate) struct RunOptions {
+    pub(crate) txgen_bin: PathBuf,
+    pub(crate) report_dir: Option<PathBuf>,
+    pub(crate) failure_policy: String,
+    pub(crate) step_timeout: String,
+    pub(crate) sample_instances: usize,
+    pub(crate) allow_governance: bool,
+    pub(crate) fund_accounts: bool,
+    pub(crate) validate_only: bool,
+}
+
+pub(crate) struct RunOutcome {
+    pub(crate) report: RunReport,
+    pub(crate) report_path: PathBuf,
+}
+
+impl RunOutcome {
+    pub(crate) fn succeeded(&self) -> bool {
+        !self.report.cancelled
+            && self
+                .report
+                .cases
+                .iter()
+                .all(|result| result.status == CaseStatus::Passed)
+            && self.report.cases.len() == self.report.plan.cases.len()
+    }
+}
+
+pub(crate) async fn check_txgen(txgen_bin: &Path) -> Result<String> {
+    let output = Command::new(txgen_bin)
+        .args(["scenario", "validate", "--help"])
+        .output()
+        .await
+        .wrap_err_with(|| {
+            format!(
+                "failed executing {} scenario validate --help",
+                txgen_bin.display()
+            )
+        })?;
+    ensure!(
+        output.status.success(),
+        "{} scenario validate --help exited with {}: {}",
+        txgen_bin.display(),
+        output.status,
+        String::from_utf8_lossy(&output.stderr).trim()
+    );
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    Ok(stdout
+        .lines()
+        .find(|line| !line.trim().is_empty())
+        .unwrap_or("scenario validator available")
+        .trim()
+        .to_owned())
+}
+
+pub(crate) async fn validate_plan(
+    plan: &RunPlan,
+    deployment: &DeploymentContext,
+    txgen_bin: &Path,
+) -> Result<()> {
+    let env = deployment.command_env();
+    let requirements = plan_requirements(plan);
+    let missing = deployment.missing_requirements(&requirements);
+    ensure!(
+        missing.is_empty(),
+        "missing workload environment values: {}",
+        missing.join(", ")
+    );
+
+    for case in &plan.cases {
+        ensure!(
+            case.scenario.is_file(),
+            "scenario for {} does not exist: {}",
+            case.id,
+            case.scenario.display()
+        );
+        let output = Command::new(txgen_bin)
+            .args(["scenario", "validate", "--scenario"])
+            .arg(&case.scenario)
+            .envs(&env)
+            .output()
+            .await
+            .wrap_err_with(|| format!("failed validating scenario {}", case.id))?;
+        ensure!(
+            output.status.success(),
+            "scenario {} is invalid: {}{}",
+            case.id,
+            String::from_utf8_lossy(&output.stdout),
+            String::from_utf8_lossy(&output.stderr)
+        );
+    }
+    Ok(())
+}
+
+#[derive(Debug, Deserialize)]
+struct FundingScenario {
+    chains: BTreeMap<String, FundingChain>,
+}
+
+#[derive(Debug, Deserialize)]
+struct FundingChain {
+    workload: PathBuf,
+}
+
+async fn fund_plan_accounts(
+    plan: &RunPlan,
+    deployment: &DeploymentContext,
+    txgen_bin: &Path,
+) -> Result<usize> {
+    let workloads = l1_workloads(plan)?;
+    let env = deployment.command_env();
+    let mut addresses = BTreeSet::new();
+
+    for workload in workloads {
+        let output = Command::new(txgen_bin)
+            .args(["addresses", "--spec"])
+            .arg(&workload)
+            .args(["--format", "json"])
+            .envs(&env)
+            .output()
+            .await
+            .wrap_err_with(|| {
+                format!(
+                    "failed deriving funding addresses from {}",
+                    workload.display()
+                )
+            })?;
+        ensure!(
+            output.status.success(),
+            "failed deriving funding addresses from {}: {}{}",
+            workload.display(),
+            String::from_utf8_lossy(&output.stdout),
+            String::from_utf8_lossy(&output.stderr)
+        );
+        let derived: Vec<Address> = serde_json::from_slice(&output.stdout).wrap_err_with(|| {
+            format!("failed parsing txgen addresses for {}", workload.display())
+        })?;
+        addresses.extend(derived);
+    }
+
+    ensure!(
+        !addresses.is_empty(),
+        "selected scenarios do not define any L1 workload accounts to fund"
+    );
+    eprintln!(
+        "funding {} L1 workload account(s) through tempo_fundAddress...",
+        addresses.len()
+    );
+    let provider = ProviderBuilder::new_with_network::<TempoNetwork>()
+        .connect(&deployment.l1_rpc_url)
+        .await
+        .wrap_err("failed connecting to the L1 faucet RPC")?;
+    for (index, address) in addresses.iter().copied().enumerate() {
+        let hashes: Vec<B256> = provider
+            .raw_request("tempo_fundAddress".into(), (address,))
+            .await
+            .wrap_err_with(|| format!("tempo_fundAddress failed for {address}"))?;
+        ensure!(
+            !hashes.is_empty(),
+            "tempo_fundAddress returned no transactions for {address}"
+        );
+        for hash in hashes {
+            let receipt = PendingTransactionBuilder::new(provider.root().clone(), hash)
+                .get_receipt()
+                .await
+                .wrap_err_with(|| format!("failed waiting for funding transaction {hash}"))?;
+            ensure!(
+                receipt.status(),
+                "funding transaction {hash} reverted for {address}"
+            );
+        }
+        let completed = index + 1;
+        if completed % 10 == 0 || completed == addresses.len() {
+            eprintln!(
+                "funded {completed}/{} L1 workload account(s)",
+                addresses.len()
+            );
+        }
+    }
+    Ok(addresses.len())
+}
+
+fn l1_workloads(plan: &RunPlan) -> Result<BTreeSet<PathBuf>> {
+    let mut workloads = BTreeSet::new();
+    for case in &plan.cases {
+        let contents = std::fs::read_to_string(&case.scenario).wrap_err_with(|| {
+            format!(
+                "failed reading scenario {} for account funding",
+                case.scenario.display()
+            )
+        })?;
+        let scenario: FundingScenario = serde_yaml::from_str(&contents).wrap_err_with(|| {
+            format!(
+                "failed parsing scenario {} for account funding",
+                case.scenario.display()
+            )
+        })?;
+        let l1 = scenario.chains.get("l1").ok_or_else(|| {
+            eyre::eyre!(
+                "scenario {} has no `l1` chain to fund",
+                case.scenario.display()
+            )
+        })?;
+        let parent = case.scenario.parent().unwrap_or_else(|| Path::new("."));
+        let workload = parent.join(&l1.workload).canonicalize().wrap_err_with(|| {
+            format!(
+                "failed resolving L1 workload {} from scenario {}",
+                l1.workload.display(),
+                case.scenario.display()
+            )
+        })?;
+        workloads.insert(workload);
+    }
+    Ok(workloads)
+}
+
+pub(crate) async fn execute_plan(
+    catalog: &Catalog,
+    deployment: DeploymentContext,
+    plan: RunPlan,
+    options: RunOptions,
+) -> Result<RunOutcome> {
+    ensure!(!plan.cases.is_empty(), "run plan has no cases");
+    ensure!(
+        options.failure_policy == "continue" || options.failure_policy == "fail-fast",
+        "failure policy must be continue or fail-fast"
+    );
+    if let Some(case) = plan.cases.iter().find(|case| case.dangerous)
+        && !options.allow_governance
+    {
+        bail!(
+            "case {} mutates governance; rerun with --allow-governance against a disposable deployment",
+            case.id
+        );
+    }
+    validate_mutation_groups(&plan)?;
+    validate_plan(&plan, &deployment, &options.txgen_bin).await?;
+    let funded_accounts = if options.fund_accounts && !options.validate_only {
+        fund_plan_accounts(&plan, &deployment, &options.txgen_bin).await?
+    } else {
+        0
+    };
+
+    let started_at_unix_ms = unix_ms();
+    let run_id = format!(
+        "{}-{}-{:016x}",
+        started_at_unix_ms,
+        std::process::id(),
+        plan.seed
+    );
+    let report_dir = options
+        .report_dir
+        .clone()
+        .unwrap_or_else(|| PathBuf::from("target/zones-load").join(&run_id));
+    let report_path = report_dir.join("run.json");
+    ensure!(
+        !report_path.exists(),
+        "refusing to overwrite existing report {}",
+        report_path.display()
+    );
+    std::fs::create_dir_all(report_dir.join("cases"))
+        .wrap_err_with(|| format!("failed creating report directory {}", report_dir.display()))?;
+
+    let journal_path = report_dir.join("run.ndjson");
+    let journal = Arc::new(Mutex::new(Journal::create(&journal_path, &run_id)?));
+    journal.lock().await.record(
+        "run_started",
+        None,
+        Some(json!({
+            "profile": plan.profile,
+            "seed": plan.seed,
+            "execution": plan.execution,
+            "case_count": plan.cases.len(),
+        })),
+    )?;
+
+    if options.validate_only {
+        journal.lock().await.record("run_validated", None, None)?;
+    }
+
+    let started = Instant::now();
+    let (mut results, cancelled) = if options.validate_only {
+        (Vec::new(), false)
+    } else {
+        match plan.execution {
+            ExecutionMode::Sequential => {
+                run_sequential(&plan, &deployment, &options, &report_dir, &run_id, &journal).await
+            }
+            ExecutionMode::Parallel => {
+                run_parallel(&plan, &deployment, &options, &report_dir, &run_id, &journal).await
+            }
+        }
+    };
+    results.sort_by_key(|result| {
+        plan.cases
+            .iter()
+            .position(|case| case.id == result.plan.id)
+            .unwrap_or(usize::MAX)
+    });
+
+    let coverage = CoverageReport::build(catalog, &plan, &results);
+    let report = RunReport {
+        version: 1,
+        run_id: run_id.clone(),
+        profile: plan.profile.clone(),
+        seed: plan.seed,
+        started_at_unix_ms,
+        elapsed_ms: started.elapsed().as_millis(),
+        cancelled,
+        txgen_bin: options.txgen_bin.display().to_string(),
+        failure_policy: options.failure_policy.clone(),
+        step_timeout: options.step_timeout.clone(),
+        funded_accounts,
+        deployment: deployment.sanitized(),
+        plan,
+        cases: results,
+        coverage,
+    };
+    write_json_atomic(&report_path, &report)?;
+    journal.lock().await.record(
+        if cancelled {
+            "run_cancelled"
+        } else {
+            "run_completed"
+        },
+        None,
+        Some(json!({
+            "report": report_path,
+            "passed": report.cases.iter().filter(|case| case.status == CaseStatus::Passed).count(),
+            "failed": report.cases.iter().filter(|case| case.status == CaseStatus::Failed).count(),
+        })),
+    )?;
+
+    Ok(RunOutcome {
+        report,
+        report_path,
+    })
+}
+
+async fn run_sequential(
+    plan: &RunPlan,
+    deployment: &DeploymentContext,
+    options: &RunOptions,
+    report_dir: &Path,
+    run_id: &str,
+    journal: &Arc<Mutex<Journal>>,
+) -> (Vec<CaseResult>, bool) {
+    let mut results = Vec::with_capacity(plan.cases.len());
+    let mut cancelled = false;
+    for case in &plan.cases {
+        let execution = run_case(
+            case.clone(),
+            deployment.clone(),
+            options.clone(),
+            report_dir.to_path_buf(),
+            run_id.to_owned(),
+            Arc::clone(journal),
+        );
+        let result = tokio::select! {
+            result = execution => result,
+            _ = shutdown_signal() => {
+                cancelled = true;
+                break;
+            }
+        };
+        let failed = result.status != CaseStatus::Passed;
+        results.push(result);
+        if failed && options.failure_policy == "fail-fast" {
+            break;
+        }
+    }
+    (results, cancelled)
+}
+
+async fn run_parallel(
+    plan: &RunPlan,
+    deployment: &DeploymentContext,
+    options: &RunOptions,
+    report_dir: &Path,
+    run_id: &str,
+    journal: &Arc<Mutex<Journal>>,
+) -> (Vec<CaseResult>, bool) {
+    let mut set = JoinSet::new();
+    for case in &plan.cases {
+        set.spawn(run_case(
+            case.clone(),
+            deployment.clone(),
+            options.clone(),
+            report_dir.to_path_buf(),
+            run_id.to_owned(),
+            Arc::clone(journal),
+        ));
+    }
+
+    let mut results = Vec::with_capacity(plan.cases.len());
+    let mut cancelled = false;
+    while !set.is_empty() {
+        tokio::select! {
+            joined = set.join_next() => {
+                match joined {
+                    Some(Ok(result)) => {
+                        let failed = result.status != CaseStatus::Passed;
+                        results.push(result);
+                        if failed && options.failure_policy == "fail-fast" {
+                            set.abort_all();
+                            cancelled = true;
+                        }
+                    }
+                    Some(Err(error)) if !error.is_cancelled() => {
+                        eprintln!("case task failed: {error}");
+                        set.abort_all();
+                        cancelled = true;
+                    }
+                    Some(Err(_)) => {}
+                    None => break,
+                }
+            }
+            _ = shutdown_signal() => {
+                set.abort_all();
+                cancelled = true;
+            }
+        }
+    }
+    (results, cancelled)
+}
+
+async fn run_case(
+    plan: CasePlan,
+    deployment: DeploymentContext,
+    options: RunOptions,
+    report_dir: PathBuf,
+    run_id: String,
+    journal: Arc<Mutex<Journal>>,
+) -> CaseResult {
+    let started = Instant::now();
+    let txgen_report = report_dir.join("cases").join(format!("{}.json", plan.id));
+    let mut command = Command::new(&options.txgen_bin);
+    command
+        .args(["scenario", "run", "--scenario"])
+        .arg(&plan.scenario)
+        .args(["--seed", &plan.seed.to_string()])
+        .args(["--starts-per-second", &format_rate(plan.starts_per_second)])
+        .args(["--tx-rate", &plan.transactions_per_second.to_string()])
+        .args(["--max-in-flight", &plan.max_in_flight.to_string()])
+        .args(["--max-rpc-in-flight", &plan.max_rpc_in_flight.to_string()])
+        .args(["--failure-policy", &options.failure_policy])
+        .args(["--step-timeout", &options.step_timeout])
+        .args(["--sample-instances", &options.sample_instances.to_string()])
+        .args(["--report"])
+        .arg(&txgen_report)
+        .args(["--metadata", &format!("zones-load-run-id={run_id}")])
+        .args(["--metadata", &format!("zones-load-case={}", plan.id)])
+        .envs(deployment.command_env())
+        .stdin(Stdio::null())
+        .stdout(Stdio::inherit())
+        .stderr(Stdio::inherit())
+        .kill_on_drop(true);
+    if let Some(count) = plan.count {
+        command.args(["--count", &count.to_string()]);
+    }
+    if let Some(duration) = &plan.duration {
+        command.args(["--duration", duration]);
+    }
+
+    let _ = journal.lock().await.record(
+        "case_started",
+        Some(&plan.id),
+        Some(json!({
+            "scenario": plan.scenario,
+            "seed": plan.seed,
+            "count": plan.count,
+            "duration": plan.duration,
+            "covers": plan.covers,
+        })),
+    );
+
+    let (status, exit_code, txgen, error) = match command.spawn() {
+        Ok(mut child) => match child.wait().await {
+            Ok(exit) => {
+                let summary = load_txgen_summary(&txgen_report);
+                match summary {
+                    Ok(summary)
+                        if exit.success()
+                            && summary.started > 0
+                            && summary.completed == summary.started
+                            && summary.failed == 0
+                            && summary.timed_out == 0 =>
+                    {
+                        (CaseStatus::Passed, exit.code(), Some(summary), None)
+                    }
+                    Ok(summary) => (
+                        CaseStatus::Failed,
+                        exit.code(),
+                        Some(summary),
+                        Some(format!("txgen exited with {exit}")),
+                    ),
+                    Err(error) => (
+                        CaseStatus::Failed,
+                        exit.code(),
+                        None,
+                        Some(error.to_string()),
+                    ),
+                }
+            }
+            Err(error) => (
+                CaseStatus::Failed,
+                None,
+                None,
+                Some(format!("failed waiting for txgen: {error}")),
+            ),
+        },
+        Err(error) => (
+            CaseStatus::Failed,
+            None,
+            None,
+            Some(format!("failed starting txgen: {error}")),
+        ),
+    };
+
+    let result = CaseResult {
+        plan,
+        status,
+        exit_code,
+        elapsed_ms: started.elapsed().as_millis(),
+        txgen_report,
+        txgen,
+        error,
+    };
+    let _ = journal.lock().await.record(
+        "case_completed",
+        Some(&result.plan.id),
+        Some(json!({
+            "status": result.status,
+            "exit_code": result.exit_code,
+            "elapsed_ms": result.elapsed_ms,
+            "error": result.error,
+        })),
+    );
+    result
+}
+
+fn plan_requirements(plan: &RunPlan) -> Vec<String> {
+    plan.cases
+        .iter()
+        .flat_map(|case| case.requires.iter().cloned())
+        .collect::<BTreeSet<_>>()
+        .into_iter()
+        .collect()
+}
+
+fn validate_mutation_groups(plan: &RunPlan) -> Result<()> {
+    if plan.execution != ExecutionMode::Parallel {
+        return Ok(());
+    }
+    let groups = plan
+        .cases
+        .iter()
+        .filter_map(|case| case.mutation_group.as_ref())
+        .collect::<Vec<_>>();
+    ensure!(
+        groups.is_empty(),
+        "cases in mutation groups must use a sequential profile (found: {})",
+        groups
+            .into_iter()
+            .cloned()
+            .collect::<BTreeSet<_>>()
+            .into_iter()
+            .collect::<Vec<_>>()
+            .join(", ")
+    );
+    Ok(())
+}
+
+fn format_rate(rate: f64) -> String {
+    let mut value = format!("{rate:.6}");
+    while value.ends_with('0') {
+        value.pop();
+    }
+    if value.ends_with('.') {
+        value.push('0');
+    }
+    value
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn discovers_unique_l1_workloads_for_account_funding() {
+        let scenario = Path::new(env!("CARGO_MANIFEST_DIR"))
+            .join("../../contrib/loadtest/scenarios/encrypted-deposit.yml");
+        let plan = RunPlan {
+            version: 1,
+            profile: "test".to_owned(),
+            execution: ExecutionMode::Sequential,
+            seed: 1,
+            requested_count: Some(1),
+            duration: None,
+            forever: false,
+            starts_per_second: 0.0,
+            transactions_per_second: 0,
+            max_in_flight: 1,
+            max_rpc_in_flight: 1,
+            cases: vec![CasePlan {
+                id: "encrypted-deposit".to_owned(),
+                description: "test".to_owned(),
+                scenario,
+                seed: 1,
+                count: Some(1),
+                duration: None,
+                starts_per_second: 0.0,
+                transactions_per_second: 0,
+                max_in_flight: 1,
+                max_rpc_in_flight: 1,
+                dangerous: false,
+                mutation_group: None,
+                covers: vec!["test".to_owned()],
+                requires: Vec::new(),
+            }],
+        };
+
+        let workloads = l1_workloads(&plan).unwrap();
+        assert_eq!(workloads.len(), 1);
+        assert!(
+            workloads
+                .iter()
+                .next()
+                .unwrap()
+                .ends_with("scenarios/l1.yml")
+        );
+    }
+
+    #[test]
+    fn rates_are_cli_friendly() {
+        assert_eq!(format_rate(0.0), "0.0");
+        assert_eq!(format_rate(12.5), "12.5");
+        assert_eq!(format_rate(0.333333333), "0.333333");
+    }
+}

--- a/contrib/loadtest/catalog.yml
+++ b/contrib/loadtest/catalog.yml
@@ -1,0 +1,290 @@
+version: 1
+
+profiles:
+  smoke:
+    description: One encrypted L1-to-Zone deposit with cross-chain event verification.
+    execution: sequential
+    default_count: 1
+    cases: [encrypted-deposit]
+
+  core:
+    description: Self-contained deposit and plain-withdrawal coverage without Neobank callbacks.
+    execution: sequential
+    default_count: 2
+    cases: [encrypted-deposit, plain-withdrawal]
+
+  branch-sweep:
+    description: Deterministic pass over every currently executable Zones scenario family.
+    execution: sequential
+    default_count: 8
+    cases:
+      - encrypted-deposit
+      - plain-withdrawal
+      - direct-lifecycle
+      - private-withdrawal
+      - slippage-bounce
+      - swapped-lifecycle
+      - swapped-redemption
+      - third-party-recipient
+
+  steady:
+    description: Weighted, parallel production-like deposits, withdrawals, callbacks, and swaps.
+    execution: parallel
+    default_count: 100
+    cases:
+      - encrypted-deposit
+      - plain-withdrawal
+      - direct-lifecycle
+      - private-withdrawal
+      - swapped-lifecycle
+      - third-party-recipient
+
+  chaos:
+    description: The steady transaction mix with durable markers for an external fault controller.
+    execution: parallel
+    default_count: 100
+    cases:
+      - encrypted-deposit
+      - plain-withdrawal
+      - direct-lifecycle
+      - private-withdrawal
+      - swapped-lifecycle
+      - third-party-recipient
+
+cases:
+  encrypted-deposit:
+    description: Encrypted Portal deposit accepted on L1 and minted by the Zone inbox.
+    scenario: contrib/loadtest/scenarios/encrypted-deposit.yml
+    weight: 30
+    covers:
+      - portal.deposit.encrypted.accepted
+      - sequencer.advance_tempo.deposit
+      - inbox.deposit.processed
+    requires: []
+
+  plain-withdrawal:
+    description: Self-contained deposit, Zone approval, plain withdrawal, and L1 processing.
+    scenario: contrib/loadtest/scenarios/plain-withdrawal.yml
+    weight: 30
+    covers:
+      - portal.deposit.encrypted.accepted
+      - inbox.deposit.processed
+      - ztip20.approve.outbox
+      - outbox.withdrawal.plain.requested
+      - outbox.withdrawal.self_paid
+      - sequencer.finalize_withdrawal_batch
+      - portal.withdrawal.plain.processed
+    requires: []
+
+  direct-lifecycle:
+    description: Deposit, callback withdrawal, and return deposit lifecycle.
+    scenario: contrib/bench/neobank/direct-lifecycle-scenario.yml
+    weight: 35
+    covers:
+      - portal.deposit.encrypted.accepted
+      - outbox.withdrawal.callback.requested
+      - portal.withdrawal.callback.processed
+      - messenger.callback.success
+      - inbox.deposit.processed
+    requires:
+      - L1_WS_RPC_URL
+      - ZONE_WS_RPC_URL
+      - ZONE_REDACTED_RPC_URL
+      - ZONES_BENCH_ZONE_AUTH_MAP
+      - ZONES_BENCH_MNEMONIC
+      - ZONES_BENCH_ACCOUNT_START
+      - ZONES_BENCH_ACCOUNT_END
+      - ZONES_BENCH_PATHUSD
+      - ZONES_BENCH_EARN_TOKEN
+      - ZONES_BENCH_EARN_ROUTER
+      - ZONES_BENCH_DEPOSIT_AMOUNT
+      - ZONES_BENCH_WITHDRAWAL_AMOUNT
+      - ZONES_BENCH_CALLBACK_GAS_LIMIT
+      - ZONES_BENCH_L1_MAX_FEE_PER_GAS
+      - ZONES_BENCH_ZONE_MAX_FEE_PER_GAS
+
+  private-withdrawal:
+    description: Callback withdrawal, routed redemption, and encrypted return deposit.
+    scenario: contrib/bench/neobank/private-withdrawal-scenario.yml
+    weight: 15
+    covers:
+      - outbox.withdrawal.callback.requested
+      - portal.withdrawal.callback.processed
+      - router.redeem.success
+      - inbox.deposit.processed
+    requires:
+      - L1_WS_RPC_URL
+      - ZONE_WS_RPC_URL
+      - ZONE_REDACTED_RPC_URL
+      - ZONES_BENCH_ZONE_AUTH_MAP
+      - ZONES_BENCH_MNEMONIC
+      - ZONES_BENCH_ACCOUNT_START
+      - ZONES_BENCH_ACCOUNT_END
+      - ZONES_BENCH_DLUSD
+      - ZONES_BENCH_EARN_TOKEN
+      - ZONES_BENCH_EARN_ROUTER
+      - ZONES_BENCH_WITHDRAWAL_AMOUNT
+      - ZONES_BENCH_CALLBACK_GAS_LIMIT
+      - ZONES_BENCH_L1_MAX_FEE_PER_GAS
+      - ZONES_BENCH_ZONE_MAX_FEE_PER_GAS
+
+  slippage-bounce:
+    description: Callback swap failure followed by L1 and Zone withdrawal bounceback processing.
+    scenario: contrib/bench/neobank/slippage-bounce-scenario.yml
+    weight: 1
+    covers:
+      - outbox.withdrawal.callback.requested
+      - router.swap.slippage
+      - portal.withdrawal.callback.failed
+      - portal.withdrawal.bounceback.enqueued
+      - inbox.withdrawal_bounceback.processed
+    requires:
+      - L1_WS_RPC_URL
+      - ZONE_WS_RPC_URL
+      - ZONE_REDACTED_RPC_URL
+      - ZONES_BENCH_ZONE_AUTH_MAP
+      - ZONES_BENCH_MNEMONIC
+      - ZONES_BENCH_ACCOUNT_START
+      - ZONES_BENCH_ACCOUNT_END
+      - ZONES_BENCH_DLUSD
+      - ZONES_BENCH_EARN_TOKEN
+      - ZONES_BENCH_EARN_ROUTER
+      - ZONES_BENCH_DEPOSIT_AMOUNT
+      - ZONES_BENCH_WITHDRAWAL_AMOUNT
+      - ZONES_BENCH_CALLBACK_GAS_LIMIT
+      - ZONES_BENCH_L1_MAX_FEE_PER_GAS
+      - ZONES_BENCH_ZONE_MAX_FEE_PER_GAS
+
+  swapped-lifecycle:
+    description: Callback router swaps the withdrawn token and deposits the output into the Zone.
+    scenario: contrib/bench/neobank/swapped-lifecycle-scenario.yml
+    weight: 15
+    covers:
+      - outbox.withdrawal.callback.requested
+      - router.swap.success
+      - portal.withdrawal.callback.processed
+      - inbox.deposit.processed
+    requires:
+      - L1_WS_RPC_URL
+      - ZONE_WS_RPC_URL
+      - ZONE_REDACTED_RPC_URL
+      - ZONES_BENCH_ZONE_AUTH_MAP
+      - ZONES_BENCH_MNEMONIC
+      - ZONES_BENCH_ACCOUNT_START
+      - ZONES_BENCH_ACCOUNT_END
+      - ZONES_BENCH_DLUSD
+      - ZONES_BENCH_PATHUSD
+      - ZONES_BENCH_EARN_TOKEN
+      - ZONES_BENCH_EARN_ROUTER
+      - ZONES_BENCH_DEPOSIT_AMOUNT
+      - ZONES_BENCH_WITHDRAWAL_AMOUNT
+      - ZONES_BENCH_CALLBACK_GAS_LIMIT
+      - ZONES_BENCH_L1_MAX_FEE_PER_GAS
+      - ZONES_BENCH_ZONE_MAX_FEE_PER_GAS
+
+  swapped-redemption:
+    description: Routed redemption swaps its output before returning it to the Zone.
+    scenario: contrib/bench/neobank/swapped-redemption-scenario.yml
+    weight: 1
+    covers:
+      - outbox.withdrawal.callback.requested
+      - router.redeem.success
+      - router.swap.success
+      - portal.withdrawal.callback.processed
+      - inbox.deposit.processed
+    requires:
+      - L1_WS_RPC_URL
+      - ZONE_WS_RPC_URL
+      - ZONE_REDACTED_RPC_URL
+      - ZONES_BENCH_ZONE_AUTH_MAP
+      - ZONES_BENCH_MNEMONIC
+      - ZONES_BENCH_ACCOUNT_START
+      - ZONES_BENCH_ACCOUNT_END
+      - ZONES_BENCH_DLUSD
+      - ZONES_BENCH_PATHUSD
+      - ZONES_BENCH_EARN_TOKEN
+      - ZONES_BENCH_EARN_ROUTER
+      - ZONES_BENCH_WITHDRAWAL_AMOUNT
+      - ZONES_BENCH_CALLBACK_GAS_LIMIT
+      - ZONES_BENCH_L1_MAX_FEE_PER_GAS
+      - ZONES_BENCH_ZONE_MAX_FEE_PER_GAS
+
+  third-party-recipient:
+    description: A callback deposits its output to a recipient different from the withdrawal sender.
+    scenario: contrib/bench/neobank/third-party-recipient-scenario.yml
+    weight: 5
+    covers:
+      - outbox.withdrawal.callback.requested
+      - messenger.callback.success
+      - inbox.deposit.third_party_recipient
+    requires:
+      - L1_WS_RPC_URL
+      - ZONE_WS_RPC_URL
+      - ZONE_REDACTED_RPC_URL
+      - ZONES_BENCH_ZONE_AUTH_MAP
+      - ZONES_BENCH_MNEMONIC
+      - ZONES_BENCH_ACCOUNT_START
+      - ZONES_BENCH_ACCOUNT_END
+      - ZONES_BENCH_RECIPIENT_ACCOUNT_START
+      - ZONES_BENCH_RECIPIENT_ACCOUNT_END
+      - ZONES_BENCH_DLUSD
+      - ZONES_BENCH_EARN_TOKEN
+      - ZONES_BENCH_EARN_ROUTER
+      - ZONES_BENCH_DEPOSIT_AMOUNT
+      - ZONES_BENCH_WITHDRAWAL_AMOUNT
+      - ZONES_BENCH_CALLBACK_GAS_LIMIT
+      - ZONES_BENCH_L1_MAX_FEE_PER_GAS
+      - ZONES_BENCH_ZONE_MAX_FEE_PER_GAS
+
+  malformed-deposit-bounceback:
+    description: Accepted encrypted deposit that fails Zone decryption and completes its bounceback.
+    implemented: false
+    weight: 0
+    covers:
+      - inbox.deposit.decrypt_failed
+      - outbox.deposit_bounceback.enqueued
+      - portal.deposit_bounceback.refunded
+
+  parked-refund:
+    description: Failed bounceback transfer followed by a successful claimRefund.
+    implemented: false
+    weight: 0
+    covers:
+      - portal.refund.parked
+      - portal.refund.claimed
+      - inbox.refund.parked
+      - inbox.refund.claimed
+
+  envelope-rejections:
+    description: Invalid transaction types, nonce states, validity windows, sponsorship, and admission checks.
+    implemented: false
+    weight: 0
+    covers:
+      - txpool.reject.blob
+      - txpool.reject.authorization_list
+      - txpool.reject.contract_creation
+      - txpool.reject.no_enabled_token_balance
+      - txpool.reject.validity_window
+
+  settlement-boundaries:
+    description: Empty, split, and ancestry-anchored settlement batches.
+    implemented: false
+    weight: 0
+    covers:
+      - settlement.empty_batch
+      - settlement.withdrawal_split
+      - settlement.ancestry_anchor
+
+  governance-transitions:
+    description: Admin, leader, sequencer-set, policy, mode, and encryption-key transitions.
+    implemented: false
+    dangerous: true
+    mutation_group: portal-governance
+    weight: 0
+    covers:
+      - portal.admin.transfer
+      - portal.leader.rotate
+      - portal.sequencer_set.update
+      - portal.access_mode.update
+      - portal.gateway_mode.update
+      - portal.encryption_key.rotate

--- a/contrib/loadtest/scenarios/encrypted-deposit.yml
+++ b/contrib/loadtest/scenarios/encrypted-deposit.yml
@@ -1,0 +1,107 @@
+version: 1
+
+chains:
+  l1:
+    network: tempo
+    rpc_url: "${L1_RPC_URL}"
+    query_rpc_url: "${L1_RPC_URL}"
+    observation:
+      mode: poll
+      poll_interval: 50ms
+    chain_id: ${ZONES_LOAD_EXPECTED_L1_CHAIN_ID}
+    workload: ./l1.yml
+
+  zone:
+    network: tempo
+    rpc_url: "${ZONE_RPC_URL}"
+    query_rpc_url: "${ZONE_RPC_URL}"
+    observation:
+      mode: poll
+      poll_interval: 50ms
+    chain_id: ${ZONES_LOAD_EXPECTED_ZONE_CHAIN_ID}
+    workload: ./zone.yml
+
+scenario:
+  name: zones-load-encrypted-deposit
+  execution: dag
+  timeout: 5m
+
+  bindings:
+    account:
+      account: { pool: users, select: lease }
+    action_id:
+      bytes32: { random_bytes: 32 }
+
+  steps:
+    - id: zone_before
+      checkpoint: { chain: zone }
+      save: zone_before
+
+    - id: approve
+      submit:
+        chain: l1
+        template: approve_portal
+        with:
+          from: { var: account.ref }
+        await: receipt
+      save: approve
+
+    - id: encryption
+      invoke:
+        chain: l1
+        action: prepare_encrypted_deposit
+        with:
+          sender: { var: account.address }
+          recipient: { var: account.address }
+          zoneId: ${ZONES_LOAD_ZONE_ID}
+          portalAddress: "${L1_PORTAL_ADDRESS}"
+          memo: { var: action_id }
+      save: encryption
+
+    - id: deposit
+      depends_on: [approve, encryption]
+      submit:
+        chain: l1
+        template: encrypted_deposit
+        with:
+          from: { var: account.ref }
+          call:
+            args:
+              - "${ZONES_LOAD_TOKEN}"
+              - ${ZONES_LOAD_DEPOSIT_AMOUNT}
+              - { var: encryption.keyIndex }
+              - { var: encryption.encrypted }
+              - { var: account.address }
+      save: deposit
+
+    - id: enqueued
+      depends_on: [deposit]
+      wait_log:
+        chain: l1
+        transaction_hash: { var: deposit.tx_hash }
+        sender: { var: deposit.sender }
+        address: "${L1_PORTAL_ADDRESS}"
+        abi: ZonePortal
+        event: DepositMade
+        where:
+          sender: { var: account.address }
+          token: "${ZONES_LOAD_TOKEN}"
+      save: enqueued
+
+    - id: processed
+      depends_on: [zone_before, enqueued]
+      wait_log:
+        chain: zone
+        from_block: { var: zone_before.block_number }
+        address: "${ZONES_LOAD_INBOX}"
+        abi: ZoneInbox
+        event: DepositProcessed
+        where:
+          depositHash: { var: enqueued.args.newCurrentDepositQueueHash }
+          sender: { var: account.address }
+          to: { var: account.address }
+          token: "${ZONES_LOAD_TOKEN}"
+          amount: { var: enqueued.args.netAmount }
+          memo: { var: action_id }
+        max_block_range: 1000
+      save: processed

--- a/contrib/loadtest/scenarios/l1.yml
+++ b/contrib/loadtest/scenarios/l1.yml
@@ -1,0 +1,52 @@
+chain_id: ${ZONES_LOAD_EXPECTED_L1_CHAIN_ID}
+
+gas:
+  max_fee_per_gas: ${ZONES_LOAD_L1_MAX_FEE_PER_GAS}
+  max_priority_fee_per_gas: 0
+
+accounts:
+  users:
+    mnemonic: "${ZONES_LOAD_MNEMONIC}"
+    range: [${ZONES_LOAD_ACCOUNT_START}, ${ZONES_LOAD_ACCOUNT_END}]
+
+artifacts:
+  TIP20: ../../bench/neobank/abis/tip20.json
+  ZonePortal: ../../bench/neobank/abis/neobank-zone-portal.json
+
+setup: { steps: [] }
+
+templates:
+  approve_portal:
+    type: tempo
+    from: { var: account.ref }
+    gas_limit: 2000000
+    fee_token: "${ZONES_LOAD_TOKEN}"
+    expiring_nonce: true
+    valid_for_secs: 25
+    call:
+      to: "${ZONES_LOAD_TOKEN}"
+      abi: TIP20
+      function: "approve(address,uint256)"
+      args:
+        - "${L1_PORTAL_ADDRESS}"
+        - "115792089237316195423570985008687907853269984665640564039457584007913129639935"
+
+  encrypted_deposit:
+    type: tempo
+    from: { var: account.ref }
+    gas_limit: 2000000
+    fee_token: "${ZONES_LOAD_TOKEN}"
+    expiring_nonce: true
+    valid_for_secs: 25
+    call:
+      to: "${L1_PORTAL_ADDRESS}"
+      abi: ZonePortal
+      function: "deposit(address,uint128,uint256,(bytes32,uint8,bytes,bytes12,bytes16),address)"
+      args:
+        - "${ZONES_LOAD_TOKEN}"
+        - ${ZONES_LOAD_DEPOSIT_AMOUNT}
+        - { var: encrypted.keyIndex }
+        - { var: encrypted.encrypted }
+        - { var: account.address }
+
+mix: []

--- a/contrib/loadtest/scenarios/plain-withdrawal.yml
+++ b/contrib/loadtest/scenarios/plain-withdrawal.yml
@@ -1,0 +1,183 @@
+version: 1
+
+chains:
+  l1:
+    network: tempo
+    rpc_url: "${L1_RPC_URL}"
+    query_rpc_url: "${L1_RPC_URL}"
+    observation:
+      mode: poll
+      poll_interval: 50ms
+    chain_id: ${ZONES_LOAD_EXPECTED_L1_CHAIN_ID}
+    workload: ./l1.yml
+
+  zone:
+    network: tempo
+    rpc_url: "${ZONE_RPC_URL}"
+    query_rpc_url: "${ZONE_RPC_URL}"
+    observation:
+      mode: poll
+      poll_interval: 50ms
+    chain_id: ${ZONES_LOAD_EXPECTED_ZONE_CHAIN_ID}
+    workload: ./zone.yml
+
+scenario:
+  name: zones-load-plain-withdrawal
+  execution: dag
+  timeout: 5m
+
+  bindings:
+    account:
+      account: { pool: users, select: lease }
+    action_id:
+      bytes32: { random_bytes: 32 }
+
+  steps:
+    - id: zone_before
+      checkpoint: { chain: zone }
+      save: zone_before
+
+    - id: approve_portal
+      submit:
+        chain: l1
+        template: approve_portal
+        with:
+          from: { var: account.ref }
+        await: receipt
+      save: approve_portal
+
+    - id: encryption
+      invoke:
+        chain: l1
+        action: prepare_encrypted_deposit
+        with:
+          sender: { var: account.address }
+          recipient: { var: account.address }
+          zoneId: ${ZONES_LOAD_ZONE_ID}
+          portalAddress: "${L1_PORTAL_ADDRESS}"
+          memo: { var: action_id }
+      save: encryption
+
+    - id: deposit
+      depends_on: [approve_portal, encryption]
+      submit:
+        chain: l1
+        template: encrypted_deposit
+        with:
+          from: { var: account.ref }
+          call:
+            args:
+              - "${ZONES_LOAD_TOKEN}"
+              - ${ZONES_LOAD_DEPOSIT_AMOUNT}
+              - { var: encryption.keyIndex }
+              - { var: encryption.encrypted }
+              - { var: account.address }
+      save: deposit
+
+    - id: deposit_enqueued
+      depends_on: [deposit]
+      wait_log:
+        chain: l1
+        transaction_hash: { var: deposit.tx_hash }
+        sender: { var: deposit.sender }
+        address: "${L1_PORTAL_ADDRESS}"
+        abi: ZonePortal
+        event: DepositMade
+        where:
+          sender: { var: account.address }
+          token: "${ZONES_LOAD_TOKEN}"
+      save: deposit_enqueued
+
+    - id: deposit_processed
+      depends_on: [zone_before, deposit_enqueued]
+      wait_log:
+        chain: zone
+        from_block: { var: zone_before.block_number }
+        address: "${ZONES_LOAD_INBOX}"
+        abi: ZoneInbox
+        event: DepositProcessed
+        where:
+          depositHash: { var: deposit_enqueued.args.newCurrentDepositQueueHash }
+          sender: { var: account.address }
+          to: { var: account.address }
+          token: "${ZONES_LOAD_TOKEN}"
+          amount: { var: deposit_enqueued.args.netAmount }
+          memo: { var: action_id }
+        max_block_range: 1000
+      save: deposit_processed
+
+    - id: l1_before_withdrawal
+      depends_on: [deposit_processed]
+      checkpoint: { chain: l1 }
+      save: l1_before_withdrawal
+
+    - id: approve_outbox
+      depends_on: [deposit_processed]
+      submit:
+        chain: zone
+        template: approve_outbox
+        with:
+          from: { var: account.ref }
+        await: receipt
+      save: approve_outbox
+
+    - id: withdrawal
+      depends_on: [l1_before_withdrawal, approve_outbox]
+      submit:
+        chain: zone
+        template: plain_withdrawal
+        with:
+          from: { var: account.ref }
+          call:
+            args:
+              - "${ZONES_LOAD_TOKEN}"
+              - { var: account.address }
+              - ${ZONES_LOAD_WITHDRAWAL_AMOUNT}
+              - { var: action_id }
+              - 0
+              - { var: account.address }
+              - "0x"
+              - "0x"
+      save: withdrawal
+
+    - id: withdrawal_requested
+      depends_on: [withdrawal]
+      wait_log:
+        chain: zone
+        transaction_hash: { var: withdrawal.tx_hash }
+        sender: { var: withdrawal.sender }
+        address: "${ZONES_LOAD_OUTBOX}"
+        abi: ZoneOutbox
+        event: WithdrawalRequested
+        where:
+          sender: { var: account.address }
+          token: "${ZONES_LOAD_TOKEN}"
+          to: { var: account.address }
+          amount: ${ZONES_LOAD_WITHDRAWAL_AMOUNT}
+          gasLimit: 0
+          data: "0x"
+          revealTo: "0x"
+      save: withdrawal_requested
+
+    - id: withdrawal_processed
+      depends_on: [l1_before_withdrawal, withdrawal, withdrawal_requested]
+      wait_log:
+        chain: l1
+        from_block: { var: l1_before_withdrawal.block_number }
+        address: "${L1_PORTAL_ADDRESS}"
+        abi: ZonePortal
+        event: WithdrawalProcessed
+        where:
+          to: { var: account.address }
+          senderTag:
+            keccak256_packed:
+              types: [address, bytes32, uint64]
+              values:
+                - { var: account.address }
+                - { var: withdrawal.tx_hash }
+                - { var: withdrawal_requested.args.fallbackNonce }
+          token: "${ZONES_LOAD_TOKEN}"
+          amount: ${ZONES_LOAD_WITHDRAWAL_AMOUNT}
+          callbackSuccess: true
+        max_block_range: 1000
+      save: withdrawal_processed

--- a/contrib/loadtest/scenarios/zone.yml
+++ b/contrib/loadtest/scenarios/zone.yml
@@ -1,0 +1,56 @@
+chain_id: ${ZONES_LOAD_EXPECTED_ZONE_CHAIN_ID}
+
+gas:
+  max_fee_per_gas: ${ZONES_LOAD_ZONE_MAX_FEE_PER_GAS}
+  max_priority_fee_per_gas: 0
+
+accounts:
+  users:
+    mnemonic: "${ZONES_LOAD_MNEMONIC}"
+    range: [${ZONES_LOAD_ACCOUNT_START}, ${ZONES_LOAD_ACCOUNT_END}]
+
+artifacts:
+  TIP20: ../../bench/neobank/abis/tip20.json
+  ZoneOutbox: ../../bench/neobank/abis/zone-outbox.json
+  ZoneInbox: ../../bench/neobank/abis/neobank-zone-inbox.json
+
+setup: { steps: [] }
+
+templates:
+  approve_outbox:
+    type: tempo
+    from: { var: account.ref }
+    gas_limit: 500000
+    fee_token: "${ZONES_LOAD_TOKEN}"
+    expiring_nonce: true
+    valid_for_secs: 25
+    call:
+      to: "${ZONES_LOAD_TOKEN}"
+      abi: TIP20
+      function: "approve(address,uint256)"
+      args:
+        - "${ZONES_LOAD_OUTBOX}"
+        - "115792089237316195423570985008687907853269984665640564039457584007913129639935"
+
+  plain_withdrawal:
+    type: tempo
+    from: { var: account.ref }
+    gas_limit: 10000000
+    fee_token: "${ZONES_LOAD_TOKEN}"
+    expiring_nonce: true
+    valid_for_secs: 25
+    call:
+      to: "${ZONES_LOAD_OUTBOX}"
+      abi: ZoneOutbox
+      function: "requestWithdrawal(address,address,uint128,bytes32,uint64,address,bytes,bytes)"
+      args:
+        - "${ZONES_LOAD_TOKEN}"
+        - { var: account.address }
+        - ${ZONES_LOAD_WITHDRAWAL_AMOUNT}
+        - { var: action_id }
+        - 0
+        - { var: account.address }
+        - "0x"
+        - "0x"
+
+mix: []

--- a/docker/Dockerfile.zones-load
+++ b/docker/Dockerfile.zones-load
@@ -1,0 +1,62 @@
+# syntax=docker/dockerfile:1.7
+
+ARG RUST_IMAGE=rust:1.96-bookworm@sha256:5e2214abe154fe26e39f64488952e5c991eeed1d6d6da7cc8381ae83927f0cfc
+
+FROM ${RUST_IMAGE} AS builder
+
+ARG TXGEN_REPOSITORY=https://github.com/tempoxyz/txgen
+ARG TXGEN_REVISION=20414d500847ec2b58882a08fc146726cdfd41a7
+
+RUN apt-get update \
+    && apt-get install --no-install-recommends -y \
+        build-essential \
+        clang \
+        cmake \
+        git \
+        libclang-dev \
+        libssl-dev \
+        pkg-config \
+    && rm -rf /var/lib/apt/lists/*
+
+WORKDIR /app
+COPY . .
+
+RUN --mount=type=cache,target=/usr/local/cargo/registry,sharing=locked,id=zones-load-cargo-registry \
+    --mount=type=cache,target=/usr/local/cargo/git,sharing=locked,id=zones-load-cargo-git \
+    --mount=type=cache,target=/app/target,sharing=locked,id=zones-load-target \
+    cargo build --locked --release -p zones-load \
+    && install -Dm755 /app/target/release/zones-load /out/zones-load
+
+RUN --mount=type=cache,target=/usr/local/cargo/registry,sharing=locked,id=zones-load-cargo-registry \
+    --mount=type=cache,target=/usr/local/cargo/git,sharing=locked,id=zones-load-cargo-git \
+    --mount=type=cache,target=/tmp/txgen-target,sharing=locked,id=txgen-tempo-target \
+    CARGO_TARGET_DIR=/tmp/txgen-target \
+    cargo install \
+        --locked \
+        --git "${TXGEN_REPOSITORY}" \
+        --rev "${TXGEN_REVISION}" \
+        --root /out/txgen \
+        txgen-tempo
+
+FROM debian:bookworm-slim@sha256:4724b8cc51e33e398f0e2e15e18d5ec2851ff0c2280647e1310bc1642182655d AS runtime
+
+RUN apt-get update \
+    && apt-get install --no-install-recommends -y ca-certificates \
+    && rm -rf /var/lib/apt/lists/* \
+    && mkdir -p /opt/zones/contrib/bench /opt/zones/contrib/loadtest /reports \
+    && chown 65532:65532 /reports
+
+COPY --from=builder /out/zones-load /usr/local/bin/zones-load
+COPY --from=builder /out/txgen/bin/txgen-tempo /usr/local/bin/txgen-tempo
+COPY --chown=65532:65532 contrib/loadtest /opt/zones/contrib/loadtest
+COPY --chown=65532:65532 contrib/bench/neobank /opt/zones/contrib/bench/neobank
+
+ENV HOME=/tmp \
+    RUST_BACKTRACE=1 \
+    TXGEN_TEMPO_BIN=/usr/local/bin/txgen-tempo
+
+WORKDIR /opt/zones
+USER 65532:65532
+
+ENTRYPOINT ["/usr/local/bin/zones-load"]
+CMD ["catalog"]


### PR DESCRIPTION
## Summary

- add a `zones-load` CLI for deterministic multi-chain transaction workloads, preflight checks, replay, reporting, and codepath coverage
- add self-contained deposit and withdrawal scenarios plus steady, smoke, core, branch-sweep, and chaos profiles
- support devnet account funding, bounded or forever load, rate/concurrency controls, and graceful SIGINT/SIGTERM shutdown
- add a multi-stage runtime image containing `zones-load`, a pinned `txgen-tempo`, and the built-in scenario assets

## Why

Running repeatable load and chaos experiments against a Tempo L1 devnet and a dedicated Zone previously required manual transaction setup. This adds a single orchestrator that validates deployment inputs, drives stateful cross-chain journeys, and emits durable reports suitable for coverage and fault-injection coordination.

## Validation

- `cargo test -p zones-load`
- `cargo clippy -p zones-load --all-targets -- -D warnings`
- `docker build -f docker/Dockerfile.zones-load -t zones-load:local .`
- `docker run --rm zones-load:local catalog --profile core`
- `docker run --rm zones-load:local plan --profile core --count 2`
- packaged `txgen-tempo scenario validate --help` smoke test