### PR TITLE
feat(xtask): manage ZonePortal access policy

### DIFF
--- a/Justfile
+++ b/Justfile
@@ -464,22 +464,54 @@ pause-portal:
 [group('zone')]
 [doc('Enables or disables closed-loop account enforcement. Pass true to close access or false to open it. Requires L1_RPC_URL, L1_PORTAL_ADDRESS, and ADMIN_KEY.')]
 set-access-mode enforced:
-    cargo run -p tempo-xtask -- set-access-mode {{ if enforced == "true" { "--enforced" } else { "" } }}
+    #!/bin/bash
+    set -euo pipefail
+    ENFORCED="{{enforced}}"
+    case "$ENFORCED" in
+        true) ARGS=(--enforced) ;;
+        false) ARGS=() ;;
+        *) echo "Error: enforced must be 'true' or 'false'" >&2; exit 1 ;;
+    esac
+    cargo run -p tempo-xtask -- set-access-mode "${ARGS[@]}"
 
 [group('zone')]
 [doc('Enables or disables callback gateway enforcement. Pass true to enforce registered gateways or false to allow arbitrary targets. Requires L1_RPC_URL, L1_PORTAL_ADDRESS, and ADMIN_KEY.')]
 set-gateway-mode enforced:
-    cargo run -p tempo-xtask -- set-gateway-mode {{ if enforced == "true" { "--enforced" } else { "" } }}
+    #!/bin/bash
+    set -euo pipefail
+    ENFORCED="{{enforced}}"
+    case "$ENFORCED" in
+        true) ARGS=(--enforced) ;;
+        false) ARGS=() ;;
+        *) echo "Error: enforced must be 'true' or 'false'" >&2; exit 1 ;;
+    esac
+    cargo run -p tempo-xtask -- set-gateway-mode "${ARGS[@]}"
 
 [group('zone')]
 [doc('Adds or removes an account from closed-loop portal flows. Pass true to add or false to remove. Requires L1_RPC_URL, L1_PORTAL_ADDRESS, and ADMIN_KEY.')]
 set-allowed-account account allowed:
-    cargo run -p tempo-xtask -- set-allowed-account {{account}} {{ if allowed == "true" { "--allowed" } else { "" } }}
+    #!/bin/bash
+    set -euo pipefail
+    ALLOWED="{{allowed}}"
+    case "$ALLOWED" in
+        true) ARGS=(--allowed) ;;
+        false) ARGS=() ;;
+        *) echo "Error: allowed must be 'true' or 'false'" >&2; exit 1 ;;
+    esac
+    cargo run -p tempo-xtask -- set-allowed-account "{{account}}" "${ARGS[@]}"
 
 [group('zone')]
 [doc('Adds or removes a callback gateway. Pass true to add or false to remove. Requires L1_RPC_URL, L1_PORTAL_ADDRESS, and ADMIN_KEY.')]
 set-gateway account allowed:
-    cargo run -p tempo-xtask -- set-gateway {{account}} {{ if allowed == "true" { "--allowed" } else { "" } }}
+    #!/bin/bash
+    set -euo pipefail
+    ALLOWED="{{allowed}}"
+    case "$ALLOWED" in
+        true) ARGS=(--allowed) ;;
+        false) ARGS=() ;;
+        *) echo "Error: allowed must be 'true' or 'false'" >&2; exit 1 ;;
+    esac
+    cargo run -p tempo-xtask -- set-gateway "{{account}}" "${ARGS[@]}"
 
 [group('zone')]
 [doc('Lists TIP-20 token addresses currently enabled on the ZonePortal. Pass a portal address or set L1_PORTAL_ADDRESS. Requires L1_RPC_URL.')]

--- a/Justfile
+++ b/Justfile
@@ -462,6 +462,26 @@ pause-portal:
     cargo run -p tempo-xtask -- pause-portal
 
 [group('zone')]
