### PR TITLE
chore: deny cast_lossless clippy lint

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -38,6 +38,7 @@ manual-string-new = "warn"
 uninlined-format-args = "warn"
 use-self = "warn"
 redundant-clone = "warn"
+cast-lossless = "deny"
 default-constructed-unit-structs = "allow"
 
 [workspace.lints.rust]

--- a/crates/node/src/rpc.rs
+++ b/crates/node/src/rpc.rs
@@ -1361,7 +1361,9 @@ async fn set_leader(
             .setLeader(target, expected_epoch)
             .nonce_key(zone_sequencer::nonce_keys::ADMIN_OPS_NONCE_KEY)
             .nonce(nonce)
-            .max_fee_per_gas(tempo_chainspec::constants::gas::TEMPO_T1_BASE_FEE as u128)
+            .max_fee_per_gas(u128::from(
+                tempo_chainspec::constants::gas::TEMPO_T1_BASE_FEE,
+            ))
             .max_priority_fee_per_gas(0)
             .send_sync(),
     )

--- a/crates/node/tests/it/main.rs
+++ b/crates/node/tests/it/main.rs
@@ -1,3 +1,5 @@
+#![allow(clippy::cast_lossless)]
+
 mod demo_asset_swap;
 mod demo_cross_zone;
 mod demo_shield_and_send;

--- a/crates/primitives/src/constants.rs
+++ b/crates/primitives/src/constants.rs
@@ -181,9 +181,9 @@ pub fn zone_chain_id(parent_chain_id: u64, zone_id: u32) -> Result<u64, ZoneChai
     validate_chain_id(parent_chain_id, zone_id)?;
 
     let chain_id = match parent_chain_id {
-        MAINNET_CHAIN_ID => ZONE_CHAIN_ID_BASE + zone_id as u64,
-        MODERATO_CHAIN_ID => ZONE_CHAIN_ID_BASE_TESTNET + zone_id as u64,
-        _ => (parent_chain_id << 32) | zone_id as u64,
+        MAINNET_CHAIN_ID => ZONE_CHAIN_ID_BASE + u64::from(zone_id),
+        MODERATO_CHAIN_ID => ZONE_CHAIN_ID_BASE_TESTNET + u64::from(zone_id),
+        _ => (parent_chain_id << 32) | u64::from(zone_id),
     };
 
     Ok(chain_id)
@@ -220,8 +220,9 @@ fn validate_chain_id(parent_chain_id: u64, zone_id: u32) -> Result<(), ZoneChain
         return Err(ZoneChainIdError::InvalidParentChainId(parent_chain_id));
     }
 
-    if (parent_chain_id == MAINNET_CHAIN_ID && zone_id as u64 >= ZONE_CHAIN_ID_RANGE)
-        || (parent_chain_id == MODERATO_CHAIN_ID && zone_id as u64 >= ZONE_CHAIN_ID_RANGE_TESTNET)
+    if (parent_chain_id == MAINNET_CHAIN_ID && u64::from(zone_id) >= ZONE_CHAIN_ID_RANGE)
+        || (parent_chain_id == MODERATO_CHAIN_ID
+            && u64::from(zone_id) >= ZONE_CHAIN_ID_RANGE_TESTNET)
     {
         return Err(ZoneChainIdError::ZoneIdOutOfRange {
             parent_chain_id,

--- a/crates/rpc/src/provider.rs
+++ b/crates/rpc/src/provider.rs
@@ -115,7 +115,7 @@ fn build_provider_with_token(
     let mut blob = Vec::with_capacity(65 + fields.len());
     blob.extend_from_slice(&sig.r().to_be_bytes::<32>());
     blob.extend_from_slice(&sig.s().to_be_bytes::<32>());
-    blob.push(sig.v() as u8);
+    blob.push(u8::from(sig.v()));
     blob.extend_from_slice(&fields);
 
     let mut auth_header = reqwest::header::HeaderValue::from_str(&hex::encode(&blob))?;

--- a/crates/rpc/tests/it/ws.rs
+++ b/crates/rpc/tests/it/ws.rs
@@ -317,7 +317,7 @@ impl TestContext {
         let mut blob = Vec::with_capacity(65 + fields.len());
         blob.extend_from_slice(&sig.r().to_be_bytes::<32>());
         blob.extend_from_slice(&sig.s().to_be_bytes::<32>());
-        blob.push(sig.v() as u8);
+        blob.push(u8::from(sig.v()));
         blob.extend_from_slice(&fields);
 
         alloy_primitives::hex::encode(&blob)

--- a/crates/sequencer/src/encryption_key.rs
+++ b/crates/sequencer/src/encryption_key.rs
@@ -29,7 +29,7 @@ pub async fn register_encryption_key<P: Provider<TempoNetwork>>(
 
     let message = keccak256((portal, x, U256::from(y_parity)).abi_encode());
     let signature = signer.sign_hash_sync(&message)?;
-    let pop_v = signature.v() as u8 + 27;
+    let pop_v = u8::from(signature.v()) + 27;
     let pop_r = B256::from(signature.r().to_be_bytes::<32>());
     let pop_s = B256::from(signature.s().to_be_bytes::<32>());
 

--- a/crates/sequencer/src/settlement.rs
+++ b/crates/sequencer/src/settlement.rs
@@ -582,7 +582,7 @@ impl BatchSubmitter {
         let mut encoded = Vec::with_capacity(65);
         encoded.extend_from_slice(&signature.r().to_be_bytes::<32>());
         encoded.extend_from_slice(&signature.s().to_be_bytes::<32>());
-        encoded.push(signature.v() as u8 + 27);
+        encoded.push(u8::from(signature.v()) + 27);
         Ok(encoded.into())
     }
 

--- a/xtask/src/demo_swap_and_deposit.rs
+++ b/xtask/src/demo_swap_and_deposit.rs
@@ -757,7 +757,7 @@ async fn register_sequencer_encryption_key<P: Provider<TempoNetwork>>(
         .sign_hash(&message)
         .await
         .wrap_err("failed to sign the encryption key proof-of-possession")?;
-    let pop_v = sig.v() as u8 + 27;
+    let pop_v = u8::from(sig.v()) + 27;
     let pop_r = B256::from(sig.r().to_be_bytes::<32>());
     let pop_s = B256::from(sig.s().to_be_bytes::<32>());
 


### PR DESCRIPTION
Mirrors tempoxyz/tempo#4077 for the Zones codebase.

## Summary

- deny Clippy’s `cast_lossless` lint workspace-wide
- replace Zones-specific lossless casts with explicit `From` conversions
- retain the integration-test allowance from the source change

## Testing

- `cargo +nightly fmt --all -- --check`
- `cargo +nightly clippy --workspace --all-targets --all-features --message-format short -q`

Prompted by: @0xalpharush