### PR TITLE
feat(xtask): Add portal backing verifier

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4199,9 +4199,9 @@ dependencies = [
 
 [[package]]
 name = "h2"
-version = "0.4.15"
+version = "0.4.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6cb093c84e8bd9b188d4c4a8cb6579fc016968d14c99882163cd3ff402a4f155"
+checksum = "a9f37a958b41b3b19ee2707c06439c0e9e547e847223eb791ecb0cb821c65e27"
 dependencies = [
  "atomic-waker",
  "bytes",

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -7,7 +7,8 @@ use crate::{
     generate_p2p_key::GenerateP2pKey, generate_zone_genesis::GenerateZoneGenesis,
     install_reference_zone_factory::InstallReferenceZoneFactory, portal_pause::PausePortal,
     set_encryption_key::SetEncryptionKey, spam_deposits::SpamDeposits,
-    verify_closed_loop::VerifyClosedLoop, zone_info::ZoneInfoCmd,
+    verify_closed_loop::VerifyClosedLoop, verify_portal_backing::VerifyPortalBacking,
+    zone_info::ZoneInfoCmd,
 };
 use clap::Parser as _;
 use eyre::Context;
@@ -28,6 +29,7 @@ mod portal_pause;
 mod set_encryption_key;
 mod spam_deposits;
 mod verify_closed_loop;
+mod verify_portal_backing;
 mod zone_info;
 mod zone_utils;
 
@@ -70,6 +72,10 @@ async fn main() -> eyre::Result<()> {
         Action::VerifyClosedLoop(args) => {
             args.run().await.wrap_err("closed-loop verification failed")
         }
+        Action::VerifyPortalBacking(args) => args
+            .run()
+            .await
+            .wrap_err("Portal backing verification failed"),
         Action::ZoneInfo(args) => args.run().await.wrap_err("failed to fetch zone info"),
     }
 }
@@ -102,5 +108,6 @@ enum Action {
     SetEncryptionKey(SetEncryptionKey),
     SpamDeposits(SpamDeposits),
     VerifyClosedLoop(VerifyClosedLoop),
+    VerifyPortalBacking(VerifyPortalBacking),
     ZoneInfo(ZoneInfoCmd),
 }

--- a/xtask/src/verify_portal_backing.rs
+++ b/xtask/src/verify_portal_backing.rs
@@ -8,7 +8,10 @@ use alloy::{
 use eyre::{WrapErr as _, ensure};
 use tempo_alloy::TempoNetwork;
 use tempo_contracts::precompiles::ITIP20 as TIP20Token;
-use tempo_zone_contracts::{IZoneInbox, ZONE_INBOX_ADDRESS, ZonePortal};
+use tempo_zone_contracts::{
+    IZoneInbox, ZONE_FACTORY_ADDRESS, ZONE_INBOX_ADDRESS, ZoneFactory, ZonePortal,
+};
+use zone_primitives::constants::zone_chain_id;
 
 use crate::zone_utils::normalize_http_rpc;
 
@@ -62,9 +65,13 @@ impl VerifyPortalBacking {
             .await
             .wrap_err("failed connecting to Zone RPC")?;
 
-        let (l1_snapshot, zone_snapshot) =
-            tokio::try_join!(l1.get_block_number(), zone.get_block_number(),)
-                .wrap_err("failed reading snapshot blocks")?;
+        let (l1_snapshot, zone_snapshot, l1_chain_id, actual_zone_chain_id) = tokio::try_join!(
+            l1.get_block_number(),
+            zone.get_block_number(),
+            l1.get_chain_id(),
+            zone.get_chain_id(),
+        )
+        .wrap_err("failed reading snapshot blocks and chain IDs")?;
         ensure!(
             self.l1_from_block <= l1_snapshot,
             "L1 scan start {} is after snapshot block {l1_snapshot}",
@@ -78,6 +85,7 @@ impl VerifyPortalBacking {
         let l1_block = BlockId::number(l1_snapshot);
         let zone_block = BlockId::number(zone_snapshot);
         let portal = ZonePortal::new(self.portal, &l1);
+        let factory = ZoneFactory::new(ZONE_FACTORY_ADDRESS, &l1);
         let l1_token = TIP20Token::new(self.token, &l1);
         let zone_token = TIP20Token::new(self.token, &zone);
         let inbox = IZoneInbox::new(ZONE_INBOX_ADDRESS, &zone);
@@ -89,12 +97,16 @@ impl VerifyPortalBacking {
             .add(portal.withdrawalQueueHead())
             .add(portal.withdrawalQueueTail())
             .add(portal.depositCount())
-            .add(portal.lastProcessedDepositNumber());
+            .add(portal.lastProcessedDepositNumber())
+            .add(portal.zoneId())
+            .add(portal.isTokenEnabled(self.token))
+            .add(factory.isZonePortal(self.portal));
         let zone_reads = zone
             .multicall()
             .block(zone_block)
             .add(zone_token.totalSupply())
-            .add(inbox.processedDepositNumber());
+            .add(inbox.processedDepositNumber())
+            .add(inbox.tempoPortal());
         let (
             (
                 portal_balance,
@@ -102,10 +114,38 @@ impl VerifyPortalBacking {
                 withdrawal_tail,
                 deposit_count,
                 l1_processed_deposits,
+                portal_zone_id,
+                token_enabled,
+                portal_registered,
             ),
-            (zone_supply, zone_processed_deposits),
+            (zone_supply, zone_processed_deposits, inbox_portal),
         ) = tokio::try_join!(l1_reads.aggregate(), zone_reads.aggregate())
             .wrap_err("failed reading backing state")?;
+
+        let factory_zone = factory
+            .zones(portal_zone_id)
+            .block(l1_block)
+            .call()
+            .await
+            .wrap_err("failed reading ZoneFactory registration")?;
+        let expected_zone_chain_id =
+            zone_chain_id(l1_chain_id, portal_zone_id).wrap_err("failed deriving Zone chain ID")?;
+
+        ensure!(portal_registered, "Portal is not registered in ZoneFactory");
+        ensure!(
+            factory_zone.portal == self.portal && factory_zone.zoneId == portal_zone_id,
+            "Portal does not match ZoneFactory registration for zone {portal_zone_id}"
+        );
+        ensure!(
+            inbox_portal == self.portal,
+            "ZoneInbox Portal mismatch: expected {}, got {inbox_portal}",
+            self.portal
+        );
+        ensure!(
+            actual_zone_chain_id == expected_zone_chain_id,
+            "Zone chain ID mismatch: expected {expected_zone_chain_id} for L1 chain {l1_chain_id} and zone {portal_zone_id}, got {actual_zone_chain_id}"
+        );
+        ensure!(token_enabled, "Token is not enabled on the Portal");
 
         ensure!(
             zone_processed_deposits <= deposit_count,

--- a/xtask/src/verify_portal_backing.rs
+++ b/xtask/src/verify_portal_backing.rs
@@ -1,0 +1,243 @@
+//! Verifies the settled token-backing invariant for a ZonePortal.
+
+use alloy::{
+    primitives::{Address, U256},
+    providers::{Provider, ProviderBuilder},
+    rpc::types::BlockId,
+};
+use eyre::{WrapErr as _, ensure};
+use std::collections::BTreeSet;
+use tempo_alloy::TempoNetwork;
+use tempo_contracts::precompiles::ITIP20 as TIP20Token;
+use tempo_zone_contracts::{IZoneInbox, ZONE_INBOX_ADDRESS, ZonePortal};
+
+use crate::zone_utils::normalize_http_rpc;
+
+const LOG_QUERY_BLOCK_CHUNK: u64 = 5_000;
+
+#[derive(Debug, clap::Parser)]
+pub(crate) struct VerifyPortalBacking {
+    /// Tempo L1 HTTP RPC URL.
+    #[arg(long, env = "L1_RPC_URL")]
+    l1_rpc_url: String,
+
+    /// Unredacted Zone HTTP RPC URL. Refund reads for arbitrary owners require operator access.
+    #[arg(long, env = "ZONE_RPC_URL")]
+    zone_rpc_url: String,
+
+    /// ZonePortal address on Tempo L1.
+    #[arg(long)]
+    portal: Address,
+
+    /// TIP-20 token address, shared by Tempo L1 and the Zone.
+    #[arg(long)]
+    token: Address,
+
+    /// First L1 block to scan. Must not exclude any still-outstanding refund owner.
+    #[arg(long, default_value_t = 0)]
+    l1_from_block: u64,
+
+    /// First Zone block to scan. Must not exclude any still-outstanding refund owner.
+    #[arg(long, default_value_t = 0)]
+    zone_from_block: u64,
+}
+
+impl VerifyPortalBacking {
+    pub(crate) async fn run(self) -> eyre::Result<()> {
+        let l1_rpc_url = normalize_http_rpc(&self.l1_rpc_url);
+        let zone_rpc_url = normalize_http_rpc(&self.zone_rpc_url);
+        let l1 = ProviderBuilder::new_with_network::<TempoNetwork>()
+            .connect(&l1_rpc_url)
+            .await
+            .wrap_err("failed connecting to Tempo L1")?;
+        let zone = ProviderBuilder::new_with_network::<TempoNetwork>()
+            .connect(&zone_rpc_url)
+            .await
+            .wrap_err("failed connecting to Zone RPC")?;
+
+        let (l1_snapshot, zone_snapshot) =
+            tokio::try_join!(l1.get_block_number(), zone.get_block_number(),)
+                .wrap_err("failed reading snapshot blocks")?;
+        ensure!(
+            self.l1_from_block <= l1_snapshot,
+            "L1 scan start {} is after snapshot block {l1_snapshot}",
+            self.l1_from_block
+        );
+        ensure!(
+            self.zone_from_block <= zone_snapshot,
+            "Zone scan start {} is after snapshot block {zone_snapshot}",
+            self.zone_from_block
+        );
+
+        let l1_block = BlockId::number(l1_snapshot);
+        let zone_block = BlockId::number(zone_snapshot);
+        let portal = ZonePortal::new(self.portal, &l1);
+        let l1_token = TIP20Token::new(self.token, &l1);
+        let zone_token = TIP20Token::new(self.token, &zone);
+        let inbox = IZoneInbox::new(ZONE_INBOX_ADDRESS, &zone);
+
+        let l1_reads = l1
+            .multicall()
+            .block(l1_block)
+            .add(l1_token.balanceOf(self.portal))
+            .add(portal.withdrawalQueueHead())
+            .add(portal.withdrawalQueueTail())
+            .add(portal.depositCount())
+            .add(portal.lastProcessedDepositNumber());
+        let zone_reads = zone
+            .multicall()
+            .block(zone_block)
+            .add(zone_token.totalSupply())
+            .add(inbox.processedDepositNumber());
+        let (
+            (
+                portal_balance,
+                withdrawal_head,
+                withdrawal_tail,
+                deposit_count,
+                l1_processed_deposits,
+            ),
+            (zone_supply, zone_processed_deposits),
+        ) = tokio::try_join!(l1_reads.aggregate(), zone_reads.aggregate())
+            .wrap_err("failed reading backing state")?;
+
+        ensure!(
+            withdrawal_head == withdrawal_tail,
+            "withdrawal queue is not settled: head={withdrawal_head}, tail={withdrawal_tail}"
+        );
+        ensure!(
+            deposit_count == l1_processed_deposits,
+            "L1 deposit queue is not settled: depositCount={deposit_count}, \
+             lastProcessedDepositNumber={l1_processed_deposits}"
+        );
+        ensure!(
+            zone_processed_deposits == l1_processed_deposits,
+            "Zone and L1 deposit counters disagree: ZoneInbox={zone_processed_deposits}, \
+             ZonePortal={l1_processed_deposits}"
+        );
+
+        let (portal_owners, inbox_owners) = tokio::try_join!(
+            portal_refund_owners(
+                &l1,
+                self.portal,
+                self.token,
+                self.l1_from_block,
+                l1_snapshot,
+            ),
+            inbox_refund_owners(&zone, self.token, self.zone_from_block, zone_snapshot,),
+        )?;
+
+        let mut portal_refunds = U256::ZERO;
+        for owner in &portal_owners {
+            let amount = portal
+                .refunds(self.token, *owner)
+                .block(l1_block)
+                .call()
+                .await
+                .wrap_err_with(|| format!("failed reading Portal refund for {owner}"))?;
+            portal_refunds = portal_refunds
+                .checked_add(U256::from(amount))
+                .ok_or_else(|| eyre::eyre!("Portal refund total overflow"))?;
+        }
+
+        let mut inbox_refunds = U256::ZERO;
+        for owner in &inbox_owners {
+            let amount = inbox
+                .refunds(self.token, *owner)
+                .block(zone_block)
+                .call()
+                .await
+                .wrap_err_with(|| format!("failed reading ZoneInbox refund for {owner}"))?;
+            inbox_refunds = inbox_refunds
+                .checked_add(U256::from(amount))
+                .ok_or_else(|| eyre::eyre!("ZoneInbox refund total overflow"))?;
+        }
+
+        let required_backing = zone_supply
+            .checked_add(portal_refunds)
+            .and_then(|value| value.checked_add(inbox_refunds))
+            .ok_or_else(|| eyre::eyre!("required backing overflow"))?;
+
+        println!("Portal backing audit");
+        println!("  L1 snapshot block:       {l1_snapshot}");
+        println!("  Zone snapshot block:     {zone_snapshot}");
+        println!(
+            "  L1 refund scan:          {}..={l1_snapshot}",
+            self.l1_from_block
+        );
+        println!(
+            "  Zone refund scan:        {}..={zone_snapshot}",
+            self.zone_from_block
+        );
+        println!("  Portal:                  {}", self.portal);
+        println!("  Token:                   {}", self.token);
+        println!("  Portal balance:          {portal_balance}");
+        println!("  Zone total supply:       {zone_supply}");
+        println!(
+            "  Portal refunds:          {portal_refunds} ({} owner(s))",
+            portal_owners.len()
+        );
+        println!(
+            "  ZoneInbox refunds:       {inbox_refunds} ({} owner(s))",
+            inbox_owners.len()
+        );
+        println!("  Required backing:        {required_backing}");
+
+        if portal_balance >= required_backing {
+            println!(
+                "  PASS: backing surplus    {}",
+                portal_balance - required_backing
+            );
+            Ok(())
+        } else {
+            let deficit = required_backing - portal_balance;
+            println!("  FAIL: backing deficit    {deficit}");
+            Err(eyre::eyre!("Portal is underbacked by {deficit} base units"))
+        }
+    }
+}
+
+async fn portal_refund_owners<P: Provider<TempoNetwork>>(
+    provider: &P,
+    portal: Address,
+    token: Address,
+    from_block: u64,
+    to_block: u64,
+) -> eyre::Result<BTreeSet<Address>> {
+    let events = ZonePortal::new(portal, provider)
+        .DepositBounceBackPending_filter()
+        .from_block(from_block)
+        .to_block(to_block)
+        .chunked()
+        .chunk_size(LOG_QUERY_BLOCK_CHUNK)
+        .query()
+        .await
+        .wrap_err("failed scanning ZonePortal DepositBounceBackPending events")?;
+
+    Ok(events
+        .into_iter()
+        .filter_map(|(event, _)| (event.token == token).then_some(event.tempoRefundRecipient))
+        .collect())
+}
+
+async fn inbox_refund_owners<P: Provider<TempoNetwork>>(
+    provider: &P,
+    token: Address,
+    from_block: u64,
+    to_block: u64,
+) -> eyre::Result<BTreeSet<Address>> {
+    let events = IZoneInbox::new(ZONE_INBOX_ADDRESS, provider)
+        .WithdrawalBounceBackPending_filter()
+        .from_block(from_block)
+        .to_block(to_block)
+        .chunked()
+        .chunk_size(LOG_QUERY_BLOCK_CHUNK)
+        .query()
+        .await
+        .wrap_err("failed scanning ZoneInbox WithdrawalBounceBackPending events")?;
+
+    Ok(events
+        .into_iter()
+        .filter_map(|(event, _)| (event.token == token).then_some(event.zoneFallbackRecipient))
+        .collect())
+}

--- a/xtask/src/verify_portal_backing.rs
+++ b/xtask/src/verify_portal_backing.rs
@@ -6,7 +6,6 @@ use alloy::{
     rpc::types::BlockId,
 };
 use eyre::{WrapErr as _, ensure};
-use std::collections::BTreeSet;
 use tempo_alloy::TempoNetwork;
 use tempo_contracts::precompiles::ITIP20 as TIP20Token;
 use tempo_zone_contracts::{IZoneInbox, ZONE_INBOX_ADDRESS, ZonePortal};
@@ -21,7 +20,7 @@ pub(crate) struct VerifyPortalBacking {
     #[arg(long, env = "L1_RPC_URL")]
     l1_rpc_url: String,
 
-    /// Unredacted Zone HTTP RPC URL. Refund reads for arbitrary owners require operator access.
+    /// Zone HTTP RPC URL.
     #[arg(long, env = "ZONE_RPC_URL")]
     zone_rpc_url: String,
 
@@ -33,13 +32,9 @@ pub(crate) struct VerifyPortalBacking {
     #[arg(long)]
     token: Address,
 
-    /// First L1 block to scan. Must not exclude any still-outstanding refund owner.
+    /// First L1 block to scan. Must include the Portal's complete event history.
     #[arg(long, default_value_t = 0)]
     l1_from_block: u64,
-
-    /// First Zone block to scan. Must not exclude any still-outstanding refund owner.
-    #[arg(long, default_value_t = 0)]
-    zone_from_block: u64,
 }
 
 impl VerifyPortalBacking {
@@ -63,12 +58,6 @@ impl VerifyPortalBacking {
             "L1 scan start {} is after snapshot block {l1_snapshot}",
             self.l1_from_block
         );
-        ensure!(
-            self.zone_from_block <= zone_snapshot,
-            "Zone scan start {} is after snapshot block {zone_snapshot}",
-            self.zone_from_block
-        );
-
         let l1_block = BlockId::number(l1_snapshot);
         let zone_block = BlockId::number(zone_snapshot);
         let portal = ZonePortal::new(self.portal, &l1);
@@ -116,46 +105,17 @@ impl VerifyPortalBacking {
              ZonePortal={l1_processed_deposits}"
         );
 
-        let (portal_owners, inbox_owners) = tokio::try_join!(
-            portal_refund_owners(
-                &l1,
-                self.portal,
-                self.token,
-                self.l1_from_block,
-                l1_snapshot,
-            ),
-            inbox_refund_owners(&zone, self.token, self.zone_from_block, zone_snapshot,),
-        )?;
-
-        let mut portal_refunds = U256::ZERO;
-        for owner in &portal_owners {
-            let amount = portal
-                .refunds(self.token, *owner)
-                .block(l1_block)
-                .call()
-                .await
-                .wrap_err_with(|| format!("failed reading Portal refund for {owner}"))?;
-            portal_refunds = portal_refunds
-                .checked_add(U256::from(amount))
-                .ok_or_else(|| eyre::eyre!("Portal refund total overflow"))?;
-        }
-
-        let mut inbox_refunds = U256::ZERO;
-        for owner in &inbox_owners {
-            let amount = inbox
-                .refunds(self.token, *owner)
-                .block(zone_block)
-                .call()
-                .await
-                .wrap_err_with(|| format!("failed reading ZoneInbox refund for {owner}"))?;
-            inbox_refunds = inbox_refunds
-                .checked_add(U256::from(amount))
-                .ok_or_else(|| eyre::eyre!("ZoneInbox refund total overflow"))?;
-        }
+        let portal_refunds = portal_refund_liability(
+            &l1,
+            self.portal,
+            self.token,
+            self.l1_from_block,
+            l1_snapshot,
+        )
+        .await?;
 
         let required_backing = zone_supply
             .checked_add(portal_refunds)
-            .and_then(|value| value.checked_add(inbox_refunds))
             .ok_or_else(|| eyre::eyre!("required backing overflow"))?;
 
         println!("Portal backing audit");
@@ -165,22 +125,11 @@ impl VerifyPortalBacking {
             "  L1 refund scan:          {}..={l1_snapshot}",
             self.l1_from_block
         );
-        println!(
-            "  Zone refund scan:        {}..={zone_snapshot}",
-            self.zone_from_block
-        );
         println!("  Portal:                  {}", self.portal);
         println!("  Token:                   {}", self.token);
         println!("  Portal balance:          {portal_balance}");
         println!("  Zone total supply:       {zone_supply}");
-        println!(
-            "  Portal refunds:          {portal_refunds} ({} owner(s))",
-            portal_owners.len()
-        );
-        println!(
-            "  ZoneInbox refunds:       {inbox_refunds} ({} owner(s))",
-            inbox_owners.len()
-        );
+        println!("  Portal refund liability: {portal_refunds}");
         println!("  Required backing:        {required_backing}");
 
         if portal_balance >= required_backing {
@@ -197,14 +146,15 @@ impl VerifyPortalBacking {
     }
 }
 
-async fn portal_refund_owners<P: Provider<TempoNetwork>>(
+async fn portal_refund_liability<P: Provider<TempoNetwork>>(
     provider: &P,
     portal: Address,
     token: Address,
     from_block: u64,
     to_block: u64,
-) -> eyre::Result<BTreeSet<Address>> {
-    let events = ZonePortal::new(portal, provider)
+) -> eyre::Result<U256> {
+    let portal = ZonePortal::new(portal, provider);
+    let pending = portal
         .DepositBounceBackPending_filter()
         .from_block(from_block)
         .to_block(to_block)
@@ -213,31 +163,58 @@ async fn portal_refund_owners<P: Provider<TempoNetwork>>(
         .query()
         .await
         .wrap_err("failed scanning ZonePortal DepositBounceBackPending events")?;
-
-    Ok(events
-        .into_iter()
-        .filter_map(|(event, _)| (event.token == token).then_some(event.tempoRefundRecipient))
-        .collect())
-}
-
-async fn inbox_refund_owners<P: Provider<TempoNetwork>>(
-    provider: &P,
-    token: Address,
-    from_block: u64,
-    to_block: u64,
-) -> eyre::Result<BTreeSet<Address>> {
-    let events = IZoneInbox::new(ZONE_INBOX_ADDRESS, provider)
-        .WithdrawalBounceBackPending_filter()
+    let claimed = portal
+        .RefundClaimed_filter()
         .from_block(from_block)
         .to_block(to_block)
         .chunked()
         .chunk_size(LOG_QUERY_BLOCK_CHUNK)
         .query()
         .await
-        .wrap_err("failed scanning ZoneInbox WithdrawalBounceBackPending events")?;
+        .wrap_err("failed scanning ZonePortal RefundClaimed events")?;
 
-    Ok(events
+    let pending_total = pending
         .into_iter()
-        .filter_map(|(event, _)| (event.token == token).then_some(event.zoneFallbackRecipient))
-        .collect())
+        .filter(|(event, _)| event.token == token)
+        .try_fold(U256::ZERO, |total, (event, _)| {
+            total
+                .checked_add(U256::from(event.amount))
+                .ok_or_else(|| eyre::eyre!("Portal pending refund total overflow"))
+        })?;
+    let claimed_total = claimed
+        .into_iter()
+        .filter(|(event, _)| event.token == token)
+        .try_fold(U256::ZERO, |total, (event, _)| {
+            total
+                .checked_add(U256::from(event.amount))
+                .ok_or_else(|| eyre::eyre!("Portal claimed refund total overflow"))
+        })?;
+
+    outstanding_refunds(pending_total, claimed_total)
+}
+
+fn outstanding_refunds(pending: U256, claimed: U256) -> eyre::Result<U256> {
+    pending.checked_sub(claimed).ok_or_else(|| {
+        eyre::eyre!(
+            "Portal refund event history is incomplete: claimed {claimed}, pending {pending}"
+        )
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn outstanding_refunds_subtracts_claims() {
+        assert_eq!(
+            outstanding_refunds(U256::from(100), U256::from(35)).unwrap(),
+            U256::from(65)
+        );
+    }
+
+    #[test]
+    fn outstanding_refunds_rejects_incomplete_history() {
+        assert!(outstanding_refunds(U256::from(10), U256::from(11)).is_err());
+    }
 }

--- a/xtask/src/verify_portal_backing.rs
+++ b/xtask/src/verify_portal_backing.rs
@@ -35,6 +35,10 @@ pub(crate) struct VerifyPortalBacking {
     /// First L1 block to scan. Must include the Portal's complete event history.
     #[arg(long, default_value_t = 0)]
     l1_from_block: u64,
+
+    /// First Zone block to scan. Must include the ZoneInbox's complete event history.
+    #[arg(long, default_value_t = 0)]
+    zone_from_block: u64,
 }
 
 impl VerifyPortalBacking {
@@ -57,6 +61,11 @@ impl VerifyPortalBacking {
             self.l1_from_block <= l1_snapshot,
             "L1 scan start {} is after snapshot block {l1_snapshot}",
             self.l1_from_block
+        );
+        ensure!(
+            self.zone_from_block <= zone_snapshot,
+            "Zone scan start {} is after snapshot block {zone_snapshot}",
+            self.zone_from_block
         );
         let l1_block = BlockId::number(l1_snapshot);
         let zone_block = BlockId::number(zone_snapshot);
@@ -113,9 +122,12 @@ impl VerifyPortalBacking {
             l1_snapshot,
         )
         .await?;
+        let inbox_refunds =
+            inbox_refund_liability(&zone, self.token, self.zone_from_block, zone_snapshot).await?;
 
         let required_backing = zone_supply
             .checked_add(portal_refunds)
+            .and_then(|total| total.checked_add(inbox_refunds))
             .ok_or_else(|| eyre::eyre!("required backing overflow"))?;
 
         println!("Portal backing audit");
@@ -125,11 +137,16 @@ impl VerifyPortalBacking {
             "  L1 refund scan:          {}..={l1_snapshot}",
             self.l1_from_block
         );
+        println!(
+            "  Zone refund scan:        {}..={zone_snapshot}",
+            self.zone_from_block
+        );
         println!("  Portal:                  {}", self.portal);
         println!("  Token:                   {}", self.token);
         println!("  Portal balance:          {portal_balance}");
         println!("  Zone total supply:       {zone_supply}");
         println!("  Portal refund liability: {portal_refunds}");
+        println!("  Inbox refund liability:  {inbox_refunds}");
         println!("  Required backing:        {required_backing}");
 
         if portal_balance >= required_backing {
@@ -190,13 +207,59 @@ async fn portal_refund_liability<P: Provider<TempoNetwork>>(
                 .ok_or_else(|| eyre::eyre!("Portal claimed refund total overflow"))
         })?;
 
-    outstanding_refunds(pending_total, claimed_total)
+    outstanding_refunds("Portal", pending_total, claimed_total)
 }
 
-fn outstanding_refunds(pending: U256, claimed: U256) -> eyre::Result<U256> {
+async fn inbox_refund_liability<P: Provider<TempoNetwork>>(
+    provider: &P,
+    token: Address,
+    from_block: u64,
+    to_block: u64,
+) -> eyre::Result<U256> {
+    let inbox = IZoneInbox::new(ZONE_INBOX_ADDRESS, provider);
+    let pending = inbox
+        .WithdrawalBounceBackPending_filter()
+        .from_block(from_block)
+        .to_block(to_block)
+        .chunked()
+        .chunk_size(LOG_QUERY_BLOCK_CHUNK)
+        .query()
+        .await
+        .wrap_err("failed scanning ZoneInbox WithdrawalBounceBackPending events")?;
+    let claimed = inbox
+        .RefundClaimed_filter()
+        .from_block(from_block)
+        .to_block(to_block)
+        .chunked()
+        .chunk_size(LOG_QUERY_BLOCK_CHUNK)
+        .query()
+        .await
+        .wrap_err("failed scanning ZoneInbox RefundClaimed events")?;
+
+    let pending_total = pending
+        .into_iter()
+        .filter(|(event, _)| event.token == token)
+        .try_fold(U256::ZERO, |total, (event, _)| {
+            total
+                .checked_add(U256::from(event.amount))
+                .ok_or_else(|| eyre::eyre!("Inbox pending refund total overflow"))
+        })?;
+    let claimed_total = claimed
+        .into_iter()
+        .filter(|(event, _)| event.token == token)
+        .try_fold(U256::ZERO, |total, (event, _)| {
+            total
+                .checked_add(U256::from(event.amount))
+                .ok_or_else(|| eyre::eyre!("Inbox claimed refund total overflow"))
+        })?;
+
+    outstanding_refunds("Inbox", pending_total, claimed_total)
+}
+
+fn outstanding_refunds(scope: &str, pending: U256, claimed: U256) -> eyre::Result<U256> {
     pending.checked_sub(claimed).ok_or_else(|| {
         eyre::eyre!(
-            "Portal refund event history is incomplete: claimed {claimed}, pending {pending}"
+            "{scope} refund event history is incomplete: claimed {claimed}, pending {pending}"
         )
     })
 }
@@ -208,13 +271,13 @@ mod tests {
     #[test]
     fn outstanding_refunds_subtracts_claims() {
         assert_eq!(
-            outstanding_refunds(U256::from(100), U256::from(35)).unwrap(),
+            outstanding_refunds("test", U256::from(100), U256::from(35)).unwrap(),
             U256::from(65)
         );
     }
 
     #[test]
     fn outstanding_refunds_rejects_incomplete_history() {
-        assert!(outstanding_refunds(U256::from(10), U256::from(11)).is_err());
+        assert!(outstanding_refunds("test", U256::from(10), U256::from(11)).is_err());
     }
 }

--- a/xtask/src/verify_portal_backing.rs
+++ b/xtask/src/verify_portal_backing.rs
@@ -1,4 +1,4 @@
-//! Verifies the settled token-backing invariant for a ZonePortal.
+//! Verifies the token-backing invariant for a ZonePortal, including queued flows.
 
 use alloy::{
     primitives::{Address, U256},
@@ -13,6 +13,14 @@ use tempo_zone_contracts::{IZoneInbox, ZONE_INBOX_ADDRESS, ZonePortal};
 use crate::zone_utils::normalize_http_rpc;
 
 const LOG_QUERY_BLOCK_CHUNK: u64 = 5_000;
+
+#[derive(Clone, Copy)]
+struct EventRanges {
+    l1_from: u64,
+    l1_to: u64,
+    zone_from: u64,
+    zone_to: u64,
+}
 
 #[derive(Debug, clap::Parser)]
 pub(crate) struct VerifyPortalBacking {
@@ -100,18 +108,9 @@ impl VerifyPortalBacking {
             .wrap_err("failed reading backing state")?;
 
         ensure!(
-            withdrawal_head == withdrawal_tail,
-            "withdrawal queue is not settled: head={withdrawal_head}, tail={withdrawal_tail}"
-        );
-        ensure!(
-            deposit_count == l1_processed_deposits,
-            "L1 deposit queue is not settled: depositCount={deposit_count}, \
-             lastProcessedDepositNumber={l1_processed_deposits}"
-        );
-        ensure!(
-            zone_processed_deposits == l1_processed_deposits,
-            "Zone and L1 deposit counters disagree: ZoneInbox={zone_processed_deposits}, \
-             ZonePortal={l1_processed_deposits}"
+            zone_processed_deposits <= deposit_count,
+            "Zone processed more deposits than the Portal has recorded: ZoneInbox={zone_processed_deposits}, \
+             ZonePortal={deposit_count}"
         );
 
         let portal_refunds = portal_refund_liability(
@@ -124,10 +123,34 @@ impl VerifyPortalBacking {
         .await?;
         let inbox_refunds =
             inbox_refund_liability(&zone, self.token, self.zone_from_block, zone_snapshot).await?;
+        let pending_deposits = pending_deposit_liability(
+            &l1,
+            self.portal,
+            self.token,
+            zone_processed_deposits,
+            self.l1_from_block,
+            l1_snapshot,
+        )
+        .await?;
+        let pending_withdrawals = withdrawal_liability(
+            &l1,
+            &zone,
+            self.portal,
+            self.token,
+            EventRanges {
+                l1_from: self.l1_from_block,
+                l1_to: l1_snapshot,
+                zone_from: self.zone_from_block,
+                zone_to: zone_snapshot,
+            },
+        )
+        .await?;
 
         let required_backing = zone_supply
             .checked_add(portal_refunds)
             .and_then(|total| total.checked_add(inbox_refunds))
+            .and_then(|total| total.checked_add(pending_deposits))
+            .and_then(|total| total.checked_add(pending_withdrawals))
             .ok_or_else(|| eyre::eyre!("required backing overflow"))?;
 
         println!("Portal backing audit");
@@ -145,6 +168,12 @@ impl VerifyPortalBacking {
         println!("  Token:                   {}", self.token);
         println!("  Portal balance:          {portal_balance}");
         println!("  Zone total supply:       {zone_supply}");
+        println!(
+            "  Deposit queue:           portal={deposit_count}, l1-settled={l1_processed_deposits}, zone={zone_processed_deposits}"
+        );
+        println!("  Withdrawal queue:        head={withdrawal_head}, tail={withdrawal_tail}");
+        println!("  Pending deposit liability: {pending_deposits}");
+        println!("  Pending withdrawal liability: {pending_withdrawals}");
         println!("  Portal refund liability: {portal_refunds}");
         println!("  Inbox refund liability:  {inbox_refunds}");
         println!("  Required backing:        {required_backing}");
@@ -161,6 +190,176 @@ impl VerifyPortalBacking {
             Err(eyre::eyre!("Portal is underbacked by {deficit} base units"))
         }
     }
+}
+
+/// Deposits after the Zone snapshot's processed-deposit watermark have reached the Portal but
+/// have not yet been minted on the Zone. `WithdrawalBounceBack` entries are intentionally not
+/// counted here: they remain represented by their original outstanding withdrawal until the
+/// Inbox either re-mints them or turns them into an Inbox refund.
+async fn pending_deposit_liability<P: Provider<TempoNetwork>>(
+    provider: &P,
+    portal_address: Address,
+    token: Address,
+    zone_processed_deposits: u64,
+    from_block: u64,
+    to_block: u64,
+) -> eyre::Result<U256> {
+    let portal = ZonePortal::new(portal_address, provider);
+    let deposits = portal
+        .DepositMade_filter()
+        .from_block(from_block)
+        .to_block(to_block)
+        .chunked()
+        .chunk_size(LOG_QUERY_BLOCK_CHUNK)
+        .query()
+        .await
+        .wrap_err("failed scanning ZonePortal DepositMade events")?;
+
+    deposits
+        .into_iter()
+        .filter(|(event, _)| event.token == token && event.depositNumber > zone_processed_deposits)
+        .try_fold(U256::ZERO, |total, (event, _)| {
+            total
+                .checked_add(U256::from(event.netAmount))
+                .ok_or_else(|| eyre::eyre!("pending deposit total overflow"))
+        })
+}
+
+/// Tracks every burned withdrawal until it is paid on L1, re-minted on the Zone, or moved into a
+/// Portal or Inbox refund registry. This covers both finalized Portal queue entries and
+/// withdrawals still waiting in the Zone outbox.
+async fn withdrawal_liability<P: Provider<TempoNetwork>>(
+    l1: &P,
+    zone: &P,
+    portal_address: Address,
+    token: Address,
+    ranges: EventRanges,
+) -> eyre::Result<U256> {
+    let portal = ZonePortal::new(portal_address, l1);
+    let inbox = IZoneInbox::new(ZONE_INBOX_ADDRESS, zone);
+    let outbox =
+        tempo_zone_contracts::IZoneOutbox::new(tempo_zone_contracts::ZONE_OUTBOX_ADDRESS, zone);
+
+    let requested_filter = outbox
+        .WithdrawalRequested_filter()
+        .from_block(ranges.zone_from)
+        .to_block(ranges.zone_to)
+        .chunked()
+        .chunk_size(LOG_QUERY_BLOCK_CHUNK);
+    let paid_filter = portal
+        .WithdrawalProcessed_filter()
+        .from_block(ranges.l1_from)
+        .to_block(ranges.l1_to)
+        .chunked()
+        .chunk_size(LOG_QUERY_BLOCK_CHUNK);
+    let reminted_filter = inbox
+        .WithdrawalBounceBackProcessed_filter()
+        .from_block(ranges.zone_from)
+        .to_block(ranges.zone_to)
+        .chunked()
+        .chunk_size(LOG_QUERY_BLOCK_CHUNK);
+    let refunded_filter = inbox
+        .WithdrawalBounceBackPending_filter()
+        .from_block(ranges.zone_from)
+        .to_block(ranges.zone_to)
+        .chunked()
+        .chunk_size(LOG_QUERY_BLOCK_CHUNK);
+    let deposit_bounce_back_filter = portal
+        .DepositBounceBack_filter()
+        .from_block(ranges.l1_from)
+        .to_block(ranges.l1_to)
+        .chunked()
+        .chunk_size(LOG_QUERY_BLOCK_CHUNK);
+    let portal_refund_filter = portal
+        .DepositBounceBackPending_filter()
+        .from_block(ranges.l1_from)
+        .to_block(ranges.l1_to)
+        .chunked()
+        .chunk_size(LOG_QUERY_BLOCK_CHUNK);
+    let (requested, paid, deposit_bounce_backs, portal_refunds, reminted, refunded) =
+        tokio::try_join!(
+            requested_filter.query(),
+            paid_filter.query(),
+            deposit_bounce_back_filter.query(),
+            portal_refund_filter.query(),
+            reminted_filter.query(),
+            refunded_filter.query(),
+        )
+        .wrap_err("failed scanning withdrawal lifecycle events")?;
+
+    let requested = requested
+        .into_iter()
+        .filter(|(event, _)| event.token == token)
+        .try_fold(U256::ZERO, |total, (event, _)| {
+            total
+                .checked_add(U256::from(event.amount))
+                .ok_or_else(|| eyre::eyre!("requested withdrawal total overflow"))
+        })?;
+    let paid = paid
+        .into_iter()
+        .filter(|(event, _)| event.token == token && event.callbackSuccess)
+        .try_fold(U256::ZERO, |total, (event, _)| {
+            total
+                .checked_add(U256::from(event.amount))
+                .ok_or_else(|| eyre::eyre!("paid withdrawal total overflow"))
+        })?;
+    let deposit_bounce_backs = deposit_bounce_backs
+        .into_iter()
+        .filter(|(event, _)| event.token == token)
+        .try_fold(U256::ZERO, |total, (event, _)| {
+            total
+                .checked_add(U256::from(event.amount))
+                .ok_or_else(|| eyre::eyre!("paid deposit bounce-back total overflow"))
+        })?;
+    let paid = paid
+        .checked_add(deposit_bounce_backs)
+        .ok_or_else(|| eyre::eyre!("paid withdrawal total overflow"))?;
+    let reminted = reminted
+        .into_iter()
+        .filter(|(event, _)| event.token == token)
+        .try_fold(U256::ZERO, |total, (event, _)| {
+            total
+                .checked_add(U256::from(event.amount))
+                .ok_or_else(|| eyre::eyre!("re-minted withdrawal bounce-back total overflow"))
+        })?;
+    let portal_refunds = portal_refunds
+        .into_iter()
+        .filter(|(event, _)| event.token == token)
+        .try_fold(U256::ZERO, |total, (event, _)| {
+            total
+                .checked_add(U256::from(event.amount))
+                .ok_or_else(|| eyre::eyre!("Portal refund transition total overflow"))
+        })?;
+    let refunded = refunded
+        .into_iter()
+        .filter(|(event, _)| event.token == token)
+        .try_fold(U256::ZERO, |total, (event, _)| {
+            total
+                .checked_add(U256::from(event.amount))
+                .ok_or_else(|| eyre::eyre!("refunded withdrawal bounce-back total overflow"))
+        })?
+        .checked_add(portal_refunds)
+        .ok_or_else(|| eyre::eyre!("refunded withdrawal total overflow"))?;
+
+    outstanding_withdrawals(requested, paid, reminted, refunded)
+}
+
+fn outstanding_withdrawals(
+    requested: U256,
+    paid: U256,
+    reminted: U256,
+    refunded: U256,
+) -> eyre::Result<U256> {
+    requested
+        .checked_sub(paid)
+        .and_then(|total| total.checked_sub(reminted))
+        .and_then(|total| total.checked_sub(refunded))
+        .ok_or_else(|| {
+            eyre::eyre!(
+                "withdrawal event history is incomplete: requested={requested}, paid={paid}, \
+                 reminted={reminted}, refunded={refunded}"
+            )
+        })
 }
 
 async fn portal_refund_liability<P: Provider<TempoNetwork>>(
@@ -279,5 +478,27 @@ mod tests {
     #[test]
     fn outstanding_refunds_rejects_incomplete_history() {
         assert!(outstanding_refunds("test", U256::from(10), U256::from(11)).is_err());
+    }
+
+    #[test]
+    fn outstanding_withdrawals_tracks_all_terminal_paths() {
+        assert_eq!(
+            outstanding_withdrawals(
+                U256::from(100),
+                U256::from(25),
+                U256::from(30),
+                U256::from(20),
+            )
+            .unwrap(),
+            U256::from(25)
+        );
+    }
+
+    #[test]
+    fn outstanding_withdrawals_rejects_incomplete_history() {
+        assert!(
+            outstanding_withdrawals(U256::from(10), U256::from(11), U256::ZERO, U256::ZERO,)
+                .is_err()
+        );
     }
 }

--- a/xtask/src/verify_portal_backing.rs
+++ b/xtask/src/verify_portal_backing.rs
@@ -308,7 +308,10 @@ async fn withdrawal_liability<P: Provider<TempoNetwork>>(
         .filter(|(event, _)| event.token == token)
         .try_fold(U256::ZERO, |total, (event, _)| {
             total
-                .checked_add(U256::from(event.amount))
+                .checked_add(deposit_bounce_back_retired_amount(
+                    event.amount,
+                    event.bouncebackFee,
+                ))
                 .ok_or_else(|| eyre::eyre!("paid deposit bounce-back total overflow"))
         })?;
     let paid = paid
@@ -327,7 +330,10 @@ async fn withdrawal_liability<P: Provider<TempoNetwork>>(
         .filter(|(event, _)| event.token == token)
         .try_fold(U256::ZERO, |total, (event, _)| {
             total
-                .checked_add(U256::from(event.amount))
+                .checked_add(deposit_bounce_back_retired_amount(
+                    event.amount,
+                    event.bouncebackFee,
+                ))
                 .ok_or_else(|| eyre::eyre!("Portal refund transition total overflow"))
         })?;
     let refunded = refunded
@@ -342,6 +348,10 @@ async fn withdrawal_liability<P: Provider<TempoNetwork>>(
         .ok_or_else(|| eyre::eyre!("refunded withdrawal total overflow"))?;
 
     outstanding_withdrawals(requested, paid, reminted, refunded)
+}
+
+fn deposit_bounce_back_retired_amount(amount: u128, bounceback_fee: u128) -> U256 {
+    U256::from(amount) + U256::from(bounceback_fee)
 }
 
 fn outstanding_withdrawals(
@@ -499,6 +509,30 @@ mod tests {
         assert!(
             outstanding_withdrawals(U256::from(10), U256::from(11), U256::ZERO, U256::ZERO,)
                 .is_err()
+        );
+    }
+
+    #[test]
+    fn successful_deposit_bounce_back_retires_refund_and_fee() {
+        let retired = deposit_bounce_back_retired_amount(990, 10);
+
+        assert_eq!(
+            outstanding_withdrawals(U256::from(1_000), retired, U256::ZERO, U256::ZERO).unwrap(),
+            U256::ZERO
+        );
+    }
+
+    #[test]
+    fn pending_deposit_bounce_back_retires_fee_and_tracks_refund() {
+        let retired = deposit_bounce_back_retired_amount(990, 10);
+
+        assert_eq!(
+            outstanding_withdrawals(U256::from(1_000), U256::ZERO, U256::ZERO, retired).unwrap(),
+            U256::ZERO
+        );
+        assert_eq!(
+            outstanding_refunds("Portal", U256::from(990), U256::ZERO).unwrap(),
+            U256::from(990)
         );
     }
 }


### PR DESCRIPTION
## Summary

- add `verify-portal-backing` to audit Portal solvency at fixed L1 and Zone snapshots
- calculate outstanding Portal refunds from `DepositBounceBackPending` and `RefundClaimed` events
- calculate outstanding ZoneInbox refunds from `WithdrawalBounceBackPending` and `RefundClaimed` events
- require settled queues and verify the Portal balance covers Zone total supply plus all outstanding refund liabilities

## Validation

- `cargo test -p tempo-xtask verify_portal_backing`
- `cargo +nightly fmt --all -- --check`
- `cargo +nightly clippy -p tempo-xtask --all-targets`
- `cargo run -q -p tempo-xtask -- verify-portal-backing --help`

Prompted by: @0xalpharush