### PR TITLE
Backrun withdrawals with ordered 2D nonces

### DIFF
--- a/crates/node/tests/it/l1_e2e.rs
+++ b/crates/node/tests/it/l1_e2e.rs
@@ -21,8 +21,8 @@ use futures::future::try_join_all;
 use std::{collections::HashMap, time::Duration};
 use tempo_precompiles::{PATH_USD_ADDRESS, zone_factory::portal};
 use tempo_zone_contracts::{
-    IZoneOutbox, TEMPO_STATE_ADDRESS, TempoState, ZONE_OUTBOX_ADDRESS, ZONE_TOKEN_ADDRESS,
-    ZonePortal, ZonePortal::Role as PortalRole,
+    IZoneOutbox, NO_QUEUE_INDEX, TEMPO_STATE_ADDRESS, TempoState, ZONE_OUTBOX_ADDRESS,
+    ZONE_TOKEN_ADDRESS, ZonePortal, ZonePortal::Role as PortalRole,
 };
 use zone_node::dev::{ProvisionConfig, provision_zone};
 
@@ -570,6 +570,7 @@ async fn test_deposit_via_real_l1() -> eyre::Result<()> {
 
     // Request withdrawal on L2
     let withdrawal_amount: u128 = 500_000; // 0.5 pathUSD
+    let withdrawal_start_block = l1.provider().get_block_number().await?;
     account.withdraw(withdrawal_amount).await?;
 
     // Wait for the withdrawal to be fully processed on L1
@@ -581,6 +582,46 @@ async fn test_deposit_via_real_l1() -> eyre::Result<()> {
         withdrawal_timeout,
     )
     .await?;
+
+    // The empty-queue fast path must put submitBatch immediately before processWithdrawals in
+    // one Tempo block. Consecutive nonces on the same 2D lane make the ordering non-optional.
+    let portal = ZonePortal::new(portal_address, l1.provider());
+    let (_, submitted_log) = portal
+        .BatchSubmitted_filter()
+        .from_block(withdrawal_start_block)
+        .query()
+        .await?
+        .into_iter()
+        .find(|(event, _)| event.withdrawalQueueIndex != NO_QUEUE_INDEX)
+        .ok_or_else(|| eyre::eyre!("withdrawal BatchSubmitted event not found"))?;
+    let (_, processed_log) = portal
+        .WithdrawalProcessed_filter()
+        .from_block(withdrawal_start_block)
+        .query()
+        .await?
+        .into_iter()
+        .find(|(event, _)| event.to == account.address() && event.amount == withdrawal_amount)
+        .ok_or_else(|| eyre::eyre!("matching WithdrawalProcessed event not found"))?;
+    let submitted_block = submitted_log
+        .block_number
+        .ok_or_else(|| eyre::eyre!("BatchSubmitted log missing block number"))?;
+    let processed_block = processed_log
+        .block_number
+        .ok_or_else(|| eyre::eyre!("WithdrawalProcessed log missing block number"))?;
+    let submitted_tx_index = submitted_log
+        .transaction_index
+        .ok_or_else(|| eyre::eyre!("BatchSubmitted log missing transaction index"))?;
+    let processed_tx_index = processed_log
+        .transaction_index
+        .ok_or_else(|| eyre::eyre!("WithdrawalProcessed log missing transaction index"))?;
+    assert_eq!(
+        submitted_block, processed_block,
+        "submitBatch and processWithdrawals should land in the same Tempo block"
+    );
+    assert!(
+        submitted_tx_index < processed_tx_index,
+        "processWithdrawals must execute after submitBatch"
+    );
 
     // Verify the L2 balance decreased by at least the withdrawal amount
     let l2_balance_after = zone

--- a/crates/node/tests/it/restart_e2e.rs
+++ b/crates/node/tests/it/restart_e2e.rs
@@ -191,6 +191,10 @@ async fn test_sequencer_restart_with_pending_withdrawal_queue() -> eyre::Result<
     // Keep batch submission running, but stop L1 processing so the portal queue
     // is guaranteed to remain pending until after the restart.
     abort_task(withdrawal_handle).await;
+    let admin_provider = l1.admin_provider();
+    let admin_portal = ZonePortal::new(portal_address, &admin_provider);
+    let pause_receipt = admin_portal.pause().send().await?.get_receipt().await?;
+    eyre::ensure!(pause_receipt.status(), "failed to pause portal");
 
     // Request withdrawal — wait for the batch to be submitted to L1
     let withdrawal_amount: u128 = 500_000;
@@ -220,6 +224,8 @@ async fn test_sequencer_restart_with_pending_withdrawal_queue() -> eyre::Result<
 
     // --- Abort sequencer BEFORE the withdrawal is processed ---
     abort_task(monitor_handle).await;
+    let resume_receipt = admin_portal.resume().send().await?.get_receipt().await?;
+    eyre::ensure!(resume_receipt.status(), "failed to resume portal");
 
     // --- Respawn sequencer (fetch_pending_withdrawals runs during init) ---
     let seq_handle2 = spawn_sequencer(&l1, &zone, portal_address, l1.dev_signer()).await;

--- a/crates/node/tests/it/restart_e2e.rs
+++ b/crates/node/tests/it/restart_e2e.rs
@@ -9,6 +9,7 @@
 
 use crate::utils::{L1TestNode, ZoneAccount, ZoneTestNode, spawn_sequencer};
 use alloy::primitives::{Address, U256};
+use tempo_precompiles::PATH_USD_ADDRESS;
 use tempo_zone_contracts::{IZoneOutbox, ZONE_OUTBOX_ADDRESS, ZONE_TOKEN_ADDRESS, ZonePortal};
 
 /// Longer timeout for real L1 tests.
@@ -183,23 +184,22 @@ async fn test_sequencer_restart_with_pending_withdrawal_queue() -> eyre::Result<
     l1.fund_user(account.address(), deposit_amount).await?;
     account.deposit(deposit_amount, L1_TIMEOUT, &zone).await?;
 
-    let zone_sequencer::ZoneSequencerHandle {
-        withdrawal_handle,
-        monitor_handle,
-    } = spawn_sequencer(&l1, &zone, portal_address, l1.dev_signer()).await;
+    // Finalize the withdrawal on L2 before starting L1 settlement. Pausing the portal before the
+    // L2 request would make the ZoneOutbox reject it as well.
+    let withdrawal_amount: u128 = 500_000;
+    account.withdraw(withdrawal_amount).await?;
+    wait_for_withdrawal_requested(&zone, account.address(), withdrawal_amount).await?;
 
-    // Keep batch submission running, but stop L1 processing so the portal queue
-    // is guaranteed to remain pending until after the restart.
-    abort_task(withdrawal_handle).await;
+    // Pause only L1 withdrawal processing, then start settlement. submitBatch remains available,
+    // while both the ordered backrun and the recovery processor stay idle.
     let admin_provider = l1.admin_provider();
     let admin_portal = ZonePortal::new(portal_address, &admin_provider);
     let pause_receipt = admin_portal.pause().send().await?.get_receipt().await?;
     eyre::ensure!(pause_receipt.status(), "failed to pause portal");
-
-    // Request withdrawal — wait for the batch to be submitted to L1
-    let withdrawal_amount: u128 = 500_000;
-    account.withdraw(withdrawal_amount).await?;
-    wait_for_withdrawal_requested(&zone, account.address(), withdrawal_amount).await?;
+    let zone_sequencer::ZoneSequencerHandle {
+        withdrawal_handle,
+        monitor_handle,
+    } = spawn_sequencer(&l1, &zone, portal_address, l1.dev_signer()).await;
 
     // Wait for the batch to land on L1 (portal tail advances)
     crate::utils::poll_until(
@@ -224,6 +224,7 @@ async fn test_sequencer_restart_with_pending_withdrawal_queue() -> eyre::Result<
 
     // --- Abort sequencer BEFORE the withdrawal is processed ---
     abort_task(monitor_handle).await;
+    abort_task(withdrawal_handle).await;
     let resume_receipt = admin_portal.resume().send().await?.get_receipt().await?;
     eyre::ensure!(resume_receipt.status(), "failed to resume portal");
 
@@ -261,14 +262,17 @@ async fn test_sequencer_restart_with_pending_withdrawal_queue() -> eyre::Result<
 
     // Request a NEW withdrawal after restart to verify normal operation continues.
     let second_withdrawal: u128 = 400_000;
+    let l1_balance_before_second = l1.balance_of(PATH_USD_ADDRESS, account.address()).await?;
     account.withdraw(second_withdrawal).await?;
-    l1.wait_for_withdrawal_on_l1(
-        portal_address,
+    l1.wait_for_balance(
+        PATH_USD_ADDRESS,
         account.address(),
-        second_withdrawal,
+        l1_balance_before_second + U256::from(second_withdrawal),
         WITHDRAWAL_TIMEOUT,
     )
     .await?;
+    l1.assert_withdrawal_processed(portal_address, account.address(), second_withdrawal)
+        .await?;
 
     // Portal queue should have advanced further
     let (head_after, tail_after) = portal_queue_state(&l1, portal_address).await?;
@@ -457,6 +461,7 @@ async fn test_finalized_withdrawal_survives_sequencer_restart() -> eyre::Result<
     let deposit_amount: u128 = 2_000_000;
     l1.fund_user(account.address(), deposit_amount).await?;
     account.deposit(deposit_amount, L1_TIMEOUT, &zone).await?;
+    let l1_balance_before = l1.balance_of(PATH_USD_ADDRESS, account.address()).await?;
 
     let seq_handle = spawn_sequencer(&l1, &zone, portal_address, l1.dev_signer()).await;
 
@@ -484,13 +489,18 @@ async fn test_finalized_withdrawal_survives_sequencer_restart() -> eyre::Result<
     tokio::time::sleep(std::time::Duration::from_secs(1)).await;
     let _seq_handle2 = spawn_sequencer(&l1, &zone, portal_address, l1.dev_signer()).await;
 
-    l1.wait_for_withdrawal_on_l1(
-        portal_address,
+    // Use the pre-withdrawal balance. The fast path may complete before this code resumes after
+    // spawning the sequencer, so taking the baseline here would wait for a second withdrawal.
+    l1.wait_for_balance(
+        PATH_USD_ADDRESS,
         account.address(),
-        withdrawal_amount,
+        l1_balance_before + U256::from(withdrawal_amount),
         WITHDRAWAL_TIMEOUT,
     )
     .await?;
+    l1.assert_batch_submitted(portal_address).await?;
+    l1.assert_withdrawal_processed(portal_address, account.address(), withdrawal_amount)
+        .await?;
 
     Ok(())
 }

--- a/crates/sequencer/src/lib.rs
+++ b/crates/sequencer/src/lib.rs
@@ -38,7 +38,8 @@ pub use encryption_key::{
 pub use monitor::{ZoneMonitorConfig, ZoneMonitorSharedState};
 pub use prover::ShadowProverConfig;
 pub use settlement::{
-    BatchAnchorConfig, BatchData, BatchSubmitter, PortalZoneAnchor, resolve_portal_zone_anchor,
+    BatchAnchorConfig, BatchData, BatchSubmission, BatchSubmitter, PortalZoneAnchor,
+    resolve_portal_zone_anchor,
 };
 pub use withdrawals::{
     DEFAULT_MAX_IN_FLIGHT_WITHDRAWAL_BATCHES, DEFAULT_MAX_WITHDRAWAL_BATCH_GAS,
@@ -184,6 +185,7 @@ pub async fn spawn_zone_sequencer<P: ZoneSequencerProvider>(
         poll_interval: config.zone_poll_interval,
         portal_address: config.portal_address,
         batch_anchor_config: config.batch_anchor_config,
+        withdrawal_batch_limits: config.withdrawal_batch_limits,
         attestation_store: config.attestation_store,
     };
     let withdrawal_handle = withdrawals::spawn_withdrawal_processor(

--- a/crates/sequencer/src/monitor.rs
+++ b/crates/sequencer/src/monitor.rs
@@ -45,7 +45,7 @@ use crate::{
         WithdrawalPage, ZoneBlockSnapshot, fetch_finalized_batch, fetch_finalized_batch_boundaries,
         read_zone_block_snapshot,
     },
-    withdrawals::SharedWithdrawalStore,
+    withdrawals::{SharedWithdrawalStore, WithdrawalBatchLimits},
 };
 
 /// Maximum number of times to retry a failed batch submission before resyncing.
@@ -70,6 +70,8 @@ pub struct ZoneMonitorConfig {
     pub portal_address: Address,
     /// EIP-2935 history and safety-margin limits used by the batch submitter.
     pub batch_anchor_config: BatchAnchorConfig,
+    /// Gas limits used to decide whether a new withdrawal slot can use the ordered backrun.
+    pub withdrawal_batch_limits: WithdrawalBatchLimits,
     /// Shared P2P attestations, required after a settlement signer set is activated.
     pub attestation_store: Option<AttestationStore>,
 }
@@ -569,10 +571,16 @@ impl<P: ZoneSequencerProvider> ZoneMonitor<P> {
             let submit_started = std::time::Instant::now();
             match self
                 .batch_submitter
-                .submit_batch(batch_data, shutdown)
+                .submit_batch(
+                    batch_data,
+                    &withdrawals,
+                    self.config.withdrawal_batch_limits.max_batch_gas,
+                    shutdown,
+                )
                 .await
             {
-                Ok(event) => {
+                Ok(submission) => {
+                    let event = submission.event;
                     let portal_index = if event.withdrawalQueueIndex == NO_QUEUE_INDEX {
                         None
                     } else {
@@ -613,7 +621,12 @@ impl<P: ZoneSequencerProvider> ZoneMonitor<P> {
                     self.update_submission_lag();
 
                     // Store withdrawals under the logical portal queue index assigned on-chain.
-                    if let Some(portal_index) = portal_index {
+                    if submission.withdrawals_backrun {
+                        info!(
+                            withdrawal_count = withdrawals.len(),
+                            "Withdrawals processed by ordered submitBatch backrun"
+                        );
+                    } else if let Some(portal_index) = portal_index {
                         if !withdrawals.is_empty() {
                             let count = withdrawals.len();
                             let mut store = self.withdrawal_store.lock();
@@ -635,7 +648,9 @@ impl<P: ZoneSequencerProvider> ZoneMonitor<P> {
                         }
                     }
 
-                    self.withdrawal_notify.notify_one();
+                    if !submission.withdrawals_backrun {
+                        self.withdrawal_notify.notify_one();
+                    }
 
                     return Ok(());
                 }
@@ -1008,6 +1023,7 @@ mod tests {
             poll_interval: Duration::from_secs(1),
             portal_address,
             batch_anchor_config: BatchAnchorConfig::default(),
+            withdrawal_batch_limits: WithdrawalBatchLimits::default(),
             attestation_store: None,
         };
         let l1_provider = mock_provider(l1);
@@ -1053,6 +1069,8 @@ mod tests {
         // Preflight portal hash, followed by submission metadata with a 2-of-N threshold.
         l1.push_success(&abi_encode_b256(batch_data.prev_block_hash));
         l1.push_success(&abi_encode_multicall(vec![
+            abi_encode_u64(0),
+            abi_encode_u64(0),
             abi_encode_u64(0),
             abi_encode_u64(1),
             abi_encode_u64(2),
@@ -1107,6 +1125,7 @@ mod tests {
             poll_interval: Duration::from_secs(1),
             portal_address,
             batch_anchor_config: BatchAnchorConfig::default(),
+            withdrawal_batch_limits: WithdrawalBatchLimits::default(),
             attestation_store: None,
         };
 

--- a/crates/sequencer/src/monitor.rs
+++ b/crates/sequencer/src/monitor.rs
@@ -1072,6 +1072,7 @@ mod tests {
             abi_encode_u64(0),
             abi_encode_u64(0),
             abi_encode_u64(0),
+            abi_encode_u64(0),
             abi_encode_u64(1),
             abi_encode_u64(2),
             abi_encode_u64(1),

--- a/crates/sequencer/src/monitor.rs
+++ b/crates/sequencer/src/monitor.rs
@@ -574,7 +574,7 @@ impl<P: ZoneSequencerProvider> ZoneMonitor<P> {
                 .submit_batch(
                     batch_data,
                     &withdrawals,
-                    self.config.withdrawal_batch_limits.max_batch_gas,
+                    self.config.withdrawal_batch_limits,
                     shutdown,
                 )
                 .await

--- a/crates/sequencer/src/nonce_keys.rs
+++ b/crates/sequencer/src/nonce_keys.rs
@@ -2,8 +2,11 @@
 //!
 //! Tempo's 2D nonce system allows each account to maintain independent nonce
 //! counters ("lanes") keyed by a `U256` nonce key. Each sequencer operation
-//! type uses a dedicated lane so that `submitBatch`, `processWithdrawals`, and
-//! admin transactions can be submitted concurrently without nonce contention.
+//! type normally uses a dedicated lane so that `submitBatch`, recovery
+//! `processWithdrawals`, and admin transactions can be submitted concurrently
+//! without nonce contention. A withdrawal backrun paired with `submitBatch`
+//! deliberately uses the submit lane's next nonce, which makes Tempo execute
+//! both transactions in order while still allowing them into the same block.
 //!
 //! Nonce management is handled by [`NonceKeyFiller`](tempo_alloy::fillers::NonceKeyFiller)
 //! in the provider pipeline — callers only need to set `.nonce_key(KEY)` on
@@ -11,10 +14,10 @@
 
 use alloy_primitives::{U256, uint};
 
-/// Nonce key for `submitBatch` calls (highest throughput, one per batch cycle).
+/// Nonce key for `submitBatch` calls and their ordered withdrawal backruns.
 pub const SUBMIT_BATCH_NONCE_KEY: U256 = uint!(1_U256);
 
-/// Nonce key for `processWithdrawals` calls (high throughput, N per batch).
+/// Nonce key for recovery/backlog `processWithdrawals` calls.
 pub const PROCESS_WITHDRAWAL_NONCE_KEY: U256 = uint!(2_U256);
 
 /// Nonce key for admin operations (`enableToken`, `setZoneGasRate`, `setMaxTempoGasRate`,

--- a/crates/sequencer/src/nonce_keys.rs
+++ b/crates/sequencer/src/nonce_keys.rs
@@ -4,9 +4,9 @@
 //! counters ("lanes") keyed by a `U256` nonce key. Each sequencer operation
 //! type normally uses a dedicated lane so that `submitBatch`, recovery
 //! `processWithdrawals`, and admin transactions can be submitted concurrently
-//! without nonce contention. A withdrawal backrun paired with `submitBatch`
-//! deliberately uses the submit lane's next nonce, which makes Tempo execute
-//! both transactions in order while still allowing them into the same block.
+//! without nonce contention. A withdrawal backrun and its paired `submitBatch`
+//! use a dedicated best-effort lane, which orders the pair without allowing a
+//! stuck withdrawal to block the mandatory settlement lane.
 //!
 //! Nonce management is handled by [`NonceKeyFiller`](tempo_alloy::fillers::NonceKeyFiller)
 //! in the provider pipeline — callers only need to set `.nonce_key(KEY)` on
@@ -14,11 +14,17 @@
 
 use alloy_primitives::{U256, uint};
 
-/// Nonce key for `submitBatch` calls and their ordered withdrawal backruns.
+/// Nonce key for mandatory `submitBatch` calls.
 pub const SUBMIT_BATCH_NONCE_KEY: U256 = uint!(1_U256);
 
 /// Nonce key for recovery/backlog `processWithdrawals` calls.
 pub const PROCESS_WITHDRAWAL_NONCE_KEY: U256 = uint!(2_U256);
+
+/// Nonce key for best-effort `submitBatch` plus ordered withdrawal backruns.
+///
+/// Any uncertain transaction disables this lane for the process lifetime. Mandatory settlement
+/// continues on [`SUBMIT_BATCH_NONCE_KEY`] while lane 2 recovers the withdrawal queue.
+pub const WITHDRAWAL_BACKRUN_NONCE_KEY: U256 = uint!(4_U256);
 
 /// Nonce key for admin operations (`enableToken`, `setZoneGasRate`, `setMaxTempoGasRate`,
 /// `setBouncebackGas`, `setSequencerEncryptionKey`, `pause`, `abdicate`,

--- a/crates/sequencer/src/settlement.rs
+++ b/crates/sequencer/src/settlement.rs
@@ -23,13 +23,21 @@
 //! configured direct window by falling back to ancestry mode — a recent anchor
 //! block plus a locally validated parent-hash header chain.
 
-use std::{collections::BTreeMap, fmt, sync::OnceLock, time::Duration};
+use std::{
+    collections::BTreeMap,
+    fmt,
+    sync::{
+        OnceLock,
+        atomic::{AtomicBool, Ordering},
+    },
+    time::Duration,
+};
 
 use crate::{
     ZoneSequencerProvider,
     abi::{self, BlockTransition, DepositQueueTransition, IZoneInbox, IZoneOutbox, ZonePortal},
     attestation::{AttestationStore, SettlementAttestation, SettlementCertificate},
-    withdrawals::single_batch_gas_limit,
+    withdrawals::{WithdrawalBatch, build_withdrawal_batches},
 };
 use alloy_consensus::{Transaction, TxReceipt as _, transaction::TxHashRef as _};
 use alloy_eips::BlockHashOrNumber;
@@ -41,7 +49,7 @@ use alloy_signer::SignerSync;
 use alloy_signer_local::PrivateKeySigner;
 use alloy_sol_types::{SolCall, SolEvent, SolStruct, SolValue, eip712_domain};
 use eyre::{OptionExt as _, Result, WrapErr as _};
-use futures::{StreamExt, TryStreamExt};
+use futures::{StreamExt, TryStreamExt, future};
 use parking_lot::RwLock;
 use reth_storage_api::BlockNumReader;
 use schnellru::{ByLength, LruMap};
@@ -50,7 +58,7 @@ use tempo_primitives::{Block, TempoReceipt};
 use tokio_util::sync;
 use tracing::{info, instrument, warn};
 
-use crate::nonce_keys::SUBMIT_BATCH_NONCE_KEY;
+use crate::nonce_keys::{SUBMIT_BATCH_NONCE_KEY, WITHDRAWAL_BACKRUN_NONCE_KEY};
 
 #[derive(Debug)]
 pub enum BatchSubmitError {
@@ -236,6 +244,8 @@ pub struct BatchSubmitter {
     anchor_config: BatchAnchorConfig,
     /// Signatures from followers attesting to the batch.
     attestation_store: Option<AttestationStore>,
+    /// False after any uncertain fast-path result. Mandatory settlement remains on lane 1.
+    backrun_lane_healthy: AtomicBool,
     /// Validated, RLP-encoded L1 headers retained across overlapping ancestry
     /// requests. Settlement batches are submitted in order, so later requests
     /// can reuse almost the entire preceding range.
@@ -307,6 +317,7 @@ impl BatchSubmitter {
             l1_fetch_concurrency: 16,
             anchor_config,
             attestation_store: None,
+            backrun_lane_healthy: AtomicBool::new(true),
             ancestry_header_cache: RwLock::new(LruMap::new(ByLength::new(
                 DEFAULT_ANCESTRY_HEADER_CACHE_CAPACITY,
             ))),
@@ -332,9 +343,9 @@ impl BatchSubmitter {
     /// implemented.
     ///
     /// Returns the `BatchSubmitted` event decoded from the confirmed receipt. When the portal
-    /// queue is empty and this batch fits in one withdrawal transaction, an ordered
-    /// `processWithdrawals` transaction is broadcast immediately on the same 2D nonce lane. The
-    /// two transactions can then execute in order in the same Tempo block.
+    /// queue is empty, gas-bounded `processWithdrawals` transactions are broadcast concurrently
+    /// behind `submitBatch` on a dedicated 2D nonce lane. The lane orders every transaction while
+    /// keeping optional withdrawal work off the mandatory settlement lane.
     ///
     /// Waiting for a settlement quorum is cancelled when the leader generation shuts down.
     // TODO: pass real proof bytes once proof generation is implemented.
@@ -455,22 +466,28 @@ impl BatchSubmitter {
             )?]
         };
 
-        // Refetch the committed lane nonce for every submission attempt. The provider's
-        // process-local nonce cache advances before a send is known to have succeeded, so
-        // relying on it after a failed send can create an unfillable 2D-nonce gap.
         let submission_address = signer
             .ok_or_eyre("batch submission requires the local sequencer signer")?
             .address();
+        let backrun_batches = plan_withdrawal_backruns(
+            metadata,
+            self.backrun_lane_healthy.load(Ordering::Acquire),
+            withdrawals,
+            max_withdrawal_batch_gas,
+        );
+        let submission_nonce_key = if backrun_batches.is_empty() {
+            SUBMIT_BATCH_NONCE_KEY
+        } else {
+            WITHDRAWAL_BACKRUN_NONCE_KEY
+        };
+        // Refetch the committed nonce for the selected lane on every attempt. The mandatory
+        // settlement lane never contains optional withdrawals. Any uncertainty on the fast lane
+        // disables it, so later batches can continue on the mandatory lane without a collision.
         let nonce = self
             .l1_provider
-            .get_transaction_count_with_nonce_key(submission_address, SUBMIT_BATCH_NONCE_KEY)
+            .get_transaction_count_with_nonce_key(submission_address, submission_nonce_key)
             .await
             .map_err(|error| BatchSubmitError::Other(error.into()))?;
-        let backrun_gas_limit = if metadata.withdrawal_queue_is_empty() {
-            single_batch_gas_limit(withdrawals, max_withdrawal_batch_gas)
-        } else {
-            None
-        };
 
         info!(
             anchor_mode = %anchor_mode,
@@ -478,7 +495,7 @@ impl BatchSubmitter {
             current_l1_block,
             anchors_to_current_tip,
             batch_prev_block_hash = %batch.prev_block_hash,
-            nonce_key = ?SUBMIT_BATCH_NONCE_KEY,
+            nonce_key = ?submission_nonce_key,
             nonce,
             "Submitting batch to ZonePortal on L1"
         );
@@ -496,7 +513,7 @@ impl BatchSubmitter {
                 U256::from(batch.zone_height),
                 signatures,
             )
-            .nonce_key(SUBMIT_BATCH_NONCE_KEY)
+            .nonce_key(submission_nonce_key)
             .nonce(nonce)
             .max_fee_per_gas(crate::TEMPO_L1_MAX_FEE_PER_GAS)
             .max_priority_fee_per_gas(0);
@@ -506,77 +523,113 @@ impl BatchSubmitter {
             submission = submission.gas(SUBMIT_BATCH_GAS_LIMIT);
         }
 
-        let (receipt, withdrawals_backrun) = if let Some(gas_limit) = backrun_gas_limit {
-            let backrun_nonce = nonce
-                .checked_add(1)
-                .ok_or_else(|| eyre::eyre!("submitBatch nonce overflow at {nonce}"))?;
+        let (receipt, withdrawals_backrun) = if !backrun_batches.is_empty() {
+            let backrun_count = u64::try_from(backrun_batches.len())
+                .map_err(|_| eyre::eyre!("withdrawal backrun count overflow"))?;
+            nonce
+                .checked_add(backrun_count)
+                .ok_or_else(|| eyre::eyre!("withdrawal backrun nonce range overflow at {nonce}"))?;
             // Submit the first transaction before broadcasting the future-nonce backrun. Both use
-            // the same nonce key, so Tempo cannot execute the backrun before submitBatch.
-            let pending_submission = submission
-                .send()
-                .await
-                .map_err(|error| BatchSubmitError::Other(error.into()))?;
+            // the dedicated fast-path key, so Tempo cannot execute a withdrawal first. This lane
+            // is never required for later settlement.
+            let pending_submission = match submission.send().await {
+                Ok(pending) => pending,
+                Err(error) => {
+                    self.backrun_lane_healthy.store(false, Ordering::Release);
+                    return Err(BatchSubmitError::Other(error.into()));
+                }
+            };
             let submit_tx_hash = *pending_submission.tx_hash();
-            let backrun = self
-                .portal
-                .processWithdrawals(withdrawals.to_vec(), B256::ZERO)
-                .from(submission_address)
-                .nonce_key(SUBMIT_BATCH_NONCE_KEY)
-                .nonce(backrun_nonce)
-                .max_fee_per_gas(crate::TEMPO_L1_MAX_FEE_PER_GAS)
-                .max_priority_fee_per_gas(0)
-                .gas(gas_limit);
 
             info!(
                 %submit_tx_hash,
-                nonce_key = ?SUBMIT_BATCH_NONCE_KEY,
+                nonce_key = ?WITHDRAWAL_BACKRUN_NONCE_KEY,
                 submit_nonce = nonce,
-                backrun_nonce,
                 withdrawals = withdrawals.len(),
-                gas_limit,
-                "Broadcasting ordered withdrawal backrun"
+                transactions = backrun_batches.len(),
+                "Broadcasting ordered withdrawal backruns"
             );
 
-            let (submission_result, backrun_result) = tokio::join!(
+            let backruns =
+                backrun_batches
+                    .iter()
+                    .copied()
+                    .enumerate()
+                    .map(|(batch_index, batch)| {
+                        let backrun_nonce = nonce + 1 + batch_index as u64;
+                        let batch_withdrawals = withdrawals[batch.start..batch.end].to_vec();
+                        let remaining_queue =
+                            abi::Withdrawal::queue_hash(&withdrawals[batch.end..]);
+                        let backrun = self
+                            .portal
+                            .processWithdrawals(batch_withdrawals, remaining_queue)
+                            .from(submission_address)
+                            .nonce_key(WITHDRAWAL_BACKRUN_NONCE_KEY)
+                            .nonce(backrun_nonce)
+                            .max_fee_per_gas(crate::TEMPO_L1_MAX_FEE_PER_GAS)
+                            .max_priority_fee_per_gas(0)
+                            .gas(batch.gas_limit);
+                        async move {
+                            let result = tokio::time::timeout(
+                                WITHDRAWAL_BACKRUN_CONFIRM_TIMEOUT,
+                                backrun.send_sync(),
+                            )
+                            .await;
+                            (batch, backrun_nonce, result)
+                        }
+                    });
+            let (submission_result, backrun_results) = tokio::join!(
                 tokio::time::timeout(Duration::from_secs(30), pending_submission.get_receipt()),
-                tokio::time::timeout(WITHDRAWAL_BACKRUN_CONFIRM_TIMEOUT, backrun.send_sync()),
+                future::join_all(backruns),
             );
+            if !matches!(&submission_result, Ok(Ok(_))) {
+                self.backrun_lane_healthy.store(false, Ordering::Release);
+            }
             let receipt = submission_result
                 .map_err(|_| eyre::eyre!("submitBatch receipt timed out after 30 seconds"))?
                 .map_err(|error| BatchSubmitError::Other(error.into()))?;
 
-            let withdrawals_backrun = match backrun_result {
-                Ok(Ok(backrun_receipt)) if backrun_receipt.status() => {
-                    info!(
-                        tx_hash = %backrun_receipt.transaction_hash(),
-                        l1_block = ?backrun_receipt.block_number,
-                        withdrawals = withdrawals.len(),
-                        "Ordered withdrawal backrun confirmed"
-                    );
-                    true
+            let mut withdrawals_backrun = true;
+            for (batch, backrun_nonce, result) in backrun_results {
+                match result {
+                    Ok(Ok(backrun_receipt)) if backrun_receipt.status() => {
+                        info!(
+                            tx_hash = %backrun_receipt.transaction_hash(),
+                            l1_block = ?backrun_receipt.block_number,
+                            backrun_nonce,
+                            withdrawals = batch.len(),
+                            "Ordered withdrawal backrun confirmed"
+                        );
+                    }
+                    Ok(Ok(backrun_receipt)) => {
+                        warn!(
+                            tx_hash = %backrun_receipt.transaction_hash(),
+                            backrun_nonce,
+                            "Ordered withdrawal backrun reverted"
+                        );
+                        withdrawals_backrun = false;
+                    }
+                    Ok(Err(error)) => {
+                        warn!(%error, backrun_nonce, "Ordered withdrawal backrun failed");
+                        withdrawals_backrun = false;
+                    }
+                    Err(_) => {
+                        warn!(
+                            backrun_nonce,
+                            timeout_seconds = WITHDRAWAL_BACKRUN_CONFIRM_TIMEOUT.as_secs(),
+                            "Ordered withdrawal backrun timed out"
+                        );
+                        withdrawals_backrun = false;
+                    }
                 }
-                Ok(Ok(backrun_receipt)) => {
-                    warn!(
-                        tx_hash = %backrun_receipt.transaction_hash(),
-                        "Ordered withdrawal backrun reverted; falling back to queue processor"
-                    );
-                    false
-                }
-                Ok(Err(error)) => {
-                    warn!(
-                        %error,
-                        "Ordered withdrawal backrun failed; falling back to queue processor"
-                    );
-                    false
-                }
-                Err(_) => {
-                    warn!(
-                        timeout_seconds = WITHDRAWAL_BACKRUN_CONFIRM_TIMEOUT.as_secs(),
-                        "Ordered withdrawal backrun timed out; falling back to queue processor"
-                    );
-                    false
-                }
-            };
+            }
+            if !withdrawals_backrun {
+                self.backrun_lane_healthy.store(false, Ordering::Release);
+                warn!(
+                    nonce_key = ?WITHDRAWAL_BACKRUN_NONCE_KEY,
+                    "Disabling withdrawal backrun lane; mandatory settlement remains available"
+                );
+            }
             (receipt, withdrawals_backrun)
         } else {
             let receipt = tokio::time::timeout(Duration::from_secs(30), submission.send_sync())
@@ -588,6 +641,9 @@ impl BatchSubmitter {
 
         let tx_hash = receipt.transaction_hash();
         if !receipt.status() {
+            if submission_nonce_key == WITHDRAWAL_BACKRUN_NONCE_KEY {
+                self.backrun_lane_healthy.store(false, Ordering::Release);
+            }
             return Err(
                 eyre::eyre!("submitBatch tx {tx_hash} was included but reverted on L1").into(),
             );
@@ -701,6 +757,7 @@ impl BatchSubmitter {
                 withdrawal_batch_index,
                 withdrawal_queue_head,
                 withdrawal_queue_tail,
+                paused,
                 sequencer_set_version,
                 sequencer_threshold,
                 signer_is_sequencer,
@@ -711,6 +768,7 @@ impl BatchSubmitter {
                 .add(self.portal.withdrawalBatchIndex())
                 .add(self.portal.withdrawalQueueHead())
                 .add(self.portal.withdrawalQueueTail())
+                .add(self.portal.paused())
                 .add(self.portal.sequencerSetVersion())
                 .add(self.portal.sequencerThreshold())
                 .add(self.portal.isSequencer(signer))
@@ -722,6 +780,7 @@ impl BatchSubmitter {
                     withdrawal_batch_index,
                     withdrawal_queue_head,
                     withdrawal_queue_tail,
+                    paused,
                     sequencer_set_version,
                     sequencer_threshold,
                     signer_is_sequencer,
@@ -735,6 +794,7 @@ impl BatchSubmitter {
             withdrawal_batch_index,
             withdrawal_queue_head,
             withdrawal_queue_tail,
+            paused,
             sequencer_set_version,
             sequencer_threshold,
             signer_is_sequencer,
@@ -747,6 +807,7 @@ impl BatchSubmitter {
             .add(self.portal.withdrawalBatchIndex())
             .add(self.portal.withdrawalQueueHead())
             .add(self.portal.withdrawalQueueTail())
+            .add(self.portal.paused())
             .add(self.portal.sequencerSetVersion())
             .add(self.portal.sequencerThreshold())
             .add(self.portal.isSequencer(signer))
@@ -767,6 +828,7 @@ impl BatchSubmitter {
                 withdrawal_batch_index,
                 withdrawal_queue_head,
                 withdrawal_queue_tail,
+                paused,
                 sequencer_set_version,
                 sequencer_threshold,
                 signer_is_sequencer,
@@ -784,6 +846,7 @@ impl BatchSubmitter {
             withdrawal_batch_index: raw.withdrawal_batch_index,
             withdrawal_queue_head: raw.withdrawal_queue_head,
             withdrawal_queue_tail: raw.withdrawal_queue_tail,
+            paused: raw.paused,
             stable,
             sequencer_set_version: raw.sequencer_set_version,
             sequencer_threshold: raw.sequencer_threshold,
@@ -1367,6 +1430,7 @@ struct RawPortalSubmissionMetadata {
     withdrawal_batch_index: u64,
     withdrawal_queue_head: U256,
     withdrawal_queue_tail: U256,
+    paused: bool,
     sequencer_set_version: u64,
     sequencer_threshold: u8,
     signer_is_sequencer: bool,
@@ -1378,6 +1442,7 @@ struct PortalSubmissionMetadata {
     withdrawal_batch_index: u64,
     withdrawal_queue_head: U256,
     withdrawal_queue_tail: U256,
+    paused: bool,
     stable: StablePortalMetadata,
     sequencer_set_version: u64,
     sequencer_threshold: u8,
@@ -1390,6 +1455,20 @@ impl PortalSubmissionMetadata {
         self.withdrawal_queue_head == self.withdrawal_queue_tail
     }
 }
+
+fn plan_withdrawal_backruns(
+    metadata: PortalSubmissionMetadata,
+    lane_healthy: bool,
+    withdrawals: &[abi::Withdrawal],
+    max_batch_gas: u64,
+) -> Vec<WithdrawalBatch> {
+    if metadata.withdrawal_queue_is_empty() && !metadata.paused && lane_healthy {
+        build_withdrawal_batches(withdrawals, max_batch_gas)
+    } else {
+        Vec::new()
+    }
+}
+
 /// One validated L1 header retained for ancestry proof construction.
 #[derive(Debug, Clone)]
 struct CachedAncestryHeader {
@@ -2195,6 +2274,41 @@ mod tests {
     }
 
     #[test]
+    fn withdrawal_backruns_require_an_empty_unpaused_queue_and_healthy_lane() {
+        let withdrawals = vec![test_withdrawal(Address::repeat_byte(0x22), 1)];
+        let mut metadata = PortalSubmissionMetadata {
+            withdrawal_batch_index: 0,
+            withdrawal_queue_head: U256::ZERO,
+            withdrawal_queue_tail: U256::ZERO,
+            paused: false,
+            stable: StablePortalMetadata {
+                zone_id: 1,
+                chain_id: 1,
+            },
+            sequencer_set_version: 1,
+            sequencer_threshold: 1,
+            signer_is_sequencer: true,
+            verifier: Address::ZERO,
+        };
+
+        assert_eq!(
+            plan_withdrawal_backruns(metadata, true, &withdrawals, u64::MAX).len(),
+            1
+        );
+        assert!(plan_withdrawal_backruns(metadata, true, &[], u64::MAX).is_empty());
+        assert!(plan_withdrawal_backruns(metadata, false, &withdrawals, u64::MAX).is_empty());
+
+        metadata.paused = true;
+        assert!(plan_withdrawal_backruns(metadata, true, &withdrawals, u64::MAX).is_empty());
+
+        metadata.paused = false;
+        metadata.withdrawal_queue_tail = U256::from(1);
+        assert!(plan_withdrawal_backruns(metadata, true, &withdrawals, u64::MAX).is_empty());
+
+        assert_ne!(SUBMIT_BATCH_NONCE_KEY, WITHDRAWAL_BACKRUN_NONCE_KEY);
+    }
+
+    #[test]
     fn batch_anchor_config_validates_effective_window() {
         let config = BatchAnchorConfig::new(10, 4).unwrap();
         assert_eq!(config.history_window(), 10);
@@ -2354,6 +2468,7 @@ mod tests {
             abi_word(7_u64),
             abi_word(U256::from(3)),
             abi_word(U256::from(3)),
+            abi_word(false),
             abi_word(11_u64),
             abi_word(U256::from(1)),
             abi_word(true),
@@ -2364,6 +2479,7 @@ mod tests {
         let first = submitter.read_submission_metadata(signer).await.unwrap();
         assert_eq!(first.withdrawal_batch_index, 7);
         assert!(first.withdrawal_queue_is_empty());
+        assert!(!first.paused);
         assert_eq!(first.sequencer_set_version, 11);
         assert!(first.signer_is_sequencer);
         assert_eq!(first.verifier, verifier);
@@ -2375,6 +2491,7 @@ mod tests {
             abi_word(8_u64),
             abi_word(U256::from(3)),
             abi_word(U256::from(4)),
+            abi_word(true),
             abi_word(12_u64),
             abi_word(U256::from(1)),
             abi_word(false),
@@ -2383,6 +2500,7 @@ mod tests {
         let second = submitter.read_submission_metadata(signer).await.unwrap();
         assert_eq!(second.withdrawal_batch_index, 8);
         assert!(!second.withdrawal_queue_is_empty());
+        assert!(second.paused);
         assert_eq!(second.sequencer_set_version, 12);
         assert!(!second.signer_is_sequencer);
         assert_eq!(second.verifier, next_verifier);
@@ -2413,6 +2531,7 @@ mod tests {
             withdrawal_batch_index: 0,
             withdrawal_queue_head: U256::ZERO,
             withdrawal_queue_tail: U256::ZERO,
+            paused: false,
             stable: StablePortalMetadata {
                 zone_id: 1,
                 chain_id: 1,

--- a/crates/sequencer/src/settlement.rs
+++ b/crates/sequencer/src/settlement.rs
@@ -37,7 +37,9 @@ use crate::{
     ZoneSequencerProvider,
     abi::{self, BlockTransition, DepositQueueTransition, IZoneInbox, IZoneOutbox, ZonePortal},
     attestation::{AttestationStore, SettlementAttestation, SettlementCertificate},
-    withdrawals::{WithdrawalBatch, build_withdrawal_batches},
+    withdrawals::{
+        MAX_WITHDRAWAL_BATCH_GAS, WithdrawalBatch, WithdrawalBatchLimits, build_withdrawal_batches,
+    },
 };
 use alloy_consensus::{Transaction, TxReceipt as _, transaction::TxHashRef as _};
 use alloy_eips::BlockHashOrNumber;
@@ -107,6 +109,17 @@ const DEFAULT_ANCESTRY_HEADER_CACHE_CAPACITY: u32 = 262_144;
 /// observing N can only execute in N+1 or later, where that hash is available. Eight certificate
 /// signatures still fit comfortably within this limit.
 const SUBMIT_BATCH_GAS_LIMIT: u64 = 2_000_000;
+
+/// Aggregate planned gas admitted for same-block withdrawal backruns.
+///
+/// Tempo currently caps the general (non-payment) gas section at 30M. Together with the 2M
+/// `submitBatch` allowance, this leaves 8M of general-gas headroom for unrelated transactions.
+const MAX_WITHDRAWAL_BACKRUN_GAS: u64 = MAX_WITHDRAWAL_BATCH_GAS;
+
+/// Maximum withdrawals admitted to one same-block backrun sequence.
+///
+/// ZonePortal reserves capacity for 20 worst-case withdrawal bounceback deposits per Tempo block.
+const MAX_WITHDRAWAL_BACKRUN_ITEMS: usize = 20;
 
 /// Maximum time to wait for an ordered `processWithdrawals` backrun receipt.
 const WITHDRAWAL_BACKRUN_CONFIRM_TIMEOUT: Duration = Duration::from_secs(30);
@@ -343,9 +356,9 @@ impl BatchSubmitter {
     /// implemented.
     ///
     /// Returns the `BatchSubmitted` event decoded from the confirmed receipt. When the portal
-    /// queue is empty, gas-bounded `processWithdrawals` transactions are broadcast concurrently
-    /// behind `submitBatch` on a dedicated 2D nonce lane. The lane orders every transaction while
-    /// keeping optional withdrawal work off the mandatory settlement lane.
+    /// queue is empty, a bounded prefix of gas-bounded `processWithdrawals` transactions is
+    /// broadcast concurrently behind `submitBatch` on a dedicated 2D nonce lane. The lane orders
+    /// every transaction while keeping optional withdrawal work off the mandatory settlement lane.
     ///
     /// Waiting for a settlement quorum is cancelled when the leader generation shuts down.
     // TODO: pass real proof bytes once proof generation is implemented.
@@ -361,7 +374,7 @@ impl BatchSubmitter {
         &self,
         batch: &BatchData,
         withdrawals: &[abi::Withdrawal],
-        max_withdrawal_batch_gas: u64,
+        withdrawal_batch_limits: WithdrawalBatchLimits,
         shutdown: &sync::CancellationToken,
     ) -> std::result::Result<BatchSubmission, BatchSubmitError> {
         let block_transition = BlockTransition {
@@ -473,8 +486,11 @@ impl BatchSubmitter {
             metadata,
             self.backrun_lane_healthy.load(Ordering::Acquire),
             withdrawals,
-            max_withdrawal_batch_gas,
+            withdrawal_batch_limits,
         );
+        let backruns_cover_all_withdrawals = backrun_batches
+            .last()
+            .is_some_and(|batch| batch.end == withdrawals.len());
         let submission_nonce_key = if backrun_batches.is_empty() {
             SUBMIT_BATCH_NONCE_KEY
         } else {
@@ -546,6 +562,7 @@ impl BatchSubmitter {
                 nonce_key = ?WITHDRAWAL_BACKRUN_NONCE_KEY,
                 submit_nonce = nonce,
                 withdrawals = withdrawals.len(),
+                backrun_withdrawals = backrun_batches.last().map_or(0, |batch| batch.end),
                 transactions = backrun_batches.len(),
                 "Broadcasting ordered withdrawal backruns"
             );
@@ -589,7 +606,7 @@ impl BatchSubmitter {
                 .map_err(|_| eyre::eyre!("submitBatch receipt timed out after 30 seconds"))?
                 .map_err(|error| BatchSubmitError::Other(error.into()))?;
 
-            let mut withdrawals_backrun = true;
+            let mut all_backruns_succeeded = true;
             for (batch, backrun_nonce, result) in backrun_results {
                 match result {
                     Ok(Ok(backrun_receipt)) if backrun_receipt.status() => {
@@ -607,11 +624,11 @@ impl BatchSubmitter {
                             backrun_nonce,
                             "Ordered withdrawal backrun reverted"
                         );
-                        withdrawals_backrun = false;
+                        all_backruns_succeeded = false;
                     }
                     Ok(Err(error)) => {
                         warn!(%error, backrun_nonce, "Ordered withdrawal backrun failed");
-                        withdrawals_backrun = false;
+                        all_backruns_succeeded = false;
                     }
                     Err(_) => {
                         warn!(
@@ -619,17 +636,18 @@ impl BatchSubmitter {
                             timeout_seconds = WITHDRAWAL_BACKRUN_CONFIRM_TIMEOUT.as_secs(),
                             "Ordered withdrawal backrun timed out"
                         );
-                        withdrawals_backrun = false;
+                        all_backruns_succeeded = false;
                     }
                 }
             }
-            if !withdrawals_backrun {
+            if !all_backruns_succeeded {
                 self.backrun_lane_healthy.store(false, Ordering::Release);
                 warn!(
                     nonce_key = ?WITHDRAWAL_BACKRUN_NONCE_KEY,
                     "Disabling withdrawal backrun lane; mandatory settlement remains available"
                 );
             }
+            let withdrawals_backrun = backruns_cover_all_withdrawals && all_backruns_succeeded;
             (receipt, withdrawals_backrun)
         } else {
             let receipt = tokio::time::timeout(Duration::from_secs(30), submission.send_sync())
@@ -1460,13 +1478,30 @@ fn plan_withdrawal_backruns(
     metadata: PortalSubmissionMetadata,
     lane_healthy: bool,
     withdrawals: &[abi::Withdrawal],
-    max_batch_gas: u64,
+    limits: WithdrawalBatchLimits,
 ) -> Vec<WithdrawalBatch> {
-    if metadata.withdrawal_queue_is_empty() && !metadata.paused && lane_healthy {
-        build_withdrawal_batches(withdrawals, max_batch_gas)
-    } else {
-        Vec::new()
+    if !metadata.withdrawal_queue_is_empty() || metadata.paused || !lane_healthy {
+        return Vec::new();
     }
+
+    let mut planned_gas = 0u64;
+    build_withdrawal_batches(withdrawals, limits.max_batch_gas)
+        .into_iter()
+        .take(limits.max_in_flight_batches)
+        .take_while(|batch| {
+            if batch.end > MAX_WITHDRAWAL_BACKRUN_ITEMS {
+                return false;
+            }
+            let Some(next_gas) = planned_gas.checked_add(batch.gas_limit) else {
+                return false;
+            };
+            if next_gas > MAX_WITHDRAWAL_BACKRUN_GAS {
+                return false;
+            }
+            planned_gas = next_gas;
+            true
+        })
+        .collect()
 }
 
 /// One validated L1 header retained for ancestry proof construction.
@@ -2276,6 +2311,7 @@ mod tests {
     #[test]
     fn withdrawal_backruns_require_an_empty_unpaused_queue_and_healthy_lane() {
         let withdrawals = vec![test_withdrawal(Address::repeat_byte(0x22), 1)];
+        let limits = WithdrawalBatchLimits::default();
         let mut metadata = PortalSubmissionMetadata {
             withdrawal_batch_index: 0,
             withdrawal_queue_head: U256::ZERO,
@@ -2292,20 +2328,70 @@ mod tests {
         };
 
         assert_eq!(
-            plan_withdrawal_backruns(metadata, true, &withdrawals, u64::MAX).len(),
+            plan_withdrawal_backruns(metadata, true, &withdrawals, limits).len(),
             1
         );
-        assert!(plan_withdrawal_backruns(metadata, true, &[], u64::MAX).is_empty());
-        assert!(plan_withdrawal_backruns(metadata, false, &withdrawals, u64::MAX).is_empty());
+        assert!(plan_withdrawal_backruns(metadata, true, &[], limits).is_empty());
+        assert!(plan_withdrawal_backruns(metadata, false, &withdrawals, limits).is_empty());
 
         metadata.paused = true;
-        assert!(plan_withdrawal_backruns(metadata, true, &withdrawals, u64::MAX).is_empty());
+        assert!(plan_withdrawal_backruns(metadata, true, &withdrawals, limits).is_empty());
 
         metadata.paused = false;
         metadata.withdrawal_queue_tail = U256::from(1);
-        assert!(plan_withdrawal_backruns(metadata, true, &withdrawals, u64::MAX).is_empty());
+        assert!(plan_withdrawal_backruns(metadata, true, &withdrawals, limits).is_empty());
 
         assert_ne!(SUBMIT_BATCH_NONCE_KEY, WITHDRAWAL_BACKRUN_NONCE_KEY);
+    }
+
+    #[test]
+    fn withdrawal_backruns_are_bounded_by_concurrency_and_aggregate_gas() {
+        const ONE_SIMPLE_WITHDRAWAL_GAS: u64 = 1_500_000;
+        let withdrawals = (0u8..20)
+            .map(|index| test_withdrawal(Address::repeat_byte(index), 1))
+            .collect::<Vec<_>>();
+        let metadata = PortalSubmissionMetadata {
+            withdrawal_batch_index: 0,
+            withdrawal_queue_head: U256::ZERO,
+            withdrawal_queue_tail: U256::ZERO,
+            paused: false,
+            stable: StablePortalMetadata {
+                zone_id: 1,
+                chain_id: 1,
+            },
+            sequencer_set_version: 1,
+            sequencer_threshold: 1,
+            signer_is_sequencer: true,
+            verifier: Address::ZERO,
+        };
+
+        let concurrency_limited = plan_withdrawal_backruns(
+            metadata,
+            true,
+            &withdrawals,
+            WithdrawalBatchLimits {
+                max_batch_gas: ONE_SIMPLE_WITHDRAWAL_GAS,
+                max_in_flight_batches: 2,
+            },
+        );
+        assert_eq!(concurrency_limited.len(), 2);
+        assert_eq!(concurrency_limited.last().unwrap().end, 2);
+
+        let gas_limited = plan_withdrawal_backruns(
+            metadata,
+            true,
+            &withdrawals,
+            WithdrawalBatchLimits {
+                max_batch_gas: ONE_SIMPLE_WITHDRAWAL_GAS,
+                max_in_flight_batches: 20,
+            },
+        );
+        assert_eq!(gas_limited.len(), 13);
+        assert!(
+            gas_limited.iter().map(|batch| batch.gas_limit).sum::<u64>()
+                <= MAX_WITHDRAWAL_BACKRUN_GAS
+        );
+        assert_eq!(gas_limited.last().unwrap().end, 13);
     }
 
     #[test]

--- a/crates/sequencer/src/settlement.rs
+++ b/crates/sequencer/src/settlement.rs
@@ -29,6 +29,7 @@ use crate::{
     ZoneSequencerProvider,
     abi::{self, BlockTransition, DepositQueueTransition, IZoneInbox, IZoneOutbox, ZonePortal},
     attestation::{AttestationStore, SettlementAttestation, SettlementCertificate},
+    withdrawals::single_batch_gas_limit,
 };
 use alloy_consensus::{Transaction, TxReceipt as _, transaction::TxHashRef as _};
 use alloy_eips::BlockHashOrNumber;
@@ -98,6 +99,9 @@ const DEFAULT_ANCESTRY_HEADER_CACHE_CAPACITY: u32 = 262_144;
 /// observing N can only execute in N+1 or later, where that hash is available. Eight certificate
 /// signatures still fit comfortably within this limit.
 const SUBMIT_BATCH_GAS_LIMIT: u64 = 2_000_000;
+
+/// Maximum time to wait for an ordered `processWithdrawals` backrun receipt.
+const WITHDRAWAL_BACKRUN_CONFIRM_TIMEOUT: Duration = Duration::from_secs(30);
 
 /// Maximum number of pending withdrawal slots reconstructed in one recovery page.
 /// Bounds L1 topic filters and temporary withdrawal data without limiting the on-chain FIFO.
@@ -237,6 +241,14 @@ pub struct BatchSubmitter {
     /// can reuse almost the entire preceding range.
     ancestry_header_cache: RwLock<LruMap<u64, CachedAncestryHeader>>,
 }
+
+/// Confirmed batch submission and the result of its optional same-block withdrawal backrun.
+#[derive(Debug)]
+pub struct BatchSubmission {
+    pub event: ZonePortal::BatchSubmitted,
+    /// True when every withdrawal in this batch was processed by the ordered backrun.
+    pub withdrawals_backrun: bool,
+}
 impl BatchSubmitter {
     /// Shared Tempo L1 provider backing portal reads and submissions.
     pub(crate) const fn l1_provider(&self) -> &DynProvider<TempoNetwork> {
@@ -319,8 +331,12 @@ impl BatchSubmitter {
     /// `verifierConfig` and `proof` are empty until real proof generation is
     /// implemented.
     ///
-    /// Returns the `BatchSubmitted` event decoded from the confirmed receipt. Waiting for a
-    /// settlement quorum is cancelled when the leader generation shuts down.
+    /// Returns the `BatchSubmitted` event decoded from the confirmed receipt. When the portal
+    /// queue is empty and this batch fits in one withdrawal transaction, an ordered
+    /// `processWithdrawals` transaction is broadcast immediately on the same 2D nonce lane. The
+    /// two transactions can then execute in order in the same Tempo block.
+    ///
+    /// Waiting for a settlement quorum is cancelled when the leader generation shuts down.
     // TODO: pass real proof bytes once proof generation is implemented.
     #[instrument(skip_all, fields(
         portal = %self.portal_address,
@@ -333,8 +349,10 @@ impl BatchSubmitter {
     pub async fn submit_batch(
         &self,
         batch: &BatchData,
+        withdrawals: &[abi::Withdrawal],
+        max_withdrawal_batch_gas: u64,
         shutdown: &sync::CancellationToken,
-    ) -> std::result::Result<ZonePortal::BatchSubmitted, BatchSubmitError> {
+    ) -> std::result::Result<BatchSubmission, BatchSubmitError> {
         let block_transition = BlockTransition {
             prevBlockHash: batch.prev_block_hash,
             nextBlockHash: batch.next_block_hash,
@@ -353,6 +371,11 @@ impl BatchSubmitter {
             .read_submission_metadata(signer.map_or(Address::ZERO, PrivateKeySigner::address))
             .await?;
         self.validate_submission_metadata(batch, metadata)?;
+        if abi::Withdrawal::queue_hash(withdrawals) != batch.withdrawal_queue_hash {
+            return Err(
+                eyre::eyre!("withdrawal payload hash does not match batch commitment").into(),
+            );
+        }
         let (certificate, anchor_mode, current_l1_block) =
             if let Some(store) = &self.attestation_store {
                 let threshold = metadata.sequencer_threshold as usize;
@@ -443,6 +466,11 @@ impl BatchSubmitter {
             .get_transaction_count_with_nonce_key(submission_address, SUBMIT_BATCH_NONCE_KEY)
             .await
             .map_err(|error| BatchSubmitError::Other(error.into()))?;
+        let backrun_gas_limit = if metadata.withdrawal_queue_is_empty() {
+            single_batch_gas_limit(withdrawals, max_withdrawal_batch_gas)
+        } else {
+            None
+        };
 
         info!(
             anchor_mode = %anchor_mode,
@@ -478,11 +506,85 @@ impl BatchSubmitter {
             submission = submission.gas(SUBMIT_BATCH_GAS_LIMIT);
         }
 
-        let receipt =
-            tokio::time::timeout(std::time::Duration::from_secs(30), submission.send_sync())
+        let (receipt, withdrawals_backrun) = if let Some(gas_limit) = backrun_gas_limit {
+            let backrun_nonce = nonce
+                .checked_add(1)
+                .ok_or_else(|| eyre::eyre!("submitBatch nonce overflow at {nonce}"))?;
+            // Submit the first transaction before broadcasting the future-nonce backrun. Both use
+            // the same nonce key, so Tempo cannot execute the backrun before submitBatch.
+            let pending_submission = submission
+                .send()
+                .await
+                .map_err(|error| BatchSubmitError::Other(error.into()))?;
+            let submit_tx_hash = *pending_submission.tx_hash();
+            let backrun = self
+                .portal
+                .processWithdrawals(withdrawals.to_vec(), B256::ZERO)
+                .from(submission_address)
+                .nonce_key(SUBMIT_BATCH_NONCE_KEY)
+                .nonce(backrun_nonce)
+                .max_fee_per_gas(crate::TEMPO_L1_MAX_FEE_PER_GAS)
+                .max_priority_fee_per_gas(0)
+                .gas(gas_limit);
+
+            info!(
+                %submit_tx_hash,
+                nonce_key = ?SUBMIT_BATCH_NONCE_KEY,
+                submit_nonce = nonce,
+                backrun_nonce,
+                withdrawals = withdrawals.len(),
+                gas_limit,
+                "Broadcasting ordered withdrawal backrun"
+            );
+
+            let (submission_result, backrun_result) = tokio::join!(
+                tokio::time::timeout(Duration::from_secs(30), pending_submission.get_receipt()),
+                tokio::time::timeout(WITHDRAWAL_BACKRUN_CONFIRM_TIMEOUT, backrun.send_sync()),
+            );
+            let receipt = submission_result
+                .map_err(|_| eyre::eyre!("submitBatch receipt timed out after 30 seconds"))?
+                .map_err(|error| BatchSubmitError::Other(error.into()))?;
+
+            let withdrawals_backrun = match backrun_result {
+                Ok(Ok(backrun_receipt)) if backrun_receipt.status() => {
+                    info!(
+                        tx_hash = %backrun_receipt.transaction_hash(),
+                        l1_block = ?backrun_receipt.block_number,
+                        withdrawals = withdrawals.len(),
+                        "Ordered withdrawal backrun confirmed"
+                    );
+                    true
+                }
+                Ok(Ok(backrun_receipt)) => {
+                    warn!(
+                        tx_hash = %backrun_receipt.transaction_hash(),
+                        "Ordered withdrawal backrun reverted; falling back to queue processor"
+                    );
+                    false
+                }
+                Ok(Err(error)) => {
+                    warn!(
+                        %error,
+                        "Ordered withdrawal backrun failed; falling back to queue processor"
+                    );
+                    false
+                }
+                Err(_) => {
+                    warn!(
+                        timeout_seconds = WITHDRAWAL_BACKRUN_CONFIRM_TIMEOUT.as_secs(),
+                        "Ordered withdrawal backrun timed out; falling back to queue processor"
+                    );
+                    false
+                }
+            };
+            (receipt, withdrawals_backrun)
+        } else {
+            let receipt = tokio::time::timeout(Duration::from_secs(30), submission.send_sync())
                 .await
                 .map_err(|_| eyre::eyre!("submitBatch sync submission timed out after 30 seconds"))?
                 .map_err(|error| BatchSubmitError::Other(error.into()))?;
+            (receipt, false)
+        };
 
         let tx_hash = receipt.transaction_hash();
         if !receipt.status() {
@@ -504,7 +606,10 @@ impl BatchSubmitter {
             "Batch submitted to L1"
         );
 
-        Ok(event)
+        Ok(BatchSubmission {
+            event,
+            withdrawals_backrun,
+        })
     }
 
     /// Wait for a local quorum while periodically checking that the proposal still extends the
@@ -594,6 +699,8 @@ impl BatchSubmitter {
         if let Some(stable) = self.stable_portal_metadata.get().copied() {
             let (
                 withdrawal_batch_index,
+                withdrawal_queue_head,
+                withdrawal_queue_tail,
                 sequencer_set_version,
                 sequencer_threshold,
                 signer_is_sequencer,
@@ -602,6 +709,8 @@ impl BatchSubmitter {
                 .l1_provider
                 .multicall()
                 .add(self.portal.withdrawalBatchIndex())
+                .add(self.portal.withdrawalQueueHead())
+                .add(self.portal.withdrawalQueueTail())
                 .add(self.portal.sequencerSetVersion())
                 .add(self.portal.sequencerThreshold())
                 .add(self.portal.isSequencer(signer))
@@ -611,6 +720,8 @@ impl BatchSubmitter {
             return Ok(Self::build_submission_metadata(
                 RawPortalSubmissionMetadata {
                     withdrawal_batch_index,
+                    withdrawal_queue_head,
+                    withdrawal_queue_tail,
                     sequencer_set_version,
                     sequencer_threshold,
                     signer_is_sequencer,
@@ -622,6 +733,8 @@ impl BatchSubmitter {
 
         let (
             withdrawal_batch_index,
+            withdrawal_queue_head,
+            withdrawal_queue_tail,
             sequencer_set_version,
             sequencer_threshold,
             signer_is_sequencer,
@@ -632,6 +745,8 @@ impl BatchSubmitter {
             .l1_provider
             .multicall()
             .add(self.portal.withdrawalBatchIndex())
+            .add(self.portal.withdrawalQueueHead())
+            .add(self.portal.withdrawalQueueTail())
             .add(self.portal.sequencerSetVersion())
             .add(self.portal.sequencerThreshold())
             .add(self.portal.isSequencer(signer))
@@ -650,6 +765,8 @@ impl BatchSubmitter {
         Ok(Self::build_submission_metadata(
             RawPortalSubmissionMetadata {
                 withdrawal_batch_index,
+                withdrawal_queue_head,
+                withdrawal_queue_tail,
                 sequencer_set_version,
                 sequencer_threshold,
                 signer_is_sequencer,
@@ -665,6 +782,8 @@ impl BatchSubmitter {
     ) -> PortalSubmissionMetadata {
         PortalSubmissionMetadata {
             withdrawal_batch_index: raw.withdrawal_batch_index,
+            withdrawal_queue_head: raw.withdrawal_queue_head,
+            withdrawal_queue_tail: raw.withdrawal_queue_tail,
             stable,
             sequencer_set_version: raw.sequencer_set_version,
             sequencer_threshold: raw.sequencer_threshold,
@@ -691,6 +810,12 @@ impl BatchSubmitter {
         eyre::ensure!(
             metadata.sequencer_threshold > 0,
             "portal sequencer threshold is zero"
+        );
+        eyre::ensure!(
+            metadata.withdrawal_queue_head <= metadata.withdrawal_queue_tail,
+            "portal withdrawal queue head {} exceeds tail {}",
+            metadata.withdrawal_queue_head,
+            metadata.withdrawal_queue_tail,
         );
         if self.attestation_store.is_none() {
             eyre::ensure!(
@@ -1240,6 +1365,8 @@ struct StablePortalMetadata {
 
 struct RawPortalSubmissionMetadata {
     withdrawal_batch_index: u64,
+    withdrawal_queue_head: U256,
+    withdrawal_queue_tail: U256,
     sequencer_set_version: u64,
     sequencer_threshold: u8,
     signer_is_sequencer: bool,
@@ -1249,11 +1376,19 @@ struct RawPortalSubmissionMetadata {
 #[derive(Debug, Clone, Copy)]
 struct PortalSubmissionMetadata {
     withdrawal_batch_index: u64,
+    withdrawal_queue_head: U256,
+    withdrawal_queue_tail: U256,
     stable: StablePortalMetadata,
     sequencer_set_version: u64,
     sequencer_threshold: u8,
     signer_is_sequencer: bool,
     verifier: Address,
+}
+
+impl PortalSubmissionMetadata {
+    fn withdrawal_queue_is_empty(self) -> bool {
+        self.withdrawal_queue_head == self.withdrawal_queue_tail
+    }
 }
 /// One validated L1 header retained for ancestry proof construction.
 #[derive(Debug, Clone)]
@@ -2217,6 +2352,8 @@ mod tests {
 
         asserter.push_success(&abi_encode_multicall(vec![
             abi_word(7_u64),
+            abi_word(U256::from(3)),
+            abi_word(U256::from(3)),
             abi_word(11_u64),
             abi_word(U256::from(1)),
             abi_word(true),
@@ -2226,6 +2363,7 @@ mod tests {
         ]));
         let first = submitter.read_submission_metadata(signer).await.unwrap();
         assert_eq!(first.withdrawal_batch_index, 7);
+        assert!(first.withdrawal_queue_is_empty());
         assert_eq!(first.sequencer_set_version, 11);
         assert!(first.signer_is_sequencer);
         assert_eq!(first.verifier, verifier);
@@ -2235,6 +2373,8 @@ mod tests {
         let next_verifier = Address::repeat_byte(0x55);
         asserter.push_success(&abi_encode_multicall(vec![
             abi_word(8_u64),
+            abi_word(U256::from(3)),
+            abi_word(U256::from(4)),
             abi_word(12_u64),
             abi_word(U256::from(1)),
             abi_word(false),
@@ -2242,6 +2382,7 @@ mod tests {
         ]));
         let second = submitter.read_submission_metadata(signer).await.unwrap();
         assert_eq!(second.withdrawal_batch_index, 8);
+        assert!(!second.withdrawal_queue_is_empty());
         assert_eq!(second.sequencer_set_version, 12);
         assert!(!second.signer_is_sequencer);
         assert_eq!(second.verifier, next_verifier);
@@ -2270,6 +2411,8 @@ mod tests {
         };
         let metadata = PortalSubmissionMetadata {
             withdrawal_batch_index: 0,
+            withdrawal_queue_head: U256::ZERO,
+            withdrawal_queue_tail: U256::ZERO,
             stable: StablePortalMetadata {
                 zone_id: 1,
                 chain_id: 1,

--- a/crates/sequencer/src/withdrawals.rs
+++ b/crates/sequencer/src/withdrawals.rs
@@ -932,6 +932,22 @@ fn build_withdrawal_batches(
     batches
 }
 
+/// Return the gas limit for an entire withdrawal slot when it fits in one transaction.
+///
+/// The settlement fast path uses this to backrun `submitBatch` on the same nonce lane. Slots that
+/// require multiple transactions stay on the normal processor path, which preserves its bounded
+/// in-flight scheduling and recovery behavior.
+pub(crate) fn single_batch_gas_limit(
+    withdrawals: &[abi::Withdrawal],
+    max_batch_gas: u64,
+) -> Option<u64> {
+    let batches = build_withdrawal_batches(withdrawals, max_batch_gas);
+    let [batch] = batches.as_slice() else {
+        return None;
+    };
+    (batch.gas_limit <= max_batch_gas).then_some(batch.gas_limit)
+}
+
 /// Outcome of submitting and confirming a sequence of `processWithdrawals` transactions.
 enum SubmitOutcome {
     /// Every transaction was included on L1 and succeeded.
@@ -1122,6 +1138,29 @@ mod tests {
         assert_eq!(batches[0].end, 2);
         assert_eq!(batches[1].start, 2);
         assert_eq!(batches[1].end, 3);
+    }
+
+    #[test]
+    fn fast_path_requires_one_nonempty_withdrawal_batch() {
+        let withdrawals = simple_withdrawals(2);
+        let one = PROCESS_SIMPLE_WITHDRAWAL_ITEM_OVERHEAD_GAS;
+
+        assert_eq!(single_batch_gas_limit(&[], u64::MAX), None);
+        assert_eq!(
+            single_batch_gas_limit(
+                &withdrawals[..1],
+                PROCESS_WITHDRAWAL_TX_OVERHEAD_GAS + one - 1
+            ),
+            None
+        );
+        assert_eq!(
+            single_batch_gas_limit(&withdrawals, PROCESS_WITHDRAWAL_TX_OVERHEAD_GAS + one),
+            None
+        );
+        assert_eq!(
+            single_batch_gas_limit(&withdrawals, PROCESS_WITHDRAWAL_TX_OVERHEAD_GAS + 2 * one),
+            Some(PROCESS_WITHDRAWAL_TX_OVERHEAD_GAS + 2 * one)
+        );
     }
 
     #[test]

--- a/crates/sequencer/src/withdrawals.rs
+++ b/crates/sequencer/src/withdrawals.rs
@@ -881,14 +881,14 @@ const fn process_withdrawal_item_gas(callback_gas_limit: u64, fallback_nonce: u6
 
 /// A contiguous, gas-bounded transaction within one withdrawal queue slot.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
-struct WithdrawalBatch {
-    start: usize,
-    end: usize,
-    gas_limit: u64,
+pub(crate) struct WithdrawalBatch {
+    pub(crate) start: usize,
+    pub(crate) end: usize,
+    pub(crate) gas_limit: u64,
 }
 
 impl WithdrawalBatch {
-    fn len(self) -> usize {
+    pub(crate) fn len(self) -> usize {
         self.end - self.start
     }
 }
@@ -896,7 +896,7 @@ impl WithdrawalBatch {
 /// Split FIFO withdrawals by the configured per-transaction gas limit.
 ///
 /// A withdrawal that exceeds the limit is kept as a singleton so it cannot block the queue.
-fn build_withdrawal_batches(
+pub(crate) fn build_withdrawal_batches(
     withdrawals: &[abi::Withdrawal],
     max_batch_gas: u64,
 ) -> Vec<WithdrawalBatch> {
@@ -930,22 +930,6 @@ fn build_withdrawal_batches(
     }
 
     batches
-}
-
-/// Return the gas limit for an entire withdrawal slot when it fits in one transaction.
-///
-/// The settlement fast path uses this to backrun `submitBatch` on the same nonce lane. Slots that
-/// require multiple transactions stay on the normal processor path, which preserves its bounded
-/// in-flight scheduling and recovery behavior.
-pub(crate) fn single_batch_gas_limit(
-    withdrawals: &[abi::Withdrawal],
-    max_batch_gas: u64,
-) -> Option<u64> {
-    let batches = build_withdrawal_batches(withdrawals, max_batch_gas);
-    let [batch] = batches.as_slice() else {
-        return None;
-    };
-    (batch.gas_limit <= max_batch_gas).then_some(batch.gas_limit)
 }
 
 /// Outcome of submitting and confirming a sequence of `processWithdrawals` transactions.
@@ -1141,26 +1125,21 @@ mod tests {
     }
 
     #[test]
-    fn fast_path_requires_one_nonempty_withdrawal_batch() {
+    fn withdrawal_batches_expose_fast_path_chunks() {
         let withdrawals = simple_withdrawals(2);
         let one = PROCESS_SIMPLE_WITHDRAWAL_ITEM_OVERHEAD_GAS;
 
-        assert_eq!(single_batch_gas_limit(&[], u64::MAX), None);
-        assert_eq!(
-            single_batch_gas_limit(
-                &withdrawals[..1],
-                PROCESS_WITHDRAWAL_TX_OVERHEAD_GAS + one - 1
-            ),
-            None
-        );
-        assert_eq!(
-            single_batch_gas_limit(&withdrawals, PROCESS_WITHDRAWAL_TX_OVERHEAD_GAS + one),
-            None
-        );
-        assert_eq!(
-            single_batch_gas_limit(&withdrawals, PROCESS_WITHDRAWAL_TX_OVERHEAD_GAS + 2 * one),
-            Some(PROCESS_WITHDRAWAL_TX_OVERHEAD_GAS + 2 * one)
-        );
+        assert!(build_withdrawal_batches(&[], u64::MAX).is_empty());
+        let split =
+            build_withdrawal_batches(&withdrawals, PROCESS_WITHDRAWAL_TX_OVERHEAD_GAS + one);
+        assert_eq!(split.len(), 2);
+        assert_eq!((split[0].start, split[0].end), (0, 1));
+        assert_eq!((split[1].start, split[1].end), (1, 2));
+
+        let packed =
+            build_withdrawal_batches(&withdrawals, PROCESS_WITHDRAWAL_TX_OVERHEAD_GAS + 2 * one);
+        assert_eq!(packed.len(), 1);
+        assert_eq!((packed[0].start, packed[0].end), (0, 2));
     }
 
     #[test]


### PR DESCRIPTION
This PR uses an isolated 2D nonce lane to backrun `submitBatch` with ordered withdrawal processing in the same Tempo block. It falls back to the existing recovery path when the fast path is unavailable or uncertain.