### PR TITLE
feat(checker): add structured activity logs

### DIFF
--- a/crates/checker/README.md
+++ b/crates/checker/README.md
@@ -119,6 +119,45 @@ At minimum, alert when `disabled` or `divergence_active` is `1`, verification
 lag continues to grow, or the verified height stops advancing while the Zone
 head advances.
 
+### Verified activity logs
+
+After a Zone block is durably verified, the checker emits one structured
+`zone::checker` log for each authenticated bridge activity. These fields form
+the stable schema for log-backed dashboards:
+
+- `activity_schema_version`: currently `1`.
+- `activity_event`: the stable event name from the table below.
+- `activity_source`: `tempo` for Portal activity or `zone` for Zone activity.
+- `activity_id`: `<zone_hash>:<activity_source>:<activity_index>`, which remains
+  stable if recovery replays the same canonical block.
+- `activity_index`: the event's canonical order within its source for the Zone
+  block.
+- `zone_block`, `zone_hash`, `tempo_block`, and `tempo_hash`: exact verified
+  coordinates.
+- Event-specific fields such as `token`, `amount`, `recipient`, `sender`,
+  `deposit_number`, `withdrawal_index`, `fee`, and `callback_success`.
+
+| `activity_event` | Meaning |
+| --- | --- |
+| `portal_deposit_accounted` | Authenticated Portal deposit entered accounting. |
+| `portal_token_enabled` | Authenticated Portal token entered accounting coverage. |
+| `portal_withdrawal_accounted` | Authenticated Portal withdrawal and callback result. |
+| `portal_withdrawal_bounce_back` | Authenticated Portal withdrawal bounce-back. |
+| `portal_deposit_bounce_back` | Authenticated processed Portal deposit bounce-back. |
+| `portal_deposit_bounce_back_pending` | Authenticated pending Portal deposit bounce-back. |
+| `portal_refund_accounted` | Authenticated Portal refund entered accounting. |
+| `zone_deposit_minted` | Verified Zone deposit mint. |
+| `zone_deposit_failed` | Verified failed Zone deposit. |
+| `zone_deposit_bounce_back_requested` | Authenticated Zone deposit bounce-back request. |
+| `zone_withdrawal_burned` | Verified user withdrawal debit and burn. |
+| `zone_withdrawal_bounce_back_minted` | Verified Zone withdrawal bounce-back mint. |
+| `zone_withdrawal_bounce_back_pending` | Verified pending Zone withdrawal bounce-back. |
+| `zone_refund_minted` | Verified Zone refund mint. |
+
+`activity_id` lets a log consumer deduplicate replayed activities, but logs are
+still retention-bound diagnostic evidence rather than the canonical accounting
+ledger.
+
 ## Modes
 
 | Mode | Behavior |

--- a/crates/checker/README.md
+++ b/crates/checker/README.md
@@ -121,37 +121,44 @@ head advances.
 
 ### Verified activity logs
 
-After a Zone block is durably verified, the checker emits one structured
-`zone::checker` log for each authenticated bridge activity. These fields form
-the stable schema for log-backed dashboards:
+After a Zone block is durably verified, the checker emits structured
+`zone::checker` logs for authenticated bridge activity. Zero-value Portal
+refund claims are accounting no-ops and are omitted. Within that block,
+`authenticated` denotes canonical protocol evidence, `accounted` denotes a
+ghost-liability change, and `verified` denotes additional reconciliation
+against TIP-20 movements and exact post-block state.
+
+These fields form the stable schema for log-backed dashboards:
 
 - `activity_schema_version`: currently `1`.
 - `activity_event`: the stable event name from the table below.
 - `activity_source`: `tempo` for Portal activity or `zone` for Zone activity.
-- `activity_id`: `<zone_hash>:<activity_source>:<activity_index>`, which remains
-  stable if recovery replays the same canonical block.
+- `activity_id`: `v<schema_version>:<zone_hash>:<activity_source>:<activity_index>`,
+  which remains stable if recovery replays the same canonical block under the
+  same schema.
 - `activity_index`: the event's canonical order within its source for the Zone
   block.
 - `zone_block`, `zone_hash`, `tempo_block`, and `tempo_hash`: exact verified
   coordinates.
