### PR TITLE
feat(prover): produce Nitro NSM attestations

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1592,6 +1592,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "aws-nitro-enclaves-nsm-api"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "986ca4c3a91a67cadc5ae92b3dfe9de373c2b432bb2288eed90203343e9f47c4"
+dependencies = [
+ "libc",
+ "log",
+ "nix",
+ "serde",
+ "serde_bytes",
+ "serde_cbor",
+]
+
+[[package]]
 name = "axum"
 version = "0.8.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2158,7 +2172,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "57663b653d948a338bfb3eeba9bb2fd5fcfaecb9e199e87e1eda4d9e8b240fd9"
 dependencies = [
  "ciborium-io",
- "half",
+ "half 2.7.1",
 ]
 
 [[package]]
@@ -4236,6 +4250,12 @@ dependencies = [
  "tokio-util",
  "tracing",
 ]
+
+[[package]]
+name = "half"
+version = "1.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1b43ede17f21864e81be2fa654110bf1e793774238d86ef8555c37e6519c0403"
 
 [[package]]
 name = "half"
@@ -10757,6 +10777,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_bytes"
+version = "0.11.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a5d440709e79d88e51ac01c4b72fc6cb7314017bb7da9eeff678aa94c10e3ea8"
+dependencies = [
+ "serde",
+ "serde_core",
+]
+
+[[package]]
+name = "serde_cbor"
+version = "0.11.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2bef2ebfde456fb76bbcf9f59315333decc4fda0b2b44b420243c11e0f5ec1f5"
+dependencies = [
+ "half 1.8.3",
+ "serde",
+]
+
+[[package]]
 name = "serde_core"
 version = "1.0.228"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -11856,8 +11896,10 @@ dependencies = [
  "alloy-genesis",
  "alloy-primitives",
  "alloy-rlp",
+ "aws-nitro-enclaves-nsm-api",
  "clap",
  "reth-trie-common",
+ "serde_bytes",
  "serde_json",
  "tempo-chainspec",
  "tempo-primitives",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -139,6 +139,9 @@ zone-sequencer = { path = "crates/sequencer" }
 zone-spf = { path = "crates/spf" }
 zone-checker = { path = "crates/checker" }
 
+# AWS Nitro Enclaves
+aws-nitro-enclaves-nsm-api = "0.5.2"
+
 # reth
 reth-basic-payload-builder = { git = "https://github.com/paradigmxyz/reth", rev = "5f02aa3" }
 reth-chain-state = { git = "https://github.com/paradigmxyz/reth", rev = "5f02aa3" }
@@ -250,6 +253,7 @@ serde = { version = "1.0.219", default-features = false, features = [
   "alloc",
 ] }
 tempfile = "3.20"
+serde_bytes = "0.11"
 serde_json = "1.0.142"
 serde_yaml = "0.9.34"
 schnellru = "0.2.4"

--- a/bin/prover/enclave/Cargo.toml
+++ b/bin/prover/enclave/Cargo.toml
@@ -11,6 +11,7 @@ publish.workspace = true
 workspace = true
 
 [dependencies]
+alloy-primitives.workspace = true
 alloy-genesis.workspace = true
 zone-chainspec.workspace = true
 zone-primitives.workspace = true
@@ -26,6 +27,8 @@ tracing.workspace = true
 tracing-subscriber.workspace = true
 
 [target.'cfg(target_os = "linux")'.dependencies]
+aws-nitro-enclaves-nsm-api.workspace = true
+serde_bytes.workspace = true
 tokio-vsock.workspace = true
 
 [dev-dependencies]

--- a/bin/prover/enclave/README.md
+++ b/bin/prover/enclave/README.md
@@ -25,12 +25,22 @@ Requests use this envelope:
 compiled into Tempo plus custom genesis files configured by the enclave operator through a
 `--tempo-genesis` directory. A request cannot supply its own chain specification. Responses have
 `status: "ok"` with a `zone_spf::BatchOutput`, or `status: "error"` with a stable `code` and a
-diagnostic `message`.
+diagnostic `message`. The requested `tempoChainId` must match the witness's `parentChainId`.
+
+After successful SPF execution, the enclave derives the canonical Zone batch digest and asks the
+Nitro Secure Module to place it in the signed attestation document's `user_data`. A successful
+response includes `proofBundle.verifierConfig = 0x01` and the raw COSE/CBOR document in
+`proofBundle.proof`. The prover returns `attestation_unavailable` when `/dev/nsm` is unavailable or
+the NSM request fails.
 
 Pass `--use-tcp` to listen on localhost TCP instead of AF_VSOCK. This works on every supported
 operating system; AF_VSOCK remains the default and is available only on Linux. Set `SPF_PORT` or
 pass `--port` to change the selected transport's port. The maximum request payload defaults to 512
 MiB and can be changed with `SPF_MAX_REQUEST_BYTES` or `--max-request-bytes`.
+
+TCP mode is intended for development of framing, chain validation, and SPF error handling. The
+binary still requires the Nitro Secure Module after a successful SPF replay, so a valid request run
+outside an enclave ends with `attestation_unavailable` rather than an unattested success response.
 Set `SPF_TEMPO_GENESIS` or pass `--tempo-genesis` with a directory containing trusted Tempo genesis
 JSON files. Files are loaded in filename order. Each custom chain ID must be unique and cannot
 override a built-in Tempo network.
@@ -45,6 +55,7 @@ To build the same artifacts locally, first load the payload into the local Docke
 
 ```console
 docker buildx bake \
+  -f docker/docker-bake.hcl \
   --load \
   --set tempo-zone-prover-enclave.tags=tempo-zone-prover-enclave:local \
   tempo-zone-prover-enclave
@@ -59,6 +70,7 @@ host image:
 
 ```console
 docker buildx bake \
+  -f docker/docker-bake.hcl \
   --load \
   --set tempo-zone-prover-eif-builder.tags=tempo-zone-prover-eif-builder:local \
   tempo-zone-prover-eif-builder
@@ -73,6 +85,7 @@ docker run --rm \
   --output-file /output/tempo-zone-prover.eif \
   | tee target/tempo-zone-prover-eif/measurements.json
 docker buildx bake \
+  -f docker/docker-bake.hcl \
   --load \
   --set tempo-zone-prover.tags=tempo-zone-prover:local \
   tempo-zone-prover

--- a/bin/prover/enclave/src/main.rs
+++ b/bin/prover/enclave/src/main.rs
@@ -8,10 +8,11 @@ use tracing_subscriber::EnvFilter;
 use zone_chainspec::ZoneChainSpec;
 use zone_primitives::constants::zone_chain_id;
 use zone_prover::{
-    DEFAULT_MAX_REQUEST_BYTES, ErrorCode, PROTOCOL_VERSION, ProverConnection, TrustedChainSpecs,
-    VerifyRequest, VerifyResponse, request_error_response,
+    DEFAULT_MAX_REQUEST_BYTES, ErrorCode, NITRO_VERIFIER_CONFIG_V1, PROTOCOL_VERSION, ProofBundle,
+    ProverConnection, TrustedChainSpecs, VerifyRequest, VerifyResponse,
+    nitro_batch_attestation_hash, request_error_response,
 };
-use zone_spf::{SpfConfig, prove_zone_batch};
+use zone_spf::{BatchOutput, PublicInputs, SpfConfig, prove_zone_batch};
 
 #[tokio::main]
 async fn main() -> ExitCode {
@@ -267,12 +268,21 @@ fn process_request(request: VerifyRequest, specs: &TrustedChainSpecs) -> VerifyR
     };
     let config = SpfConfig::new(Arc::new(zone_spec), request.witness.public_inputs.portal);
 
+    let public_inputs = request.witness.public_inputs.clone();
     match prove_zone_batch(&config, request.witness) {
-        Ok(output) => VerifyResponse::Ok {
-            version: PROTOCOL_VERSION,
-            request_id: request.request_id,
-            output: Box::new(output),
-            proof_bundle: None,
+        Ok(output) => match build_proof_bundle(&public_inputs, &output, nitro_attestation) {
+            Ok(proof_bundle) => VerifyResponse::Ok {
+                version: PROTOCOL_VERSION,
+                request_id: request.request_id,
+                output: Box::new(output),
+                proof_bundle: Some(proof_bundle),
+            },
+            Err(message) => VerifyResponse::Error {
+                version: PROTOCOL_VERSION,
+                request_id: Some(request.request_id),
+                code: ErrorCode::AttestationUnavailable,
+                message,
+            },
         },
         Err(error) => VerifyResponse::Error {
             version: PROTOCOL_VERSION,
@@ -283,13 +293,65 @@ fn process_request(request: VerifyRequest, specs: &TrustedChainSpecs) -> VerifyR
     }
 }
 
+fn build_proof_bundle<F>(
+    public_inputs: &PublicInputs,
+    output: &BatchOutput,
+    attestor: F,
+) -> Result<ProofBundle, String>
+where
+    F: FnOnce(alloy_primitives::B256) -> Result<Vec<u8>, String>,
+{
+    let digest = nitro_batch_attestation_hash(public_inputs, output);
+    let document = attestor(digest)?;
+    Ok(ProofBundle {
+        verifier_config: NITRO_VERIFIER_CONFIG_V1.to_vec().into(),
+        proof: document.into(),
+    })
+}
+
+#[cfg(target_os = "linux")]
+fn nitro_attestation(digest: alloy_primitives::B256) -> Result<Vec<u8>, String> {
+    use aws_nitro_enclaves_nsm_api::{
+        api::{Request, Response},
+        driver::{nsm_exit, nsm_init, nsm_process_request},
+    };
+    use serde_bytes::ByteBuf;
+
+    let descriptor = nsm_init();
+    if descriptor < 0 {
+        return Err("Nitro Secure Module device is unavailable".into());
+    }
+    let response = nsm_process_request(
+        descriptor,
+        Request::Attestation {
+            user_data: Some(ByteBuf::from(digest.to_vec())),
+            nonce: None,
+            public_key: None,
+        },
+    );
+    nsm_exit(descriptor);
+    match response {
+        Response::Attestation { document } => Ok(document),
+        Response::Error(code) => Err(format!("Nitro attestation request failed: {code:?}")),
+        _ => Err("Nitro Secure Module returned an unexpected response".into()),
+    }
+}
+
+#[cfg(not(target_os = "linux"))]
+fn nitro_attestation(_digest: alloy_primitives::B256) -> Result<Vec<u8>, String> {
+    Err("Nitro attestation is supported only on Linux".into())
+}
+
 #[cfg(test)]
 mod tests {
     use alloy_consensus::Header;
     use alloy_primitives::{Address, B256, Bytes};
     use reth_trie_common::EMPTY_ROOT_HASH;
     use tempo_primitives::TempoHeader;
-    use zone_spf::{BatchWitness, PublicInputs, TempoStateWitness, ZoneStateWitness};
+    use zone_spf::{
+        BatchWitness, BlockTransition, DepositQueueTransition, LastBatchCommitment, PublicInputs,
+        TempoStateWitness, ZoneStateWitness,
+    };
 
     use super::*;
 
@@ -310,6 +372,59 @@ mod tests {
                 ..
             } if id == "version-test"
         ));
+    }
+
+    #[test]
+    fn rejects_unknown_chain_before_execution() {
+        let mut witness = empty_witness();
+        witness.public_inputs.parent_chain_id = 99;
+        let request = VerifyRequest {
+            version: PROTOCOL_VERSION,
+            request_id: "chain-test".into(),
+            witness,
+        };
+        let response = process_request(request, &TrustedChainSpecs::default());
+
+        assert!(matches!(
+            response,
+            VerifyResponse::Error {
+                request_id: Some(id),
+                code: ErrorCode::UnsupportedChain,
+                ..
+            } if id == "chain-test"
+        ));
+    }
+
+    #[test]
+    fn binds_the_canonical_digest_into_the_proof_bundle() {
+        let public_inputs = empty_witness().public_inputs;
+        let output = BatchOutput {
+            block_transition: BlockTransition {
+                prevBlockHash: B256::with_last_byte(1),
+                nextBlockHash: B256::with_last_byte(2),
+            },
+            deposit_queue_transition: DepositQueueTransition {
+                prevProcessedHash: B256::with_last_byte(3),
+                nextProcessedHash: B256::with_last_byte(4),
+                prevDepositNumber: 5,
+                nextDepositNumber: 6,
+            },
+            withdrawal_queue_hash: B256::with_last_byte(7),
+            last_batch_commitment: LastBatchCommitment {
+                withdrawal_batch_index: 8,
+            },
+        };
+        let expected_digest = nitro_batch_attestation_hash(&public_inputs, &output);
+        let document = vec![0xd2, 0x84, 0x43];
+
+        let bundle = build_proof_bundle(&public_inputs, &output, |digest| {
+            assert_eq!(digest, expected_digest);
+            Ok(document.clone())
+        })
+        .unwrap();
+
+        assert_eq!(bundle.verifier_config.as_ref(), NITRO_VERIFIER_CONFIG_V1);
+        assert_eq!(bundle.proof.as_ref(), document);
     }
 
     #[test]

