### PR TITLE
feat(node): coordinate deferred Tempo imports

### DIFF
--- a/crates/l1/src/queue.rs
+++ b/crates/l1/src/queue.rs
@@ -10,6 +10,8 @@ use std::collections::VecDeque;
 pub(crate) struct PendingDeposits {
     /// Pending L1 blocks with their portal events, not yet processed by the Zone.
     pending: VecDeque<L1BlockDeposits>,
+    /// Portal work crossed by checkpoint-only Zone blocks and owed by the next full block.
+    deferred: Vec<L1BlockDeposits>,
     /// Highest L1 block ever enqueued (number + hash). Survives `confirm` /
     /// `drain` so that reconnecting subscribers know where the queue left off,
     /// even if the engine has already consumed the blocks.
@@ -83,6 +85,14 @@ impl PendingDeposits {
         self.pending.front()
     }
 
+    pub(crate) fn peek_headers(&self, maximum: usize) -> Vec<SealedHeader<TempoHeader>> {
+        self.pending
+            .iter()
+            .take(maximum)
+            .map(|block| block.header.clone())
+            .collect()
+    }
+
     /// Confirm the next pending L1 block was successfully processed and remove it.
     ///
     /// The caller must pass the [`NumHash`] returned by [`Self::peek`]. A
@@ -102,6 +112,81 @@ impl PendingDeposits {
             .pending
             .pop_front()
             .expect("front was checked immediately before pop"))
+    }
+
+    pub(crate) fn defer(&mut self, expected: NumHash) -> eyre::Result<()> {
+        let block = self.confirm(expected)?;
+        self.deferred.push(block);
+        Ok(())
+    }
+
+    /// Defer every pending block through a canonical checkpoint anchor.
+    ///
+    /// This is idempotent so follower imports can replay their post-forkchoice bookkeeping after
+    /// an interruption. Entries older than `expected` are also deferred because they belong to
+    /// the same checkpoint-only range.
+    pub(crate) fn defer_through(&mut self, expected: NumHash) -> eyre::Result<()> {
+        while let Some(front) = self.pending.front().map(|entry| entry.header.num_hash()) {
+            if front.number > expected.number {
+                break;
+            }
+            eyre::ensure!(
+                front.number < expected.number || front.hash == expected.hash,
+                "deposit queue holds L1 block {} with hash {}, but the checkpoint consumed {}",
+                front.number,
+                front.hash,
+                expected.hash,
+            );
+            self.defer(front)?;
+        }
+        if let Some(found) = self
+            .deferred
+            .iter()
+            .find(|entry| entry.header.number() == expected.number)
+        {
+            eyre::ensure!(
+                found.header.hash() == expected.hash,
+                "deferred L1 block {} has hash {}, but the checkpoint consumed {}",
+                expected.number,
+                found.header.hash(),
+                expected.hash,
+            );
+        }
+        Ok(())
+    }
+
+    pub(crate) fn operational_work(
+        &self,
+        current: &L1BlockDeposits,
+    ) -> eyre::Result<Vec<L1BlockDeposits>> {
+        let front = self
+            .pending
+            .front()
+            .ok_or_else(|| eyre::eyre!("cannot prepare work from an empty finalized L1 queue"))?;
+        eyre::ensure!(
+            front.header.num_hash() == current.header.num_hash(),
+            "operational L1 work does not match the queue front"
+        );
+        let mut work = self.deferred.clone();
+        work.push(current.clone());
+        Ok(work)
+    }
+
+    pub(crate) fn confirm_operational(&mut self, expected: NumHash) -> eyre::Result<()> {
+        self.confirm(expected)?;
+        self.deferred.clear();
+        Ok(())
+    }
+
+    /// Reconcile an already-canonical full import, including after its exact-front bookkeeping
+    /// was interrupted.
+    pub(crate) fn confirm_operational_through(&mut self, expected: NumHash) -> eyre::Result<()> {
+        self.confirm_through(expected)?;
+        // A delayed duplicate of an older full block must not erase checkpoint work deferred by
+        // newer canonical blocks. Only release work at or before the full block's anchor.
+        self.deferred
+            .retain(|entry| entry.header.number() > expected.number);
+        Ok(())
     }
 
     /// Confirm every pending L1 block up to and including `expected`.
@@ -225,10 +310,67 @@ impl DepositQueue {
         self.inner.lock().peek().cloned()
     }
 
+    /// Return up to `maximum` consecutive queued headers without consuming portal work.
+    pub fn peek_headers(&self, maximum: usize) -> Vec<SealedHeader<TempoHeader>> {
+        self.inner.lock().peek_headers(maximum)
+    }
+
     /// Confirm the next L1 block was successfully processed and remove it.
     ///
     pub fn confirm(&self, expected: NumHash) -> eyre::Result<L1BlockDeposits> {
         self.inner.lock().confirm(expected)
+    }
+
+    /// Move checkpointed portal work out of the header queue while retaining it for the next full
+    /// operational import. This state is shared across leadership-engine instances.
+    pub fn defer(&self, expected: NumHash) -> eyre::Result<()> {
+        self.inner.lock().defer(expected)
+    }
+
+    /// Idempotently move every pending block through a canonical checkpoint anchor to deferred
+    /// portal work.
+    pub fn defer_through(&self, expected: NumHash) -> eyre::Result<()> {
+        self.inner.lock().defer_through(expected)
+    }
+
+    /// Return deferred portal work followed by the current operational L1 block.
+    pub fn operational_work(
+        &self,
+        current: &L1BlockDeposits,
+    ) -> eyre::Result<Vec<L1BlockDeposits>> {
+        self.inner.lock().operational_work(current)
+    }
+
+    /// Restore portal work crossed by already-canonical checkpoint-only blocks after restart.
+    pub fn seed_deferred(&self, blocks: Vec<L1BlockDeposits>) -> eyre::Result<()> {
+        let mut recovered = PendingDeposits::default();
+        for block in blocks {
+            recovered.try_enqueue(block.header, block.events)?;
+        }
+        while let Some(front) = recovered
+            .pending
+            .front()
+            .map(|block| block.header.num_hash())
+        {
+            recovered.defer(front)?;
+        }
+        let mut queue = self.inner.lock();
+        eyre::ensure!(
+            queue.pending.is_empty() && queue.deferred.is_empty() && queue.last_enqueued.is_none(),
+            "cannot seed deferred portal work into a nonempty queue"
+        );
+        *queue = recovered;
+        Ok(())
+    }
+
+    /// Confirm a full operational import and release all deferred work it consumed.
+    pub fn confirm_operational(&self, expected: NumHash) -> eyre::Result<()> {
+        self.inner.lock().confirm_operational(expected)
+    }
+
+    /// Idempotently reconcile a canonical full import and release the deferred work it consumed.
+    pub fn confirm_operational_through(&self, expected: NumHash) -> eyre::Result<()> {
+        self.inner.lock().confirm_operational_through(expected)
     }
 
     /// Advance the queue past a canonical follower anchor.

--- a/crates/l1/src/subscriber.rs
+++ b/crates/l1/src/subscriber.rs
@@ -15,6 +15,7 @@ struct L1BlockTrackerState {
     observed: BTreeMap<u64, L1BlockObservation>,
     latest: Option<NumHash>,
     pruned_through: Option<u64>,
+    finalized_target: Option<u64>,
 }
 
 #[derive(Debug, Clone)]
