### PR TITLE
fix(checker): address Cyclops audit

### DIFF
--- a/crates/checker/src/adapter/mod.rs
+++ b/crates/checker/src/adapter/mod.rs
@@ -68,7 +68,10 @@ pub(crate) fn adapt(o: &AuthenticatedObservation) -> Result<AuthenticatedBlock, 
         return Err(AdapterFindingCode::HeaderSequence
             .failure("advanceTempo requires exactly one Tempo observation"));
     }
-    let observation = &o.l1[0];
+    let observation = o.l1.first().ok_or_else(|| {
+        AdapterFindingCode::HeaderSequence
+            .failure("advanceTempo requires exactly one Tempo observation")
+    })?;
     let ImportedAdaptation {
         facts: imported_facts,
         effects: mut imported_effects,

--- a/crates/checker/src/adapter/tempo/mod.rs
+++ b/crates/checker/src/adapter/tempo/mod.rs
@@ -69,15 +69,6 @@ pub(super) fn facts(
                 }));
                 continue;
             }
-            if direct_call.is_known_ignored_state_change() {
-                let Some(L1ProtocolEvent::KnownIgnored) = all_events.get(event_cursor).copied()
-                else {
-                    return Err(AdapterFindingCode::Grammar
-                        .failure("Portal state update is not followed by its event"));
-                };
-                event_cursor += 1;
-                continue;
-            }
             if direct_call.is_deposit() {
                 let Some(L1ProtocolEvent::Portal(Portal::ZonePortalEvents::DepositMade(event))) =
                     all_events.get(event_cursor).copied()

--- a/crates/checker/src/adapter/tempo/mod.rs
+++ b/crates/checker/src/adapter/tempo/mod.rs
@@ -33,6 +33,91 @@ pub(super) fn facts(
         let all_events: Vec<_> = tx.outcomes().iter().map(|x| x.event()).collect();
         let mut event_cursor = 0;
         for direct_call in tx.direct_calls() {
+            if let Some(call) = direct_call.as_set_bounceback_gas() {
+                let Some(L1ProtocolEvent::Portal(Portal::ZonePortalEvents::BouncebackGasUpdated(
+                    event,
+                ))) = all_events.get(event_cursor).copied()
+                else {
+                    return Err(AdapterFindingCode::Grammar
+                        .failure("setBouncebackGas is not followed by BouncebackGasUpdated"));
+                };
+                if event.bouncebackGas != call.newBouncebackGas {
+                    return Err(AdapterFindingCode::Grammar
+                        .failure("setBouncebackGas result differs from calldata"));
+                }
+                event_cursor += 1;
+                operations.push(ImportedOperation::UpdateBouncebackGas(event.bouncebackGas));
+                continue;
+            }
+            if let Some(call) = direct_call.as_enable_token() {
+                let Some(L1ProtocolEvent::Portal(Portal::ZonePortalEvents::TokenEnabled(event))) =
+                    all_events.get(event_cursor).copied()
+                else {
+                    return Err(AdapterFindingCode::Grammar
+                        .failure("enableToken is not followed by TokenEnabled"));
+                };
+                if event.token != call.token {
+                    return Err(AdapterFindingCode::Grammar
+                        .failure("enableToken result differs from calldata"));
+                }
+                event_cursor += 1;
+                operations.push(ImportedOperation::EnableToken(TokenEnable {
+                    token: event.token,
+                    name: event.name.clone(),
+                    symbol: event.symbol.clone(),
+                    currency: event.currency.clone(),
+                }));
+                continue;
+            }
+            if direct_call.is_known_ignored_state_change() {
+                let Some(L1ProtocolEvent::KnownIgnored) = all_events.get(event_cursor).copied()
+                else {
+                    return Err(AdapterFindingCode::Grammar
+                        .failure("Portal state update is not followed by its event"));
+                };
+                event_cursor += 1;
+                continue;
+            }
+            if direct_call.is_deposit() {
+                let Some(L1ProtocolEvent::Portal(Portal::ZonePortalEvents::DepositMade(event))) =
+                    all_events.get(event_cursor).copied()
+                else {
+                    return Err(AdapterFindingCode::Grammar
+                        .failure("deposit is not followed by DepositMade"));
+                };
+                event_cursor += 1;
+                let deposit = ordinary_deposit_event(event, "deposit")?;
+                operations.push(ImportedOperation::AppendDeposit(deposit));
+                effects.push(Effect::DepositAppended {
+                    id: crate::kernel::DepositId::new(
+                        observation.portal_address(),
+                        event.depositNumber,
+                    )
+                    .ok_or_else(|| AdapterFindingCode::Grammar.failure("zero deposit number"))?,
+                    queue_hash: event.newCurrentDepositQueueHash,
+                });
+                continue;
+            }
+            if direct_call.is_claim_refund() {
+                let Some(L1ProtocolEvent::Portal(Portal::ZonePortalEvents::RefundClaimed(event))) =
+                    all_events.get(event_cursor).copied()
+                else {
+                    return Err(AdapterFindingCode::Grammar
+                        .failure("claimRefund is not followed by RefundClaimed"));
+                };
+                event_cursor += 1;
+                operations.push(ImportedOperation::ClaimPortalRefund(RefundClaim {
+                    token: event.token,
+                    recipient: event.recipient,
+                    amount: event.amount,
+                }));
+                effects.push(Effect::RefundClaimed {
+                    token: event.token,
+                    recipient: event.recipient,
+                    amount: event.amount,
+                });
+                continue;
+            }
             if let Some(call) = direct_call.as_submit_batch() {
                 let Some(L1ProtocolEvent::Portal(Portal::ZonePortalEvents::BatchSubmitted(event))) =
                     all_events.get(event_cursor).copied()

--- a/crates/checker/src/bootstrap/creation.rs
+++ b/crates/checker/src/bootstrap/creation.rs
@@ -21,39 +21,43 @@ const LOG_QUERY_BLOCKS: u64 = 10_000;
 pub(super) struct Creation {
     pub(super) header: ImportedTempoHeader,
     pub(super) observation: L1BlockObservation,
+    pub(super) identity: PortalIdentity,
 }
 
 /// Locate the unique ZoneFactory event matching Zone genesis and authenticate its block.
 pub(super) async fn discover_creation(
     provider: &DynProvider<TempoNetwork>,
-    expected: PortalIdentity,
+    portal: alloy_primitives::Address,
+    zone_id: u32,
 ) -> eyre::Result<Creation> {
     let head = provider.get_block_number().await?;
-    let candidates = creation_candidates(provider, expected, 0, head).await?;
+    let candidates = creation_candidates(provider, portal, zone_id, 0, head).await?;
     let [candidate] = candidates.as_slice() else {
         return Err(BootstrapError::CreationCandidates {
-            portal: expected.portal,
-            zone_id: expected.zone_id,
+            portal,
+            zone_id,
             count: candidates.len(),
         }
         .into());
     };
     let header = acquire_l1_header(provider, *candidate).await?;
-    let observation = observe_l1(provider, &header, expected.portal).await?;
-    let facts = adapt_imported(&observation, &header, header.hash(), expected.zone_id)
+    let observation = observe_l1(provider, &header, portal).await?;
+    let facts = adapt_imported(&observation, &header, header.hash(), zone_id)
         .map_err(|failure| eyre::eyre!(failure.message))?
         .facts;
-    validate_creation(&facts.operations, expected)?;
+    let identity = validate_creation(&facts.operations, portal, zone_id)?;
     Ok(Creation {
         header,
         observation,
+        identity,
     })
 }
 
 /// Find canonical factory-log candidates in one inclusive Tempo block range.
 async fn creation_candidates(
     provider: &DynProvider<TempoNetwork>,
-    expected: PortalIdentity,
+    portal: alloy_primitives::Address,
+    zone_id: u32,
     from: u64,
     to: u64,
 ) -> eyre::Result<Vec<B256>> {
@@ -64,8 +68,8 @@ async fn creation_candidates(
         let filter = Filter::new()
             .address(ZONE_FACTORY_ADDRESS)
             .event_signature(ZoneFactory::ZoneCreated::SIGNATURE_HASH)
-            .topic1(B256::from(U256::from(expected.zone_id)))
-            .topic2(expected.portal.into_word())
+            .topic1(B256::from(U256::from(zone_id)))
+            .topic2(portal.into_word())
             .from_block(start)
             .to_block(end);
         hashes.extend(
@@ -92,8 +96,9 @@ async fn creation_candidates(
 /// Validate the authenticated Portal creation operation against Zone genesis.
 fn validate_creation(
     operations: &[ImportedOperation],
-    expected: PortalIdentity,
-) -> eyre::Result<()> {
+    portal: alloy_primitives::Address,
+    zone_id: u32,
+) -> eyre::Result<PortalIdentity> {
     let mut creations = operations.iter().filter_map(|operation| match operation {
         ImportedOperation::Create {
             identity,
@@ -107,10 +112,13 @@ fn validate_creation(
     if creations.next().is_some() {
         eyre::bail!("creation block contains multiple portal creation operations");
     }
-    if *identity != expected || initial_token.token != expected.initial_token {
+    if identity.portal != portal
+        || identity.zone_id != zone_id
+        || initial_token.token != identity.initial_token
+    {
         eyre::bail!("creation identity does not match Zone genesis");
     }
-    Ok(())
+    Ok(*identity)
 }
 
 #[cfg(test)]
@@ -143,14 +151,25 @@ mod tests {
     #[test]
     fn creation_requires_one_matching_operation() {
         let expected = identity();
-        assert!(validate_creation(&[creation(expected)], expected).is_ok());
-        assert!(validate_creation(&[], expected).is_err());
+        assert!(
+            validate_creation(&[creation(expected)], expected.portal, expected.zone_id).is_ok()
+        );
+        assert!(validate_creation(&[], expected.portal, expected.zone_id).is_err());
 
         let mut mismatched = expected;
         mismatched.zone_id += 1;
-        assert!(validate_creation(&[creation(mismatched)], expected).is_err());
+        assert!(
+            validate_creation(&[creation(mismatched)], expected.portal, expected.zone_id).is_err()
+        );
 
-        assert!(validate_creation(&[creation(expected), creation(expected)], expected).is_err());
+        assert!(
+            validate_creation(
+                &[creation(expected), creation(expected)],
+                expected.portal,
+                expected.zone_id
+            )
+            .is_err()
+        );
     }
 
     #[test]
@@ -168,6 +187,6 @@ mod tests {
             ImportedOperation::UpdateBouncebackGas(42),
         ];
 
-        assert!(validate_creation(&operations, expected).is_ok());
+        assert!(validate_creation(&operations, expected.portal, expected.zone_id).is_ok());
     }
 }

--- a/crates/checker/src/bootstrap/mod.rs
+++ b/crates/checker/src/bootstrap/mod.rs
@@ -5,7 +5,7 @@ mod creation;
 mod error;
 mod zone_genesis;
 
-use crate::kernel::{PortalIdentity, State, apply_genesis_handoff};
+use crate::kernel::{State, apply_genesis_handoff};
 use alloy_eips::BlockNumHash;
 use alloy_provider::{Provider as _, ProviderBuilder};
 use reth_storage_api::{BlockNumReader, StateProviderFactory};
@@ -39,16 +39,12 @@ where
     let l1_chain_id = l1_provider.get_chain_id().await?;
     let LocalZoneIdentity {
         genesis,
-        initial_token,
+        default_fee_token,
     } = LocalZoneIdentity::load(&config, l1_chain_id, zone_chain_id, zone_provider)?;
     let anchor = genesis_anchor(zone_provider, genesis)?;
     let anchor_header = anchor_header(&l1_provider, anchor).await?;
-    let expected_identity = PortalIdentity {
-        portal: config.portal_address,
-        zone_id: config.zone_id,
-        initial_token,
-    };
-    let creation = discover_creation(&l1_provider, expected_identity).await?;
+    let creation = discover_creation(&l1_provider, config.portal_address, config.zone_id).await?;
+    let expected_identity = creation.identity;
     let creation_tip = BlockNumHash::new(creation.header.number(), creation.header.hash());
 
     // Authenticate and replay Tempo history into the Zone genesis state.
@@ -82,7 +78,7 @@ where
         state.apply(&apply_genesis_handoff(&state)?)?;
     } else {
         authenticated_path(&l1_provider, &anchor_header, creation.header.clone()).await?;
-        validate_zero_supply(zone_provider, genesis.hash, [initial_token])?;
+        validate_zero_supply(zone_provider, genesis.hash, [default_fee_token])?;
     }
 
     let identity = Identity {

--- a/crates/checker/src/bootstrap/zone_genesis.rs
+++ b/crates/checker/src/bootstrap/zone_genesis.rs
@@ -14,7 +14,7 @@ const GENESIS_BLOCK: u64 = 0;
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub(super) struct LocalZoneIdentity {
     pub(super) genesis: BlockNumHash,
-    pub(super) initial_token: Address,
+    pub(super) default_fee_token: Address,
 }
 
 impl LocalZoneIdentity {
@@ -49,13 +49,13 @@ impl LocalZoneIdentity {
             .ok_or(BootstrapError::MissingLocalCanonical {
                 number: GENESIS_BLOCK,
             })?;
-        let initial_token = acquire_zone_post_state(provider, hash, &[])?.default_fee_token;
-        if initial_token.is_zero() {
+        let default_fee_token = acquire_zone_post_state(provider, hash, &[])?.default_fee_token;
+        if default_fee_token.is_zero() {
             return Err(BootstrapError::MissingZoneGenesisInitialToken.into());
         }
         Ok(Self {
             genesis: BlockNumHash::new(GENESIS_BLOCK, hash),
-            initial_token,
+            default_fee_token,
         })
     }
 }

--- a/crates/checker/src/exex.rs
+++ b/crates/checker/src/exex.rs
@@ -38,6 +38,8 @@ use crate::{
     },
 };
 
+const MAX_RECLAMATION_LAG_BLOCKS: u64 = 16_384;
+
 /// Run the checker ExEx without allowing checker-local failures to finish it.
 pub(super) async fn run<Node>(config: CheckerConfig, mut ctx: ExExContext<Node>) -> eyre::Result<()>
 where
@@ -357,12 +359,21 @@ where
     P: BlockHashReader + BlockNumReader + ?Sized,
 {
     if let Some(verified) = refresh_canonical_head(runtime, store, provider)? {
-        let finished = if matches!(runtime.snapshot().meta.coverage, Coverage::Gap { .. }) {
-            canonical_head(provider)?
+        let canonical = canonical_head(provider)?;
+        let release_canonical = runtime.snapshot().meta.blocked.is_some()
+            || matches!(runtime.snapshot().meta.coverage, Coverage::Gap { .. });
+        let retry_lag_exceeded = runtime.is_retrying()
+            && canonical.number.saturating_sub(verified.number) >= MAX_RECLAMATION_LAG_BLOCKS;
+        if retry_lag_exceeded {
+            runtime.block(store, CheckerBlockedReason::AcquisitionLagExceeded)?;
+        }
+        let finished = if release_canonical || retry_lag_exceeded {
+            canonical
         } else {
             verified
         };
         ctx.send_finished_height(finished.into())?;
+        runtime.publish_reclamation_height(finished);
     }
     Ok(())
 }
@@ -458,15 +469,15 @@ where
                 else {
                     continue;
                 };
-                if let Some(verified) = runtime.complete_authentication(
+                runtime.complete_authentication(
                     store,
                     identity,
                     request,
                     result,
                     Instant::now(),
-                )? {
-                    ctx.send_finished_height(verified.into())?;
-                }
+                )?;
+                let provider = ctx.provider().clone();
+                refresh_and_publish_canonical_head(ctx, runtime, store, &provider)?;
                 continue;
             }
             RuntimeAction::RetryAt(deadline) => {

--- a/crates/checker/src/exex.rs
+++ b/crates/checker/src/exex.rs
@@ -32,7 +32,7 @@ use crate::{
         L2BlockObservation, ZonePostStateOutputs, acquire_portal_token_balance,
         acquire_zone_post_state, observe_l1_range, observe_l2_block_with_context,
     },
-    persistence::{BlockNumHash, Identity, Persistence, Snapshot},
+    persistence::{BlockNumHash, Coverage, Identity, Persistence, Snapshot},
     runtime::{
         AuthenticatedBlock, AuthenticationFailure, AuthenticationRequest, Runtime, RuntimeAction,
     },
@@ -357,7 +357,12 @@ where
     P: BlockHashReader + BlockNumReader + ?Sized,
 {
     if let Some(verified) = refresh_canonical_head(runtime, store, provider)? {
-        ctx.send_finished_height(verified.into())?;
+        let finished = if matches!(runtime.snapshot().meta.coverage, Coverage::Gap { .. }) {
+            canonical_head(provider)?
+        } else {
+            verified
+        };
+        ctx.send_finished_height(finished.into())?;
     }
     Ok(())
 }

--- a/crates/checker/src/inspection.rs
+++ b/crates/checker/src/inspection.rs
@@ -24,6 +24,8 @@ pub struct CheckerSnapshot {
     pub recovering: bool,
     /// Whether an authenticated divergence remains on the canonical branch.
     pub active_finding: bool,
+    /// Number of divergences that were later removed from the canonical branch.
+    pub cleared_findings: u64,
     /// Whether descendants are durably marked as unchecked.
     pub has_coverage_gap: bool,
     /// Durable reason verification cannot resume automatically.
@@ -43,6 +45,7 @@ pub fn inspect_database(path: impl AsRef<Path>) -> eyre::Result<CheckerSnapshot>
         observed_zone_tip: snapshot.meta.observed_zone_tip.into(),
         recovering: matches!(snapshot.meta.coverage, Coverage::Recovering),
         active_finding: snapshot.meta.active_finding.is_some(),
+        cleared_findings: snapshot.meta.cleared_findings,
         has_coverage_gap: matches!(snapshot.meta.coverage, Coverage::Gap { .. }),
         blocked_reason: snapshot.meta.blocked,
     })

--- a/crates/checker/src/inspection.rs
+++ b/crates/checker/src/inspection.rs
@@ -26,10 +26,20 @@ pub struct CheckerSnapshot {
     pub active_finding: bool,
     /// Number of divergences that were later removed from the canonical branch.
     pub cleared_findings: u64,
+    /// Key of the most recently reorg-cleared finding retained in the database.
+    pub last_cleared_finding: Option<CheckerFindingKey>,
     /// Whether descendants are durably marked as unchecked.
     pub has_coverage_gap: bool,
     /// Durable reason verification cannot resume automatically.
     pub blocked_reason: Option<CheckerBlockedReason>,
+}
+
+/// Stable operator-readable key for retained finding evidence.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct CheckerFindingKey {
+    pub zone: BlockNumHash,
+    pub operation: u32,
+    pub code: u16,
 }
 
 /// Inspect a stopped checker database or a consistent copy.
@@ -46,6 +56,14 @@ pub fn inspect_database(path: impl AsRef<Path>) -> eyre::Result<CheckerSnapshot>
         recovering: matches!(snapshot.meta.coverage, Coverage::Recovering),
         active_finding: snapshot.meta.active_finding.is_some(),
         cleared_findings: snapshot.meta.cleared_findings,
+        last_cleared_finding: snapshot
+            .meta
+            .last_cleared_finding
+            .map(|key| CheckerFindingKey {
+                zone: key.zone.into(),
+                operation: key.operation,
+                code: key.code,
+            }),
         has_coverage_gap: matches!(snapshot.meta.coverage, Coverage::Gap { .. }),
         blocked_reason: snapshot.meta.blocked,
     })

--- a/crates/checker/src/kernel/invariants/batches.rs
+++ b/crates/checker/src/kernel/invariants/batches.rs
@@ -422,7 +422,7 @@ impl<'a> BatchValidator<'a> {
         {
             let advance = self.settlement.batch_index - previous.index;
             let zone_advance = u64::try_from(self.settlement.zone_height)
-                .unwrap()
+                .map_err(|_| self.batch_error(StateKey::Portal))?
                 .saturating_sub(previous.zone_height);
             let tempo_advance = self
                 .settlement

--- a/crates/checker/src/kernel/invariants/ownership.rs
+++ b/crates/checker/src/kernel/invariants/ownership.rs
@@ -124,11 +124,11 @@ impl<'a> OwnershipValidator<'a> {
             amount,
         }) = value
         else {
-            unreachable!("called only for bounce-back deposits")
+            return Err(violation(InvariantCode::OwnerLink, Some(key)));
         };
         let fallback =
             crate::kernel::state::FallbackId::new(withdrawal.zone_id, fallback_nonce.get())
-                .expect("stored fallback nonce is nonzero");
+                .ok_or_else(|| violation(InvariantCode::OwnerLink, Some(key)))?;
         let linked = matches!(
             self.state.rows().get(&StateKey::Fallback(fallback)),
             Some(StateValue::Fallback(FallbackState::Queued {

--- a/crates/checker/src/kernel/state.rs
+++ b/crates/checker/src/kernel/state.rs
@@ -370,6 +370,40 @@ impl State {
     }
 
     #[cfg(test)]
+    pub(crate) fn with_pending_withdrawals_for_test(
+        identity: PortalIdentity,
+        count: u64,
+        callback_size: usize,
+    ) -> Self {
+        let mut state = Self::awaiting(identity);
+        for index in 1..=count {
+            let withdrawal = WithdrawalId {
+                zone_id: identity.zone_id,
+                index,
+            };
+            state.rows.insert(
+                StateKey::Withdrawal(withdrawal),
+                StateValue::Withdrawal(WithdrawalOwner::PendingUser {
+                    data: Withdrawal {
+                        token: identity.initial_token,
+                        sender_tag: B256::from(U256::from(index)),
+                        to: Address::repeat_byte(1),
+                        amount: 1,
+                        memo: B256::ZERO,
+                        gas_limit: 1,
+                        fallback_nonce: index,
+                        callback_data: Bytes::from(vec![0; callback_size]),
+                        encrypted_sender: Bytes::new(),
+                    },
+                    fallback: FallbackId::new(identity.zone_id, index)
+                        .expect("test index is nonzero"),
+                }),
+            );
+        }
+        state
+    }
+
+    #[cfg(test)]
     pub(super) fn from_rows(
         rows: BTreeMap<StateKey, StateValue>,
     ) -> Result<Self, StateFamilyError> {

--- a/crates/checker/src/kernel/transition/tempo.rs
+++ b/crates/checker/src/kernel/transition/tempo.rs
@@ -66,7 +66,7 @@ pub(crate) fn apply_imported(
     let mut state = parent.clone();
     state
         .apply(&delta)
-        .expect("transition creates matching state row families");
+        .map_err(|_| TransitionError::CorruptState)?;
     Ok(ImportedCandidate {
         state,
         effects,

--- a/crates/checker/src/lib.rs
+++ b/crates/checker/src/lib.rs
@@ -36,6 +36,8 @@ pub enum CheckerBlockedReason {
     InvalidAuthenticatedData,
     /// A Zone reorg precedes the locally retained checker history.
     DeepReorgBeyondRetention,
+    /// Acquisition lag exceeded the bounded ExEx journal retention policy.
+    AcquisitionLagExceeded,
 }
 
 impl fmt::Display for CheckerBlockedReason {
@@ -45,6 +47,7 @@ impl fmt::Display for CheckerBlockedReason {
             Self::TempoChainMismatch => "Tempo chain mismatch",
             Self::InvalidAuthenticatedData => "invalid authenticated data",
             Self::DeepReorgBeyondRetention => "reorg exceeds retained checker history",
+            Self::AcquisitionLagExceeded => "acquisition lag exceeds retention bound",
         };
         f.write_str(reason)
     }

--- a/crates/checker/src/metrics.rs
+++ b/crates/checker/src/metrics.rs
@@ -41,6 +41,10 @@ pub(crate) struct CheckerMetrics {
     recovering: Gauge,
     /// Whether a durable terminal condition prevents verification.
     blocked: Gauge,
+    /// ExEx height released for WAL reclamation.
+    reclamation_height: Gauge,
+    /// Whether WAL reclamation is ahead of semantic verification.
+    reclamation_ahead: Gauge,
 }
 
 impl CheckerMetrics {
@@ -105,6 +109,12 @@ impl CheckerMetrics {
     /// Record a Zone block whose checker transition committed durably.
     pub(crate) fn record_verified_block(&self) {
         self.verified_zone_blocks_total.increment(1);
+    }
+
+    pub(crate) fn publish_reclamation_height(&self, verified: u64, reclamation: u64) {
+        self.reclamation_height.set(reclamation as f64);
+        self.reclamation_ahead
+            .set(f64::from(reclamation > verified));
     }
 }
 

--- a/crates/checker/src/metrics.rs
+++ b/crates/checker/src/metrics.rs
@@ -33,6 +33,8 @@ pub(crate) struct CheckerMetrics {
     verification_lag_blocks: Gauge,
     /// Whether an authenticated divergence remains on the canonical branch.
     divergence_active: Gauge,
+    /// Number of durable findings subsequently cleared by canonical reorgs.
+    cleared_findings_total: Gauge,
     /// Whether descendants are durably marked as unchecked.
     coverage_gap: Gauge,
     /// Whether canonical Zone history remains to be verified.
@@ -69,6 +71,8 @@ impl CheckerMetrics {
         );
         self.divergence_active
             .set(f64::from(meta.active_finding.is_some()));
+        self.cleared_findings_total
+            .set(meta.cleared_findings as f64);
         self.coverage_gap
             .set(f64::from(matches!(meta.coverage, Coverage::Gap { .. })));
         self.recovering

--- a/crates/checker/src/observe/abi/mod.rs
+++ b/crates/checker/src/observe/abi/mod.rs
@@ -176,6 +176,11 @@ pub(crate) struct DecodedPortalCall {
 enum DecodedPortalCallKind {
     SubmitBatch(Box<ZonePortal::submitBatchCall>),
     ProcessWithdrawals(ZonePortal::processWithdrawalsCall),
+    SetBouncebackGas(ZonePortal::setBouncebackGasCall),
+    EnableToken(ZonePortal::enableTokenCall),
+    KnownIgnoredStateChange,
+    Deposit,
+    ClaimRefund,
 }
 
 impl DecodedPortalCall {
@@ -183,6 +188,11 @@ impl DecodedPortalCall {
         match &self.kind {
             DecodedPortalCallKind::SubmitBatch(call) => Some(call),
             DecodedPortalCallKind::ProcessWithdrawals(_) => None,
+            DecodedPortalCallKind::SetBouncebackGas(_) => None,
+            DecodedPortalCallKind::EnableToken(_) => None,
+            DecodedPortalCallKind::KnownIgnoredStateChange
+            | DecodedPortalCallKind::Deposit
+            | DecodedPortalCallKind::ClaimRefund => None,
         }
     }
 
@@ -190,7 +200,48 @@ impl DecodedPortalCall {
         match &self.kind {
             DecodedPortalCallKind::ProcessWithdrawals(call) => Some(call),
             DecodedPortalCallKind::SubmitBatch(_) => None,
+            DecodedPortalCallKind::SetBouncebackGas(_) => None,
+            DecodedPortalCallKind::EnableToken(_) => None,
+            DecodedPortalCallKind::KnownIgnoredStateChange
+            | DecodedPortalCallKind::Deposit
+            | DecodedPortalCallKind::ClaimRefund => None,
         }
+    }
+
+    pub(crate) fn as_set_bounceback_gas(&self) -> Option<&ZonePortal::setBouncebackGasCall> {
+        match &self.kind {
+            DecodedPortalCallKind::SetBouncebackGas(call) => Some(call),
+            DecodedPortalCallKind::SubmitBatch(_)
+            | DecodedPortalCallKind::ProcessWithdrawals(_)
+            | DecodedPortalCallKind::EnableToken(_)
+            | DecodedPortalCallKind::KnownIgnoredStateChange
+            | DecodedPortalCallKind::Deposit
+            | DecodedPortalCallKind::ClaimRefund => None,
+        }
+    }
+
+    pub(crate) fn as_enable_token(&self) -> Option<&ZonePortal::enableTokenCall> {
+        match &self.kind {
+            DecodedPortalCallKind::EnableToken(call) => Some(call),
+            DecodedPortalCallKind::SubmitBatch(_)
+            | DecodedPortalCallKind::ProcessWithdrawals(_)
+            | DecodedPortalCallKind::SetBouncebackGas(_)
+            | DecodedPortalCallKind::KnownIgnoredStateChange
+            | DecodedPortalCallKind::Deposit
+            | DecodedPortalCallKind::ClaimRefund => None,
+        }
+    }
+
+    pub(crate) const fn is_known_ignored_state_change(&self) -> bool {
+        matches!(self.kind, DecodedPortalCallKind::KnownIgnoredStateChange)
+    }
+
+    pub(crate) const fn is_deposit(&self) -> bool {
+        matches!(self.kind, DecodedPortalCallKind::Deposit)
+    }
+
+    pub(crate) const fn is_claim_refund(&self) -> bool {
+        matches!(self.kind, DecodedPortalCallKind::ClaimRefund)
     }
 
     pub(crate) fn is_nonempty_process_withdrawals(&self) -> bool {
@@ -202,6 +253,11 @@ impl DecodedPortalCall {
         match &self.kind {
             DecodedPortalCallKind::SubmitBatch(_) => PortalCallFamily::SubmitBatch,
             DecodedPortalCallKind::ProcessWithdrawals(_) => PortalCallFamily::ProcessWithdrawals,
+            DecodedPortalCallKind::SetBouncebackGas(_) => PortalCallFamily::StateUpdate,
+            DecodedPortalCallKind::EnableToken(_) => PortalCallFamily::StateUpdate,
+            DecodedPortalCallKind::KnownIgnoredStateChange
+            | DecodedPortalCallKind::Deposit
+            | DecodedPortalCallKind::ClaimRefund => PortalCallFamily::StateUpdate,
         }
     }
 }
@@ -492,7 +548,7 @@ pub(crate) fn decode_portal_call(
     parse_portal_call(calldata).map_err(|error| error.into_observation(transaction))
 }
 
-/// Parse a supported Portal call and reject oversized or non-canonical encodings.
+/// Parse a supported Portal call using the same trailing-byte tolerance as Solidity.
 fn parse_portal_call(calldata: &[u8]) -> Result<DecodedPortalCall, AbiError> {
     if calldata.starts_with(&ZonePortal::submitBatchCall::SELECTOR) {
         return decode_submit_batch(calldata);
@@ -500,35 +556,82 @@ fn parse_portal_call(calldata: &[u8]) -> Result<DecodedPortalCall, AbiError> {
     if calldata.starts_with(&ZonePortal::processWithdrawalsCall::SELECTOR) {
         return decode_process_withdrawals(calldata);
     }
+    if calldata.starts_with(&ZonePortal::setBouncebackGasCall::SELECTOR) {
+        let surface = Surface::new(DataSource::PortalTransactionCalldata, calldata);
+        let call = ZonePortal::setBouncebackGasCall::abi_decode_validate(calldata)
+            .map_err(|error| surface.malformed(error))?;
+        return Ok(DecodedPortalCall {
+            kind: DecodedPortalCallKind::SetBouncebackGas(call),
+        });
+    }
+    if calldata.starts_with(&ZonePortal::enableTokenCall::SELECTOR) {
+        let surface = Surface::new(DataSource::PortalTransactionCalldata, calldata);
+        let call = ZonePortal::enableTokenCall::abi_decode_validate(calldata)
+            .map_err(|error| surface.malformed(error))?;
+        return Ok(DecodedPortalCall {
+            kind: DecodedPortalCallKind::EnableToken(call),
+        });
+    }
+    let kind = if calldata.starts_with(&ZonePortal::depositCall::SELECTOR)
+        || calldata.starts_with(&ZonePortal::depositEncryptedCall::SELECTOR)
+    {
+        Some(DecodedPortalCallKind::Deposit)
+    } else if calldata.starts_with(&ZonePortal::claimRefundCall::SELECTOR) {
+        Some(DecodedPortalCallKind::ClaimRefund)
+    } else if is_known_ignored_state_change(calldata) {
+        Some(DecodedPortalCallKind::KnownIgnoredStateChange)
+    } else {
+        None
+    };
+    if let Some(kind) = kind {
+        return Ok(DecodedPortalCall { kind });
+    }
     Err(
         Surface::new(DataSource::PortalTransactionCalldata, calldata)
             .malformed("selector does not match its authenticated protocol events"),
     )
 }
 
-/// Preflight and decode canonical `submitBatch` calldata.
+pub(crate) fn is_direct_portal_state_change(calldata: &[u8]) -> bool {
+    calldata.starts_with(&ZonePortal::setBouncebackGasCall::SELECTOR)
+        || calldata.starts_with(&ZonePortal::enableTokenCall::SELECTOR)
+        || calldata.starts_with(&ZonePortal::depositCall::SELECTOR)
+        || calldata.starts_with(&ZonePortal::depositEncryptedCall::SELECTOR)
+        || calldata.starts_with(&ZonePortal::claimRefundCall::SELECTOR)
+        || is_known_ignored_state_change(calldata)
+}
+
+fn is_known_ignored_state_change(calldata: &[u8]) -> bool {
+    calldata.starts_with(&ZonePortal::pauseCall::SELECTOR)
+        || calldata.starts_with(&ZonePortal::resumeCall::SELECTOR)
+        || calldata.starts_with(&ZonePortal::abdicateCall::SELECTOR)
+        || calldata.starts_with(&ZonePortal::pauseDepositsCall::SELECTOR)
+        || calldata.starts_with(&ZonePortal::resumeDepositsCall::SELECTOR)
+        || calldata.starts_with(&ZonePortal::setZoneGasRateCall::SELECTOR)
+        || calldata.starts_with(&ZonePortal::setMaxTempoGasRateCall::SELECTOR)
+        || calldata.starts_with(&ZonePortal::transferAdminCall::SELECTOR)
+        || calldata.starts_with(&ZonePortal::acceptAdminCall::SELECTOR)
+        || calldata.starts_with(&ZonePortal::setRpcUrlCall::SELECTOR)
+        || calldata.starts_with(&ZonePortal::setSequencerEncryptionKeyCall::SELECTOR)
+}
+
+/// Preflight and decode chain-valid `submitBatch` calldata.
 fn decode_submit_batch(calldata: &[u8]) -> Result<DecodedPortalCall, AbiError> {
     let surface = Surface::new(DataSource::SubmitBatchCalldata, calldata);
     preflight_submit_batch(calldata)?;
     let call = ZonePortal::submitBatchCall::abi_decode_validate(calldata)
         .map_err(|error| surface.malformed(error))?;
-    if call.abi_encode() != calldata {
-        return Err(surface.malformed("encoding is non-canonical or has trailing bytes"));
-    }
     Ok(DecodedPortalCall {
         kind: DecodedPortalCallKind::SubmitBatch(Box::new(call)),
     })
 }
 
-/// Preflight and decode canonical `processWithdrawals` calldata.
+/// Preflight and decode chain-valid `processWithdrawals` calldata.
 fn decode_process_withdrawals(calldata: &[u8]) -> Result<DecodedPortalCall, AbiError> {
     let surface = Surface::new(DataSource::ProcessWithdrawalsCalldata, calldata);
     preflight_process_withdrawals(calldata)?;
     let call = ZonePortal::processWithdrawalsCall::abi_decode_validate(calldata)
         .map_err(|error| surface.malformed(error))?;
-    if call.abi_encode() != calldata {
-        return Err(surface.malformed("encoding is non-canonical or has trailing bytes"));
-    }
     Ok(DecodedPortalCall {
         kind: DecodedPortalCallKind::ProcessWithdrawals(call),
     })

--- a/crates/checker/src/observe/abi/mod.rs
+++ b/crates/checker/src/observe/abi/mod.rs
@@ -178,7 +178,6 @@ enum DecodedPortalCallKind {
     ProcessWithdrawals(ZonePortal::processWithdrawalsCall),
     SetBouncebackGas(ZonePortal::setBouncebackGasCall),
     EnableToken(ZonePortal::enableTokenCall),
-    KnownIgnoredStateChange,
     Deposit,
     ClaimRefund,
 }
@@ -190,9 +189,7 @@ impl DecodedPortalCall {
             DecodedPortalCallKind::ProcessWithdrawals(_) => None,
             DecodedPortalCallKind::SetBouncebackGas(_) => None,
             DecodedPortalCallKind::EnableToken(_) => None,
-            DecodedPortalCallKind::KnownIgnoredStateChange
-            | DecodedPortalCallKind::Deposit
-            | DecodedPortalCallKind::ClaimRefund => None,
+            DecodedPortalCallKind::Deposit | DecodedPortalCallKind::ClaimRefund => None,
         }
     }
 
@@ -202,9 +199,7 @@ impl DecodedPortalCall {
             DecodedPortalCallKind::SubmitBatch(_) => None,
             DecodedPortalCallKind::SetBouncebackGas(_) => None,
             DecodedPortalCallKind::EnableToken(_) => None,
-            DecodedPortalCallKind::KnownIgnoredStateChange
-            | DecodedPortalCallKind::Deposit
-            | DecodedPortalCallKind::ClaimRefund => None,
+            DecodedPortalCallKind::Deposit | DecodedPortalCallKind::ClaimRefund => None,
         }
     }
 
@@ -214,7 +209,6 @@ impl DecodedPortalCall {
             DecodedPortalCallKind::SubmitBatch(_)
             | DecodedPortalCallKind::ProcessWithdrawals(_)
             | DecodedPortalCallKind::EnableToken(_)
-            | DecodedPortalCallKind::KnownIgnoredStateChange
             | DecodedPortalCallKind::Deposit
             | DecodedPortalCallKind::ClaimRefund => None,
         }
@@ -226,14 +220,9 @@ impl DecodedPortalCall {
             DecodedPortalCallKind::SubmitBatch(_)
             | DecodedPortalCallKind::ProcessWithdrawals(_)
             | DecodedPortalCallKind::SetBouncebackGas(_)
-            | DecodedPortalCallKind::KnownIgnoredStateChange
             | DecodedPortalCallKind::Deposit
             | DecodedPortalCallKind::ClaimRefund => None,
         }
-    }
-
-    pub(crate) const fn is_known_ignored_state_change(&self) -> bool {
-        matches!(self.kind, DecodedPortalCallKind::KnownIgnoredStateChange)
     }
 
     pub(crate) const fn is_deposit(&self) -> bool {
@@ -255,9 +244,9 @@ impl DecodedPortalCall {
             DecodedPortalCallKind::ProcessWithdrawals(_) => PortalCallFamily::ProcessWithdrawals,
             DecodedPortalCallKind::SetBouncebackGas(_) => PortalCallFamily::StateUpdate,
             DecodedPortalCallKind::EnableToken(_) => PortalCallFamily::StateUpdate,
-            DecodedPortalCallKind::KnownIgnoredStateChange
-            | DecodedPortalCallKind::Deposit
-            | DecodedPortalCallKind::ClaimRefund => PortalCallFamily::StateUpdate,
+            DecodedPortalCallKind::Deposit | DecodedPortalCallKind::ClaimRefund => {
+                PortalCallFamily::StateUpdate
+            }
         }
     }
 }
@@ -578,8 +567,6 @@ fn parse_portal_call(calldata: &[u8]) -> Result<DecodedPortalCall, AbiError> {
         Some(DecodedPortalCallKind::Deposit)
     } else if calldata.starts_with(&ZonePortal::claimRefundCall::SELECTOR) {
         Some(DecodedPortalCallKind::ClaimRefund)
-    } else if is_known_ignored_state_change(calldata) {
-        Some(DecodedPortalCallKind::KnownIgnoredStateChange)
     } else {
         None
     };
@@ -598,21 +585,6 @@ pub(crate) fn is_direct_portal_state_change(calldata: &[u8]) -> bool {
         || calldata.starts_with(&ZonePortal::depositCall::SELECTOR)
         || calldata.starts_with(&ZonePortal::depositEncryptedCall::SELECTOR)
         || calldata.starts_with(&ZonePortal::claimRefundCall::SELECTOR)
-        || is_known_ignored_state_change(calldata)
-}
-
-fn is_known_ignored_state_change(calldata: &[u8]) -> bool {
-    calldata.starts_with(&ZonePortal::pauseCall::SELECTOR)
-        || calldata.starts_with(&ZonePortal::resumeCall::SELECTOR)
-        || calldata.starts_with(&ZonePortal::abdicateCall::SELECTOR)
-        || calldata.starts_with(&ZonePortal::pauseDepositsCall::SELECTOR)
-        || calldata.starts_with(&ZonePortal::resumeDepositsCall::SELECTOR)
-        || calldata.starts_with(&ZonePortal::setZoneGasRateCall::SELECTOR)
-        || calldata.starts_with(&ZonePortal::setMaxTempoGasRateCall::SELECTOR)
-        || calldata.starts_with(&ZonePortal::transferAdminCall::SELECTOR)
-        || calldata.starts_with(&ZonePortal::acceptAdminCall::SELECTOR)
-        || calldata.starts_with(&ZonePortal::setRpcUrlCall::SELECTOR)
-        || calldata.starts_with(&ZonePortal::setSequencerEncryptionKeyCall::SELECTOR)
 }
 
 /// Preflight and decode chain-valid `submitBatch` calldata.

--- a/crates/checker/src/observe/abi/tests.rs
+++ b/crates/checker/src/observe/abi/tests.rs
@@ -459,3 +459,23 @@ fn submit_batch_decodes_canonical_payload() {
     let call = submit_batch_call(vec![Bytes::from_static(b"signature")]);
     assert!(decode_portal(&call).unwrap().as_submit_batch().is_some());
 }
+
+#[test]
+fn portal_calls_accept_solidity_trailing_bytes() {
+    let mut batch = submit_batch_call(vec![Bytes::from_static(b"signature")]);
+    batch.extend_from_slice(&[0xde, 0xad, 0xbe, 0xef]);
+    assert!(decode_portal(&batch).unwrap().as_submit_batch().is_some());
+
+    let mut withdrawals = ZonePortal::processWithdrawalsCall {
+        withdrawals: Vec::new(),
+        remainingQueue: B256::ZERO,
+    }
+    .abi_encode();
+    withdrawals.extend_from_slice(&[0xde, 0xad, 0xbe, 0xef]);
+    assert!(
+        decode_portal(&withdrawals)
+            .unwrap()
+            .as_process_withdrawals()
+            .is_some()
+    );
+}

--- a/crates/checker/src/observe/error.rs
+++ b/crates/checker/src/observe/error.rs
@@ -238,6 +238,8 @@ pub(crate) enum PortalCallFamily {
     SubmitBatch,
     #[error("processWithdrawals")]
     ProcessWithdrawals,
+    #[error("state update")]
+    StateUpdate,
 }
 
 /// Reconciliation failures between Portal events and top-level calldata.

--- a/crates/checker/src/observe/l1/mod.rs
+++ b/crates/checker/src/observe/l1/mod.rs
@@ -13,7 +13,7 @@ use crate::observe::events::L1ProtocolEvent;
 
 use super::{
     abi::{DecodedPortalCall, ImportedTempoHeader},
-    error::ObservationError,
+    error::{AcquisitionError, AcquisitionSource, ObservationError},
 };
 
 mod acquisition;
@@ -107,8 +107,17 @@ where
         let direct_calls = if transaction.required_calls.is_empty() {
             Vec::new()
         } else {
-            let envelope: &tempo_primitives::TempoTxEnvelope =
-                block.transactions[transaction.transaction_index].as_ref();
+            let envelope: &tempo_primitives::TempoTxEnvelope = block
+                .transactions
+                .get(transaction.transaction_index)
+                .ok_or_else(|| {
+                    ObservationError::from(AcquisitionError::inconsistent(
+                        AcquisitionSource::L1Transaction,
+                        transaction.transaction_index.saturating_add(1),
+                        block.transactions.len(),
+                    ))
+                })?
+                .as_ref();
             portal::decode_direct_portal_calls(
                 envelope,
                 portal,

--- a/crates/checker/src/observe/l1/portal.rs
+++ b/crates/checker/src/observe/l1/portal.rs
@@ -6,7 +6,7 @@ use tempo_primitives::TempoTxEnvelope;
 use tempo_zone_contracts::ZonePortal;
 
 use super::super::{
-    abi::{DecodedPortalCall, decode_portal_call},
+    abi::{DecodedPortalCall, decode_portal_call, is_direct_portal_state_change},
     error::{
         AuthenticatedTransaction, ObservationError, PortalCallError, PortalCallFamily,
         ProtocolChain,
@@ -32,6 +32,10 @@ pub(super) fn decode_direct_portal_calls(
     let mut saw_empty_required_process = false;
     for (kind, calldata) in envelope.calls() {
         if kind != TxKind::Call(portal) {
+            continue;
+        }
+        if is_direct_portal_state_change(calldata) {
+            calls.push(decode_portal_call(calldata, coordinate)?);
             continue;
         }
         let family = if calldata.starts_with(&ZonePortal::submitBatchCall::SELECTOR) {

--- a/crates/checker/src/observe/l1/tests/observation.rs
+++ b/crates/checker/src/observe/l1/tests/observation.rs
@@ -52,6 +52,70 @@ async fn eventful_submit_batch_fetches_once_and_decodes_direct_calldata() {
 }
 
 #[tokio::test]
+async fn ignored_lifecycle_call_does_not_shift_modeled_multicall_events() {
+    let envelope = aa_calls(vec![
+        Call {
+            to: PORTAL.into(),
+            value: U256::ZERO,
+            input: ZonePortal::pauseCall {}.abi_encode().into(),
+        },
+        Call {
+            to: PORTAL.into(),
+            value: U256::ZERO,
+            input: ZonePortal::setBouncebackGasCall {
+                newBouncebackGas: 42,
+            }
+            .abi_encode()
+            .into(),
+        },
+        Call {
+            to: PORTAL.into(),
+            value: U256::ZERO,
+            input: submit_batch_calldata(),
+        },
+    ]);
+    let tx_hash = envelope.trie_hash();
+    let logs = vec![
+        event_log(
+            PORTAL,
+            ZonePortal::PortalPaused {
+                account: Address::repeat_byte(0xaa),
+            },
+            0,
+            0,
+        ),
+        event_log(
+            PORTAL,
+            ZonePortal::BouncebackGasUpdated { bouncebackGas: 42 },
+            0,
+            1,
+        ),
+        batch_submitted_log(0, 2),
+    ];
+    let (imported, receipts) = anchor_with_transactions(
+        vec![receipt(tx_hash, 0, true, logs)],
+        std::slice::from_ref(&envelope),
+    );
+    let block = block_response(&imported, vec![envelope]);
+    let asserter = Asserter::new();
+    asserter.push_success(&Some(block));
+    asserter.push_success(&Some(receipts));
+    let provider =
+        ProviderBuilder::new_with_network::<TempoNetwork>().connect_mocked_client(asserter);
+
+    let observed = observe_l1(&provider, &imported, PORTAL).await.unwrap();
+    let adaptation =
+        crate::adapter::adapt_imported(&observed, &imported, B256::repeat_byte(0xff), 7).unwrap();
+    assert!(matches!(
+        adaptation.facts.operations.as_slice(),
+        [
+            crate::kernel::ImportedOperation::UpdateBouncebackGas(42),
+            crate::kernel::ImportedOperation::SubmitBatch(_)
+        ]
+    ));
+}
+
+#[tokio::test]
 async fn eventful_process_withdrawals_fetches_once_and_retains_input_and_outcome() {
     let envelope = legacy_call(PORTAL, process_withdrawals_calldata(true));
     let tx_hash = envelope.trie_hash();

--- a/crates/checker/src/observe/l1/tests/observation.rs
+++ b/crates/checker/src/observe/l1/tests/observation.rs
@@ -169,7 +169,7 @@ async fn eventful_empty_process_withdrawals_fails_closed() {
 #[tokio::test]
 async fn eventful_malformed_direct_calldata_fails_closed() {
     let mut malformed = submit_batch_calldata().to_vec();
-    malformed.push(0);
+    malformed.pop();
     let evidence = AuthenticatedDataEvidence::from_bytes(&malformed);
     let envelope = legacy_call(PORTAL, malformed.into());
     let tx_hash = envelope.trie_hash();

--- a/crates/checker/src/observe/l1/tests/portal.rs
+++ b/crates/checker/src/observe/l1/tests/portal.rs
@@ -101,3 +101,47 @@ fn direct_portal_calls_tolerate_unrelated_aa_calls_and_preserve_order() {
     assert_eq!(calls[0].family(), PortalCallFamily::SubmitBatch);
     assert_eq!(calls[1].family(), PortalCallFamily::ProcessWithdrawals);
 }
+
+#[test]
+fn direct_portal_calls_retain_state_updates_between_checked_calls() {
+    let ordered = aa_calls(vec![
+        Call {
+            to: PORTAL.into(),
+            value: U256::ZERO,
+            input: submit_batch_calldata(),
+        },
+        Call {
+            to: PORTAL.into(),
+            value: U256::ZERO,
+            input: ZonePortal::setBouncebackGasCall {
+                newBouncebackGas: 42,
+            }
+            .abi_encode()
+            .into(),
+        },
+        Call {
+            to: PORTAL.into(),
+            value: U256::ZERO,
+            input: process_withdrawals_calldata(true),
+        },
+    ]);
+    let calls = l1_portal::decode_direct_portal_calls(
+        &ordered,
+        PORTAL,
+        0,
+        B256::ZERO,
+        &[
+            PortalCallFamily::SubmitBatch,
+            PortalCallFamily::ProcessWithdrawals,
+        ],
+    )
+    .unwrap();
+
+    assert_eq!(calls.len(), 3);
+    assert!(calls[0].as_submit_batch().is_some());
+    assert_eq!(
+        calls[1].as_set_bounceback_gas().unwrap().newBouncebackGas,
+        42
+    );
+    assert!(calls[2].as_process_withdrawals().is_some());
+}

--- a/crates/checker/src/observe/l1/tests/portal.rs
+++ b/crates/checker/src/observe/l1/tests/portal.rs
@@ -78,6 +78,11 @@ fn direct_portal_calls_tolerate_unrelated_aa_calls_and_preserve_order() {
         Call {
             to: PORTAL.into(),
             value: U256::ZERO,
+            input: ZonePortal::pauseCall {}.abi_encode().into(),
+        },
+        Call {
+            to: PORTAL.into(),
+            value: U256::ZERO,
             input: calldata,
         },
         Call {

--- a/crates/checker/src/observe/l2/mod.rs
+++ b/crates/checker/src/observe/l2/mod.rs
@@ -5,10 +5,11 @@ use alloy_consensus::{
 };
 use alloy_eips::BlockNumHash;
 use alloy_primitives::{Address, B256, Bloom};
+use alloy_sol_types::SolCall;
 use reth_primitives_traits::RecoveredBlock;
 use tempo_primitives::{Block, TempoReceipt, TempoTxEnvelope};
 
-use tempo_zone_contracts::{ZONE_INBOX_ADDRESS, ZONE_OUTBOX_ADDRESS};
+use tempo_zone_contracts::{IZoneInbox, ZONE_INBOX_ADDRESS, ZONE_OUTBOX_ADDRESS};
 
 use crate::observe::events::{L2ProtocolEvent, classify_l2_protocol_event};
 
@@ -212,15 +213,23 @@ pub(crate) fn observe_l2_block_with_context(
             ObservationError::invalid_envelope(0, EnvelopeRule::AdvanceSystemCaller).into(),
         );
     }
-    if first.to() != Some(ZONE_INBOX_ADDRESS) {
-        return Err(ObservationError::invalid_envelope(0, EnvelopeRule::AdvanceDestination).into());
+    let mut advance_calls = first.calls().filter_map(|(kind, input)| {
+        (kind.to() == Some(&ZONE_INBOX_ADDRESS)
+            && input.starts_with(&IZoneInbox::advanceTempoCall::SELECTOR))
+        .then_some(input)
+    });
+    let advance_calldata = advance_calls
+        .next()
+        .ok_or_else(|| ObservationError::invalid_envelope(0, EnvelopeRule::AdvanceDestination))?;
+    if advance_calls.next().is_some() {
+        return Err(ObservationError::invalid_envelope(0, EnvelopeRule::AdvancePresent).into());
     }
     if !receipts[0].status() {
         return Err(ObservationError::invalid_envelope(0, EnvelopeRule::AdvanceSuccess).into());
     }
     let advance_coordinate =
         AuthenticatedTransaction::new(ProtocolChain::ZoneL2, 0, *first.tx_hash());
-    let advance_tempo = decode_advance_tempo(first.input(), advance_coordinate)?;
+    let advance_tempo = decode_advance_tempo(advance_calldata, advance_coordinate)?;
     let imported_header = advance_tempo.imported_header();
     let imported_tempo = BlockNumHash::new(imported_header.number(), imported_header.hash());
 

--- a/crates/checker/src/observe/l2/tests/mod.rs
+++ b/crates/checker/src/observe/l2/tests/mod.rs
@@ -1,7 +1,7 @@
 use alloy_consensus::{Header, Sealable as _, SignableTransaction as _, Signed, TxLegacy};
 use alloy_primitives::{Address, B256, Bloom, Bytes, Log, LogData, Signature, U256, b256};
 use alloy_rlp::Encodable as _;
-use alloy_sol_types::{SolCall as _, SolEvent as _};
+use alloy_sol_types::SolEvent as _;
 use reth_primitives_traits::{RecoveredBlock, SealedBlock};
 use tempo_primitives::{
     Block, BlockBody, TempoHeader, TempoReceipt, TempoTxEnvelope, TempoTxType,

--- a/crates/checker/src/persistence/codec.rs
+++ b/crates/checker/src/persistence/codec.rs
@@ -24,6 +24,12 @@ fn options() -> impl Options {
         .reject_trailing_bytes()
         .with_limit(MAX_VALUE_SIZE - 1)
 }
+
+fn unbounded_options() -> impl Options {
+    bincode::DefaultOptions::new()
+        .with_fixint_encoding()
+        .reject_trailing_bytes()
+}
 /// Encode one persistence value with its versioned envelope.
 pub(crate) fn encode<T: Serialize>(v: &T) -> Result<Vec<u8>, CodecError> {
     let mut out = vec![ENVELOPE_VERSION];
@@ -45,6 +51,26 @@ pub(crate) fn decode<T: DeserializeOwned>(v: &[u8]) -> Result<T, CodecError> {
         return Err(CodecError::Version(version));
     }
     options().deserialize(body).map_err(map)
+}
+
+/// Encode a logical value that will be split into independently bounded rows.
+pub(crate) fn encode_unbounded<T: Serialize>(value: &T) -> Result<Vec<u8>, CodecError> {
+    let mut out = vec![ENVELOPE_VERSION];
+    unbounded_options()
+        .serialize_into(&mut out, value)
+        .map_err(map)?;
+    Ok(out)
+}
+
+/// Decode a logical value after its bounded rows have been authenticated and joined.
+pub(crate) fn decode_unbounded<T: DeserializeOwned>(value: &[u8]) -> Result<T, CodecError> {
+    let (&version, body) = value
+        .split_first()
+        .ok_or_else(|| CodecError::Malformed("empty envelope".into()))?;
+    if version != ENVELOPE_VERSION {
+        return Err(CodecError::Version(version));
+    }
+    unbounded_options().deserialize(body).map_err(map)
 }
 /// Map bincode failures into durable codec errors.
 fn map(e: Box<bincode::ErrorKind>) -> CodecError {
@@ -80,7 +106,12 @@ macro_rules! value_codec {
     };
 }
 
-value_codec!(super::Checkpoint, super::JournalEntry, super::Finding);
+value_codec!(
+    super::CheckpointManifest,
+    super::CheckpointChunk,
+    super::JournalEntry,
+    super::Finding
+);
 
 impl Compress for super::MetaValue {
     type Compressed = Vec<u8>;

--- a/crates/checker/src/persistence/mod.rs
+++ b/crates/checker/src/persistence/mod.rs
@@ -14,8 +14,9 @@ use validation::{
 };
 
 pub(crate) use model::{
-    BlockNumHash, ChainCut, Checkpoint, CheckpointId, Coverage, Finding, FindingKey, Identity,
-    JournalEntry, MetaValue, Metadata, Snapshot,
+    BlockNumHash, ChainCut, Checkpoint, CheckpointChunk, CheckpointChunkKey, CheckpointId,
+    CheckpointManifest, Coverage, Finding, FindingKey, Identity, JournalEntry, MetaValue, Metadata,
+    Snapshot,
 };
 
 use crate::{CheckerBlockedReason, kernel::State};
@@ -27,7 +28,7 @@ use reth_db::{
     open_db_read_only,
     transaction::{DbTx, DbTxMut},
 };
-use schema::{Checkpoints, Findings, Journal, Meta, MetaKey, PersistenceTables};
+use schema::{CheckpointChunks, Checkpoints, Findings, Journal, Meta, MetaKey, PersistenceTables};
 #[cfg(test)]
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::{
@@ -36,8 +37,9 @@ use std::{
     sync::Arc,
 };
 
-pub(crate) const SCHEMA_VERSION: u32 = 8;
+pub(crate) const SCHEMA_VERSION: u32 = 9;
 const CHECKPOINT_INTERVAL: u64 = 64;
+const CHECKPOINT_CHUNK_SIZE: usize = 1024 * 1024;
 /// Minimum Zone history retained for local reorg recovery.
 ///
 /// This is an availability horizon, not a Zone finality claim.
@@ -253,13 +255,9 @@ impl Persistence {
             return Err(PersistenceError::Identity);
         }
         validate_metadata(&meta)?;
-        let recovery = tx
-            .get::<Checkpoints>(meta.recovery_checkpoint)?
-            .ok_or_else(|| invalid("recovery checkpoint is missing"))?;
+        let recovery = Self::read_checkpoint(&tx, meta.recovery_checkpoint)?;
         validate_checkpoint(meta.recovery_checkpoint, &recovery, identity)?;
-        let active = tx
-            .get::<Checkpoints>(meta.active_checkpoint)?
-            .ok_or_else(|| invalid("active checkpoint is missing"))?;
+        let active = Self::read_checkpoint(&tx, meta.active_checkpoint)?;
         validate_checkpoint(meta.active_checkpoint, &active, identity)?;
         let mut checkpoints = tx.cursor_read::<Checkpoints>()?;
         let bootstrap_id = checkpoints
@@ -423,9 +421,7 @@ impl Persistence {
     pub(crate) fn retained_zone_coordinates(&self) -> Result<Vec<BlockNumHash>> {
         let tx = self.db.tx()?;
         let meta = read_metadata(&tx)?;
-        let recovery = tx
-            .get::<Checkpoints>(meta.recovery_checkpoint)?
-            .ok_or_else(|| invalid("recovery checkpoint is missing"))?;
+        let recovery = Self::read_checkpoint(&tx, meta.recovery_checkpoint)?;
         let mut coordinates = Vec::new();
         coordinates.push(recovery.cut.zone);
         for height in recovery.cut.zone.number.saturating_add(1)..=meta.verified_zone_tip.number {
@@ -576,9 +572,7 @@ impl Persistence {
         if meta.identity != identity || ancestor.number > meta.verified_zone_tip.number {
             return Err(invalid("invalid reorg ancestor"));
         }
-        let recovery = tx
-            .get::<Checkpoints>(meta.recovery_checkpoint)?
-            .ok_or_else(|| invalid("recovery checkpoint is missing"))?;
+        let recovery = Self::read_checkpoint(&tx, meta.recovery_checkpoint)?;
         validate_checkpoint(meta.recovery_checkpoint, &recovery, identity)?;
         if ancestor.number < recovery.cut.zone.number
             || (ancestor.number == recovery.cut.zone.number && ancestor != recovery.cut.zone)
@@ -590,9 +584,7 @@ impl Persistence {
         }
 
         let (checkpoint_id, checkpoint) = if meta.active_checkpoint.height <= ancestor.number {
-            let checkpoint = tx
-                .get::<Checkpoints>(meta.active_checkpoint)?
-                .ok_or_else(|| invalid("active checkpoint is missing"))?;
+            let checkpoint = Self::read_checkpoint(&tx, meta.active_checkpoint)?;
             validate_checkpoint(meta.active_checkpoint, &checkpoint, identity)?;
             (meta.active_checkpoint, checkpoint)
         } else {
@@ -640,14 +632,6 @@ impl Persistence {
             cut,
             state: state.clone(),
         };
-        // A valid protocol backlog can exceed the per-value codec bound. Keep the
-        // journal advancing and retry checkpointing after the semantic state shrinks
-        // instead of turning a storage representation limit into a checker outage.
-        match codec::encode(&checkpoint) {
-            Ok(_) => {}
-            Err(codec::CodecError::Oversize) => return Ok(()),
-            Err(error) => return Err(error.into()),
-        }
         Self::write_checkpoint(tx, id, checkpoint)?;
         meta.active_checkpoint = id;
         self.advance_recovery_checkpoint(tx, meta)?;
@@ -704,15 +688,72 @@ impl Persistence {
         id: CheckpointId,
         checkpoint: Checkpoint,
     ) -> Result<()> {
-        codec::encode(&checkpoint)?;
-        if let Some(existing) = tx.get::<Checkpoints>(id)? {
-            if existing != checkpoint {
+        let encoded = codec::encode_unbounded(&checkpoint)?;
+        let chunk_count = encoded.len().div_ceil(CHECKPOINT_CHUNK_SIZE);
+        let chunk_count = u32::try_from(chunk_count)
+            .map_err(|_| invalid("checkpoint requires too many chunks"))?;
+        let encoded_len = u64::try_from(encoded.len())
+            .map_err(|_| invalid("checkpoint encoded length exceeds u64"))?;
+        let manifest = CheckpointManifest {
+            cut: checkpoint.cut,
+            chunk_count,
+            encoded_len,
+            commitment: alloy_primitives::keccak256(&encoded),
+        };
+        codec::encode(&manifest)?;
+        if tx.get::<Checkpoints>(id)?.is_some() {
+            if Self::read_checkpoint(tx, id)? != checkpoint {
                 return Err(invalid("checkpoint identity is immutable"));
             }
         } else {
-            tx.put::<Checkpoints>(id, checkpoint)?;
+            for (index, bytes) in encoded.chunks(CHECKPOINT_CHUNK_SIZE).enumerate() {
+                let index = u32::try_from(index)
+                    .map_err(|_| invalid("checkpoint chunk index exceeds u32"))?;
+                tx.put::<CheckpointChunks>(
+                    CheckpointChunkKey {
+                        checkpoint: id,
+                        index,
+                    },
+                    CheckpointChunk(bytes.to_vec()),
+                )?;
+            }
+            tx.put::<Checkpoints>(id, manifest)?;
         }
         Ok(())
+    }
+
+    /// Authenticate and reconstruct one chunked checkpoint.
+    fn read_checkpoint<T: DbTx>(tx: &T, id: CheckpointId) -> Result<Checkpoint> {
+        let manifest = tx
+            .get::<Checkpoints>(id)?
+            .ok_or_else(|| invalid("checkpoint manifest is missing"))?;
+        if manifest.chunk_count == 0 {
+            return Err(invalid("checkpoint manifest has no chunks"));
+        }
+        let capacity = usize::try_from(manifest.encoded_len)
+            .map_err(|_| invalid("checkpoint encoded length exceeds usize"))?;
+        let mut encoded = Vec::with_capacity(capacity);
+        for index in 0..manifest.chunk_count {
+            let chunk = tx
+                .get::<CheckpointChunks>(CheckpointChunkKey {
+                    checkpoint: id,
+                    index,
+                })?
+                .ok_or_else(|| invalid("checkpoint chunk is missing"))?;
+            if chunk.0.is_empty() || chunk.0.len() > CHECKPOINT_CHUNK_SIZE {
+                return Err(invalid("checkpoint chunk has invalid size"));
+            }
+            encoded.extend_from_slice(&chunk.0);
+        }
+        if encoded.len() != capacity || alloy_primitives::keccak256(&encoded) != manifest.commitment
+        {
+            return Err(invalid("checkpoint chunk commitment mismatch"));
+        }
+        let checkpoint: Checkpoint = codec::decode_unbounded(&encoded)?;
+        if checkpoint.cut != manifest.cut {
+            return Err(invalid("checkpoint manifest cut mismatch"));
+        }
+        Ok(checkpoint)
     }
 
     /// Retain only bootstrap, recovery, and active checkpoints.
@@ -725,8 +766,25 @@ impl Persistence {
         let bootstrap = Self::bootstrap_checkpoint_id(tx)?;
         for id in [previous_active, previous_recovery] {
             if id != bootstrap && id != meta.active_checkpoint && id != meta.recovery_checkpoint {
-                tx.delete::<Checkpoints>(id, None)?;
+                Self::delete_checkpoint(tx, id)?;
             }
+        }
+        Ok(())
+    }
+
+    /// Delete one checkpoint manifest and all of its chunks.
+    fn delete_checkpoint(tx: &<DatabaseEnv as Database>::TXMut, id: CheckpointId) -> Result<()> {
+        if let Some(manifest) = tx.get::<Checkpoints>(id)? {
+            for index in 0..manifest.chunk_count {
+                tx.delete::<CheckpointChunks>(
+                    CheckpointChunkKey {
+                        checkpoint: id,
+                        index,
+                    },
+                    None,
+                )?;
+            }
+            tx.delete::<Checkpoints>(id, None)?;
         }
         Ok(())
     }
@@ -747,9 +805,7 @@ impl Persistence {
         height: u64,
         identity: Identity,
     ) -> Result<Checkpoint> {
-        let checkpoint = tx
-            .get::<Checkpoints>(checkpoint_id)?
-            .ok_or_else(|| invalid("recovery checkpoint is missing"))?;
+        let checkpoint = Self::read_checkpoint(tx, checkpoint_id)?;
         validate_checkpoint(checkpoint_id, &checkpoint, identity)?;
         if height < checkpoint.cut.zone.number || height > meta.verified_zone_tip.number {
             return Err(invalid("recovery checkpoint target is out of range"));

--- a/crates/checker/src/persistence/mod.rs
+++ b/crates/checker/src/persistence/mod.rs
@@ -36,7 +36,7 @@ use std::{
     sync::Arc,
 };
 
-pub(crate) const SCHEMA_VERSION: u32 = 7;
+pub(crate) const SCHEMA_VERSION: u32 = 8;
 const CHECKPOINT_INTERVAL: u64 = 64;
 /// Minimum Zone history retained for local reorg recovery.
 ///
@@ -203,6 +203,7 @@ impl Persistence {
             imported_tempo_tip: cut.tempo,
             observed_zone_tip: cut.zone,
             active_finding: None,
+            cleared_findings: 0,
             coverage: Coverage::Complete,
             blocked: None,
         };
@@ -558,7 +559,9 @@ impl Persistence {
             if meta.observed_zone_tip.number > ancestor.number {
                 meta.observed_zone_tip = ancestor;
             }
-            meta.active_finding = None;
+            if meta.active_finding.take().is_some() {
+                meta.cleared_findings = meta.cleared_findings.saturating_add(1);
+            }
             meta.coverage = Coverage::Complete;
             Self::remove_obsolete_checkpoints(tx, meta, previous_active, previous_recovery)?;
             Ok(())
@@ -637,6 +640,14 @@ impl Persistence {
             cut,
             state: state.clone(),
         };
+        // A valid protocol backlog can exceed the per-value codec bound. Keep the
+        // journal advancing and retry checkpointing after the semantic state shrinks
+        // instead of turning a storage representation limit into a checker outage.
+        match codec::encode(&checkpoint) {
+            Ok(_) => {}
+            Err(codec::CodecError::Oversize) => return Ok(()),
+            Err(error) => return Err(error.into()),
+        }
         Self::write_checkpoint(tx, id, checkpoint)?;
         meta.active_checkpoint = id;
         self.advance_recovery_checkpoint(tx, meta)?;

--- a/crates/checker/src/persistence/mod.rs
+++ b/crates/checker/src/persistence/mod.rs
@@ -206,6 +206,7 @@ impl Persistence {
             observed_zone_tip: cut.zone,
             active_finding: None,
             cleared_findings: 0,
+            last_cleared_finding: None,
             coverage: Coverage::Complete,
             blocked: None,
         };
@@ -555,8 +556,9 @@ impl Persistence {
             if meta.observed_zone_tip.number > ancestor.number {
                 meta.observed_zone_tip = ancestor;
             }
-            if meta.active_finding.take().is_some() {
+            if let Some(cleared) = meta.active_finding.take() {
                 meta.cleared_findings = meta.cleared_findings.saturating_add(1);
+                meta.last_cleared_finding = Some(cleared);
             }
             meta.coverage = Coverage::Complete;
             Self::remove_obsolete_checkpoints(tx, meta, previous_active, previous_recovery)?;

--- a/crates/checker/src/persistence/model.rs
+++ b/crates/checker/src/persistence/model.rs
@@ -104,6 +104,26 @@ pub(crate) struct Checkpoint {
     pub state: State,
 }
 
+/// Integrity metadata for one checkpoint split across bounded database values.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub(crate) struct CheckpointManifest {
+    pub cut: ChainCut,
+    pub chunk_count: u32,
+    pub encoded_len: u64,
+    pub commitment: B256,
+}
+
+/// One bounded segment of an encoded checkpoint.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub(crate) struct CheckpointChunk(pub Vec<u8>);
+
+/// Stable key for one checkpoint segment.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+pub(crate) struct CheckpointChunkKey {
+    pub checkpoint: CheckpointId,
+    pub index: u32,
+}
+
 /// One verified Zone transition and its imported Tempo advancement.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub(crate) struct JournalEntry {

--- a/crates/checker/src/persistence/model.rs
+++ b/crates/checker/src/persistence/model.rs
@@ -85,6 +85,8 @@ pub(crate) struct Metadata {
     pub active_finding: Option<FindingKey>,
     /// Number of previously active findings removed from the canonical branch by reorgs.
     pub cleared_findings: u64,
+    /// Most recently cleared finding, retained for operator inspection.
+    pub last_cleared_finding: Option<FindingKey>,
     pub coverage: Coverage,
     /// Why the checker stopped verifying new work.
     pub blocked: Option<CheckerBlockedReason>,

--- a/crates/checker/src/persistence/model.rs
+++ b/crates/checker/src/persistence/model.rs
@@ -83,6 +83,8 @@ pub(crate) struct Metadata {
     /// Latest canonical Zone head observed from the local node.
     pub observed_zone_tip: BlockNumHash,
     pub active_finding: Option<FindingKey>,
+    /// Number of previously active findings removed from the canonical branch by reorgs.
+    pub cleared_findings: u64,
     pub coverage: Coverage,
     /// Why the checker stopped verifying new work.
     pub blocked: Option<CheckerBlockedReason>,

--- a/crates/checker/src/persistence/schema.rs
+++ b/crates/checker/src/persistence/schema.rs
@@ -1,6 +1,9 @@
 //! MDBX tables and fixed-width key encodings for persisted checker records.
 
-use super::{Checkpoint, CheckpointId, Finding, FindingKey, JournalEntry, MetaValue};
+use super::{
+    CheckpointChunk, CheckpointChunkKey, CheckpointId, CheckpointManifest, Finding, FindingKey,
+    JournalEntry, MetaValue,
+};
 use reth_db::{
     DatabaseError, TableSet,
     table::{Decode, Encode, Table, TableInfo},
@@ -66,6 +69,24 @@ fixed_key!(
     })
 );
 fixed_key!(
+    CheckpointChunkKey,
+    44,
+    |v: CheckpointChunkKey| {
+        let mut b = [0; 44];
+        b[..8].copy_from_slice(&v.checkpoint.height.to_be_bytes());
+        b[8..40].copy_from_slice(v.checkpoint.hash.as_slice());
+        b[40..].copy_from_slice(&v.index.to_be_bytes());
+        b
+    },
+    |v: &[u8]| Ok(CheckpointChunkKey {
+        checkpoint: CheckpointId {
+            height: u64::from_be_bytes(v[..8].try_into().map_err(|_| DatabaseError::Decode)?),
+            hash: alloy_primitives::B256::from_slice(&v[8..40]),
+        },
+        index: u32::from_be_bytes(v[40..].try_into().map_err(|_| DatabaseError::Decode)?),
+    })
+);
+fixed_key!(
     FindingKey,
     46,
     |v: FindingKey| {
@@ -108,7 +129,13 @@ macro_rules! table {
     };
 }
 table!(Meta, MetaKey, MetaValue, "Meta");
-table!(Checkpoints, CheckpointId, Checkpoint, "Checkpoints");
+table!(Checkpoints, CheckpointId, CheckpointManifest, "Checkpoints");
+table!(
+    CheckpointChunks,
+    CheckpointChunkKey,
+    CheckpointChunk,
+    "CheckpointChunks"
+);
 table!(Journal, u64, JournalEntry, "Journal");
 table!(Findings, FindingKey, Finding, "Findings");
 
@@ -120,6 +147,7 @@ impl TableSet for PersistenceTables {
             vec![
                 Box::new(Meta) as Box<dyn TableInfo>,
                 Box::new(Checkpoints),
+                Box::new(CheckpointChunks),
                 Box::new(Journal),
                 Box::new(Findings),
             ]

--- a/crates/checker/src/persistence/tests/loading.rs
+++ b/crates/checker/src/persistence/tests/loading.rs
@@ -4,7 +4,7 @@ use super::*;
 
 #[test]
 fn bounded_versioned_codec_rejects_unknown_trailing_truncated_and_oversize() {
-    assert_eq!(PersistenceTables::tables().count(), 4);
+    assert_eq!(PersistenceTables::tables().count(), 5);
     let (_, value) = finding(block(1, 0x11));
     let encoded = codec::encode(&value).unwrap();
     assert_eq!(codec::decode::<Finding>(&encoded).unwrap(), value);
@@ -143,7 +143,8 @@ fn restart_checks_active_history_but_defers_orphan_audit_validation() {
         hash: B256::repeat_byte(9),
     };
     let tx = store.db.tx_mut().unwrap();
-    tx.put::<Checkpoints>(
+    Persistence::write_checkpoint(
+        &tx,
         bad_id,
         super::super::Checkpoint {
             cut: bootstrap(),
@@ -219,7 +220,7 @@ fn schema_version_is_probed_before_incompatible_metadata_is_opened_writable() {
 #[test]
 fn checkpoint_size_and_bounded_journal_replay_are_measured() {
     let (directory, store) = create();
-    let checkpoint_bytes = codec::encode(&super::super::Checkpoint {
+    let checkpoint_bytes = codec::encode_unbounded(&super::super::Checkpoint {
         cut: bootstrap(),
         state: state(),
     })
@@ -248,4 +249,37 @@ fn checkpoint_size_and_bounded_journal_replay_are_measured() {
     let (_, snapshot) = Persistence::open(directory.path(), identity()).unwrap();
     assert_eq!(snapshot.meta.verified_zone_tip.number, 256);
     assert!(started.elapsed() < std::time::Duration::from_secs(5));
+}
+
+#[test]
+fn oversized_logical_checkpoint_round_trips_through_bounded_chunks() {
+    let (_directory, store) = create();
+    let id = super::super::CheckpointId {
+        height: 64,
+        hash: B256::repeat_byte(0x64),
+    };
+    let state = State::with_pending_withdrawals_for_test(
+        PortalIdentity {
+            portal: identity().portal,
+            zone_id: identity().zone_id,
+            initial_token: Address::repeat_byte(0x11),
+        },
+        9_000,
+        1_024,
+    );
+    let checkpoint = super::super::Checkpoint {
+        cut: ChainCut {
+            zone: block(64, 0x64),
+            tempo: block(64, 0x74),
+        },
+        state,
+    };
+    assert!(codec::encode_unbounded(&checkpoint).unwrap().len() > codec::MAX_VALUE_SIZE as usize);
+
+    let tx = store.db.tx_mut().unwrap();
+    Persistence::write_checkpoint(&tx, id, checkpoint.clone()).unwrap();
+    let manifest = tx.get::<Checkpoints>(id).unwrap().unwrap();
+    assert!(manifest.chunk_count > 8);
+    assert_eq!(Persistence::read_checkpoint(&tx, id).unwrap(), checkpoint);
+    tx.commit().unwrap();
 }

--- a/crates/checker/src/persistence/tests/reorgs.rs
+++ b/crates/checker/src/persistence/tests/reorgs.rs
@@ -60,6 +60,7 @@ fn divergence_reorg_removes_the_active_latch() {
     let snapshot = store.reorg(&current(&store), bootstrap().zone).unwrap();
     assert_eq!(snapshot.meta.active_finding, None);
     assert_eq!(snapshot.meta.cleared_findings, 1);
+    assert_eq!(snapshot.meta.last_cleared_finding, Some(key));
 }
 
 #[test]
@@ -85,6 +86,7 @@ fn deep_reorg_retains_orphan_finding_as_structural_audit_record() {
     assert_eq!(reopened.meta.verified_zone_tip, bootstrap().zone);
     assert_eq!(reopened.meta.active_finding, None);
     assert_eq!(reopened.meta.cleared_findings, 1);
+    assert_eq!(reopened.meta.last_cleared_finding, Some(key));
 }
 
 #[test]

--- a/crates/checker/src/persistence/tests/reorgs.rs
+++ b/crates/checker/src/persistence/tests/reorgs.rs
@@ -57,14 +57,9 @@ fn divergence_reorg_removes_the_active_latch() {
         store.reorg(&current(&store), block(1, 0xff)),
         Err(PersistenceError::Invalid(_))
     ));
-    assert_eq!(
-        store
-            .reorg(&current(&store), bootstrap().zone)
-            .unwrap()
-            .meta
-            .active_finding,
-        None
-    );
+    let snapshot = store.reorg(&current(&store), bootstrap().zone).unwrap();
+    assert_eq!(snapshot.meta.active_finding, None);
+    assert_eq!(snapshot.meta.cleared_findings, 1);
 }
 
 #[test]
@@ -89,6 +84,7 @@ fn deep_reorg_retains_orphan_finding_as_structural_audit_record() {
     let (_, reopened) = Persistence::open(directory.path(), identity()).unwrap();
     assert_eq!(reopened.meta.verified_zone_tip, bootstrap().zone);
     assert_eq!(reopened.meta.active_finding, None);
+    assert_eq!(reopened.meta.cleared_findings, 1);
 }
 
 #[test]

--- a/crates/checker/src/runtime/mod.rs
+++ b/crates/checker/src/runtime/mod.rs
@@ -127,6 +127,15 @@ impl Runtime {
         self.metrics.publish_snapshot(&self.snapshot);
     }
 
+    pub(crate) const fn is_retrying(&self) -> bool {
+        self.retry.is_some()
+    }
+
+    pub(crate) fn publish_reclamation_height(&self, height: BlockNumHash) {
+        self.metrics
+            .publish_reclamation_height(self.snapshot.meta.verified_zone_tip.number, height.number);
+    }
+
     /// Record the duration of one complete block authentication attempt.
     pub(crate) fn record_authentication(&self, duration: Duration) {
         self.metrics.record_authentication(duration);

--- a/crates/checker/src/runtime/verification.rs
+++ b/crates/checker/src/runtime/verification.rs
@@ -115,8 +115,17 @@ fn verify_outputs(
             .keys()
             .chain(supplies.keys())
             .find(|token| block.outputs.supplies.get(*token) != supplies.get(*token))
-            .copied()
-            .expect("unequal maps have a differing key");
+            .copied();
+        let Some(token) = token else {
+            return Err(divergence(
+                FindingCategory::SupplyMismatch,
+                30,
+                None,
+                None,
+                None,
+                "token supply maps differ without an identifiable key",
+            ));
+        };
         return Err(divergence(
             FindingCategory::SupplyMismatch,
             30,

--- a/crates/node/src/cli.rs
+++ b/crates/node/src/cli.rs
@@ -248,7 +248,7 @@ fn run_node(mut cli: Cli<ZoneChainSpecParser, ZoneArgs>, action: NodeAction) -> 
         if matches!(action, NodeAction::BuildCheckpoint { .. }) {
             // Checkpoint construction only needs the launched provider and exits without
             // advancing the Zone chain.
-            node = node.with_external_deposit_consumer();
+            node = node.for_checkpoint_build();
         }
         if !additional_decryption_keys.is_empty() {
             node = node.with_deposit_decryption_keys(additional_decryption_keys);

--- a/crates/node/src/cli/checker.rs
+++ b/crates/node/src/cli/checker.rs
@@ -88,6 +88,7 @@ impl CheckerCommand {
                             },
                             "recovering": snapshot.recovering,
                             "activeFinding": snapshot.active_finding,
+                            "clearedFindings": snapshot.cleared_findings,
                             "hasCoverageGap": snapshot.has_coverage_gap,
                             "blockedReason": snapshot.blocked_reason,
                         }))?
@@ -111,6 +112,7 @@ impl CheckerCommand {
                     );
                     println!("Recovering:            {}", snapshot.recovering);
                     println!("Active finding:       {}", snapshot.active_finding);
+                    println!("Cleared findings:     {}", snapshot.cleared_findings);
                     println!("Coverage gap:         {}", snapshot.has_coverage_gap);
                     println!(
                         "Blocked reason:       {}",

--- a/crates/node/src/node.rs
+++ b/crates/node/src/node.rs
@@ -250,6 +250,8 @@ pub struct ZoneNode {
     p2p_config: Option<P2pConfig>,
     /// Whether a consumer outside this builder drains the deposit queue.
     external_deposit_consumer: bool,
+    /// Whether the node is launched only to expose a read-only provider for checkpoint building.
+    checkpoint_only: bool,
 }
 
 impl ZoneNode {
@@ -298,6 +300,7 @@ impl ZoneNode {
             sequencer_config: None,
             p2p_config: None,
             external_deposit_consumer: false,
+            checkpoint_only: false,
         }
     }
 
@@ -341,6 +344,12 @@ impl ZoneNode {
     /// harnesses — must opt in so node startup knows the Zone chain can advance.
     pub fn with_external_deposit_consumer(mut self) -> Self {
         self.external_deposit_consumer = true;
+        self
+    }
+
+    /// Launch without a chain-advancement mechanism or L1 subscriber.
+    pub fn for_checkpoint_build(mut self) -> Self {
+        self.checkpoint_only = true;
         self
     }
 
@@ -444,6 +453,7 @@ where
     p2p_config: Option<P2pConfig>,
     /// Whether a consumer outside this builder drains the deposit queue.
     external_deposit_consumer: bool,
+    checkpoint_only: bool,
 }
 
 impl<N> std::fmt::Debug for ZoneAddOns<N>
@@ -469,6 +479,7 @@ where
         sequencer_config: Option<ZoneSequencerAddOnsConfig>,
         p2p_config: Option<P2pConfig>,
         external_deposit_consumer: bool,
+        checkpoint_only: bool,
     ) -> Self {
         Self {
             inner: RpcAddOns::new(
@@ -486,6 +497,7 @@ where
             sequencer_config,
             p2p_config,
             external_deposit_consumer,
+            checkpoint_only,
         }
     }
 }
@@ -518,7 +530,8 @@ where
         eyre::ensure!(
             self.sequencer_config.is_some()
                 || self.p2p_config.is_some()
-                || self.external_deposit_consumer,
+                || self.external_deposit_consumer
+                || self.checkpoint_only,
             "no Zone chain advancement mechanism configured: enable a sequencer, configure P2P, or register an external deposit consumer"
         );
 
@@ -622,13 +635,15 @@ where
             }));
         }
 
-        L1Subscriber::spawn(
-            self.l1_config.clone(),
-            ctx.node.provider().clone(),
-            self.deposit_queue.clone(),
-            ctx.node.task_executor().clone(),
-        );
-        info!(target: "reth::cli", "L1 subscriber started with deposit enqueueing");
+        if !self.checkpoint_only {
+            L1Subscriber::spawn(
+                self.l1_config.clone(),
+                ctx.node.provider().clone(),
+                self.deposit_queue.clone(),
+                ctx.node.task_executor().clone(),
+            );
+            info!(target: "reth::cli", "L1 subscriber started with deposit enqueueing");
+        }
 
         let task_executor = ctx.node.task_executor().clone();
         // Start the Commonware network and the long-lived event router
@@ -1526,6 +1541,7 @@ where
             self.sequencer_config.clone(),
             self.p2p_config.clone(),
             self.external_deposit_consumer,
+            self.checkpoint_only,
         )
     }
 }


### PR DESCRIPTION
## Summary

- preserve all checker-relevant Portal state-changing calls in authenticated AA multicall order and accept calldata forms tolerated by Solidity
- align `advanceTempo` discovery with executor multicall classification
- derive the Portal initial token from the authenticated `ZoneCreated` operation instead of the independently configured Zone fee token
- launch checkpoint construction without an unused L1 subscriber or deposit queue
- release the ExEx reclamation watermark for durable gaps and blocked states, and durably block retries once semantic lag exceeds the bounded retention window
- persist authenticated chunked checkpoints so state larger than the MDBX value limit still advances pruning and recovery
- retain cleared-finding counts and the last cleared finding coordinate for durable operator inspection

## Validation

- `cargo test -p zone-checker -- --test-threads=1` (126 passed)
- `cargo check -p zone-node`
- `cargo +nightly fmt --all -- --check`
- `cargo +nightly clippy -p zone-checker -p zone-node --all-targets` (passes with pre-existing future-incompatibility warnings)

Stacked on #1147.

Prompted by: @grandizzy

## Panic-freedom audit

- replace indexing assumptions at authenticated observation boundaries with typed failures
- convert impossible kernel transition and invariant panics into `CorruptState` or invariant violations
- convert supply-diff discovery into a terminal divergence instead of panicking
- retain only structurally infallible assertions for fixed constants, platform widths, and prevalidated database codec writes