### PR TITLE
fix(xtask): account for deposit bounce-back fees

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4199,9 +4199,9 @@ dependencies = [
 
 [[package]]
 name = "h2"
-version = "0.4.15"
+version = "0.4.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6cb093c84e8bd9b188d4c4a8cb6579fc016968d14c99882163cd3ff402a4f155"
+checksum = "a9f37a958b41b3b19ee2707c06439c0e9e547e847223eb791ecb0cb821c65e27"
 dependencies = [
  "atomic-waker",
  "bytes",

--- a/xtask/src/verify_portal_backing.rs
+++ b/xtask/src/verify_portal_backing.rs
@@ -308,7 +308,10 @@ async fn withdrawal_liability<P: Provider<TempoNetwork>>(
         .filter(|(event, _)| event.token == token)
         .try_fold(U256::ZERO, |total, (event, _)| {
             total
-                .checked_add(U256::from(event.amount))
+                .checked_add(deposit_bounce_back_retired_amount(
+                    event.amount,
+                    event.bouncebackFee,
+                ))
                 .ok_or_else(|| eyre::eyre!("paid deposit bounce-back total overflow"))
         })?;
     let paid = paid
@@ -327,7 +330,10 @@ async fn withdrawal_liability<P: Provider<TempoNetwork>>(
         .filter(|(event, _)| event.token == token)
         .try_fold(U256::ZERO, |total, (event, _)| {
             total
-                .checked_add(U256::from(event.amount))
+                .checked_add(deposit_bounce_back_retired_amount(
+                    event.amount,
+                    event.bouncebackFee,
+                ))
                 .ok_or_else(|| eyre::eyre!("Portal refund transition total overflow"))
         })?;
     let refunded = refunded
@@ -342,6 +348,10 @@ async fn withdrawal_liability<P: Provider<TempoNetwork>>(
         .ok_or_else(|| eyre::eyre!("refunded withdrawal total overflow"))?;
 
     outstanding_withdrawals(requested, paid, reminted, refunded)
+}
+
+fn deposit_bounce_back_retired_amount(amount: u128, bounceback_fee: u128) -> U256 {
+    U256::from(amount) + U256::from(bounceback_fee)
 }
 
 fn outstanding_withdrawals(
@@ -499,6 +509,30 @@ mod tests {
         assert!(
             outstanding_withdrawals(U256::from(10), U256::from(11), U256::ZERO, U256::ZERO,)
                 .is_err()
+        );
+    }
+
+    #[test]
+    fn successful_deposit_bounce_back_retires_refund_and_fee() {
+        let retired = deposit_bounce_back_retired_amount(990, 10);
+
+        assert_eq!(
+            outstanding_withdrawals(U256::from(1_000), retired, U256::ZERO, U256::ZERO).unwrap(),
+            U256::ZERO
+        );
+    }
+
+    #[test]
+    fn pending_deposit_bounce_back_retires_fee_and_tracks_refund() {
+        let retired = deposit_bounce_back_retired_amount(990, 10);
+
+        assert_eq!(
+            outstanding_withdrawals(U256::from(1_000), U256::ZERO, U256::ZERO, retired).unwrap(),
+            U256::ZERO
+        );
+        assert_eq!(
+            outstanding_refunds("Portal", U256::from(990), U256::ZERO).unwrap(),
+            U256::from(990)
         );
     }
 }


### PR DESCRIPTION
## Summary

- retire both the refunded amount and the collected bounce-back fee when reconciling successful deposit bounce-backs
- apply the same accounting when a failed deposit becomes a pending Portal refund
- add regression tests for both successful and pending bounce-back paths

## Root cause

`DepositBounceBack` and `DepositBounceBackPending` split the original failed-deposit liability into a user refund amount and a collected bounce-back fee. The backing verifier retired only the refund amount, leaving the fee as a phantom outstanding withdrawal even though it had already left the Portal for the admin. A nonzero bounce-back fee could therefore produce a false underbacking result.

The Portal refund registry still carries only the user refund amount; the fee is included only when retiring the original withdrawal lifecycle entry.

## Validation

- `rustup run nightly cargo fmt --all -- --check`
- `rustup run nightly cargo test -p tempo-xtask` (28 passed)
- `rustup run nightly cargo clippy -p tempo-xtask --all-targets -- -D warnings`

Stacked on #1207.
