### PR TITLE
fix: preserve recipient resolution errors

### DIFF
--- a/crates/precompiles/src/execution.rs
+++ b/crates/precompiles/src/execution.rs
@@ -27,6 +27,7 @@ use tempo_chainspec::hardfork::TempoHardfork;
 use tempo_precompiles::{
     DelegateCallNotAllowed, charge_input_cost,
     dispatch::selector_from_calldata,
+    error::TempoPrecompileError,
     input_cost,
     storage::{
         PrecompileStorageProvider, StorageCtx, actions::StorageActions,
@@ -73,6 +74,14 @@ pub(crate) enum CallCheck {
     Continue,
     /// Revert with ABI-encoded data. The execution wrapper MUST apply input gas and reservoir.
     Revert(Bytes),
+    /// Return an error raised while evaluating an admission rule.
+    Error(CallRuleError),
+}
+
+/// Error raised while evaluating zone-specific pre-execution rules.
+pub(crate) enum CallRuleError {
+    /// An error originating in the upstream Tempo precompiles crate.
+    Tempo(TempoPrecompileError),
 }
 
 /// Selector and caller dependent precompile call rules evaluated after storage setup.
@@ -150,6 +159,13 @@ pub(crate) fn create_precompile(
                 let s = StorageCtx::default();
                 let output = s.revert_output(output);
                 add_input_cost(s, data, Ok(output))
+            }
+            CallCheck::Error(error) => {
+                let s = StorageCtx::default();
+                let result = match error {
+                    CallRuleError::Tempo(error) => s.error_result(error),
+                };
+                add_input_cost(s, data, result)
             }
         });
         if let (Ok(output), Some(gas)) = (&mut result, fixed_gas) {

--- a/crates/precompiles/src/execution.rs
+++ b/crates/precompiles/src/execution.rs
@@ -75,13 +75,7 @@ pub(crate) enum CallCheck {
     /// Revert with ABI-encoded data. The execution wrapper MUST apply input gas and reservoir.
     Revert(Bytes),
     /// Return an error raised while evaluating an admission rule.
-    Error(CallRuleError),
-}
-
-/// Error raised while evaluating zone-specific pre-execution rules.
-pub(crate) enum CallRuleError {
-    /// An error originating in the upstream Tempo precompiles crate.
-    Tempo(TempoPrecompileError),
+    Error(TempoPrecompileError),
 }
 
 /// Selector and caller dependent precompile call rules evaluated after storage setup.
@@ -162,9 +156,7 @@ pub(crate) fn create_precompile(
             }
             CallCheck::Error(error) => {
                 let s = StorageCtx::default();
-                let result = match error {
-                    CallRuleError::Tempo(error) => s.error_result(error),
-                };
+                let result = s.error_result(error);
                 add_input_cost(s, data, result)
             }
         });

--- a/crates/precompiles/src/execution.rs
+++ b/crates/precompiles/src/execution.rs
@@ -169,16 +169,17 @@ pub(crate) fn create_precompile(
     })
 }
 
-fn add_input_cost(mut s: StorageCtx, data: &[u8], mut res: PrecompileResult) -> PrecompileResult {
+fn add_input_cost(mut s: StorageCtx, data: &[u8], res: PrecompileResult) -> PrecompileResult {
+    // Fatal errors must be propagated to abort execution.
+    let mut output = res?;
+
     let gas_before = s.gas_used();
     if let Some(err) = charge_input_cost(&mut s, data) {
         return err;
     }
-    if let Ok(output) = &mut res {
-        let input_gas = s.gas_used().saturating_sub(gas_before);
-        output.gas_used = output.gas_used.saturating_add(input_gas);
-    }
-    res
+    let input_gas = s.gas_used().saturating_sub(gas_before);
+    output.gas_used = output.gas_used.saturating_add(input_gas);
+    Ok(output)
 }
 
 #[cfg(test)]
@@ -415,5 +416,38 @@ mod tests {
         assert!(!executed.get());
         assert_eq!(rejected.gas_used, FIXED_GAS);
         assert_eq!(rejected.bytes, Bytes::from_static(b"denied"));
+    }
+
+    struct FatalRules;
+
+    impl CallRules for FatalRules {
+        fn admit(&self, _data: &[u8], _caller: Address) -> CallCheck {
+            StorageCtx::default().deduct_gas(10).unwrap();
+            CallCheck::Error(TempoPrecompileError::Fatal("boom".into()))
+        }
+    }
+
+    #[test]
+    fn input_cost_does_not_replace_fatal_admission_error() {
+        let cfg = revm::context::CfgEnv::<TempoHardfork>::default();
+        let env = ZonePrecompileEnv::new(
+            &cfg,
+            zone_hardfork::ZoneHardfork::Z0,
+            StorageActions::disabled(),
+            Rc::new(RefCell::new(NonCreditableSlots::empty())),
+        );
+        let precompile = create_precompile("FatalAdmissionTest", &env, FatalRules, |_, _| {
+            panic!("fatal admission must not execute the precompile")
+        });
+        let mut ctx = test_context();
+        let calldata = [1, 2, 3, 4];
+
+        let error = precompile
+            .call(input(&mut ctx, &calldata, Address::ZERO, 10))
+            .unwrap_err();
+        assert!(matches!(
+            error,
+            revm::precompile::PrecompileError::Fatal(message) if message == "boom"
+        ));
     }
 }