--- a/bin/prover/enclave/src/main.rs
+++ b/bin/prover/enclave/src/main.rs
@@ -375,27 +375,6 @@ mod tests {
     }
 
     #[test]
-    fn rejects_unknown_chain_before_execution() {
-        let mut witness = empty_witness();
-        witness.public_inputs.parent_chain_id = 99;
-        let request = VerifyRequest {
-            version: PROTOCOL_VERSION,
-            request_id: "chain-test".into(),
-            witness,
-        };
-        let response = process_request(request, &TrustedChainSpecs::default());
-
-        assert!(matches!(
-            response,
-            VerifyResponse::Error {
-                request_id: Some(id),
-                code: ErrorCode::UnsupportedChain,
-                ..
-            } if id == "chain-test"
-        ));
-    }
-
-    #[test]
     fn binds_the_canonical_digest_into_the_proof_bundle() {
         let public_inputs = empty_witness().public_inputs;
         let output = BatchOutput {

--- a/bin/prover/enclave/src/main.rs
+++ b/bin/prover/enclave/src/main.rs
@@ -350,7 +350,7 @@ mod tests {
     use tempo_primitives::TempoHeader;
     use zone_spf::{
         BatchWitness, BlockTransition, DepositQueueTransition, LastBatchCommitment, PublicInputs,
-        TempoStateWitness, ZoneStateWitness,
+        TempoStateWitness, TokenEnablementTransition, ZoneStateWitness,
     };
 
     use super::*;
@@ -388,9 +388,13 @@ mod tests {
                 prevDepositNumber: 5,
                 nextDepositNumber: 6,
             },
-            withdrawal_queue_hash: B256::with_last_byte(7),
+            token_enablement_transition: TokenEnablementTransition {
+                prevProcessedTokenCount: 7,
+                nextProcessedTokenCount: 8,
+            },
+            withdrawal_queue_hash: B256::with_last_byte(9),
             last_batch_commitment: LastBatchCommitment {
-                withdrawal_batch_index: 8,
+                withdrawal_batch_index: 10,
             },
         };
         let expected_digest = nitro_batch_attestation_hash(&public_inputs, &output);

--- a/crates/prover/src/protocol.rs
+++ b/crates/prover/src/protocol.rs
@@ -105,6 +105,8 @@ pub enum ErrorCode {
     UnsupportedChain,
     /// Stateless proof execution rejected the supplied witness.
     VerificationFailed,
+    /// The prover could not obtain an attestation from the Nitro Secure Module.
+    AttestationUnavailable,
     /// The framed request exceeds the configured size limit.
     RequestTooLarge,
     /// The connection ended before the complete frame was received.

--- a/deny.toml
+++ b/deny.toml
@@ -14,6 +14,9 @@ ignore = [
   # https://rustsec.org/advisories/RUSTSEC-2026-0247 bitmaps is unmaintained
   # and is pulled in transitively by reth through imbl with no maintained release available.
   "RUSTSEC-2026-0247",
+  # https://rustsec.org/advisories/RUSTSEC-2021-0127 serde_cbor is unmaintained
+  # and is pulled in transitively by aws-nitro-enclaves-nsm-api with no safe upgrade available.
+  "RUSTSEC-2021-0127",
 ]
 
 # This section is considered when running `cargo deny check bans`.


### PR DESCRIPTION
## Summary

Validate the witness parent chain, execute SPF, and bind the canonical batch digest to Nitro attestation user data. Return the raw COSE/CBOR document as the proof bundle and report NSM failures explicitly.