-- Event-specific fields such as `token`, `amount`, `recipient`, `sender`,
-  `deposit_number`, `withdrawal_index`, `fee`, and `callback_success`.
+- Event-specific fields such as `token`, `recipient`, `sender`,
+  `deposit_number`, `withdrawal_index`, and `callback_success`. Monetary
+  `amount` and `fee` fields are decimal strings for both Tempo and Zone values.
 
 | `activity_event` | Meaning |
 | --- | --- |
 | `portal_deposit_accounted` | Authenticated Portal deposit entered accounting. |
 | `portal_token_enabled` | Authenticated Portal token entered accounting coverage. |
-| `portal_withdrawal_accounted` | Authenticated Portal withdrawal and callback result. |
-| `portal_withdrawal_bounce_back` | Authenticated Portal withdrawal bounce-back. |
-| `portal_deposit_bounce_back` | Authenticated processed Portal deposit bounce-back. |
-| `portal_deposit_bounce_back_pending` | Authenticated pending Portal deposit bounce-back. |
+| `portal_withdrawal_processed` | Authenticated Portal withdrawal and callback result. |
+| `portal_withdrawal_bounce_back` | Authenticated Portal withdrawal bounce-back entered accounting. |
+| `portal_deposit_bounce_back` | Authenticated processed Portal deposit bounce-back entered accounting. |
+| `portal_deposit_bounce_back_pending` | Authenticated pending Portal deposit bounce-back entered accounting. |
 | `portal_refund_accounted` | Authenticated Portal refund entered accounting. |
 | `zone_deposit_minted` | Verified Zone deposit mint. |
-| `zone_deposit_failed` | Verified failed Zone deposit. |
+| `zone_deposit_failed` | Authenticated failed Zone deposit. |
 | `zone_deposit_bounce_back_requested` | Authenticated Zone deposit bounce-back request. |
 | `zone_withdrawal_burned` | Verified user withdrawal debit and burn. |
 | `zone_withdrawal_bounce_back_minted` | Verified Zone withdrawal bounce-back mint. |
-| `zone_withdrawal_bounce_back_pending` | Verified pending Zone withdrawal bounce-back. |
+| `zone_withdrawal_bounce_back_pending` | Authenticated pending Zone withdrawal bounce-back. |
 | `zone_refund_minted` | Verified Zone refund mint. |
 
 `activity_id` lets a log consumer deduplicate replayed activities, but logs are

--- a/crates/checker/src/telemetry.rs
+++ b/crates/checker/src/telemetry.rs
@@ -1,5 +1,8 @@
 //! Checker metrics and verified protocol activity logs.
 
