### PR TITLE
fix(precompiles): preserve receive policy resolution errors

### DIFF
--- a/crates/precompiles/src/execution.rs
+++ b/crates/precompiles/src/execution.rs
@@ -27,6 +27,7 @@ use tempo_chainspec::hardfork::TempoHardfork;
 use tempo_precompiles::{
     DelegateCallNotAllowed, charge_input_cost,
     dispatch::selector_from_calldata,
+    error::TempoPrecompileError,
     input_cost,
     storage::{
         PrecompileStorageProvider, StorageCtx, actions::StorageActions,
@@ -73,6 +74,8 @@ pub(crate) enum CallCheck {
     Continue,
     /// Revert with ABI-encoded data. The execution wrapper MUST apply input gas and reservoir.
     Revert(Bytes),
+    /// Return an upstream Tempo precompile error.
+    Error(TempoPrecompileError),
 }
 
 /// Selector and caller dependent precompile call rules evaluated after storage setup.
@@ -150,6 +153,11 @@ pub(crate) fn create_precompile(
                 let s = StorageCtx::default();
                 let output = s.revert_output(output);
                 add_input_cost(s, data, Ok(output))
+            }
+            CallCheck::Error(error) => {
+                let s = StorageCtx::default();
+                let result = s.error_result(error);
+                add_input_cost(s, data, result)
             }
         });
         if let (Ok(output), Some(gas)) = (&mut result, fixed_gas) {

--- a/crates/precompiles/src/receive_policy_guard.rs
+++ b/crates/precompiles/src/receive_policy_guard.rs
@@ -46,14 +46,11 @@ impl CallRules for ReceivePolicyGuardRules {
             return CallCheck::Continue;
         }
 
-        if matches!(
-            AddressRegistry::new().resolve_recipient(receipt.recipient),
-            Ok(receiver) if caller == receiver
-        ) {
-            return CallCheck::Continue;
+        match AddressRegistry::new().resolve_recipient(receipt.recipient) {
+            Ok(receiver) if caller == receiver => CallCheck::Continue,
+            Ok(_) => CallCheck::Revert(Unauthorized {}.abi_encode().into()),
+            Err(error) => CallCheck::Error(error),
         }
-
-        CallCheck::Revert(Unauthorized {}.abi_encode().into())
     }
 }
 
@@ -165,6 +162,31 @@ mod tests {
             assert_unauthorized(&rules, &receipt, OUTSIDER);
             Ok(())
         })
+    }
+
+    #[test]
+    fn balance_admission_preserves_recipient_resolution_errors() -> eyre::Result<()> {
+        let rules = ReceivePolicyGuardRules;
+        let mut ctx = test_context();
+        ctx.cfg.spec = tempo_chainspec::hardfork::TempoHardfork::T8;
+
+        let virtual_recipient = {
+            let mut storage = test_storage_provider(&mut ctx, u64::MAX, false);
+            StorageCtx::enter(&mut storage, || {
+                let (_, virtual_recipient) = register_virtual_master(&mut AddressRegistry::new())?;
+                Ok::<_, tempo_precompiles::error::TempoPrecompileError>(virtual_recipient)
+            })?
+        };
+        let receipt = receipt(virtual_recipient, Address::ZERO);
+        let mut storage = test_storage_provider(&mut ctx, 0, true);
+
+        StorageCtx::enter(&mut storage, || {
+            assert!(matches!(
+                rules.admit(&balance_call(&receipt), OUTSIDER),
+                CallCheck::Error(tempo_precompiles::error::TempoPrecompileError::OutOfGas)
+            ));
+        });
+        Ok(())
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- propagate `TempoPrecompileError` from receive-policy recipient resolution
- reserve `Unauthorized` for successful non-matching resolutions
- cover out-of-gas propagation with a regression test

## Testing

- `cargo test -p zone-precompiles receive_policy_guard --no-fail-fast`
- `cargo +nightly clippy -p zone-precompiles --tests -- -D warnings`
- `cargo +nightly fmt --all -- --check`

[ZONE-701](https://linear.app/tempoxyz/issue/ZONE-701/receive-policy-guard-discards-state-read-errors-from-resolve-recipient)

Prompted by: @0xrusowsky