### PR TITLE
feat(prover): add stage tracing spans

### DIFF
--- a/bin/prover/utils/src/main.rs
+++ b/bin/prover/utils/src/main.rs
@@ -193,14 +193,6 @@ fn init_tracing(filter: &str) -> Result<()> {
         .map_err(|error| eyre!("initialize tracing: {error}"))
 }
 
-macro_rules! start_phase {
-    ($name:literal) => {{
-        let span = info_span!($name);
-        span.in_scope(|| info!(phase = $name, "starting phase"));
-        (Instant::now(), span)
-    }};
-}
-
 async fn generate_input(args: GenerateInputArgs) -> Result<()> {
     let total_started = Instant::now();
     let mut timings = Timings::default();
@@ -217,7 +209,7 @@ async fn generate_input(args: GenerateInputArgs) -> Result<()> {
         bail!("--zone-block-count must be greater than zero");
     }
 
-    let started = start_phase!("discovery");
+    let started = (Instant::now(), info_span!("discovery"));
     let tempo_provider = connect(&args.tempo_rpc_url, "Tempo").await?;
     let zone_provider = connect(&args.zone_unrestricted_rpc_url, "unrestricted Zone").await?;
     let signer = args
@@ -248,7 +240,7 @@ async fn generate_input(args: GenerateInputArgs) -> Result<()> {
     );
     timings.record("discovery", started, ());
 
-    let started = start_phase!("batch_extraction");
+    let started = (Instant::now(), info_span!("batch_extraction"));
     let (parent_header, parent_number, extracted) = if let Some(block_count) = args.zone_block_count
     {
         let (updated_discovery, parent_header, parent_number, extracted) = discover_counted_batch(
@@ -307,17 +299,17 @@ async fn generate_input(args: GenerateInputArgs) -> Result<()> {
     );
     timings.record("batch extraction", started, ());
 
-    let started = start_phase!("initial_checkpoint");
+    let started = (Instant::now(), info_span!("initial_checkpoint"));
     let initial_tempo_header =
         initial_tempo_header(&tempo_provider, &zone_provider, parent_number).await?;
     timings.record("initial checkpoint", started, ());
 
-    let started = start_phase!("zone_state_witness");
+    let started = (Instant::now(), info_span!("zone_state_witness"));
     let (zone_state_witness, tempo_reads) =
         zone_witnesses(&zone_provider, from_block, to_block).await?;
     timings.record("Zone state witness", started, ());
 
-    let started = start_phase!("tempo_state_witness");
+    let started = (Instant::now(), info_span!("tempo_state_witness"));
     let checkpoint_by_zone_block = extracted
         .iter()
         .map(|block| (block.input.number, block.checkpoint_number))
@@ -334,7 +326,7 @@ async fn generate_input(args: GenerateInputArgs) -> Result<()> {
         .transpose()?
         .unwrap_or_else(|| initial_tempo_header.clone());
 
-    let started = start_phase!("tempo_ancestry");
+    let started = (Instant::now(), info_span!("tempo_ancestry"));
     let (anchor_block_number, anchor_block_hash, tempo_ancestry_headers, anchor_mode) =
         tempo_anchor(&tempo_provider, &final_tempo_header).await?;
     timings.record("Tempo ancestry", started, ());
@@ -356,7 +348,7 @@ async fn generate_input(args: GenerateInputArgs) -> Result<()> {
         tempo_ancestry_headers,
     };
 
-    let started = start_phase!("spf_validation");
+    let started = (Instant::now(), info_span!("spf_validation"));
     let output = prove_zone_batch(&spf_config, witness.clone())
         .context("generated witness failed SPF validation")?;
     if output.block_transition.nextBlockHash != next_block_hash {
@@ -378,7 +370,7 @@ async fn generate_input(args: GenerateInputArgs) -> Result<()> {
         witness,
     };
 
-    let started = start_phase!("output");
+    let started = (Instant::now(), info_span!("output"));
     let output_bytes = if let Some(path) = &args.output {
         let json =
             serde_json::to_vec_pretty(&request.witness).context("serialize batch witness")?;
@@ -391,7 +383,7 @@ async fn generate_input(args: GenerateInputArgs) -> Result<()> {
     timings.record("output", started, ());
 
     let target_bytes = if let Some(target) = &args.target {
-        let started = start_phase!("target_prover");
+        let started = (Instant::now(), info_span!("target_prover"));
         let bytes = send_to_prover(target, &request, &output).await?;
         timings.record("target prover", started, ());
         Some(bytes)

--- a/bin/prover/utils/src/main.rs
+++ b/bin/prover/utils/src/main.rs
@@ -193,21 +193,12 @@ fn init_tracing(filter: &str) -> Result<()> {
         .map_err(|error| eyre!("initialize tracing: {error}"))
 }
 
-fn start_phase(name: &'static str) -> (Instant, Span) {
-    let span = match name {
-        "discovery" => info_span!("discovery"),
-        "batch extraction" => info_span!("batch_extraction"),
-        "initial checkpoint" => info_span!("initial_checkpoint"),
-        "Zone state witness" => info_span!("zone_state_witness"),
-        "Tempo state witness" => info_span!("tempo_state_witness"),
-        "Tempo ancestry" => info_span!("tempo_ancestry"),
-        "SPF validation" => info_span!("spf_validation"),
-        "output" => info_span!("output"),
-        "target prover" => info_span!("target_prover"),
-        _ => unreachable!("unknown SPF phase: {name}"),
-    };
-    span.in_scope(|| info!(phase = name, "starting phase"));
-    (Instant::now(), span)
+macro_rules! start_phase {
+    ($name:literal) => {{
+        let span = info_span!($name);
+        span.in_scope(|| info!(phase = $name, "starting phase"));
+        (Instant::now(), span)
+    }};
 }
 
 async fn generate_input(args: GenerateInputArgs) -> Result<()> {
@@ -226,7 +217,7 @@ async fn generate_input(args: GenerateInputArgs) -> Result<()> {
         bail!("--zone-block-count must be greater than zero");
     }
 
-    let started = start_phase("discovery");
+    let started = start_phase!("discovery");
     let tempo_provider = connect(&args.tempo_rpc_url, "Tempo").await?;
     let zone_provider = connect(&args.zone_unrestricted_rpc_url, "unrestricted Zone").await?;
     let signer = args
@@ -257,7 +248,7 @@ async fn generate_input(args: GenerateInputArgs) -> Result<()> {
     );
     timings.record("discovery", started, ());
 
-    let started = start_phase("batch extraction");
+    let started = start_phase!("batch_extraction");
     let (parent_header, parent_number, extracted) = if let Some(block_count) = args.zone_block_count
     {
         let (updated_discovery, parent_header, parent_number, extracted) = discover_counted_batch(
@@ -316,17 +307,17 @@ async fn generate_input(args: GenerateInputArgs) -> Result<()> {
     );
     timings.record("batch extraction", started, ());
 
-    let started = start_phase("initial checkpoint");
+    let started = start_phase!("initial_checkpoint");
     let initial_tempo_header =
         initial_tempo_header(&tempo_provider, &zone_provider, parent_number).await?;
     timings.record("initial checkpoint", started, ());
 
-    let started = start_phase("Zone state witness");
+    let started = start_phase!("zone_state_witness");
     let (zone_state_witness, tempo_reads) =
         zone_witnesses(&zone_provider, from_block, to_block).await?;
     timings.record("Zone state witness", started, ());
 
-    let started = start_phase("Tempo state witness");
+    let started = start_phase!("tempo_state_witness");
     let checkpoint_by_zone_block = extracted
         .iter()
         .map(|block| (block.input.number, block.checkpoint_number))
@@ -343,7 +334,7 @@ async fn generate_input(args: GenerateInputArgs) -> Result<()> {
         .transpose()?
         .unwrap_or_else(|| initial_tempo_header.clone());
 
-    let started = start_phase("Tempo ancestry");
+    let started = start_phase!("tempo_ancestry");
     let (anchor_block_number, anchor_block_hash, tempo_ancestry_headers, anchor_mode) =
         tempo_anchor(&tempo_provider, &final_tempo_header).await?;
     timings.record("Tempo ancestry", started, ());
@@ -365,7 +356,7 @@ async fn generate_input(args: GenerateInputArgs) -> Result<()> {
         tempo_ancestry_headers,
     };
 
-    let started = start_phase("SPF validation");
+    let started = start_phase!("spf_validation");
     let output = prove_zone_batch(&spf_config, witness.clone())
         .context("generated witness failed SPF validation")?;
     if output.block_transition.nextBlockHash != next_block_hash {
@@ -387,7 +378,7 @@ async fn generate_input(args: GenerateInputArgs) -> Result<()> {
         witness,
     };
 
-    let started = start_phase("output");
+    let started = start_phase!("output");
     let output_bytes = if let Some(path) = &args.output {
         let json =
             serde_json::to_vec_pretty(&request.witness).context("serialize batch witness")?;
@@ -400,7 +391,7 @@ async fn generate_input(args: GenerateInputArgs) -> Result<()> {
     timings.record("output", started, ());
 
     let target_bytes = if let Some(target) = &args.target {
-        let started = start_phase("target prover");
+        let started = start_phase!("target_prover");
         let bytes = send_to_prover(target, &request, &output).await?;
         timings.record("target prover", started, ());
         Some(bytes)

--- a/bin/prover/utils/src/main.rs
+++ b/bin/prover/utils/src/main.rs
@@ -194,7 +194,18 @@ fn init_tracing(filter: &str) -> Result<()> {
 }
 
 fn start_phase(name: &'static str) -> (Instant, Span) {
-    let span = info_span!("spf_stage", phase = name);
+    let span = match name {
+        "discovery" => info_span!("discovery"),
+        "batch extraction" => info_span!("batch_extraction"),
+        "initial checkpoint" => info_span!("initial_checkpoint"),
+        "Zone state witness" => info_span!("zone_state_witness"),
+        "Tempo state witness" => info_span!("tempo_state_witness"),
+        "Tempo ancestry" => info_span!("tempo_ancestry"),
+        "SPF validation" => info_span!("spf_validation"),
+        "output" => info_span!("output"),
+        "target prover" => info_span!("target_prover"),
+        _ => unreachable!("unknown SPF phase: {name}"),
+    };
     span.in_scope(|| info!(phase = name, "starting phase"));
     (Instant::now(), span)
 }

--- a/bin/prover/utils/src/main.rs
+++ b/bin/prover/utils/src/main.rs
@@ -25,7 +25,7 @@ use tempo_zone_contracts::{
     ZONE_OUTBOX_ADDRESS, ZonePortal,
 };
 use tokio::net::TcpStream;
-use tracing::{debug, info};
+use tracing::{Span, debug, info, info_span};
 use tracing_subscriber::EnvFilter;
 use zone_chainspec::ZoneChainSpec;
 use zone_precompiles::tempo_state::slots as tempo_state_slots;
@@ -126,13 +126,16 @@ struct GenerateInputArgs {
 struct Timings(Vec<(&'static str, Duration)>);
 
 impl Timings {
-    fn record<T>(&mut self, name: &'static str, started: Instant, value: T) -> T {
+    fn record<T>(&mut self, name: &'static str, phase: (Instant, Span), value: T) -> T {
+        let (started, span) = phase;
         let elapsed = started.elapsed();
-        info!(
-            phase = name,
-            elapsed_ms = elapsed.as_millis(),
-            "phase complete"
-        );
+        span.in_scope(|| {
+            info!(
+                phase = name,
+                elapsed_ms = elapsed.as_millis(),
+                "phase complete"
+            );
+        });
         self.0.push((name, elapsed));
         value
     }
@@ -190,9 +193,10 @@ fn init_tracing(filter: &str) -> Result<()> {
         .map_err(|error| eyre!("initialize tracing: {error}"))
 }
 
-fn start_phase(name: &'static str) -> Instant {
-    info!(phase = name, "starting phase");
-    Instant::now()
+fn start_phase(name: &'static str) -> (Instant, Span) {
+    let span = info_span!("spf_stage", phase = name);
+    span.in_scope(|| info!(phase = name, "starting phase"));
+    (Instant::now(), span)
 }
 
 async fn generate_input(args: GenerateInputArgs) -> Result<()> {

--- a/crates/sequencer/src/prover.rs
+++ b/crates/sequencer/src/prover.rs
@@ -26,7 +26,7 @@ use tokio::{
     net::TcpStream,
     sync::mpsc::{self, error::TrySendError},
 };
-use tracing::{debug, error, info};
+use tracing::{Instrument as _, debug, error, info, info_span};
 use zone_chainspec::ZoneChainSpec;
 use zone_l1::TempoStateExt as _;
 use zone_prover::{
@@ -85,6 +85,7 @@ struct ProverJob {
     to: u64,
     batch: BatchData,
     enqueued_at: Instant,
+    queue_span: Option<tracing::Span>,
 }
 
 #[derive(Debug)]
@@ -141,12 +142,23 @@ pub(crate) fn spawn_shadow_prover<P: ZoneSequencerProvider>(
     let metrics = ProverMetrics::default();
 
     tokio::spawn(async move {
-        while let Some(job) = receiver.recv().await {
+        while let Some(mut job) = receiver.recv().await {
             metrics
                 .queue_duration_seconds
                 .record(job.enqueued_at.elapsed().as_secs_f64());
+            if let Some(span) = job.queue_span.take() {
+                span.in_scope(|| debug!("Prover job dequeued"));
+            }
             let started = Instant::now();
-            let result = validate_candidate(&context, &job, &metrics).await;
+            let result = validate_candidate(&context, &job, &metrics)
+                .instrument(info_span!(
+                    "prover_validation",
+                    zone_from = job.from,
+                    zone_to = job.to,
+                    prev_block_hash = %job.batch.prev_block_hash,
+                    next_block_hash = %job.batch.next_block_hash,
+                ))
+                .await;
             metrics
                 .validation_duration_seconds
                 .record(started.elapsed().as_secs_f64());
@@ -196,11 +208,19 @@ pub(crate) fn spawn_shadow_prover<P: ZoneSequencerProvider>(
 impl ShadowProver {
     /// Queue a candidate without waiting for validation or queue capacity.
     pub(crate) fn try_enqueue(&self, from: u64, to: u64, batch: BatchData) {
+        let queue_span = info_span!(
+            "prover_queue",
+            zone_from = from,
+            zone_to = to,
+            prev_block_hash = %batch.prev_block_hash,
+            next_block_hash = %batch.next_block_hash,
+        );
         if let Err(err) = self.sender.try_send(ProverJob {
             from,
             to,
             batch: batch.clone(),
             enqueued_at: Instant::now(),
+            queue_span: Some(queue_span),
         }) {
             error!(
                 target: "zone::sequencer::prover",
@@ -252,6 +272,7 @@ async fn validate_candidate<P: ZoneSequencerProvider>(
             expected_next_hash,
         )
     })
+    .instrument(info_span!("zone_inputs"))
     .await
     .context("Zone input worker panicked")??;
     metrics
@@ -260,7 +281,9 @@ async fn validate_candidate<P: ZoneSequencerProvider>(
 
     let started = Instant::now();
     let (zone_state_witness, tempo_reads) =
-        zone_witnesses(context.config.debug_api.as_ref(), from, to).await?;
+        zone_witnesses(context.config.debug_api.as_ref(), from, to)
+            .instrument(info_span!("zone_witness"))
+            .await?;
     metrics
         .zone_witness_duration_seconds
         .record(started.elapsed().as_secs_f64());
@@ -301,6 +324,7 @@ async fn validate_candidate<P: ZoneSequencerProvider>(
         .await?;
         Ok::<_, eyre::Report>((initial_tempo_header, final_tempo_header, anchor))
     }
+    .instrument(info_span!("tempo_headers"))
     .await?;
     metrics
         .tempo_headers_duration_seconds
@@ -311,6 +335,7 @@ async fn validate_candidate<P: ZoneSequencerProvider>(
         let reads = collect_l1_reads(tempo_reads, &zone_inputs.checkpoint_by_zone_block)?;
         tempo_state_witness(&context.l1_provider, &initial_tempo_header, reads).await
     }
+    .instrument(info_span!("tempo_witness"))
     .await?;
     metrics
         .tempo_witness_duration_seconds
@@ -333,29 +358,34 @@ async fn validate_candidate<P: ZoneSequencerProvider>(
     };
 
     let started = Instant::now();
-    let output = if let Some(address) = &context.config.prover_address {
-        verify_remotely(
-            address,
-            context.config.parent_chain_id,
-            context.config.zone_id,
-            job,
-            &witness,
-        )
-        .await?
-    } else {
-        let spf_config = SpfConfig::new(context.config.chain_spec.clone(), context.portal);
-        let attempt = witness.clone();
-        tokio::task::spawn_blocking(move || prove_zone_batch(&spf_config, attempt))
+    let output = async {
+        if let Some(address) = &context.config.prover_address {
+            verify_remotely(
+                address,
+                context.config.parent_chain_id,
+                context.config.zone_id,
+                job,
+                &witness,
+            )
             .await
-            .context("SPF worker panicked")?
-            .context("SPF rejected generated witness")?
-    };
+        } else {
+            let spf_config = SpfConfig::new(context.config.chain_spec.clone(), context.portal);
+            let attempt = witness.clone();
+            tokio::task::spawn_blocking(move || prove_zone_batch(&spf_config, attempt))
+                .await
+                .context("SPF worker panicked")?
+                .context("SPF rejected generated witness")
+        }
+    }
+    .instrument(info_span!("spf_execution"))
+    .await?;
     metrics
         .spf_execution_duration_seconds
         .record(started.elapsed().as_secs_f64());
 
     let started = Instant::now();
-    compare_output(&output, &job.batch, witness.parent_header.hash_slow())?;
+    info_span!("output_validation")
+        .in_scope(|| compare_output(&output, &job.batch, witness.parent_header.hash_slow()))?;
     metrics
         .output_validation_duration_seconds
         .record(started.elapsed().as_secs_f64());


### PR DESCRIPTION
## Summary
- emit tracing spans for every SPF utility timing phase
- trace shadow-prover queueing, validation, and metric-aligned execution stages
- attach batch identifiers to queue and validation spans

## Validation
- `cargo +nightly fmt --all`
- `cargo check -p zone-sequencer -p tempo-zone-prover-utils`
- `cargo +nightly clippy -p zone-sequencer -p tempo-zone-prover-utils --all-targets`

Prompted by: @shekhirin