+use std::fmt;
+
+use alloy_primitives::B256;
 use reth_metrics::{
     Metrics,
     metrics::{Counter, Gauge},
@@ -19,7 +22,7 @@ const ACTIVITY_SCHEMA_VERSION: u64 = 1;
 mod activity_event {
     pub(super) const PORTAL_DEPOSIT_ACCOUNTED: &str = "portal_deposit_accounted";
     pub(super) const PORTAL_TOKEN_ENABLED: &str = "portal_token_enabled";
-    pub(super) const PORTAL_WITHDRAWAL_ACCOUNTED: &str = "portal_withdrawal_accounted";
+    pub(super) const PORTAL_WITHDRAWAL_PROCESSED: &str = "portal_withdrawal_processed";
     pub(super) const PORTAL_WITHDRAWAL_BOUNCE_BACK: &str = "portal_withdrawal_bounce_back";
     pub(super) const PORTAL_DEPOSIT_BOUNCE_BACK: &str = "portal_deposit_bounce_back";
     pub(super) const PORTAL_DEPOSIT_BOUNCE_BACK_PENDING: &str =
@@ -35,26 +38,9 @@ mod activity_event {
     pub(super) const ZONE_WITHDRAWAL_BOUNCE_BACK_PENDING: &str =
         "zone_withdrawal_bounce_back_pending";
     pub(super) const ZONE_REFUND_MINTED: &str = "zone_refund_minted";
-
-    #[cfg(test)]
-    pub(super) const ALL: [&str; 14] = [
-        PORTAL_DEPOSIT_ACCOUNTED,
-        PORTAL_TOKEN_ENABLED,
-        PORTAL_WITHDRAWAL_ACCOUNTED,
-        PORTAL_WITHDRAWAL_BOUNCE_BACK,
-        PORTAL_DEPOSIT_BOUNCE_BACK,
-        PORTAL_DEPOSIT_BOUNCE_BACK_PENDING,
-        PORTAL_REFUND_ACCOUNTED,
-        ZONE_DEPOSIT_MINTED,
-        ZONE_DEPOSIT_FAILED,
-        ZONE_DEPOSIT_BOUNCE_BACK_REQUESTED,
-        ZONE_WITHDRAWAL_BURNED,
-        ZONE_WITHDRAWAL_BOUNCE_BACK_MINTED,
-        ZONE_WITHDRAWAL_BOUNCE_BACK_PENDING,
-        ZONE_REFUND_MINTED,
-    ];
 }
 
+/// Protocol source of an activity within a verified Zone block.
 #[derive(Clone, Copy)]
 enum ActivitySource {
     Tempo,
@@ -62,7 +48,7 @@ enum ActivitySource {
 }
 
 impl ActivitySource {
-    const fn label(self) -> &'static str {
+    const fn as_str(self) -> &'static str {
         match self {
             Self::Tempo => "tempo",
             Self::Zone => "zone",
@@ -70,29 +56,50 @@ impl ActivitySource {
     }
 }
 
+/// Coordinates shared by one structured activity log.
 struct ActivityContext {
     zone: BlockRef,
     tempo: BlockRef,
     source: ActivitySource,
     index: u64,
-    id: String,
 }
 
 impl ActivityContext {
-    fn new(zone: BlockRef, tempo: BlockRef, source: ActivitySource, index: usize) -> Self {
-        let index = u64::try_from(index).expect("activity index must fit in u64");
+    const fn new(zone: BlockRef, tempo: BlockRef, source: ActivitySource, index: u64) -> Self {
         Self {
             zone,
             tempo,
             source,
             index,
-            id: activity_id(zone, source, index),
+        }
+    }
+
+    const fn id(&self) -> ActivityId {
+        ActivityId {
+            zone_hash: self.zone.hash,
+            source: self.source,
+            index: self.index,
         }
     }
 }
 
-fn activity_id(zone: BlockRef, source: ActivitySource, index: u64) -> String {
-    format!("{}:{}:{index}", zone.hash, source.label())
+/// Replay-stable identifier for one activity schema version.
+struct ActivityId {
+    zone_hash: B256,
+    source: ActivitySource,
+    index: u64,
+}
+
+impl fmt::Display for ActivityId {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(
+            f,
+            "v{ACTIVITY_SCHEMA_VERSION}:{}:{}:{}",
+            self.zone_hash,
+            self.source.as_str(),
+            self.index
+        )
+    }
 }
 
 macro_rules! activity_log {
@@ -102,8 +109,8 @@ macro_rules! activity_log {
             target: "zone::checker",
             activity_schema_version = ACTIVITY_SCHEMA_VERSION,
             activity_event = $event,
-            activity_source = context.source.label(),
-            activity_id = %context.id,
+            activity_source = context.source.as_str(),
+            activity_id = %context.id(),
             activity_index = context.index,
             zone_block = context.zone.number,
             zone_hash = %context.zone.hash,
@@ -161,13 +168,13 @@ impl CheckerMetrics {
 /// Log authenticated protocol activity after a Zone block is verified.
 pub(crate) fn log_verified_activity(tempo: &L1BlockEvidence, l2: &L2BlockEvidence, zone: BlockRef) {
     let tempo_ref = BlockRef::from(tempo.block());
-    for (index, event) in tempo.portal_events().enumerate() {
+    for (index, event) in (0u64..).zip(tempo.portal_events()) {
         log_tempo_event(
             event,
             &ActivityContext::new(zone, tempo_ref, ActivitySource::Tempo, index),
         );
     }
-    for (index, action) in l2.bridge_actions().enumerate() {
+    for (index, action) in (0u64..).zip(l2.bridge_actions()) {
         log_zone_action(
             action,
             &ActivityContext::new(zone, tempo_ref, ActivitySource::Zone, index),
@@ -185,7 +192,7 @@ fn log_tempo_event(event: &L1PortalEvent, context: &ActivityContext) {
             context,
             activity_event::PORTAL_DEPOSIT_ACCOUNTED,
             %token,
-            amount = net_amount,
+            amount = %net_amount,
             deposit_number,
             "accounted authenticated Portal deposit"
         ),
@@ -202,19 +209,19 @@ fn log_tempo_event(event: &L1PortalEvent, context: &ActivityContext) {
             callback_success,
         } => activity_log!(
             context,
-            activity_event::PORTAL_WITHDRAWAL_ACCOUNTED,
+            activity_event::PORTAL_WITHDRAWAL_PROCESSED,
             %token,
             recipient = %to,
-            amount,
+            %amount,
             callback_success,
-            "accounted authenticated Portal withdrawal"
+            "authenticated Portal withdrawal result"
         ),
         L1PortalEvent::WithdrawalBounceBack { token, amount } => activity_log!(
             context,
             activity_event::PORTAL_WITHDRAWAL_BOUNCE_BACK,
             %token,
-            amount,
-            "observed authenticated Portal withdrawal bounce-back"
+            %amount,
+            "accounted authenticated Portal withdrawal bounce-back"
         ),
         L1PortalEvent::DepositBounceBack {
             token,
@@ -224,8 +231,8 @@ fn log_tempo_event(event: &L1PortalEvent, context: &ActivityContext) {
             context,
             activity_event::PORTAL_DEPOSIT_BOUNCE_BACK,
             %token,
-            amount,
-            fee = bounceback_fee,
+            %amount,
+            fee = %bounceback_fee,
             "accounted authenticated Portal deposit bounce-back"
         ),
         L1PortalEvent::DepositBounceBackPending {
@@ -236,8 +243,8 @@ fn log_tempo_event(event: &L1PortalEvent, context: &ActivityContext) {
             context,
             activity_event::PORTAL_DEPOSIT_BOUNCE_BACK_PENDING,
             %token,
-            amount,
-            fee = bounceback_fee,
+            %amount,
+            fee = %bounceback_fee,
             "accounted authenticated pending Portal deposit bounce-back"
         ),
         L1PortalEvent::RefundClaimed { amount: 0, .. } => {}
@@ -250,7 +257,7 @@ fn log_tempo_event(event: &L1PortalEvent, context: &ActivityContext) {
             activity_event::PORTAL_REFUND_ACCOUNTED,
             %token,
             %recipient,
-            amount,
+            %amount,
             "accounted authenticated Portal refund"
         ),
     }
@@ -279,7 +286,7 @@ fn log_zone_action(action: &L2BridgeAction, context: &ActivityContext) {
             activity_event::ZONE_DEPOSIT_FAILED,
             %token,
             amount = %amount,
-            "verified Zone deposit failure"
+            "authenticated Zone deposit failure"
         ),
         L2BridgeAction::WithdrawalRequested {
             withdrawal_index,
@@ -294,7 +301,7 @@ fn log_zone_action(action: &L2BridgeAction, context: &ActivityContext) {
                 %token,
                 amount = %principal,
                 withdrawal_index,
-                "accounted authenticated Zone deposit bounce-back request"
+                "authenticated Zone deposit bounce-back request"
             ),
             WithdrawalOrigin::User { sender } => activity_log!(
                 context,
@@ -331,7 +338,7 @@ fn log_zone_action(action: &L2BridgeAction, context: &ActivityContext) {
             %token,
             %recipient,
             amount = %amount,
-            "verified pending Zone withdrawal bounce-back"
+            "authenticated pending Zone withdrawal bounce-back"
         ),
         L2BridgeAction::RefundClaimed {
             recipient,
@@ -345,43 +352,5 @@ fn log_zone_action(action: &L2BridgeAction, context: &ActivityContext) {
             amount = %amount,
             "verified Zone refund mint"
         ),
-    }
-}
-
-#[cfg(test)]
-mod tests {
-    use std::collections::BTreeSet;
-
-    use alloy_primitives::B256;
-
-    use super::*;
-
-    #[test]
-    fn activity_event_names_are_unique_snake_case() {
-        let names = activity_event::ALL;
-        assert_eq!(
-            names.iter().copied().collect::<BTreeSet<_>>().len(),
-            names.len()
-        );
-        assert!(names.iter().all(|name| {
-            !name.is_empty()
-                && name
-                    .bytes()
-                    .all(|byte| byte.is_ascii_lowercase() || byte == b'_')
-        }));
-    }
-
-    #[test]
-    fn activity_ids_are_stable_and_source_specific() {
-        let zone = BlockRef::new(42, B256::repeat_byte(0x11));
-
-        assert_eq!(
-            activity_id(zone, ActivitySource::Tempo, 3),
-            format!("{}:tempo:3", zone.hash)
-        );
-        assert_eq!(
-            activity_id(zone, ActivitySource::Zone, 3),
-            format!("{}:zone:3", zone.hash)
-        );
     }
 }

--- a/crates/checker/src/telemetry.rs
+++ b/crates/checker/src/telemetry.rs
@@ -14,6 +14,106 @@ use crate::{
     persistence::{BlockRef, Snapshot, Status},
 };
 
+const ACTIVITY_SCHEMA_VERSION: u64 = 1;
+
+mod activity_event {
+    pub(super) const PORTAL_DEPOSIT_ACCOUNTED: &str = "portal_deposit_accounted";
+    pub(super) const PORTAL_TOKEN_ENABLED: &str = "portal_token_enabled";
+    pub(super) const PORTAL_WITHDRAWAL_ACCOUNTED: &str = "portal_withdrawal_accounted";
+    pub(super) const PORTAL_WITHDRAWAL_BOUNCE_BACK: &str = "portal_withdrawal_bounce_back";
+    pub(super) const PORTAL_DEPOSIT_BOUNCE_BACK: &str = "portal_deposit_bounce_back";
+    pub(super) const PORTAL_DEPOSIT_BOUNCE_BACK_PENDING: &str =
+        "portal_deposit_bounce_back_pending";
+    pub(super) const PORTAL_REFUND_ACCOUNTED: &str = "portal_refund_accounted";
+    pub(super) const ZONE_DEPOSIT_MINTED: &str = "zone_deposit_minted";
+    pub(super) const ZONE_DEPOSIT_FAILED: &str = "zone_deposit_failed";
+    pub(super) const ZONE_DEPOSIT_BOUNCE_BACK_REQUESTED: &str =
+        "zone_deposit_bounce_back_requested";
+    pub(super) const ZONE_WITHDRAWAL_BURNED: &str = "zone_withdrawal_burned";
+    pub(super) const ZONE_WITHDRAWAL_BOUNCE_BACK_MINTED: &str =
+        "zone_withdrawal_bounce_back_minted";
+    pub(super) const ZONE_WITHDRAWAL_BOUNCE_BACK_PENDING: &str =
+        "zone_withdrawal_bounce_back_pending";
+    pub(super) const ZONE_REFUND_MINTED: &str = "zone_refund_minted";
+
+    #[cfg(test)]
+    pub(super) const ALL: [&str; 14] = [
+        PORTAL_DEPOSIT_ACCOUNTED,
+        PORTAL_TOKEN_ENABLED,
+        PORTAL_WITHDRAWAL_ACCOUNTED,
+        PORTAL_WITHDRAWAL_BOUNCE_BACK,
+        PORTAL_DEPOSIT_BOUNCE_BACK,
+        PORTAL_DEPOSIT_BOUNCE_BACK_PENDING,
+        PORTAL_REFUND_ACCOUNTED,
+        ZONE_DEPOSIT_MINTED,
+        ZONE_DEPOSIT_FAILED,
+        ZONE_DEPOSIT_BOUNCE_BACK_REQUESTED,
+        ZONE_WITHDRAWAL_BURNED,
+        ZONE_WITHDRAWAL_BOUNCE_BACK_MINTED,
+        ZONE_WITHDRAWAL_BOUNCE_BACK_PENDING,
+        ZONE_REFUND_MINTED,
+    ];
+}
+
+#[derive(Clone, Copy)]
+enum ActivitySource {
+    Tempo,
+    Zone,
+}
+
+impl ActivitySource {
+    const fn label(self) -> &'static str {
+        match self {
+            Self::Tempo => "tempo",
+            Self::Zone => "zone",
+        }
+    }
+}
+
+struct ActivityContext {
+    zone: BlockRef,
+    tempo: BlockRef,
+    source: ActivitySource,
+    index: u64,
+    id: String,
+}
+
+impl ActivityContext {
+    fn new(zone: BlockRef, tempo: BlockRef, source: ActivitySource, index: usize) -> Self {
+        let index = u64::try_from(index).expect("activity index must fit in u64");
+        Self {
+            zone,
+            tempo,
+            source,
+            index,
+            id: activity_id(zone, source, index),
+        }
+    }
+}
+
+fn activity_id(zone: BlockRef, source: ActivitySource, index: u64) -> String {
+    format!("{}:{}:{index}", zone.hash, source.label())
+}
+
+macro_rules! activity_log {
+    ($context:expr, $event:expr, $($fields:tt)*) => {{
+        let context = $context;
+        tracing::info!(
+            target: "zone::checker",
+            activity_schema_version = ACTIVITY_SCHEMA_VERSION,
+            activity_event = $event,
+            activity_source = context.source.label(),
+            activity_id = %context.id,
+            activity_index = context.index,
+            zone_block = context.zone.number,
+            zone_hash = %context.zone.hash,
+            tempo_block = context.tempo.number,
+            tempo_hash = %context.tempo.hash,
+            $($fields)*
+        )
+    }};
+}
+
 #[derive(Metrics, Clone)]
 #[metrics(scope = "tempo_zone_checker")]
 pub(crate) struct CheckerMetrics {
@@ -60,34 +160,38 @@ impl CheckerMetrics {
 
 /// Log authenticated protocol activity after a Zone block is verified.
 pub(crate) fn log_verified_activity(tempo: &L1BlockEvidence, l2: &L2BlockEvidence, zone: BlockRef) {
-    let tempo_block = tempo.block().number;
-    for event in tempo.portal_events() {
-        log_tempo_event(event, zone, tempo_block);
+    let tempo_ref = BlockRef::from(tempo.block());
+    for (index, event) in tempo.portal_events().enumerate() {
+        log_tempo_event(
+            event,
+            &ActivityContext::new(zone, tempo_ref, ActivitySource::Tempo, index),
+        );
     }
-    for action in l2.bridge_actions() {
-        log_zone_action(action, zone);
+    for (index, action) in l2.bridge_actions().enumerate() {
+        log_zone_action(
+            action,
+            &ActivityContext::new(zone, tempo_ref, ActivitySource::Zone, index),
+        );
     }
 }
 
-fn log_tempo_event(event: &L1PortalEvent, zone: BlockRef, tempo_block: u64) {
+fn log_tempo_event(event: &L1PortalEvent, context: &ActivityContext) {
     match event {
         L1PortalEvent::DepositMade {
             token,
             net_amount,
             deposit_number,
-        } => tracing::info!(
-            target: "zone::checker",
-            zone_block = zone.number,
-            tempo_block,
+        } => activity_log!(
+            context,
+            activity_event::PORTAL_DEPOSIT_ACCOUNTED,
             %token,
             amount = net_amount,
             deposit_number,
             "accounted authenticated Portal deposit"
         ),
-        L1PortalEvent::TokenEnabled { token } => tracing::info!(
-            target: "zone::checker",
-            zone_block = zone.number,
-            tempo_block,
+        L1PortalEvent::TokenEnabled { token } => activity_log!(
+            context,
+            activity_event::PORTAL_TOKEN_ENABLED,
             %token,
             "added Portal token to accounting coverage"
         ),
@@ -96,38 +200,44 @@ fn log_tempo_event(event: &L1PortalEvent, zone: BlockRef, tempo_block: u64) {
             token,
             amount,
             callback_success,
-        } => tracing::info!(
-            target: "zone::checker",
-            zone_block = zone.number,
-            tempo_block,
+        } => activity_log!(
+            context,
+            activity_event::PORTAL_WITHDRAWAL_ACCOUNTED,
             %token,
             recipient = %to,
             amount,
             callback_success,
             "accounted authenticated Portal withdrawal"
         ),
-        L1PortalEvent::WithdrawalBounceBack { token, amount } => tracing::info!(
-            target: "zone::checker",
-            zone_block = zone.number,
-            tempo_block,
+        L1PortalEvent::WithdrawalBounceBack { token, amount } => activity_log!(
+            context,
+            activity_event::PORTAL_WITHDRAWAL_BOUNCE_BACK,
             %token,
             amount,
             "observed authenticated Portal withdrawal bounce-back"
         ),
-        L1PortalEvent::DepositBounceBack { token, amount, .. } => tracing::info!(
-            target: "zone::checker",
-            zone_block = zone.number,
-            tempo_block,
+        L1PortalEvent::DepositBounceBack {
+            token,
+            amount,
+            bounceback_fee,
+        } => activity_log!(
+            context,
+            activity_event::PORTAL_DEPOSIT_BOUNCE_BACK,
             %token,
             amount,
+            fee = bounceback_fee,
             "accounted authenticated Portal deposit bounce-back"
         ),
-        L1PortalEvent::DepositBounceBackPending { token, amount, .. } => tracing::info!(
-            target: "zone::checker",
-            zone_block = zone.number,
-            tempo_block,
+        L1PortalEvent::DepositBounceBackPending {
+            token,
+            amount,
+            bounceback_fee,
+        } => activity_log!(
+            context,
+            activity_event::PORTAL_DEPOSIT_BOUNCE_BACK_PENDING,
             %token,
             amount,
+            fee = bounceback_fee,
             "accounted authenticated pending Portal deposit bounce-back"
         ),
         L1PortalEvent::RefundClaimed { amount: 0, .. } => {}
@@ -135,10 +245,9 @@ fn log_tempo_event(event: &L1PortalEvent, zone: BlockRef, tempo_block: u64) {
             recipient,
             token,
             amount,
-        } => tracing::info!(
-            target: "zone::checker",
-            zone_block = zone.number,
-            tempo_block,
+        } => activity_log!(
+            context,
+            activity_event::PORTAL_REFUND_ACCOUNTED,
             %token,
             %recipient,
             amount,
@@ -147,29 +256,29 @@ fn log_tempo_event(event: &L1PortalEvent, zone: BlockRef, tempo_block: u64) {
     }
 }
 
-fn log_zone_action(action: &L2BridgeAction, zone: BlockRef) {
+fn log_zone_action(action: &L2BridgeAction, context: &ActivityContext) {
     match action {
         L2BridgeAction::Deposit {
             token,
             amount,
             result: DepositResult::Processed { recipient },
-        } => tracing::info!(
-            target: "zone::checker",
-            zone_block = zone.number,
+        } => activity_log!(
+            context,
+            activity_event::ZONE_DEPOSIT_MINTED,
             %token,
             %recipient,
-            %amount,
+            amount = %amount,
             "verified Zone deposit mint"
         ),
         L2BridgeAction::Deposit {
             token,
             amount,
             result: DepositResult::Failed,
-        } => tracing::info!(
-            target: "zone::checker",
-            zone_block = zone.number,
+        } => activity_log!(
+            context,
+            activity_event::ZONE_DEPOSIT_FAILED,
             %token,
-            %amount,
+            amount = %amount,
             "verified Zone deposit failure"
         ),
         L2BridgeAction::WithdrawalRequested {
@@ -179,20 +288,20 @@ fn log_zone_action(action: &L2BridgeAction, zone: BlockRef) {
             principal,
             fee,
         } => match origin {
-            WithdrawalOrigin::DepositBounceBack => tracing::info!(
-                target: "zone::checker",
-                zone_block = zone.number,
+            WithdrawalOrigin::DepositBounceBack => activity_log!(
+                context,
+                activity_event::ZONE_DEPOSIT_BOUNCE_BACK_REQUESTED,
                 %token,
                 amount = %principal,
                 withdrawal_index,
                 "accounted authenticated Zone deposit bounce-back request"
             ),
-            WithdrawalOrigin::User { sender } => tracing::info!(
-                target: "zone::checker",
-                zone_block = zone.number,
+            WithdrawalOrigin::User { sender } => activity_log!(
+                context,
+                activity_event::ZONE_WITHDRAWAL_BURNED,
                 %token,
                 %sender,
-                %principal,
+                amount = %principal,
                 %fee,
                 withdrawal_index,
                 "verified Zone withdrawal debit and burn"
@@ -203,12 +312,12 @@ fn log_zone_action(action: &L2BridgeAction, zone: BlockRef) {
             token,
             amount,
             status: WithdrawalBounceBackStatus::Processed,
-        } => tracing::info!(
-            target: "zone::checker",
-            zone_block = zone.number,
+        } => activity_log!(
+            context,
+            activity_event::ZONE_WITHDRAWAL_BOUNCE_BACK_MINTED,
             %token,
             %recipient,
-            %amount,
+            amount = %amount,
             "verified Zone withdrawal bounce-back mint"
         ),
         L2BridgeAction::WithdrawalBounceBack {
@@ -216,25 +325,63 @@ fn log_zone_action(action: &L2BridgeAction, zone: BlockRef) {
             token,
             amount,
             status: WithdrawalBounceBackStatus::Pending,
-        } => tracing::info!(
-            target: "zone::checker",
-            zone_block = zone.number,
+        } => activity_log!(
+            context,
+            activity_event::ZONE_WITHDRAWAL_BOUNCE_BACK_PENDING,
             %token,
             %recipient,
-            %amount,
+            amount = %amount,
             "verified pending Zone withdrawal bounce-back"
         ),
         L2BridgeAction::RefundClaimed {
             recipient,
             token,
             amount,
-        } => tracing::info!(
-            target: "zone::checker",
-            zone_block = zone.number,
+        } => activity_log!(
+            context,
+            activity_event::ZONE_REFUND_MINTED,
             %token,
             %recipient,
-            %amount,
+            amount = %amount,
             "verified Zone refund mint"
         ),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::collections::BTreeSet;
+
+    use alloy_primitives::B256;
+
+    use super::*;
+
+    #[test]
+    fn activity_event_names_are_unique_snake_case() {
+        let names = activity_event::ALL;
+        assert_eq!(
+            names.iter().copied().collect::<BTreeSet<_>>().len(),
+            names.len()
+        );
+        assert!(names.iter().all(|name| {
+            !name.is_empty()
+                && name
+                    .bytes()
+                    .all(|byte| byte.is_ascii_lowercase() || byte == b'_')
+        }));
+    }
+
+    #[test]
+    fn activity_ids_are_stable_and_source_specific() {
+        let zone = BlockRef::new(42, B256::repeat_byte(0x11));
+
+        assert_eq!(
+            activity_id(zone, ActivitySource::Tempo, 3),
+            format!("{}:tempo:3", zone.hash)
+        );
+        assert_eq!(
+            activity_id(zone, ActivitySource::Zone, 3),
+            format!("{}:zone:3", zone.hash)
+        );
     }
 }


### PR DESCRIPTION
## Summary

- define stable, versioned event names for authenticated Portal and Zone activity logs
- include exact Zone/Tempo coordinates and replay-stable activity IDs for log deduplication
- normalize dashboard-facing fields and document the complete activity schema

## Stack

Depends on #1216.

## Testing

- `cargo +nightly fmt --all -- --check`
- `cargo test -p zone-checker` (58 passed)
- `cargo +nightly clippy -p zone-checker --all-targets`

Strict clippy with `-D warnings` remains blocked by pre-existing dead-code warnings in `zone-precompiles`.

Prompted by: @grandizzy