### PR TITLE
fix(bench): restore bridge wallet fixture

### DIFF
--- a/.github/workflows/zones-benchmark.yml
+++ b/.github/workflows/zones-benchmark.yml
@@ -708,6 +708,7 @@ jobs:
           test -s crates/contracts/benchmark-out/ERC4626Engine.sol/ERC4626Engine.json
           test -s crates/contracts/benchmark-out/Simple4626Vault.sol/Simple4626Vault.json
           test -s crates/contracts/benchmark-out/DemoTokenAuthority.sol/DemoTokenAuthority.json
+          test -s crates/contracts/benchmark-out/BridgeWalletFixture.sol/BridgeWalletFixture.json
 
       - name: Prepare or restore persistent Tempo L1 baseline
         run: |

--- a/crates/contracts/src/runtime/benchmark/BridgeWalletFixture.sol
+++ b/crates/contracts/src/runtime/benchmark/BridgeWalletFixture.sol
@@ -1,0 +1,7 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.35;
+
+/// @notice Token-only terminal recipient for the benchmark off-ramp leg.
+/// @dev This is deliberately the only local benchmark fixture. The gateway,
+///      vault, share token, and swap adapter are built from the pinned Earn source.
+contract BridgeWalletFixture { }


### PR DESCRIPTION
## Summary

- restore the benchmark-only bridge wallet fixture under the migrated contracts source root
- assert its Foundry artifact exists before topology provisioning starts

## Validation

- `forge build --root crates/contracts` with the local hardfork temporarily overridden to Cancun (sandbox Forge does not recognize `tempo:T8`)
- verified `crates/contracts/out/BridgeWalletFixture.sol/BridgeWalletFixture.json` exists
- `git diff --check`

Prompted by: @0xKitsune