@@ -51,6 +52,23 @@ impl Default for L1BlockTracker {
 }
 
 impl L1BlockTracker {
+    /// Record the highest finalized L1 height the subscriber has been asked to ingest.
+    ///
+    /// This is published before backfill starts so the Zone engine does not mistake a partially
+    /// filled queue for the end of the finalized range. The watermark remains monotonic across
+    /// reconnects so a lagging RPC endpoint cannot move the target backwards.
+    pub fn record_finalized_target(&self, number: u64) {
+        let mut state = self.state.write();
+        state.finalized_target = Some(state.finalized_target.map_or(number, |old| old.max(number)));
+        drop(state);
+        self.changed.send_replace(());
+    }
+
+    /// Return the highest finalized L1 height announced by the subscriber.
+    pub fn finalized_target(&self) -> Option<u64> {
+        self.state.read().finalized_target
+    }
+
     /// Initialize the last L1 height already represented by canonical local zone state.
     pub fn initialize_consumed_through(&self, number: u64) {
         let mut state = self.state.write();
@@ -546,6 +564,7 @@ impl L1Subscriber {
         next_block: u64,
     ) -> eyre::Result<u64> {
         let finalized = self.finalized_block_number(l1_provider).await?;
+        self.config.block_tracker.record_finalized_target(finalized);
         if next_block > finalized {
             self.record_seen_block(finalized, 0);
             return Ok(next_block);

--- a/crates/l1/src/subscriber.rs
+++ b/crates/l1/src/subscriber.rs
@@ -287,6 +287,9 @@ pub struct L1SubscriberConfig {
     pub leadership_sink: Option<Arc<dyn LeadershipSink>>,
     /// Private encryption keys bound by finalized Portal rotation events.
     pub encryption_keys: Option<crate::EncryptionKeyRing>,
+    /// First L1 block whose portal work was crossed by canonical checkpoint-only Zone blocks.
+    /// Startup reconstructs this suffix before following new finalized blocks.
+    pub deferred_work_start: Option<u64>,
 }
 
 pub(crate) trait LocalTempoCheckpointReader: Send + Sync {
@@ -765,12 +768,57 @@ impl L1Subscriber {
     /// ingestion failures as fatal.
     pub async fn run(&self) -> eyre::Result<()> {
         let provider = self.connect().await?;
+        self.recover_deferred_work(&provider).await?;
         let triggers = self.head_triggers(&provider).await?;
         info!(
             portal = %self.config.portal_address,
             "Following finalized L1 blocks"
         );
         self.follow_finalized(&provider, triggers).await
+    }
+
+    async fn recover_deferred_work(
+        &self,
+        l1_provider: &impl Provider<TempoNetwork>,
+    ) -> eyre::Result<()> {
+        let Some(from) = self.config.deferred_work_start else {
+            return Ok(());
+        };
+        if self.deposit_queue.last_enqueued().is_some() {
+            return Ok(());
+        }
+        let checkpoint = self.local_state.latest_tempo_checkpoint()?;
+        if from > checkpoint.number {
+            return Ok(());
+        }
+
+        let mut blocks = Vec::with_capacity((checkpoint.number - from + 1) as usize);
+        for block_number in from..=checkpoint.number {
+            let header = l1_provider
+                .get_header_by_number(block_number.into())
+                .await?
+                .ok_or_else(|| eyre::eyre!("L1 header not found for block {block_number}"))?;
+            let block_hash = header.hash();
+            let receipts = fetch_and_verify_receipts_for_header(
+                l1_provider,
+                NumHash::new(block_number, block_hash),
+                header.receipts_root(),
+                header.logs_bloom(),
+            )
+            .await?;
+            let (events, _) = self.extract_events(block_number, &receipts)?;
+            blocks.push(L1BlockDeposits {
+                header: SealedHeader::seal_slow(header.inner.inner),
+                events,
+            });
+        }
+        self.deposit_queue.seed_deferred(blocks)?;
+        info!(
+            from,
+            to = checkpoint.number,
+            "Recovered portal work crossed by checkpoint-only Zone blocks"
+        );
+        Ok(())
     }
 
     /// Extract portal events and raw-cache mutation barriers from fetched receipts.

--- a/crates/l1/src/tests.rs
+++ b/crates/l1/src/tests.rs
@@ -333,6 +333,17 @@ async fn l1_block_tracker_backpressures_at_one_hour_lookahead() {
 }
 
 #[test]
+fn l1_block_tracker_finalized_target_is_monotonic() {
+    let tracker = L1BlockTracker::default();
+    assert_eq!(tracker.finalized_target(), None);
+
+    tracker.record_finalized_target(200);
+    tracker.record_finalized_target(199);
+
+    assert_eq!(tracker.finalized_target(), Some(200));
+}
+
+#[test]
 fn l1_block_tracker_rejects_first_observation_above_persisted_successor() {
     let tracker = L1BlockTracker::default();
     tracker.initialize_consumed_through(10);
@@ -805,6 +816,7 @@ async fn test_sync_finalized_once_does_not_refetch_current_cursor() {
         .unwrap();
 
     assert_eq!(next, 11);
+    assert_eq!(subscriber.config.block_tracker.finalized_target(), Some(10));
     assert!(subscriber.deposit_queue.drain().is_empty());
     assert!(asserter.read_q().is_empty());
 }

--- a/crates/l1/src/tests.rs
+++ b/crates/l1/src/tests.rs
@@ -171,6 +171,7 @@ fn test_subscriber(local_state: Arc<dyn LocalTempoCheckpointReader>) -> L1Subscr
             retry_connection_interval: Duration::from_secs(1),
             leadership_sink: None,
             encryption_keys: None,
+            deferred_work_start: None,
         },
         local_state,
         deposit_queue: DepositQueue::default(),
@@ -1273,6 +1274,111 @@ fn confirm_through_is_idempotent_and_drains_stale_entries() {
     queue.confirm_through(anchor).unwrap();
     assert!(queue.peek().is_none());
     queue.confirm_through(anchor).unwrap();
+}
+
+#[test]
+fn canonical_import_reconciliation_is_idempotent_across_checkpoint_and_full_blocks() {
+    let queue = DepositQueue::new();
+    let first = SealedHeader::seal_slow(make_test_header(1));
+    let second = SealedHeader::seal_slow(make_chained_header(2, first.hash()));
+    let third = SealedHeader::seal_slow(make_chained_header(3, second.hash()));
+    for header in [&first, &second, &third] {
+        queue
+            .try_enqueue_sealed(header.clone(), L1PortalEvents::default())
+            .unwrap();
+    }
+
+    queue.defer_through(second.num_hash()).unwrap();
+    queue.defer_through(second.num_hash()).unwrap();
+    assert_eq!(queue.peek().unwrap().header.num_hash(), third.num_hash());
+    assert_eq!(
+        queue
+            .operational_work(&queue.peek().unwrap())
+            .unwrap()
+            .len(),
+        3
+    );
+
+    queue.confirm_operational_through(third.num_hash()).unwrap();
+    queue.confirm_operational_through(third.num_hash()).unwrap();
+    assert!(queue.peek().is_none());
+
+    let fourth = SealedHeader::seal_slow(make_chained_header(4, third.hash()));
+    let fifth = SealedHeader::seal_slow(make_chained_header(5, fourth.hash()));
+    queue
+        .try_enqueue_sealed(fourth.clone(), L1PortalEvents::default())
+        .unwrap();
+    queue.defer_through(fourth.num_hash()).unwrap();
+    queue
+        .try_enqueue_sealed(fifth, L1PortalEvents::default())
+        .unwrap();
+
+    // A late replay of block 3 must preserve block 4's newer deferred work.
+    queue.confirm_operational_through(third.num_hash()).unwrap();
+    assert_eq!(
+        queue
+            .operational_work(&queue.peek().unwrap())
+            .unwrap()
+            .len(),
+        2
+    );
+}
+
+#[test]
+fn deferred_checkpoint_work_survives_until_operational_confirmation() {
+    let queue = DepositQueue::new();
+    let h10 = make_test_header(10);
+    let h11 = make_chained_header(11, header_hash(&h10));
+    let h12 = make_chained_header(12, header_hash(&h11));
+    for header in [h10, h11, h12] {
+        queue
+            .try_enqueue_sealed(seal(header), L1PortalEvents::default())
+            .unwrap();
+    }
+
+    let first = queue.peek().unwrap();
+    queue.defer(first.header.num_hash()).unwrap();
+    let second = queue.peek().unwrap();
+    queue.defer(second.header.num_hash()).unwrap();
+    let current = queue.peek().unwrap();
+    let work = queue.operational_work(&current).unwrap();
+    assert_eq!(
+        work.iter()
+            .map(|block| block.header.number())
+            .collect::<Vec<_>>(),
+        vec![10, 11, 12]
+    );
+
+    queue
+        .confirm_operational(current.header.num_hash())
+        .unwrap();
+    assert!(queue.peek().is_none());
+}
+
+#[test]
+fn restart_can_seed_deferred_checkpoint_work() {
+    let queue = DepositQueue::new();
+    let h10 = make_test_header(10);
+    let h11 = make_chained_header(11, header_hash(&h10));
+    queue
+        .seed_deferred(vec![
+            L1BlockDeposits {
+                header: seal(h10),
+                events: L1PortalEvents::default(),
+            },
+            L1BlockDeposits {
+                header: seal(h11),
+                events: L1PortalEvents::default(),
+            },
+        ])
+        .unwrap();
+
+    let h12 = make_chained_header(12, queue.last_enqueued().unwrap().hash);
+    queue
+        .try_enqueue_sealed(seal(h12), L1PortalEvents::default())
+        .unwrap();
+    let current = queue.peek().unwrap();
+    assert_eq!(queue.operational_work(&current).unwrap().len(), 3);
 }
 
 #[test]

--- a/crates/node/src/engine.rs
+++ b/crates/node/src/engine.rs
@@ -59,11 +59,11 @@ use zone_l1::{DepositQueue, EncryptionKeyRing, L1BlockDeposits, L1BlockTracker};
 use zone_p2p::{LeadershipSchedule, P2pPeerId};
 use zone_payload::{TempoImport, ZonePayloadAttributes, ZonePayloadTypes};
 
-/// Per-anchor production permit backed by the effective leadership schedule.
+/// Full-block production permit backed by the effective leadership schedule.
 ///
-/// The permit is a single schedule lookup: produce anchor `N` only if the portal schedule or a
-/// forced-recovery override assigns `N` to this node. An optimistic override is open-ended until
-/// the next finalized portal transition supplies the ordinary-authority boundary.
+/// Full blocks require the leader assigned to their imported Tempo header. Checkpoint-only blocks
+/// are leader-neutral and bypass this permit. An optimistic override is open-ended until the next
+/// finalized portal transition supplies the ordinary-authority boundary.
 #[derive(Debug, Clone)]
 pub struct ProductionPermit {
     schedule: LeadershipSchedule,
@@ -79,7 +79,7 @@ impl ProductionPermit {
         }
     }
 
-    /// Decide whether this node may produce the zone block embedding `tempo_anchor`.
+    /// Decide whether this node may produce the full zone block embedding `tempo_anchor`.
     ///
     /// `None` authorizes production; `Some(exit)` is the reason the engine must stop.
     pub fn check(&self, tempo_anchor: u64) -> Option<EngineExit> {
@@ -483,6 +483,19 @@ impl AvailableBlockDrain for ZoneEngine {
     }
 
     fn permit(&self, block: &Self::Block) -> Option<EngineExit> {
+        let queued_headers = self
+            .deposit_queue
+            .peek_headers(zone_primitives::constants::MAX_TEMPO_HEADERS_PER_ZONE_BLOCK + 1);
+        if checkpoint_header_count(
+            &self.chain_spec,
+            &queued_headers,
+            self.l1_block_tracker.finalized_target(),
+        ) > 0
+        {
+            // TIP-1096 assigns no leader to checkpoint-only blocks. Leader authority resumes at
+            // the final full block, whose single imported Tempo header is checked below.
+            return None;
+        }
         self.production_permit
             .as_ref()
             .and_then(|permit| permit.check(block.header.number()))

--- a/crates/node/src/engine.rs
+++ b/crates/node/src/engine.rs
@@ -54,8 +54,8 @@ use tempo_primitives::TempoHeader;
 use tokio_util::sync::CancellationToken;
 use tracing::{error, info};
 
-use zone_chainspec::ZoneChainSpec;
-use zone_l1::{DepositQueue, EncryptionKeyRing, L1BlockDeposits, L1BlockTracker, PreparedL1Block};
+use zone_chainspec::{ZoneChainSpec, ZoneHardforks};
+use zone_l1::{DepositQueue, EncryptionKeyRing, L1BlockDeposits, L1BlockTracker};
 use zone_p2p::{LeadershipSchedule, P2pPeerId};
 use zone_payload::{TempoImport, ZonePayloadAttributes, ZonePayloadTypes};
 
@@ -314,15 +314,6 @@ impl ZoneEngine {
         }
     }
 
-    /// Decrypt deposits and ABI-encode them into a [`PreparedL1Block`] ready for
-    /// the payload builder. Mint-recipient policy is enforced during upstream TIP-20 execution
-    /// against the finalized L1 anchor.
-    async fn prepare_l1_block(&self, l1_block: L1BlockDeposits) -> eyre::Result<PreparedL1Block> {
-        l1_block
-            .prepare(&self.encryption_keys, self.portal_address)
-            .await
-    }
-
     /// Advance the chain by one block.
     ///
     /// Wraps the given L1 block into [`ZonePayloadAttributes`], sends FCU
@@ -330,24 +321,52 @@ impl ZoneEngine {
     /// via `newPayload`. Only confirms (removes) the L1 block from the
     /// deposit queue after `newPayload` succeeds.
     async fn advance(&mut self, l1_block: L1BlockDeposits) -> eyre::Result<()> {
-        let l1_num_hash = l1_block.header.num_hash();
+        let queued_headers = self
+            .deposit_queue
+            .peek_headers(zone_primitives::constants::MAX_TEMPO_HEADERS_PER_ZONE_BLOCK + 1);
+        // Do not checkpoint across the Z1 activation boundary. A pre-Z1 queue front must be
+        // imported operationally before a later Z1 header can enable advanceTempoHeaders.
+        let checkpoint_count = checkpoint_header_count(&self.chain_spec, &queued_headers);
+        let checkpoint_headers = &queued_headers[..checkpoint_count];
+        let checkpoint_only = !checkpoint_headers.is_empty();
+        let final_header = checkpoint_headers.last().unwrap_or(&l1_block.header);
+        let l1_num_hash = final_header.num_hash();
 
-        // The L1 timestamp is a lower bound so a Zone block anchored after an L1 timestamp-based
-        // fork cannot predate it. Use wall-clock time to avoid backdating transactions during
-        // catch-up, and advance by at least one millisecond to keep consecutive blocks monotonic.
-        let wall_clock_timestamp_millis = SystemTime::now()
-            .duration_since(UNIX_EPOCH)?
-            .as_millis()
-            .try_into()?;
-        let timestamp_millis = zone_timestamp_millis(
-            l1_block.header.timestamp_millis(),
-            self.last_header.timestamp_millis(),
-            wall_clock_timestamp_millis,
-        );
-        let timestamp_secs = timestamp_millis / 1000;
-        let timestamp_millis_part = timestamp_millis % 1000;
+        let (timestamp_secs, timestamp_millis_part) = if self
+            .chain_spec
+            .zone_hardfork_at(final_header.timestamp())
+            .is_z1()
+        {
+            // Z1 locks the Zone block timestamp to the final imported Tempo header.
+            (final_header.timestamp(), final_header.timestamp_millis_part)
+        } else {
+            // Before Z1, the L1 timestamp remains a lower bound. Use wall-clock time to avoid
+            // backdating transactions during catch-up, and keep consecutive blocks monotonic.
+            let wall_clock_timestamp_millis = SystemTime::now()
+                .duration_since(UNIX_EPOCH)?
+                .as_millis()
+                .try_into()?;
+            let timestamp_millis = zone_timestamp_millis(
+                l1_block.header.timestamp_millis(),
+                self.last_header.timestamp_millis(),
+                wall_clock_timestamp_millis,
+            );
+            (timestamp_millis / 1000, timestamp_millis % 1000)
+        };
 
-        let l1_block = self.prepare_l1_block(l1_block).await?;
+        let tempo_import = if checkpoint_only {
+            TempoImport::CheckpointOnly(checkpoint_headers.to_vec())
+        } else {
+            let portal_work = self.deposit_queue.operational_work(&l1_block)?;
+            TempoImport::Full(Box::new(
+                L1BlockDeposits::prepare_many(
+                    portal_work,
+                    &self.encryption_keys,
+                    self.portal_address,
+                )
+                .await?,
+            ))
+        };
 
         let attributes = ZonePayloadAttributes {
             inner: EthPayloadAttributes {
@@ -366,7 +385,7 @@ impl ZoneEngine {
                 target_gas_limit: None,
             },
             timestamp_millis_part,
-            tempo_import: TempoImport::Full(Box::new(l1_block)),
+            tempo_import,
         };
 
         // Send FCU with payload attributes through the engine API to trigger
@@ -401,7 +420,13 @@ impl ZoneEngine {
 
         // newPayload succeeded — remove the exact finalized L1 block that
         // produced it. A mismatch indicates an internal consumer-ordering bug.
-        self.deposit_queue.confirm(l1_num_hash)?;
+        if checkpoint_only {
+            for header in checkpoint_headers {
+                self.deposit_queue.defer(header.num_hash())?;
+            }
+        } else {
+            self.deposit_queue.confirm_operational(l1_num_hash)?;
+        }
         self.l1_block_tracker.prune_through(l1_num_hash.number);
         if let Some(permit) = &self.production_permit {
             permit.record_applied_anchor(l1_num_hash.number);
@@ -420,6 +445,22 @@ impl ZoneEngine {
     }
 }
 
+fn checkpoint_header_count(
+    chain_spec: &ZoneChainSpec,
+    queued_headers: &[SealedHeader<TempoHeader>],
+) -> usize {
+    if !queued_headers
+        .first()
+        .is_some_and(|header| chain_spec.zone_hardfork_at(header.timestamp()).is_z1())
+    {
+        return 0;
+    }
+    queued_headers
+        .len()
+        .saturating_sub(1)
+        .min(zone_primitives::constants::MAX_TEMPO_HEADERS_PER_ZONE_BLOCK)
+}
+
 impl AvailableBlockDrain for ZoneEngine {
     type Block = L1BlockDeposits;
 
@@ -428,7 +469,6 @@ impl AvailableBlockDrain for ZoneEngine {
     }
 
     fn permit(&self, block: &Self::Block) -> Option<EngineExit> {
-        // No permit is legacy single-sequencer mode: production is always authorized.
         self.production_permit
             .as_ref()
             .and_then(|permit| permit.check(block.header.number()))
@@ -469,6 +509,45 @@ mod tests {
     #[test]
     fn zone_timestamp_advances_past_parent_when_catching_up_in_same_millisecond() {
         assert_eq!(zone_timestamp_millis(1_000, 2_000, 2_000), 2_001);
+    }
+
+    fn z1_spec(activation: u64) -> ZoneChainSpec {
+        use reth_chainspec::EthChainSpec as _;
+        let mut genesis = tempo_chainspec::spec::DEV.genesis().clone();
+        genesis.config.chain_id =
+            zone_primitives::constants::zone_chain_id(tempo_chainspec::spec::DEV.chain().id(), 1)
+                .unwrap();
+        genesis
+            .config
+            .extra_fields
+            .insert_value("z1Time".into(), activation)
+            .unwrap();
+        ZoneChainSpec::from_genesis(genesis).unwrap()
+    }
+
+    fn header(number: u64, timestamp: u64) -> SealedHeader<TempoHeader> {
+        SealedHeader::seal_slow(TempoHeader {
+            inner: alloy_consensus::Header {
+                number,
+                timestamp,
+                ..Default::default()
+            },
+            ..Default::default()
+        })
+    }
+
+    #[test]
+    fn checkpoint_batching_does_not_cross_z1_activation() {
+        let spec = z1_spec(100);
+        assert_eq!(
+            checkpoint_header_count(&spec, &[header(1, 99), header(2, 100)]),
+            0
+        );
+        assert_eq!(
+            checkpoint_header_count(&spec, &[header(2, 100), header(3, 101)]),
+            1
+        );
+        assert_eq!(checkpoint_header_count(&spec, &[header(2, 100)]), 0);
     }
 
     struct PausedDrain {

--- a/crates/node/src/engine.rs
+++ b/crates/node/src/engine.rs
@@ -326,7 +326,11 @@ impl ZoneEngine {
             .peek_headers(zone_primitives::constants::MAX_TEMPO_HEADERS_PER_ZONE_BLOCK + 1);
         // Do not checkpoint across the Z1 activation boundary. A pre-Z1 queue front must be
         // imported operationally before a later Z1 header can enable advanceTempoHeaders.
-        let checkpoint_count = checkpoint_header_count(&self.chain_spec, &queued_headers);
+        let checkpoint_count = checkpoint_header_count(
+            &self.chain_spec,
+            &queued_headers,
+            self.l1_block_tracker.finalized_target(),
+        );
         let checkpoint_headers = &queued_headers[..checkpoint_count];
         let checkpoint_only = !checkpoint_headers.is_empty();
         let final_header = checkpoint_headers.last().unwrap_or(&l1_block.header);
@@ -448,6 +452,7 @@ impl ZoneEngine {
 fn checkpoint_header_count(
     chain_spec: &ZoneChainSpec,
     queued_headers: &[SealedHeader<TempoHeader>],
+    finalized_target: Option<u64>,
 ) -> usize {
     if !queued_headers
         .first()
@@ -455,9 +460,18 @@ fn checkpoint_header_count(
     {
         return 0;
     }
+    // During backfill, the subscriber announces its finalized target before filling the queue.
+    // Until that target is visible, every queued header may be checkpointed because a later header
+    // is known to exist for the required full block. Once the target is queued (or no target is
+    // known), reserve the final visible header for the operational import.
+    let reserve_for_full = finalized_target.is_none_or(|target| {
+        queued_headers
+            .last()
+            .is_some_and(|header| header.number() >= target)
+    });
     queued_headers
         .len()
-        .saturating_sub(1)
+        .saturating_sub(usize::from(reserve_for_full))
         .min(zone_primitives::constants::MAX_TEMPO_HEADERS_PER_ZONE_BLOCK)
 }
 
@@ -540,14 +554,36 @@ mod tests {
     fn checkpoint_batching_does_not_cross_z1_activation() {
         let spec = z1_spec(100);
         assert_eq!(
-            checkpoint_header_count(&spec, &[header(1, 99), header(2, 100)]),
+            checkpoint_header_count(&spec, &[header(1, 99), header(2, 100)], Some(2)),
             0
         );
         assert_eq!(
-            checkpoint_header_count(&spec, &[header(2, 100), header(3, 101)]),
+            checkpoint_header_count(&spec, &[header(2, 100), header(3, 101)], Some(3)),
             1
         );
-        assert_eq!(checkpoint_header_count(&spec, &[header(2, 100)]), 0);
+        assert_eq!(
+            checkpoint_header_count(&spec, &[header(2, 100)], Some(2)),
+            0
+        );
+    }
+
+    #[test]
+    fn checkpoint_batching_uses_announced_finalized_target() {
+        let spec = z1_spec(100);
+
+        // Backfill has announced 100 missing blocks, but only the first is verified and queued.
+        // It must remain a checkpoint-only import instead of becoming a premature full block.
+        assert_eq!(
+            checkpoint_header_count(&spec, &[header(100, 100)], Some(199)),
+            1
+        );
+
+        // Once all 100 are queued, reserve the target header for the full operational import and
+        // fold the preceding 99 headers into one checkpoint-only block.
+        let headers = (100..=199)
+            .map(|number| header(number, number))
+            .collect::<Vec<_>>();
+        assert_eq!(checkpoint_header_count(&spec, &headers, Some(199)), 99);
     }
 
     struct PausedDrain {

--- a/crates/node/src/node.rs
+++ b/crates/node/src/node.rs
@@ -20,11 +20,12 @@ use crate::{
     },
 };
 use alloy_chains::Chain;
-use alloy_consensus::BlockHeader as _;
-use alloy_eips::BlockNumberOrTag;
+use alloy_consensus::{BlockHeader as _, TxReceipt as _};
+use alloy_eips::{BlockHashOrNumber, BlockNumberOrTag};
 use alloy_primitives::{Address, U256};
 use alloy_provider::Provider as _;
 use alloy_signer_local::PrivateKeySigner;
+use alloy_sol_types::SolEvent as _;
 use k256::SecretKey;
 use reth_chainspec::EthChainSpec;
 use reth_eth_wire_types::primitives::BasicNetworkPrimitives;
@@ -49,7 +50,8 @@ use reth_rpc_api::Web3ApiServer as _;
 use reth_rpc_builder::Identity;
 use reth_rpc_eth_api::EthApiTypes;
 use reth_storage_api::{
-    BlockNumReader, EmptyBodyStorage, HeaderProvider, StateProvider, StateProviderFactory,
+    BlockNumReader, EmptyBodyStorage, HeaderProvider, ReceiptProvider, StateProvider,
+    StateProviderFactory,
 };
 use reth_transaction_pool::{
     Pool, PoolTransaction, TransactionValidationTaskExecutor, blobstore::InMemoryBlobStore,
@@ -72,7 +74,7 @@ use tempo_transaction_pool::{
     transaction::{TempoPoolTransactionError, TempoPooledTransaction},
     validator::{DEFAULT_MAX_TEMPO_AUTHORIZATIONS, TempoTransactionValidator},
 };
-use tempo_zone_contracts::{ZONE_INBOX_ADDRESS, ZONE_OUTBOX_ADDRESS, ZonePortal};
+use tempo_zone_contracts::{IZoneInbox, ZONE_INBOX_ADDRESS, ZONE_OUTBOX_ADDRESS, ZonePortal};
 use tracing::{debug, info, warn};
 use zone_chainspec::ZoneChainSpec;
 use zone_evm::ZoneEvmConfig;
@@ -115,6 +117,35 @@ fn validate_configured_zone_id(
         "zone ID mismatch: {source} has {configured_zone_id}, but portal has {portal_zone_id}"
     );
     Ok(())
+}
+
+fn latest_operational_tempo_block<P>(provider: &P) -> eyre::Result<u64>
+where
+    P: BlockNumReader + ReceiptProvider + StateProviderFactory,
+{
+    let best = provider.best_block_number()?;
+    for number in (1..=best).rev() {
+        let Some(receipts) = provider.receipts_by_block(BlockHashOrNumber::Number(number))? else {
+            continue;
+        };
+        for receipt in receipts {
+            for log in receipt.logs() {
+                if log.address == ZONE_INBOX_ADDRESS
+                    && log.topics().first() == Some(&IZoneInbox::TempoAdvanced::SIGNATURE_HASH)
+                {
+                    return Ok(IZoneInbox::TempoAdvanced::decode_log(log)?.tempoBlockNumber);
+                }
+            }
+        }
+    }
+
+    let genesis_hash = provider
+        .block_hash(0)?
+        .ok_or_else(|| eyre::eyre!("zone genesis block hash is unavailable"))?;
+    Ok(provider
+        .state_by_block_hash(genesis_hash)?
+        .tempo_num_hash()?
+        .number)
 }
 
 /// Network primitives for Zone Nodes
@@ -258,6 +289,7 @@ impl ZoneNode {
             retry_connection_interval,
             leadership_sink: None,
             encryption_keys: None,
+            deferred_work_start: None,
         };
 
         let l1_state_provider_config = L1StateProviderConfig {
@@ -506,6 +538,11 @@ where
         );
 
         let tempo_block_number = ctx.node.provider().latest()?.tempo_block_number()?;
+        let last_operational_tempo_block = latest_operational_tempo_block(ctx.node.provider())?;
+        if last_operational_tempo_block < tempo_block_number {
+            self.l1_config.deferred_work_start =
+                Some(last_operational_tempo_block.saturating_add(1));
+        }
         let l1_provider = alloy_provider::ProviderBuilder::new_with_network::<TempoNetwork>()
             .connect_with_config(
                 &self.l1_config.l1_rpc_url,

--- a/crates/node/src/node.rs
+++ b/crates/node/src/node.rs
@@ -74,7 +74,9 @@ use tempo_transaction_pool::{
     transaction::{TempoPoolTransactionError, TempoPooledTransaction},
     validator::{DEFAULT_MAX_TEMPO_AUTHORIZATIONS, TempoTransactionValidator},
 };
-use tempo_zone_contracts::{IZoneInbox, ZONE_INBOX_ADDRESS, ZONE_OUTBOX_ADDRESS, ZonePortal};
+use tempo_zone_contracts::{
+    IZoneInbox, LegacyTempoAdvanced, ZONE_INBOX_ADDRESS, ZONE_OUTBOX_ADDRESS, ZonePortal,
+};
 use tracing::{debug, info, warn};
 use zone_chainspec::ZoneChainSpec;
 use zone_evm::ZoneEvmConfig;
@@ -130,10 +132,17 @@ where
         };
         for receipt in receipts {
             for log in receipt.logs() {
-                if log.address == ZONE_INBOX_ADDRESS
-                    && log.topics().first() == Some(&IZoneInbox::TempoAdvanced::SIGNATURE_HASH)
-                {
-                    return Ok(IZoneInbox::TempoAdvanced::decode_log(log)?.tempoBlockNumber);
+                if log.address != ZONE_INBOX_ADDRESS {
+                    continue;
+                }
+                match log.topics().first() {
+                    Some(topic) if topic == &IZoneInbox::TempoAdvanced::SIGNATURE_HASH => {
+                        return Ok(IZoneInbox::TempoAdvanced::decode_log(log)?.tempoBlockNumber);
+                    }
+                    Some(topic) if topic == &LegacyTempoAdvanced::SIGNATURE_HASH => {
+                        return Ok(LegacyTempoAdvanced::decode_log(log)?.tempoBlockNumber);
+                    }
+                    _ => {}
                 }
             }
         }

--- a/crates/node/src/replication.rs
+++ b/crates/node/src/replication.rs
@@ -22,7 +22,7 @@ use tempo_primitives::{Block, TempoHeader, TempoTxEnvelope};
 use tokio::sync::{mpsc, oneshot};
 use tokio_util::sync;
 use tracing::{debug, info};
-use zone_l1::{DepositQueue, L1BlockTracker, L1PortalEvents, TempoStateExt as _};
+use zone_l1::{DepositQueue, L1BlockDeposits, L1BlockTracker, L1PortalEvents, TempoStateExt as _};
 use zone_p2p::{
     BackfillCommand, BackfillRequest, BackfillResponse, LeadershipSchedule, P2pCommand, P2pEvent,
     P2pPeerId, PeerTip,
@@ -1114,6 +1114,7 @@ where
     let block_number = block.number();
     let hash = block.hash();
     let best_block = provider.best_block_number()?;
+    let tempo_import = decode_advance_tempo(&block)?;
 
     // 1. Block number is correct
     if block_number <= best_block {
@@ -1121,6 +1122,9 @@ where
             eyre::eyre!("missing local canonical header at height {block_number}")
         })?;
         if existing.hash() == hash {
+            reconcile_canonical_import(deposit_queue, &tempo_import).wrap_err_with(|| {
+                format!("cannot reconcile duplicate canonical peer block {block_number}")
+            })?;
             debug!(target: "zone::p2p", block_number, ?hash, "Ignoring duplicate peer block");
             return Ok(PeerBlockImportOutcome::Imported);
         }
@@ -1151,61 +1155,94 @@ where
 
     // 3. Require the block to advance the local Tempo checkpoint by exactly
     // one independently observed L1 block.
-    let (l1_header, portal_inputs) = decode_advance_tempo(&block)?;
     let local = provider
         .state_by_block_hash(parent.hash())?
         .tempo_num_hash()?;
-    validate_l1_checkpoint_transition(&l1_header, local.number, local.hash, block_number)?;
-    let anchor = l1_header.num_hash();
+    let headers = tempo_import.headers();
+    validate_l1_checkpoint_range(headers, local.number, local.hash, block_number)?;
+    let anchor = headers.last().expect("validated nonempty range").num_hash();
+    let production_anchor = tempo_import.production_anchor();
 
-    // Anchor-aware fence for live blocks: the sender must
-    // be the scheduled leader of the block's anchor. This stops an honest stale
-    // leader's broadcast from splitting followers.
+    // Anchor-aware fence for live blocks: a full block has one imported header, while a
+    // checkpoint-only block may cross leadership boundaries and is assigned to the leader of its
+    // first imported header. This gives every live block one producer without making a later
+    // transition inside a checkpoint range invalidate the block.
     // Backfilled blocks carry no producer claim and are judged by parent/anchor/execution/conflict
     // validation only.
     //
     // Check once before waiting to reject an already-known invalid sender without blocking the
-    // import loop. `wait_for_validated_peer_anchor` checks again after observing the anchor:
-    // the anchor itself may finalize a leadership transition that changes its assigned producer.
+    // import loop, then again after observing every imported header. The first header itself may
+    // finalize a leadership transition that changes its assigned producer.
     validate_live_block_sender(
         schedule,
         peer_block.live_sender.as_ref(),
-        anchor.number,
+        production_anchor,
         block_number,
     )?;
-    let observed = match wait_for_validated_peer_anchor(
-        l1_block_tracker,
-        schedule,
-        &portal_inputs,
-        peer_block.live_sender.as_ref(),
-        anchor,
-        block_number,
-        stop,
-        PEER_ANCHOR_WAIT_TIMEOUT,
-    )
-    .await
-    {
-        Ok(observed) => observed,
-        Err(PeerAnchorWaitError::Cancelled) => return Ok(PeerBlockImportOutcome::Cancelled),
-        Err(PeerAnchorWaitError::TimedOut {
+    let mut observed_headers = Vec::with_capacity(headers.len());
+    for header in headers {
+        let observed = match wait_for_peer_anchor(
+            l1_block_tracker,
+            header.num_hash(),
             block_number,
-            anchor,
-        }) => {
-            return Ok(PeerBlockImportOutcome::TimedOut {
+            stop,
+            PEER_ANCHOR_WAIT_TIMEOUT,
+        )
+        .await
+        {
+            Ok(observed) => observed,
+            Err(PeerAnchorWaitError::Cancelled) => {
+                return Ok(PeerBlockImportOutcome::Cancelled);
+            }
+            Err(PeerAnchorWaitError::TimedOut {
                 block_number,
                 anchor,
-            });
-        }
-        Err(PeerAnchorWaitError::Other(error)) => return Err(error),
-    };
+            }) => {
+                return Ok(PeerBlockImportOutcome::TimedOut {
+                    block_number,
+                    anchor,
+                });
+            }
+            Err(PeerAnchorWaitError::Other(error)) => return Err(error),
+        };
+        observed_headers.push(observed);
+    }
+    validate_live_block_sender(
+        schedule,
+        peer_block.live_sender.as_ref(),
+        production_anchor,
+        block_number,
+    )?;
 
     // The subscriber normally enqueues immediately after recording this observation. Enqueueing
     // here as well closes that small scheduling window and makes follower import self-contained;
     // the queue treats the subscriber's later enqueue as a duplicate. This is peer-driven, so a
     // gap must surface as a rejected block rather than aborting the node.
-    deposit_queue
-        .try_enqueue_sealed(l1_header, observed)
-        .wrap_err_with(|| format!("cannot queue the anchor of block {block_number}"))?;
+    for (header, observed) in headers
+        .iter()
+        .cloned()
+        .zip(observed_headers.iter().cloned())
+    {
+        deposit_queue
+            .try_enqueue_sealed(header, observed)
+            .wrap_err_with(|| format!("cannot queue an imported header of block {block_number}"))?;
+    }
+
+    if let DecodedTempoImport::Full {
+        deposits,
+        enabled_tokens,
+        ..
+    } = &tempo_import
+    {
+        let current = L1BlockDeposits {
+            header: headers[0].clone(),
+            events: observed_headers[0].clone(),
+        };
+        validate_full_portal_inputs(deposit_queue, &current, deposits, enabled_tokens)
+            .wrap_err_with(|| {
+                format!("peer block {block_number} does not match observed portal events")
+            })?;
+    }
 
     // 4. All txns in the block execute properly
     let payload = ZonePayloadTypes::block_to_payload(block, None);
@@ -1228,9 +1265,16 @@ where
     // behind would stall the subscriber once the lookahead window fills. Advancing the queue is
     // likewise tolerant of drift; it fails only on a genuine hash conflict.
     l1_block_tracker.prune_through(anchor.number);
-    deposit_queue
-        .confirm_through(anchor)
-        .wrap_err_with(|| format!("cannot advance the deposit queue past block {block_number}"))?;
+    match &tempo_import {
+        DecodedTempoImport::CheckpointOnly { .. } => deposit_queue
+            .defer_through(anchor)
+            .wrap_err_with(|| format!("cannot defer checkpoint work from block {block_number}"))?,
+        DecodedTempoImport::Full { .. } => deposit_queue
+            .confirm_operational_through(anchor)
+            .wrap_err_with(|| {
+                format!("cannot advance the deposit queue past block {block_number}")
+            })?,
+    }
     schedule.record_applied_anchor(anchor.number);
 
     info!(target: "zone::p2p", block_number, ?hash, "Imported canonical leader block");
@@ -1261,6 +1305,85 @@ fn validate_live_block_sender(
     }
 }
 
+fn reconcile_canonical_import(
+    deposit_queue: &DepositQueue,
+    tempo_import: &DecodedTempoImport,
+) -> eyre::Result<()> {
+    let anchor = tempo_import
+        .headers()
+        .last()
+        .expect("decoded Tempo imports are nonempty")
+        .num_hash();
+    match tempo_import {
+        DecodedTempoImport::CheckpointOnly { .. } => deposit_queue.defer_through(anchor),
+        DecodedTempoImport::Full { .. } => deposit_queue.confirm_operational_through(anchor),
+    }
+}
+
+fn validate_full_portal_inputs(
+    deposit_queue: &DepositQueue,
+    current: &L1BlockDeposits,
+    deposits: &[zone_payload::abi::QueuedDeposit],
+    enabled_tokens: &[zone_payload::abi::EnabledToken],
+) -> eyre::Result<()> {
+    let work = deposit_queue.operational_work(current)?;
+    let mut deposit_offset = 0usize;
+    let mut token_offset = 0usize;
+    for block in work {
+        let next_deposit_offset = deposit_offset
+            .checked_add(block.events.deposits.len())
+            .ok_or_else(|| eyre::eyre!("advanceTempo deposit count overflow"))?;
+        let next_token_offset = token_offset
+            .checked_add(block.events.enabled_tokens.len())
+            .ok_or_else(|| eyre::eyre!("advanceTempo token count overflow"))?;
+        eyre::ensure!(
+            next_deposit_offset <= deposits.len() && next_token_offset <= enabled_tokens.len(),
+            "advanceTempo calldata is shorter than the deferred portal event range"
+        );
+        block.events.validate_advance_tempo_inputs(
+            &deposits[deposit_offset..next_deposit_offset],
+            &enabled_tokens[token_offset..next_token_offset],
+        )?;
+        deposit_offset = next_deposit_offset;
+        token_offset = next_token_offset;
+    }
+    eyre::ensure!(
+        deposit_offset == deposits.len(),
+        "advanceTempo contains {} deposits, but observed portal events contain {deposit_offset}",
+        deposits.len()
+    );
+    eyre::ensure!(
+        token_offset == enabled_tokens.len(),
+        "advanceTempo contains {} token enables, but observed portal events contain {token_offset}",
+        enabled_tokens.len()
+    );
+    Ok(())
+}
+
+async fn wait_for_peer_anchor(
+    l1_block_tracker: &L1BlockTracker,
+    anchor: NumHash,
+    block_number: u64,
+    stop: &sync::CancellationToken,
+    wait_timeout: Duration,
+) -> Result<L1PortalEvents, PeerAnchorWaitError> {
+    tokio::select! {
+        biased;
+        () = stop.cancelled() => Err(PeerAnchorWaitError::Cancelled),
+        observed = tokio::time::timeout(
+            wait_timeout,
+            l1_block_tracker.wait_for_portal_events(anchor),
+        ) => match observed {
+            Ok(observed) => observed.map_err(PeerAnchorWaitError::Other),
+            Err(_) => Err(PeerAnchorWaitError::TimedOut {
+                block_number,
+                anchor,
+            }),
+        },
+    }
+}
+
+#[cfg(test)]
 async fn wait_for_validated_peer_anchor(
     l1_block_tracker: &L1BlockTracker,
     schedule: &LeadershipSchedule,
@@ -1271,20 +1394,8 @@ async fn wait_for_validated_peer_anchor(
     stop: &sync::CancellationToken,
     wait_timeout: Duration,
 ) -> Result<L1PortalEvents, PeerAnchorWaitError> {
-    let observed = tokio::select! {
-        biased;
-        () = stop.cancelled() => return Err(PeerAnchorWaitError::Cancelled),
-        observed = tokio::time::timeout(
-            wait_timeout,
-            l1_block_tracker.wait_for_portal_events(anchor),
-        ) => match observed {
-            Ok(observed) => observed.map_err(PeerAnchorWaitError::Other)?,
-            Err(_) => return Err(PeerAnchorWaitError::TimedOut {
-                block_number,
-                anchor,
-            }),
-        },
-    };
+    let observed =
+        wait_for_peer_anchor(l1_block_tracker, anchor, block_number, stop, wait_timeout).await?;
     portal_inputs
         .validate(&observed)
         .map_err(PeerAnchorWaitError::Other)?;
@@ -1311,40 +1422,66 @@ enum PeerAnchorWaitError {
     Other(eyre::Report),
 }
 
+#[cfg(test)]
 struct AdvanceTempoPortalInputs {
     deposits: Vec<zone_payload::abi::QueuedDeposit>,
     enabled_tokens: Vec<zone_payload::abi::EnabledToken>,
 }
 
+#[cfg(test)]
 impl AdvanceTempoPortalInputs {
     fn validate(&self, observed: &L1PortalEvents) -> eyre::Result<()> {
         observed.validate_advance_tempo_inputs(&self.deposits, &self.enabled_tokens)
     }
 }
 
-fn validate_l1_checkpoint_transition(
-    l1_header: &SealedHeader<TempoHeader>,
+fn validate_l1_checkpoint_range(
+    headers: &[SealedHeader<TempoHeader>],
     local_number: u64,
     local_hash: B256,
     zone_block_number: u64,
 ) -> eyre::Result<()> {
-    if l1_header.number() != local_number.saturating_add(1) {
-        eyre::bail!(
-            "peer block {zone_block_number} advances Tempo to L1 block {}, but local checkpoint is {}; expected {}",
-            l1_header.number(),
-            local_number,
-            local_number.saturating_add(1)
-        );
+    if headers.is_empty() {
+        eyre::bail!("peer block imports no Tempo headers");
     }
-    if l1_header.parent_hash() != local_hash {
-        eyre::bail!(
-            "advanceTempo L1 header {} does not extend the local Tempo checkpoint: embedded parent {}, local hash {}",
-            l1_header.number(),
-            l1_header.parent_hash(),
-            local_hash
-        );
+    let mut previous_number = local_number;
+    let mut previous_hash = local_hash;
+    for l1_header in headers {
+        if l1_header.number() != previous_number.saturating_add(1) {
+            eyre::bail!(
+                "peer block {zone_block_number} advances Tempo to L1 block {}, but local checkpoint is {}; expected {}",
+                l1_header.number(),
+                previous_number,
+                previous_number.saturating_add(1)
+            );
+        }
+        if l1_header.parent_hash() != previous_hash {
+            eyre::bail!(
+                "advanceTempo L1 header {} does not extend the local Tempo checkpoint: embedded parent {}, local hash {}",
+                l1_header.number(),
+                l1_header.parent_hash(),
+                previous_hash
+            );
+        }
+        previous_number = l1_header.number();
+        previous_hash = l1_header.hash();
     }
     Ok(())
+}
+
+#[cfg(test)]
+fn validate_l1_checkpoint_transition(
+    header: &SealedHeader<TempoHeader>,
+    local_number: u64,
+    local_hash: B256,
+    zone_block_number: u64,
+) -> eyre::Result<()> {
+    validate_l1_checkpoint_range(
+        core::slice::from_ref(header),
+        local_number,
+        local_hash,
+        zone_block_number,
+    )
 }
 
 /// Decode the L1 header embedded in the first `IZoneInbox.advanceTempo` system transaction.
@@ -1352,12 +1489,41 @@ fn validate_l1_checkpoint_transition(
 fn decode_advance_tempo_header(
     block: &SealedBlock<Block>,
 ) -> eyre::Result<SealedHeader<TempoHeader>> {
-    decode_advance_tempo(block).map(|(header, _)| header)
+    decode_advance_tempo(block).map(|import| import.headers().last().unwrap().clone())
 }
 
-fn decode_advance_tempo(
-    block: &SealedBlock<Block>,
-) -> eyre::Result<(SealedHeader<TempoHeader>, AdvanceTempoPortalInputs)> {
+enum DecodedTempoImport {
+    Full {
+        header: Box<SealedHeader<TempoHeader>>,
+        deposits: Vec<zone_payload::abi::QueuedDeposit>,
+        enabled_tokens: Vec<zone_payload::abi::EnabledToken>,
+    },
+    CheckpointOnly {
+        headers: Vec<SealedHeader<TempoHeader>>,
+    },
+}
+
+impl DecodedTempoImport {
+    fn headers(&self) -> &[SealedHeader<TempoHeader>] {
+        match self {
+            Self::Full { header, .. } => core::slice::from_ref(header),
+            Self::CheckpointOnly { headers } => headers,
+        }
+    }
+
+    /// Tempo anchor whose leader is the unique live producer for this Zone block.
+    ///
+    /// A checkpoint-only block may cross later leadership boundaries, so its first imported
+    /// header selects the producer. A full block contains one header and follows the same rule.
+    fn production_anchor(&self) -> u64 {
+        self.headers()
+            .first()
+            .expect("decoded Tempo imports are validated as nonempty")
+            .number()
+    }
+}
+
+fn decode_advance_tempo(block: &SealedBlock<Block>) -> eyre::Result<DecodedTempoImport> {
     // Do some basic checks
 
     // 1. `advanceTempo` is the first tx
@@ -1375,6 +1541,26 @@ fn decode_advance_tempo(
     if signed.tx().to != ZONE_INBOX_ADDRESS.into() {
         eyre::bail!("first Tempo system transaction is not sent to IZoneInbox")
     }
+    if signed
+        .tx()
+        .input
+        .starts_with(&IZoneInbox::advanceTempoHeadersCall::SELECTOR)
+    {
+        if block.body().transactions.len() != 1 {
+            eyre::bail!("advanceTempoHeaders must be the only transaction in its block");
+        }
+        let call = IZoneInbox::advanceTempoHeadersCall::abi_decode(signed.tx().input.as_ref())?;
+        let mut headers = Vec::with_capacity(call.headers.len());
+        for encoded in call.headers {
+            let mut input = encoded.as_ref();
+            let header = TempoHeader::decode(&mut input)?;
+            if !input.is_empty() {
+                eyre::bail!("advanceTempoHeaders header has trailing bytes");
+            }
+            headers.push(SealedHeader::seal_slow(header));
+        }
+        return Ok(DecodedTempoImport::CheckpointOnly { headers });
+    }
     let call = IZoneInbox::advanceTempoCall::abi_decode(signed.tx().input.as_ref())
         .map_err(|err| eyre::eyre!("first transaction does not decode as advanceTempo: {err}"))?;
 
@@ -1388,13 +1574,11 @@ fn decode_advance_tempo(
             header_rlp.len()
         )
     }
-    Ok((
-        SealedHeader::seal_slow(header),
-        AdvanceTempoPortalInputs {
-            deposits: call.deposits,
-            enabled_tokens: call.enabledTokens,
-        },
-    ))
+    Ok(DecodedTempoImport::Full {
+        header: Box::new(SealedHeader::seal_slow(header)),
+        deposits: call.deposits,
+        enabled_tokens: call.enabledTokens,
+    })
 }
 
 #[cfg(test)]
@@ -1409,23 +1593,82 @@ mod tests {
 
     use alloy_eips::NumHash;
     use futures::{StreamExt as _, stream};
+    use reth_primitives_traits::SealedHeader;
+    use tempo_primitives::TempoHeader;
     use tokio::sync::{oneshot, watch};
     use tokio_util::sync;
 
     use super::{
         AdvanceTempoPortalInputs, BackfillProgress, BroadcasterShutdown, EncodedPersistedBlock,
         MAX_PENDING_BLOCKS, PEER_ANCHOR_WAIT_TIMEOUT, PersistedBlockSource, PersistedTip,
-        broadcast_persisted_blocks, buffer_pending_block, validate_live_block_sender,
-        wait_for_validated_peer_anchor,
+        broadcast_persisted_blocks, buffer_pending_block, validate_full_portal_inputs,
+        validate_live_block_sender, wait_for_validated_peer_anchor,
     };
-    use alloy_primitives::B256;
-    use zone_l1::{L1BlockTracker, L1PortalEvents};
+    use alloy_primitives::{Address, B256};
+    use zone_l1::{DepositQueue, EnabledToken, L1BlockDeposits, L1BlockTracker, L1PortalEvents};
     use zone_p2p::{BackfillCommand, LeadershipSchedule, LeadershipState, P2pCommand};
 
     #[derive(Clone)]
     struct StartupRaceSource {
         reads: Arc<AtomicUsize>,
         tip: PersistedTip,
+    }
+
+    #[test]
+    fn full_import_validates_deferred_and_current_portal_events() {
+        let queue = DepositQueue::new();
+        let first = SealedHeader::seal_slow(TempoHeader {
+            inner: alloy_consensus::Header {
+                number: 1,
+                ..Default::default()
+            },
+            ..Default::default()
+        });
+        let second = SealedHeader::seal_slow(TempoHeader {
+            inner: alloy_consensus::Header {
+                number: 2,
+                parent_hash: first.hash(),
+                ..Default::default()
+            },
+            ..Default::default()
+        });
+        let alpha = EnabledToken {
+            token: Address::repeat_byte(0x11),
+            name: "Alpha".into(),
+            symbol: "A".into(),
+            currency: "USD".into(),
+        };
+        let beta = EnabledToken {
+            token: Address::repeat_byte(0x22),
+            name: "Beta".into(),
+            symbol: "B".into(),
+            currency: "EUR".into(),
+        };
+        queue
+            .try_enqueue_sealed(
+                first.clone(),
+                L1PortalEvents {
+                    enabled_tokens: vec![alpha.clone()],
+                    ..Default::default()
+                },
+            )
+            .unwrap();
+        queue.defer_through(first.num_hash()).unwrap();
+        let current = L1BlockDeposits {
+            header: second,
+            events: L1PortalEvents {
+                enabled_tokens: vec![beta.clone()],
+                ..Default::default()
+            },
+        };
+        queue
+            .try_enqueue_sealed(current.header.clone(), current.events.clone())
+            .unwrap();
+
+        let expected = vec![alpha.to_abi(), beta.to_abi()];
+        validate_full_portal_inputs(&queue, &current, &[], &expected).unwrap();
+        let err = validate_full_portal_inputs(&queue, &current, &[], &expected[..1]).unwrap_err();
+        assert!(err.to_string().contains("shorter"));
     }
 
     impl PersistedBlockSource for StartupRaceSource {
@@ -1745,6 +1988,42 @@ mod tests {
             super::validate_l1_checkpoint_transition(&header, 10, B256::repeat_byte(0x99), 7)
                 .unwrap_err();
         assert!(wrong_parent.to_string().contains("does not extend"));
+    }
+
+    #[test]
+    fn checkpoint_live_producer_is_leader_of_first_imported_anchor() {
+        use commonware_cryptography::{Signer as _, ed25519::PrivateKey};
+        use reth_primitives_traits::SealedHeader;
+        use tempo_primitives::TempoHeader;
+
+        let outgoing = PrivateKey::from_seed(1).public_key();
+        let incoming = PrivateKey::from_seed(2).public_key();
+        let schedule = LeadershipSchedule::seeded(LeadershipState::new(1, outgoing.clone(), 0));
+        schedule
+            .publish(LeadershipState::new(2, incoming.clone(), 100))
+            .unwrap();
+
+        let headers = [90, 110]
+            .map(|number| {
+                SealedHeader::seal_slow(TempoHeader {
+                    inner: alloy_consensus::Header {
+                        number,
+                        ..Default::default()
+                    },
+                    ..Default::default()
+                })
+            })
+            .to_vec();
+        let tempo_import = super::DecodedTempoImport::CheckpointOnly { headers };
+
+        let production_anchor = tempo_import.production_anchor();
+        assert_eq!(production_anchor, 90);
+        validate_live_block_sender(&schedule, Some(&outgoing), production_anchor, 7).unwrap();
+        let error = validate_live_block_sender(&schedule, Some(&incoming), production_anchor, 7)
+            .expect_err(
+                "the later epoch leader must not produce a range beginning in the old epoch",
+            );
+        assert!(error.to_string().contains(&outgoing.to_string()));
     }
 
     #[tokio::test]

--- a/crates/node/src/replication.rs
+++ b/crates/node/src/replication.rs
@@ -702,9 +702,9 @@ pub(crate) async fn collect_follower_settlement_signatures<P>(
 
 /// Import live/backfilled blocks in canonical order on a follower.
 ///
-/// Live blocks are only imported from the leader when the sender equals
-/// `schedule.leader_for(the block's embedded anchor)`. We do this because if there are accidentally
-/// two leaders (split brain) for a block, we need to decide to import the correct one.
+/// Live full blocks are only imported when the sender equals the leader for their imported Tempo
+/// header. Checkpoint-only blocks have no designated leader and may be imported from any authorized
+/// P2P peer. The full-block check resolves accidental split brain using the finalized schedule.
 ///
 /// Backfilled blocks carry no producer claim and are judged by
 /// parent/anchor/execution/conflict validation alone. The loop exits when `stop` fires.
@@ -1161,22 +1161,21 @@ where
     let headers = tempo_import.headers();
     validate_l1_checkpoint_range(headers, local.number, local.hash, block_number)?;
     let anchor = headers.last().expect("validated nonempty range").num_hash();
-    let production_anchor = tempo_import.production_anchor();
+    let leader_anchor = tempo_import.leader_anchor();
 
-    // Anchor-aware fence for live blocks: a full block has one imported header, while a
-    // checkpoint-only block may cross leadership boundaries and is assigned to the leader of its
-    // first imported header. This gives every live block one producer without making a later
-    // transition inside a checkpoint range invalidate the block.
+    // Anchor-aware fence for live full blocks. Checkpoint-only blocks are leader-neutral and may
+    // cross leadership boundaries; leader authority resumes at the final full block and is checked
+    // against that block's single imported Tempo header.
     // Backfilled blocks carry no producer claim and are judged by parent/anchor/execution/conflict
     // validation only.
     //
     // Check once before waiting to reject an already-known invalid sender without blocking the
-    // import loop, then again after observing every imported header. The first header itself may
-    // finalize a leadership transition that changes its assigned producer.
-    validate_live_block_sender(
+    // import loop, then again after observing every imported header. The full block's imported
+    // header may itself finalize a leadership transition that changes its assigned producer.
+    validate_live_import_sender(
         schedule,
         peer_block.live_sender.as_ref(),
-        production_anchor,
+        leader_anchor,
         block_number,
     )?;
     let mut observed_headers = Vec::with_capacity(headers.len());
@@ -1207,10 +1206,10 @@ where
         };
         observed_headers.push(observed);
     }
-    validate_live_block_sender(
+    validate_live_import_sender(
         schedule,
         peer_block.live_sender.as_ref(),
-        production_anchor,
+        leader_anchor,
         block_number,
     )?;
 
@@ -1277,7 +1276,7 @@ where
     }
     schedule.record_applied_anchor(anchor.number);
 
-    info!(target: "zone::p2p", block_number, ?hash, "Imported canonical leader block");
+    info!(target: "zone::p2p", block_number, ?hash, "Imported canonical peer block");
     Ok(PeerBlockImportOutcome::Imported)
 }
 
@@ -1303,6 +1302,18 @@ fn validate_live_block_sender(
              record governs",
         ),
     }
+}
+
+fn validate_live_import_sender(
+    schedule: &LeadershipSchedule,
+    live_sender: Option<&P2pPeerId>,
+    leader_anchor: Option<u64>,
+    block_number: u64,
+) -> eyre::Result<()> {
+    let Some(anchor_number) = leader_anchor else {
+        return Ok(());
+    };
+    validate_live_block_sender(schedule, live_sender, anchor_number, block_number)
 }
 
 fn reconcile_canonical_import(
@@ -1511,15 +1522,15 @@ impl DecodedTempoImport {
         }
     }
 
-    /// Tempo anchor whose leader is the unique live producer for this Zone block.
+    /// Tempo anchor whose leader must produce this Zone block.
     ///
-    /// A checkpoint-only block may cross later leadership boundaries, so its first imported
-    /// header selects the producer. A full block contains one header and follows the same rule.
-    fn production_anchor(&self) -> u64 {
-        self.headers()
-            .first()
-            .expect("decoded Tempo imports are validated as nonempty")
-            .number()
+    /// Checkpoint-only blocks have no designated leader. A full block imports exactly one Tempo
+    /// header, whose effective leader supplies its production authority.
+    fn leader_anchor(&self) -> Option<u64> {
+        match self {
+            Self::Full { header, .. } => Some(header.number()),
+            Self::CheckpointOnly { .. } => None,
+        }
     }
 }
 
@@ -1991,7 +2002,7 @@ mod tests {
     }
 
     #[test]
-    fn checkpoint_live_producer_is_leader_of_first_imported_anchor() {
+    fn checkpoint_live_producer_is_not_leader_restricted() {
         use commonware_cryptography::{Signer as _, ed25519::PrivateKey};
         use reth_primitives_traits::SealedHeader;
         use tempo_primitives::TempoHeader;
@@ -2016,14 +2027,29 @@ mod tests {
             .to_vec();
         let tempo_import = super::DecodedTempoImport::CheckpointOnly { headers };
 
-        let production_anchor = tempo_import.production_anchor();
-        assert_eq!(production_anchor, 90);
-        validate_live_block_sender(&schedule, Some(&outgoing), production_anchor, 7).unwrap();
-        let error = validate_live_block_sender(&schedule, Some(&incoming), production_anchor, 7)
-            .expect_err(
-                "the later epoch leader must not produce a range beginning in the old epoch",
-            );
-        assert!(error.to_string().contains(&outgoing.to_string()));
+        let leader_anchor = tempo_import.leader_anchor();
+        assert_eq!(leader_anchor, None);
+        super::validate_live_import_sender(&schedule, Some(&outgoing), leader_anchor, 7).unwrap();
+        super::validate_live_import_sender(&schedule, Some(&incoming), leader_anchor, 7).unwrap();
+
+        let full_import = super::DecodedTempoImport::Full {
+            header: Box::new(SealedHeader::seal_slow(TempoHeader {
+                inner: alloy_consensus::Header {
+                    number: 110,
+                    ..Default::default()
+                },
+                ..Default::default()
+            })),
+            deposits: Vec::new(),
+            enabled_tokens: Vec::new(),
+        };
+        let leader_anchor = full_import.leader_anchor();
+        assert_eq!(leader_anchor, Some(110));
+        super::validate_live_import_sender(&schedule, Some(&incoming), leader_anchor, 8).unwrap();
+        let error =
+            super::validate_live_import_sender(&schedule, Some(&outgoing), leader_anchor, 8)
+                .expect_err("the final full block must be produced by its effective leader");
+        assert!(error.to_string().contains(&incoming.to_string()));
     }
 
     #[tokio::test]


### PR DESCRIPTION
- Queues finalized L1 blocks until they are imported by the Zone chain.
- Produces bounded checkpoint-only blocks while catching up, then resumes full advanceTempo blocks.
- Uses the finalized L1 target during catch-up.
- Retires queued L1 blocks only after their Zone imports are confirmed.
- Replicates deferred imports consistently to follower nodes.
- Recovers cursors from both legacy and Z1 TempoAdvanced events.
- Keeps checkpoint-only blocks leader-neutral so operational leadership changes only take effect in full blocks.