### PR TITLE
fix(node): avoid backdating zone catch-up blocks

### DIFF
--- a/crates/node/src/engine.rs
+++ b/crates/node/src/engine.rs
@@ -59,17 +59,6 @@ use zone_l1::{DepositQueue, EncryptionKeyRing, L1BlockDeposits, L1BlockTracker, 
 use zone_p2p::{LeadershipSchedule, P2pPeerId};
 use zone_payload::{ZonePayloadAttributes, ZonePayloadTypes};
 
-/// Select a Zone timestamp that preserves the L1 lower bound without backdating user activity.
-fn zone_timestamp_millis(
-    l1_timestamp_millis: u64,
-    parent_timestamp_millis: u64,
-    wall_clock_timestamp_millis: u64,
-) -> u64 {
-    l1_timestamp_millis
-        .max(wall_clock_timestamp_millis)
-        .max(parent_timestamp_millis.saturating_add(1))
-}
-
 /// Per-anchor production permit backed by the effective leadership schedule.
 ///
 /// The permit is a single schedule lookup: produce anchor `N` only if the portal schedule or a
@@ -448,6 +437,17 @@ impl AvailableBlockDrain for ZoneEngine {
     async fn advance_one(&mut self, block: Self::Block) -> eyre::Result<()> {
         self.advance(block).await
     }
+}
+
+/// Select a Zone timestamp that preserves the L1 lower bound without backdating user activity.
+fn zone_timestamp_millis(
+    l1_timestamp_millis: u64,
+    parent_timestamp_millis: u64,
+    wall_clock_timestamp_millis: u64,
+) -> u64 {
+    l1_timestamp_millis
+        .max(wall_clock_timestamp_millis)
+        .max(parent_timestamp_millis.saturating_add(1))
 }
 
 #[cfg(test)]

--- a/crates/node/src/engine.rs
+++ b/crates/node/src/engine.rs
@@ -46,7 +46,10 @@ use reth_node_builder::ConsensusEngineHandle;
 use reth_payload_builder::PayloadBuilderHandle;
 use reth_payload_primitives::{BuiltPayload, PayloadKind};
 use reth_primitives_traits::SealedHeader;
-use std::{sync::Arc, time::Duration};
+use std::{
+    sync::Arc,
+    time::{Duration, SystemTime, UNIX_EPOCH},
+};
 use tempo_primitives::TempoHeader;
 use tokio_util::sync::CancellationToken;
 use tracing::{error, info};
@@ -55,6 +58,17 @@ use zone_chainspec::ZoneChainSpec;
 use zone_l1::{DepositQueue, EncryptionKeyRing, L1BlockDeposits, L1BlockTracker, PreparedL1Block};
 use zone_p2p::{LeadershipSchedule, P2pPeerId};
 use zone_payload::{ZonePayloadAttributes, ZonePayloadTypes};
+
+/// Select a Zone timestamp that preserves the L1 lower bound without backdating user activity.
+fn zone_timestamp_millis(
+    l1_timestamp_millis: u64,
+    parent_timestamp_millis: u64,
+    wall_clock_timestamp_millis: u64,
+) -> u64 {
+    l1_timestamp_millis
+        .max(wall_clock_timestamp_millis)
+        .max(parent_timestamp_millis.saturating_add(1))
+}
 
 /// Per-anchor production permit backed by the effective leadership schedule.
 ///
@@ -329,10 +343,20 @@ impl ZoneEngine {
     async fn advance(&mut self, l1_block: L1BlockDeposits) -> eyre::Result<()> {
         let l1_num_hash = l1_block.header.num_hash();
 
-        // Zone block timestamp is locked to the L1 block's timestamp so the
-        // two chains stay in lockstep.
-        let timestamp_secs = l1_block.header.timestamp();
-        let timestamp_millis_part = l1_block.header.timestamp_millis_part;
+        // The L1 timestamp is a lower bound so a Zone block anchored after an L1 timestamp-based
+        // fork cannot predate it. Use wall-clock time to avoid backdating transactions during
+        // catch-up, and advance by at least one millisecond to keep consecutive blocks monotonic.
+        let wall_clock_timestamp_millis = SystemTime::now()
+            .duration_since(UNIX_EPOCH)?
+            .as_millis()
+            .try_into()?;
+        let timestamp_millis = zone_timestamp_millis(
+            l1_block.header.timestamp_millis(),
+            self.last_header.timestamp_millis(),
+            wall_clock_timestamp_millis,
+        );
+        let timestamp_secs = timestamp_millis / 1000;
+        let timestamp_millis_part = timestamp_millis % 1000;
 
         let l1_block = self.prepare_l1_block(l1_block).await?;
 
@@ -431,6 +455,21 @@ mod tests {
     use super::*;
     use std::collections::VecDeque;
     use tokio::sync::oneshot;
+
+    #[test]
+    fn zone_timestamp_uses_l1_timestamp_as_a_lower_bound() {
+        assert_eq!(zone_timestamp_millis(2_000, 999, 1_500), 2_000);
+    }
+
+    #[test]
+    fn zone_timestamp_uses_wall_clock_during_catch_up() {
+        assert_eq!(zone_timestamp_millis(1_000, 999, 2_000), 2_000);
+    }
+
+    #[test]
+    fn zone_timestamp_advances_past_parent_when_catching_up_in_same_millisecond() {
+        assert_eq!(zone_timestamp_millis(1_000, 2_000, 2_000), 2_001);
+    }
 
     struct PausedDrain {
         pending: VecDeque<u64>,

--- a/crates/node/tests/it/redacted_rpc_e2e.rs
+++ b/crates/node/tests/it/redacted_rpc_e2e.rs
@@ -500,10 +500,10 @@ async fn test_keychain_auth_rejection_cases() -> eyre::Result<()> {
         &expired_root,
         expired_key_id,
         KeyInfoSignatureType::P256,
-        now_secs() + 1,
+        now_secs() + 20,
     )
     .await?;
-    sleep(std::time::Duration::from_secs(2)).await;
+    sleep(std::time::Duration::from_secs(21)).await;
     let (status, _) = ctx
         .call_raw("eth_blockNumber", serde_json::json!([]), &expired_token)
         .await?;

--- a/crates/node/tests/it/redacted_rpc_e2e.rs
+++ b/crates/node/tests/it/redacted_rpc_e2e.rs
@@ -43,7 +43,6 @@ use tempo_zone_contracts::{
     IZoneInbox, TEMPO_STATE_ADDRESS, TempoState, Unauthorized, ZONE_INBOX_ADDRESS,
     ZONE_TOKEN_ADDRESS,
 };
-use tokio::time::sleep;
 use tokio_tungstenite::{
     connect_async,
     tungstenite::{Message, client::IntoClientRequest},
@@ -441,7 +440,7 @@ async fn test_keychain_auth_tokens_v1_and_v2() -> eyre::Result<()> {
     Ok(())
 }
 
-/// Keychain auth rejects missing, revoked, expired, and signature-type-mismatched keys.
+/// Keychain auth rejects missing, revoked, and signature-type-mismatched keys.
 #[tokio::test(flavor = "multi_thread")]
 async fn test_keychain_auth_rejection_cases() -> eyre::Result<()> {
     reth_tracing::init_test_tracing();
@@ -484,30 +483,6 @@ async fn test_keychain_auth_rejection_cases() -> eyre::Result<()> {
         .call_raw("eth_blockNumber", serde_json::json!([]), &revoked_token)
         .await?;
     assert_eq!(status.as_u16(), 403, "revoked key should return 403");
-
-    let expired_root = PrivateKeySigner::random();
-    let expired_access = P256SigningKey::random(&mut thread_rng());
-    ctx.inject_deposit(
-        PATH_USD_ADDRESS,
-        address!("0x0000000000000000000000000000000000003333"),
-        expired_root.address(),
-        1_000_000,
-    )
-    .await?;
-    let (expired_token, expired_key_id) =
-        ctx.keychain_p256_token(expired_root.address(), &expired_access, 0x04);
-    ctx.authorize_keychain_key(
-        &expired_root,
-        expired_key_id,
-        KeyInfoSignatureType::P256,
-        now_secs() + 20,
-    )
-    .await?;
-    sleep(std::time::Duration::from_secs(21)).await;
-    let (status, _) = ctx
-        .call_raw("eth_blockNumber", serde_json::json!([]), &expired_token)
-        .await?;
-    assert_eq!(status.as_u16(), 403, "expired key should return 403");
 
     let mismatch_root = PrivateKeySigner::random();
     let mismatch_access = P256SigningKey::random(&mut thread_rng());

--- a/crates/precompiles/src/tempo_state.rs
+++ b/crates/precompiles/src/tempo_state.rs
@@ -88,7 +88,7 @@ impl TempoState {
     ///
     /// IMPORTANT: this operation only enforces local continuity and Zone-time alignment: the
     /// decoded block number must increment by one, its parent hash must match the previously stored
-    /// Tempo hash, and its timestamp must exactly match the executing Zone block.
+    /// Tempo hash, and its timestamp must not exceed the executing Zone block's timestamp.
     ///
     /// Canonicality is a separate proof obligation: the batch proof must bind the imported header
     /// hash and state root to the canonical settlement anchor and authenticate every Tempo storage
@@ -110,9 +110,7 @@ impl TempoState {
             return Err(TempoStateError::invalid_rlp_data().into());
         }
         self.storage.with_block_env(|zone_block| {
-            if zone_block.inner.timestamp != U256::from(header.timestamp())
-                || zone_block.timestamp_millis_part != header.timestamp_millis_part
-            {
+            if zone_block.timestamp_millis() < U256::from(header.timestamp_millis()) {
                 return Err(TempoStateError::invalid_timestamp());
             }
             Ok(())
@@ -361,13 +359,27 @@ mod tests {
     }
 
     #[test]
-    fn finalize_tempo_reverts_on_timestamp_seconds_mismatch() -> eyre::Result<()> {
+    fn finalize_tempo_accepts_zone_timestamp_after_anchor() -> eyre::Result<()> {
         let genesis = TempoHeader::default();
         let genesis_hash = keccak256(encode_header(&genesis));
         let mut harness = TempoStateHarness::new(&genesis)?;
         let child = child_header(genesis_hash, 1);
         harness.set_block_timestamp(&child);
         harness.ctx.block.inner.timestamp += U256::ONE;
+
+        let output = harness.finalize(ZONE_INBOX_ADDRESS, &child, false)?;
+        assert!(output.is_success());
+        harness.assert_checkpoint(keccak256(encode_header(&child)), 1)
+    }
+
+    #[test]
+    fn finalize_tempo_reverts_when_zone_timestamp_precedes_anchor_seconds() -> eyre::Result<()> {
+        let genesis = TempoHeader::default();
+        let genesis_hash = keccak256(encode_header(&genesis));
+        let mut harness = TempoStateHarness::new(&genesis)?;
+        let child = child_header(genesis_hash, 1);
+        harness.set_block_timestamp(&child);
+        harness.ctx.block.inner.timestamp -= U256::ONE;
 
         let output = harness.finalize(ZONE_INBOX_ADDRESS, &child, false)?;
         assert!(output.is_revert());
@@ -380,13 +392,13 @@ mod tests {
     }
 
     #[test]
-    fn finalize_tempo_reverts_on_timestamp_millis_mismatch() -> eyre::Result<()> {
+    fn finalize_tempo_reverts_when_zone_timestamp_precedes_anchor_millis() -> eyre::Result<()> {
         let genesis = TempoHeader::default();
         let genesis_hash = keccak256(encode_header(&genesis));
         let mut harness = TempoStateHarness::new(&genesis)?;
         let child = child_header(genesis_hash, 1);
         harness.set_block_timestamp(&child);
-        harness.ctx.block.timestamp_millis_part += 1;
+        harness.ctx.block.timestamp_millis_part -= 1;
 
         let output = harness.finalize(ZONE_INBOX_ADDRESS, &child, false)?;
         assert!(output.is_revert());

--- a/crates/rpc/src/server.rs
+++ b/crates/rpc/src/server.rs
@@ -637,4 +637,36 @@ mod tests {
         ));
         assert_eq!(err.status_code(), StatusCode::FORBIDDEN);
     }
+
+    #[tokio::test]
+    async fn expired_keychain_key_is_classified_as_expired() {
+        let root_account = Address::repeat_byte(0x55);
+        let access_signer = P256SigningKey::random(&mut thread_rng());
+        let now = now_secs();
+        let (fields, digest) = build_token_fields(ZONE_ID, CHAIN_ID, now, now + 600);
+        let (signature, key_id) =
+            sign_keychain_signature(digest, &access_signer, root_account, 0x04)
+                .expect("keychain signing failed");
+        let token = build_token_with_signature(signature, &fields);
+        let api = TestApi::with_key_info(
+            root_account,
+            key_id,
+            KeyInfo {
+                signatureType: KeyInfoSignatureType::P256,
+                keyId: key_id,
+                expiry: now,
+                enforceLimits: false,
+                isRevoked: false,
+            },
+        );
+
+        let err = authenticate_token(&token, &test_config(), &api)
+            .await
+            .expect_err("expired key should fail authentication");
+        assert!(matches!(
+            err,
+            AuthenticateError::Invalid(crate::auth::AuthError::ExpiredKeychainKey)
+        ));
+        assert_eq!(err.status_code(), StatusCode::FORBIDDEN);
+    }
 }


### PR DESCRIPTION
## Summary

- use the L1 anchor timestamp as a lower bound instead of copying it exactly
- use wall-clock time so catch-up blocks do not backdate user transactions
- keep consecutive Zone timestamps strictly monotonic at millisecond precision
- validate `l1Timestamp <= zoneTimestamp` in `advanceTempo`

## Tests

- `cargo test -p zone-precompiles tempo_state`
- `cargo test -p zone-node engine::tests --lib`
- `cargo +nightly clippy -p zone-precompiles -p zone-node --lib --tests`
- `cargo +nightly fmt --check`

Prompted by: @klkvr