+[doc('Enables or disables closed-loop account enforcement. Pass true to close access or false to open it. Requires L1_RPC_URL, L1_PORTAL_ADDRESS, and ADMIN_KEY.')]
+set-access-mode enforced:
+    cargo run -p tempo-xtask -- set-access-mode {{ if enforced == "true" { "--enforced" } else { "" } }}
+
+[group('zone')]
+[doc('Enables or disables callback gateway enforcement. Pass true to enforce registered gateways or false to allow arbitrary targets. Requires L1_RPC_URL, L1_PORTAL_ADDRESS, and ADMIN_KEY.')]
+set-gateway-mode enforced:
+    cargo run -p tempo-xtask -- set-gateway-mode {{ if enforced == "true" { "--enforced" } else { "" } }}
+
+[group('zone')]
+[doc('Adds or removes an account from closed-loop portal flows. Pass true to add or false to remove. Requires L1_RPC_URL, L1_PORTAL_ADDRESS, and ADMIN_KEY.')]
+set-allowed-account account allowed:
+    cargo run -p tempo-xtask -- set-allowed-account {{account}} {{ if allowed == "true" { "--allowed" } else { "" } }}
+
+[group('zone')]
+[doc('Adds or removes a callback gateway. Pass true to add or false to remove. Requires L1_RPC_URL, L1_PORTAL_ADDRESS, and ADMIN_KEY.')]
+set-gateway account allowed:
+    cargo run -p tempo-xtask -- set-gateway {{account}} {{ if allowed == "true" { "--allowed" } else { "" } }}
+
+[group('zone')]
 [doc('Lists TIP-20 token addresses currently enabled on the ZonePortal. Pass a portal address or set L1_PORTAL_ADDRESS. Requires L1_RPC_URL.')]
 list-enabled-tokens portal="":
     #!/bin/bash

--- a/docs/ZONES.md
+++ b/docs/ZONES.md
@@ -205,6 +205,41 @@ ZONE_FACTORY_OWNER_KEY="$SEQUENCER_KEY" cargo run -p tempo-xtask -- create-zone 
 available for admin-only portal calls such as changing either mode or account roles,
 enabling tokens, and pausing or resuming deposits.
 