--- a/crates/precompiles/src/receive_policy_guard.rs
+++ b/crates/precompiles/src/receive_policy_guard.rs
@@ -5,7 +5,7 @@
 //! the return value as a receipt-existence and amount oracle.
 
 use crate::{
-    execution::{CallCheck, CallRuleError, CallRules},
+    execution::{CallCheck, CallRules},
     ztip20::TIP20_FIXED_TRANSFER_GAS,
 };
 use alloy_primitives::Address;
@@ -49,7 +49,7 @@ impl CallRules for ReceivePolicyGuardRules {
         match AddressRegistry::new().resolve_recipient(receipt.recipient) {
             Ok(receiver) if caller == receiver => CallCheck::Continue,
             Ok(_) => CallCheck::Revert(Unauthorized {}.abi_encode().into()),
-            Err(error) => CallCheck::Error(CallRuleError::Tempo(error)),
+            Err(error) => CallCheck::Error(error),
         }
     }
 }
@@ -183,9 +183,7 @@ mod tests {
         StorageCtx::enter(&mut storage, || {
             assert!(matches!(
                 rules.admit(&balance_call(&receipt), OUTSIDER),
-                CallCheck::Error(CallRuleError::Tempo(
-                    tempo_precompiles::error::TempoPrecompileError::OutOfGas
-                ))
+                CallCheck::Error(tempo_precompiles::error::TempoPrecompileError::OutOfGas)
             ));
         });
         Ok(())

--- a/crates/precompiles/src/receive_policy_guard.rs
+++ b/crates/precompiles/src/receive_policy_guard.rs
@@ -5,7 +5,7 @@
 //! the return value as a receipt-existence and amount oracle.
 
 use crate::{
-    execution::{CallCheck, CallRules},
+    execution::{CallCheck, CallRuleError, CallRules},
     ztip20::TIP20_FIXED_TRANSFER_GAS,
 };
 use alloy_primitives::Address;
@@ -46,14 +46,11 @@ impl CallRules for ReceivePolicyGuardRules {
             return CallCheck::Continue;
         }
 
-        if matches!(
-            AddressRegistry::new().resolve_recipient(receipt.recipient),
-            Ok(receiver) if caller == receiver
-        ) {
-            return CallCheck::Continue;
+        match AddressRegistry::new().resolve_recipient(receipt.recipient) {
+            Ok(receiver) if caller == receiver => CallCheck::Continue,
+            Ok(_) => CallCheck::Revert(Unauthorized {}.abi_encode().into()),
+            Err(error) => CallCheck::Error(CallRuleError::Tempo(error)),
         }
-
-        CallCheck::Revert(Unauthorized {}.abi_encode().into())
     }
 }
 
@@ -165,6 +162,33 @@ mod tests {
             assert_unauthorized(&rules, &receipt, OUTSIDER);
             Ok(())
         })
+    }
+
+    #[test]
+    fn balance_admission_preserves_recipient_resolution_errors() -> eyre::Result<()> {
+        let rules = ReceivePolicyGuardRules;
+        let mut ctx = test_context();
+        ctx.cfg.spec = tempo_chainspec::hardfork::TempoHardfork::T8;
+
+        let virtual_recipient = {
+            let mut storage = test_storage_provider(&mut ctx, u64::MAX, false);
+            StorageCtx::enter(&mut storage, || {
+                let (_, virtual_recipient) = register_virtual_master(&mut AddressRegistry::new())?;
+                Ok::<_, eyre::Report>(virtual_recipient)
+            })?
+        };
+        let receipt = receipt(virtual_recipient, Address::ZERO);
+        let mut storage = test_storage_provider(&mut ctx, 0, true);
+
+        StorageCtx::enter(&mut storage, || {
+            assert!(matches!(
+                rules.admit(&balance_call(&receipt), OUTSIDER),
+                CallCheck::Error(CallRuleError::Tempo(
+                    tempo_precompiles::error::TempoPrecompileError::OutOfGas
+                ))
+            ));
+        });
+        Ok(())
     }
 
     #[test]


### PR DESCRIPTION
ref: [ZONE-701](https://linear.app/tempoxyz/issue/ZONE-701/receive-policy-guard-discards-state-read-errors-from-resolve-recipient)

## Summary

- propagate `resolve_recipient()` failures through Tempo error handling
- reserve `Unauthorized` for successfully resolved recipient mismatches
- add regression coverage for out-of-gas recipient resolution

## Testing

- `cargo test -p zone-precompiles receive_policy_guard`
- `cargo +nightly fmt --all -- --check`
- `cargo +nightly clippy -p zone-precompiles --all-targets -- -D warnings`

Prompted by: @0xrusowsky