+### Updating closed-loop access
+
+Configure memberships before enabling their corresponding enforcement mode so existing
+traffic is not denied during the transition:
+
+```bash
+export L1_RPC_URL=https://...
+export L1_PORTAL_ADDRESS=0x<portal>
+export ADMIN_KEY=0x<portal-admin-private-key>
+
+just set-allowed-account 0x<account> true
+just set-gateway 0x<gateway> true
+just set-access-mode true
+just set-gateway-mode true
+```
+
+Account and gateway roles are mutually exclusive. To move an address between roles,
+remove its current role before adding the new one. Disabling enforcement leaves stored
+roles intact, so they take effect again if the mode is re-enabled.
+
+To remove access, revoke the role directly:
+
+```bash
+just set-allowed-account 0x<account> false
+just set-gateway 0x<gateway> false
+```
+
+Revocations apply when each portal or zone-side action executes. In-flight destinations
+and gateways that have been revoked bounce back; revoked refund recipients cannot claim
+parked refunds until their account role is restored. Before closing access or removing a
+role, confirm that affected deposits, withdrawals, callbacks, and refunds have completed.
+
+Each command verifies the signer is the current portal admin, waits for the transaction,
+and reads the resulting mode or role back from the portal.
+
 ### 5. Start the Zone Node
 
 ```bash
@@ -696,6 +731,10 @@ cast code 0x5A4d000000000000000000000000000000000000 --rpc-url "$ETH_RPC_URL"
 | `just enable-token <token>` | Enable a TIP-20 token on the portal for bridging (admin only) |
 | `just pause-deposits <token>` | Pause deposits for an enabled token on the portal (admin only) |
 | `just resume-deposits <token>` | Resume deposits for a paused token on the portal (admin only) |
+| `just set-access-mode <true\|false>` | Enable or disable closed-loop account enforcement (admin only) |
+| `just set-gateway-mode <true\|false>` | Enable or disable callback gateway enforcement (admin only) |
+| `just set-allowed-account <account> <true\|false>` | Add or remove an Account role (admin only) |
+| `just set-gateway <account> <true\|false>` | Add or remove a CallbackGateway role (admin only) |
 | `just list-enabled-tokens [portal]` | List TIP-20 token addresses enabled on a portal |
 | `just max-approve-outbox [token] [rpc]` | Approve outbox to spend tokens on zone |
 | `just send-withdrawal [amount] [to] [token] [memo] [gas-limit] [fallback-recipient] [data] [reveal-to] [rpc]` | Withdraw tokens from zone to L1 (defaults to sender) |

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -1,13 +1,24 @@
 //! xtask is a Swiss army knife of tools that help with running and testing tempo.
 use crate::{
-    admin::Admin, benchmark_results::BenchmarkResults, check_abi::CheckAbi,
-    configure_benchmark_fees::ConfigureBenchmarkFees, create_zone::CreateZone,
-    demo_blacklist::DemoBlacklist, demo_swap_and_deposit::DemoSwapAndDeposit,
-    deploy_neobank_fixtures::DeployNeobankFixtures, deploy_router::DeployRouter, deposit::Deposit,
-    generate_p2p_key::GenerateP2pKey, generate_zone_genesis::GenerateZoneGenesis,
-    install_reference_zone_factory::InstallReferenceZoneFactory, portal_pause::PausePortal,
-    set_encryption_key::SetEncryptionKey, spam_deposits::SpamDeposits,
-    verify_closed_loop::VerifyClosedLoop, verify_portal_backing::VerifyPortalBacking,
+    admin::Admin,
+    benchmark_results::BenchmarkResults,
+    check_abi::CheckAbi,
+    configure_benchmark_fees::ConfigureBenchmarkFees,
+    create_zone::CreateZone,
+    demo_blacklist::DemoBlacklist,
+    demo_swap_and_deposit::DemoSwapAndDeposit,
+    deploy_neobank_fixtures::DeployNeobankFixtures,
+    deploy_router::DeployRouter,
+    deposit::Deposit,
+    generate_p2p_key::GenerateP2pKey,
+    generate_zone_genesis::GenerateZoneGenesis,
+    install_reference_zone_factory::InstallReferenceZoneFactory,
+    portal_access::{SetAccessMode, SetAllowedAccount, SetGateway, SetGatewayMode},
+    portal_pause::PausePortal,
+    set_encryption_key::SetEncryptionKey,
+    spam_deposits::SpamDeposits,
+    verify_closed_loop::VerifyClosedLoop,
+    verify_portal_backing::VerifyPortalBacking,
     zone_info::ZoneInfoCmd,
 };
 use clap::Parser as _;
@@ -26,6 +37,7 @@ mod deposit;
 mod generate_p2p_key;
 mod generate_zone_genesis;
 mod install_reference_zone_factory;
+mod portal_access;
 mod portal_pause;
 mod set_encryption_key;
 mod spam_deposits;
@@ -69,6 +81,12 @@ async fn main() -> eyre::Result<()> {
             .run()
             .wrap_err("failed to install reference ZoneFactory"),
         Action::PausePortal(args) => args.run().await.wrap_err("failed to pause portal"),
+        Action::SetAccessMode(args) => args.run().await.wrap_err("failed to set access mode"),
+        Action::SetAllowedAccount(args) => {
+            args.run().await.wrap_err("failed to update account role")
+        }
+        Action::SetGateway(args) => args.run().await.wrap_err("failed to update gateway role"),
+        Action::SetGatewayMode(args) => args.run().await.wrap_err("failed to set gateway mode"),
         Action::SetEncryptionKey(args) => args.run().await.wrap_err("failed to set encryption key"),
         Action::SpamDeposits(args) => args.run().await.wrap_err("failed to spam deposits"),
         Action::VerifyClosedLoop(args) => {
@@ -108,6 +126,10 @@ enum Action {
     GenerateZoneGenesis(GenerateZoneGenesis),
     InstallReferenceZoneFactory(InstallReferenceZoneFactory),
     PausePortal(PausePortal),
+    SetAccessMode(SetAccessMode),
+    SetAllowedAccount(SetAllowedAccount),
+    SetGateway(SetGateway),
+    SetGatewayMode(SetGatewayMode),
     SetEncryptionKey(SetEncryptionKey),
     SpamDeposits(SpamDeposits),
     VerifyClosedLoop(VerifyClosedLoop),

--- a/xtask/src/portal_access.rs
+++ b/xtask/src/portal_access.rs
@@ -1,0 +1,211 @@
+//! Updates ZonePortal closed-loop enforcement and membership.
+
+use alloy::{
+    network::{EthereumWallet, ReceiptResponse as _},
+    primitives::Address,
+    providers::{DynProvider, Provider as _, ProviderBuilder},
+    signers::local::PrivateKeySigner,
+};
+use eyre::{WrapErr as _, ensure};
+use tempo_alloy::{TempoNetwork, provider::ext::TempoProviderExt, rpc::TempoCallBuilderExt};
+use tempo_zone_contracts::{ZonePortal, ZonePortal::Role};
+use zone_sequencer::nonce_keys::ADMIN_OPS_NONCE_KEY;
+
+#[derive(Debug, clap::Args)]
+struct PortalAccessArgs {
+    /// Tempo L1 RPC URL.
+    #[arg(long, env = "L1_RPC_URL")]
+    l1_rpc_url: String,
+
+    /// ZonePortal contract address on Tempo L1.
+    #[arg(long, env = "L1_PORTAL_ADDRESS")]
+    portal: Address,
+
+    /// ZonePortal admin private key.
+    #[arg(long, env = "ADMIN_KEY", hide_env_values = true)]
+    admin_key: String,
+}
+
+#[derive(Debug, clap::Parser)]
+pub(crate) struct SetAccessMode {
+    #[command(flatten)]
+    args: PortalAccessArgs,
+
+    /// Require the Account role for deposits, refunds, and plain withdrawals.
+    #[arg(long)]
+    enforced: bool,
+}
+
+#[derive(Debug, clap::Parser)]
+pub(crate) struct SetGatewayMode {
+    #[command(flatten)]
+    args: PortalAccessArgs,
+
+    /// Require callback targets to have the CallbackGateway role.
+    #[arg(long)]
+    enforced: bool,
+}
+
+#[derive(Debug, clap::Parser)]
+pub(crate) struct SetAllowedAccount {
+    #[command(flatten)]
+    args: PortalAccessArgs,
+
+    /// Account whose closed-loop membership should be updated.
+    account: Address,
+
+    /// Add the Account role. Omit to remove it.
+    #[arg(long)]
+    allowed: bool,
+}
+
+#[derive(Debug, clap::Parser)]
+pub(crate) struct SetGateway {
+    #[command(flatten)]
+    args: PortalAccessArgs,
+
+    /// Callback gateway whose role should be updated.
+    account: Address,
+
+    /// Add the CallbackGateway role. Omit to remove it.
+    #[arg(long)]
+    allowed: bool,
+}
+
+impl SetAccessMode {
+    pub(crate) async fn run(self) -> eyre::Result<()> {
+        let (portal, provider, nonce) = connect(self.args).await?;
+        let receipt = portal
+            .setAccessMode(self.enforced)
+            .nonce_key(ADMIN_OPS_NONCE_KEY)
+            .nonce(nonce)
+            .send()
+            .await
+            .wrap_err("failed sending ZonePortal.setAccessMode")?
+            .get_receipt()
+            .await
+            .wrap_err("failed waiting for setAccessMode receipt")?;
+        ensure!(receipt.status(), "setAccessMode transaction reverted");
+        ensure!(
+            portal.isAccessEnforced().call().await? == self.enforced,
+            "portal access mode did not update"
+        );
+        print_success("account access mode", &receipt.transaction_hash());
+        drop(provider);
+        Ok(())
+    }
+}
+
+impl SetGatewayMode {
+    pub(crate) async fn run(self) -> eyre::Result<()> {
+        let (portal, provider, nonce) = connect(self.args).await?;
+        let receipt = portal
+            .setGatewayMode(self.enforced)
+            .nonce_key(ADMIN_OPS_NONCE_KEY)
+            .nonce(nonce)
+            .send()
+            .await
+            .wrap_err("failed sending ZonePortal.setGatewayMode")?
+            .get_receipt()
+            .await
+            .wrap_err("failed waiting for setGatewayMode receipt")?;
+        ensure!(receipt.status(), "setGatewayMode transaction reverted");
+        ensure!(
+            portal.isGatewayOpen().call().await? != self.enforced,
+            "portal gateway mode did not update"
+        );
+        print_success("callback gateway mode", &receipt.transaction_hash());
+        drop(provider);
+        Ok(())
+    }
+}
+
+impl SetAllowedAccount {
+    pub(crate) async fn run(self) -> eyre::Result<()> {
+        let (portal, provider, nonce) = connect(self.args).await?;
+        let receipt = portal
+            .setAllowedAccount(self.account, self.allowed)
+            .nonce_key(ADMIN_OPS_NONCE_KEY)
+            .nonce(nonce)
+            .send()
+            .await
+            .wrap_err("failed sending ZonePortal.setAllowedAccount")?
+            .get_receipt()
+            .await
+            .wrap_err("failed waiting for setAllowedAccount receipt")?;
+        ensure!(receipt.status(), "setAllowedAccount transaction reverted");
+        ensure!(
+            portal.hasRole(self.account, Role::Account).call().await? == self.allowed,
+            "portal account role did not update"
+        );
+        print_success("allowed account", &receipt.transaction_hash());
+        drop(provider);
+        Ok(())
+    }
+}
+
+impl SetGateway {
+    pub(crate) async fn run(self) -> eyre::Result<()> {
+        let (portal, provider, nonce) = connect(self.args).await?;
+        let receipt = portal
+            .setGateway(self.account, self.allowed)
+            .nonce_key(ADMIN_OPS_NONCE_KEY)
+            .nonce(nonce)
+            .send()
+            .await
+            .wrap_err("failed sending ZonePortal.setGateway")?
+            .get_receipt()
+            .await
+            .wrap_err("failed waiting for setGateway receipt")?;
+        ensure!(receipt.status(), "setGateway transaction reverted");
+        ensure!(
+            portal
+                .hasRole(self.account, Role::CallbackGateway)
+                .call()
+                .await?
+                == self.allowed,
+            "portal gateway role did not update"
+        );
+        print_success("callback gateway", &receipt.transaction_hash());
+        drop(provider);
+        Ok(())
+    }
+}
+
+async fn connect(
+    args: PortalAccessArgs,
+) -> eyre::Result<(
+    tempo_zone_contracts::ZonePortal::ZonePortalInstance<DynProvider<TempoNetwork>, TempoNetwork>,
+    DynProvider<TempoNetwork>,
+    u64,
+)> {
+    let key = args.admin_key.strip_prefix("0x").unwrap_or(&args.admin_key);
+    let signer: PrivateKeySigner = key.parse().wrap_err("ADMIN_KEY is not valid")?;
+    let signer_address = signer.address();
+    let provider = ProviderBuilder::new_with_network::<TempoNetwork>()
+        .wallet(EthereumWallet::from(signer))
+        .connect(&args.l1_rpc_url)
+        .await
+        .wrap_err("failed connecting to Tempo L1 RPC")?
+        .erased();
+    let portal = ZonePortal::new(args.portal, provider.clone());
+    let admin = portal
+        .admin()
+        .call()
+        .await
+        .wrap_err("failed reading portal admin")?;
+    ensure!(
+        signer_address == admin,
+        "ADMIN_KEY signer {signer_address} is not portal admin {admin}"
+    );
+    let nonce = provider
+        .get_transaction_count_with_nonce_key(signer_address, ADMIN_OPS_NONCE_KEY)
+        .await
+        .wrap_err("failed reading portal admin nonce")?;
+    Ok((portal, provider, nonce))
+}
+
+fn print_success(operation: &str, tx_hash: &impl std::fmt::Display) {
+    println!("Updated {operation}");
+    println!("Transaction: {tx_hash}");
+}


### PR DESCRIPTION
## Summary

- add `set-access-mode`, `set-gateway-mode`, `set-allowed-account`, and `set-gateway` xtasks
- expose matching `just` commands for Zone operators
- document safe closed-loop rollout, role removal, and in-flight bounce-back/refund behavior

## Validation

- `cargo +nightly fmt --all -- --check`
- `cargo +nightly check -p tempo-xtask --quiet`
- `cargo +nightly clippy -p tempo-xtask --quiet` (passes with pre-existing future-compatibility warnings)
- `git diff --check`

Prompted by: @0xalpharush
