### PR TITLE
refactor(cli): validate cli arguments with `clap`

### DIFF
--- a/crates/node/src/cli.rs
+++ b/crates/node/src/cli.rs
@@ -111,6 +111,7 @@ fn run_node(mut cli: Cli<ZoneChainSpecParser, ZoneArgs>) -> eyre::Result<()> {
         }
 
         let zone_id = builder.config().chain.zone_id();
+        validate_deprecated_zone_id(args.zone_id, zone_id)?;
 
         let manifest_mode = args.sequencer_manifest.is_some();
         validate_p2p_transaction_size_limit(
@@ -482,6 +483,10 @@ pub struct ZoneArgs {
     )]
     pub l1_retry_connection_interval_ms: u64,
 
+    /// Deprecated: validates the Zone ID encoded in the genesis chain ID.
+    #[arg(long = "zone.id", env = "ZONE_ID")]
+    pub zone_id: Option<u32>,
+
     /// Port for the redacted zone RPC server (0 for OS-assigned).
     #[arg(
         long = "redacted-rpc.port",
@@ -575,6 +580,16 @@ fn parse_portal_address(value: &str) -> Result<Address, String> {
     Ok(address)
 }
 
+fn validate_deprecated_zone_id(configured: Option<u32>, derived: u32) -> eyre::Result<()> {
+    if let Some(configured) = configured {
+        eyre::ensure!(
+            configured == derived,
+            "deprecated --zone.id value {configured} does not match zone ID {derived} encoded in the genesis chain ID"
+        );
+    }
+    Ok(())
+}
+
 #[cfg(test)]
 mod tests {
     use std::{io::Write as _, process::Command, thread, time::Duration};
@@ -583,7 +598,7 @@ mod tests {
 
     use super::{
         Role, ZoneArgs, ZoneCli, load_decryption_keys, load_sequencer_signer, parse_l1_rpc_url,
-        parse_portal_address, validate_p2p_transaction_size_limit,
+        parse_portal_address, validate_deprecated_zone_id, validate_p2p_transaction_size_limit,
     };
     use zone_sequencer::MAX_WITHDRAWAL_BATCH_GAS;
 
@@ -655,6 +670,25 @@ mod tests {
     fn portal_address_must_be_nonzero() {
         assert!(parse_portal_address("0x0000000000000000000000000000000000000000").is_err());
         assert!(parse_portal_address("0x1111111111111111111111111111111111111111").is_ok());
+    }
+
+    #[test]
+    fn deprecated_zone_id_is_accepted_and_validated() {
+        assert!(validate_deprecated_zone_id(None, 7).is_ok());
+        assert!(validate_deprecated_zone_id(Some(7), 7).is_ok());
+        assert!(validate_deprecated_zone_id(Some(8), 7).is_err());
+
+        let parsed = ZoneArgsParser::try_parse_from([
+            "tempo-zone",
+            "--l1.rpc-url",
+            "ws://localhost:8546",
+            "--l1.portal-address",
+            "0x0000000000000000000000000000000000000001",
+            "--zone.id",
+            "7",
+        ])
+        .unwrap();
+        assert_eq!(parsed.zone.zone_id, Some(7));
     }
 
     #[test]

--- a/crates/node/src/cli.rs
+++ b/crates/node/src/cli.rs
@@ -115,7 +115,7 @@ fn run_node(mut cli: Cli<ZoneChainSpecParser, ZoneArgs>) -> eyre::Result<()> {
                 })?;
                 // Required for a quorum member and rejected for an `rpc_only` node, which never
                 // signs a settlement attestation; the manifest decides which this node is.
-                P2pConfig::load(
+                let config = P2pConfig::load(
                     manifest_path,
                     ed25519_key_path,
                     args.secp256k1_key.as_ref(),
@@ -123,18 +123,17 @@ fn run_node(mut cli: Cli<ZoneChainSpecParser, ZoneArgs>) -> eyre::Result<()> {
                     args.p2p_bypass_ip_check,
                     zone_id,
                     args.sequencer_role,
-                )
+                )?;
+                info!(
+                    target: "reth::cli",
+                    ed25519_public_key = %config.ed25519_public_key(),
+                    secp256k1_address = ?config.secp256k1_address(),
+                    listen = %config.listen(),
+                    "Validated multi-sequencer manifest and local identity"
+                );
+                Ok(config)
             })
             .transpose()?;
-        if let Some(config) = p2p_config.as_ref() {
-            info!(
-                target: "reth::cli",
-                ed25519_public_key = %config.ed25519_public_key(),
-                secp256k1_address = ?config.secp256k1_address(),
-                listen = %config.listen(),
-                "Validated multi-sequencer manifest and local identity"
-            );
-        }
 
         let manifest_mode = p2p_config.is_some();
         validate_p2p_transaction_size_limit(

--- a/crates/node/src/cli.rs
+++ b/crates/node/src/cli.rs
@@ -115,7 +115,7 @@ fn run_node(mut cli: Cli<ZoneChainSpecParser, ZoneArgs>) -> eyre::Result<()> {
                 })?;
                 // Required for a quorum member and rejected for an `rpc_only` node, which never
                 // signs a settlement attestation; the manifest decides which this node is.
-                let config = P2pConfig::load(
+                P2pConfig::load(
                     manifest_path,
                     ed25519_key_path,
                     args.secp256k1_key.as_ref(),
@@ -123,17 +123,18 @@ fn run_node(mut cli: Cli<ZoneChainSpecParser, ZoneArgs>) -> eyre::Result<()> {
                     args.p2p_bypass_ip_check,
                     zone_id,
                     args.sequencer_role,
-                )?;
-                info!(
-                    target: "reth::cli",
-                    ed25519_public_key = %config.ed25519_public_key(),
-                    secp256k1_address = ?config.secp256k1_address(),
-                    listen = %config.listen(),
-                    "Validated multi-sequencer manifest and local identity"
-                );
-                Ok(config)
+                )
             })
             .transpose()?;
+        if let Some(config) = p2p_config.as_ref() {
+            info!(
+                target: "reth::cli",
+                ed25519_public_key = %config.ed25519_public_key(),
+                secp256k1_address = ?config.secp256k1_address(),
+                listen = %config.listen(),
+                "Validated multi-sequencer manifest and local identity"
+            );
+        }
 
         let manifest_mode = p2p_config.is_some();
         validate_p2p_transaction_size_limit(

--- a/crates/node/src/cli.rs
+++ b/crates/node/src/cli.rs
@@ -104,10 +104,7 @@ fn run_node(mut cli: Cli<ZoneChainSpecParser, ZoneArgs>) -> eyre::Result<()> {
     cli.run_with_components::<ZoneNode>(components, async move |mut builder, args| {
         info!(target: "reth::cli", "Launching Tempo Zone node");
 
-        validate_l1_rpc_url(&args.l1_rpc_url)?;
-        validate_portal_address(args.portal_address)?;
         let zone_id = builder.config().chain.zone_id();
-        validate_deprecated_zone_id(args.zone_id, zone_id)?;
 
         let p2p_config = args
             .sequencer_manifest
@@ -288,7 +285,11 @@ async fn load_decryption_keys(
 #[derive(Debug, Clone, Args)]
 pub struct ZoneArgs {
     /// Certified Tempo follower WebSocket RPC URL for finalized L1 state, deposit events, and chain notifications.
-    #[arg(long = "l1.rpc-url", env = "L1_RPC_URL")]
+    #[arg(
+        long = "l1.rpc-url",
+        env = "L1_RPC_URL",
+        value_parser = parse_l1_rpc_url
+    )]
     pub l1_rpc_url: String,
 
     /// ZonePortal contract address on L1.
@@ -445,10 +446,6 @@ pub struct ZoneArgs {
     )]
     pub l1_retry_connection_interval_ms: u64,
 
-    /// Deprecated: validates the Zone ID encoded in the genesis chain ID.
-    #[arg(long = "zone.id", env = "ZONE_ID")]
-    pub zone_id: Option<u32>,
-
     /// Port for the redacted zone RPC server (0 for OS-assigned).
     #[arg(
         long = "redacted-rpc.port",
@@ -518,34 +515,17 @@ fn validate_p2p_transaction_size_limit(
     Ok(())
 }
 
-fn validate_l1_rpc_url(l1_rpc_url: &str) -> eyre::Result<()> {
+fn parse_l1_rpc_url(l1_rpc_url: &str) -> Result<String, String> {
     let url: url::Url = l1_rpc_url
         .parse()
-        .map_err(|err| eyre::eyre!("failed parsing --l1.rpc-url as URL: {err}"))?;
-    eyre::ensure!(
-        matches!(url.scheme(), "ws" | "wss"),
-        "--l1.rpc-url must use ws:// or wss://, got `{}`",
-        url.scheme()
-    );
-    Ok(())
-}
-
-fn validate_portal_address(portal_address: Address) -> eyre::Result<()> {
-    eyre::ensure!(
-        !portal_address.is_zero(),
-        "--l1.portal-address must be nonzero"
-    );
-    Ok(())
-}
-
-fn validate_deprecated_zone_id(configured: Option<u32>, derived: u32) -> eyre::Result<()> {
-    if let Some(configured) = configured {
-        eyre::ensure!(
-            configured == derived,
-            "deprecated --zone.id value {configured} does not match zone ID {derived} encoded in the genesis chain ID"
-        );
+        .map_err(|err| format!("failed parsing --l1.rpc-url as URL: {err}"))?;
+    if !matches!(url.scheme(), "ws" | "wss") {
+        return Err(format!(
+            "--l1.rpc-url must use ws:// or wss://, got `{}`",
+            url.scheme()
+        ));
     }
-    Ok(())
+    Ok(l1_rpc_url.to_owned())
 }
 
 #[cfg(test)]
@@ -555,9 +535,8 @@ mod tests {
     use clap::Parser as _;
 
     use super::{
-        Role, ZoneArgs, ZoneCli, load_decryption_keys, load_sequencer_signer, sequencer_enabled,
-        validate_deprecated_zone_id, validate_l1_rpc_url, validate_p2p_transaction_size_limit,
-        validate_portal_address,
+        Role, ZoneArgs, ZoneCli, load_decryption_keys, load_sequencer_signer, parse_l1_rpc_url,
+        sequencer_enabled, validate_p2p_transaction_size_limit,
     };
     use zone_sequencer::MAX_WITHDRAWAL_BATCH_GAS;
 
@@ -579,31 +558,6 @@ mod tests {
     fn dev_is_parsed_by_the_top_level_cli() {
         let parsed = ZoneCli::try_parse_from(["tempo-zone", "dev"]).unwrap();
         assert!(matches!(parsed, ZoneCli::Dev(_)));
-    }
-
-    #[test]
-    fn portal_address_must_be_nonzero() {
-        assert!(validate_portal_address(alloy_primitives::Address::ZERO).is_err());
-        assert!(validate_portal_address(alloy_primitives::Address::repeat_byte(0x11)).is_ok());
-    }
-
-    #[test]
-    fn deprecated_zone_id_is_optional_and_validated() {
-        assert!(validate_deprecated_zone_id(None, 7).is_ok());
-        assert!(validate_deprecated_zone_id(Some(7), 7).is_ok());
-        assert!(validate_deprecated_zone_id(Some(8), 7).is_err());
-
-        let parsed = ZoneArgsParser::try_parse_from([
-            "tempo-zone",
-            "--l1.rpc-url",
-            "ws://localhost:8546",
-            "--l1.portal-address",
-            "0x0000000000000000000000000000000000000001",
-            "--zone.id",
-            "7",
-        ])
-        .unwrap();
-        assert_eq!(parsed.zone.zone_id, Some(7));
     }
 
     #[test]
@@ -932,13 +886,13 @@ mod tests {
 
     #[test]
     fn l1_rpc_url_accepts_websocket_schemes() {
-        validate_l1_rpc_url("ws://localhost:8546").unwrap();
-        validate_l1_rpc_url("wss://rpc.moderato.tempo.xyz").unwrap();
+        parse_l1_rpc_url("ws://localhost:8546").unwrap();
+        parse_l1_rpc_url("wss://rpc.moderato.tempo.xyz").unwrap();
     }
 
     #[test]
     fn l1_rpc_url_rejects_non_websocket_schemes() {
-        assert!(validate_l1_rpc_url("http://localhost:8545").is_err());
-        assert!(validate_l1_rpc_url("https://rpc.moderato.tempo.xyz").is_err());
+        assert!(parse_l1_rpc_url("http://localhost:8545").is_err());
+        assert!(parse_l1_rpc_url("https://rpc.moderato.tempo.xyz").is_err());
     }
 }

--- a/crates/node/src/cli.rs
+++ b/crates/node/src/cli.rs
@@ -293,7 +293,11 @@ pub struct ZoneArgs {
     pub l1_rpc_url: String,
 
     /// ZonePortal contract address on L1.
-    #[arg(long = "l1.portal-address", env = "L1_PORTAL_ADDRESS")]
+    #[arg(
+        long = "l1.portal-address",
+        env = "L1_PORTAL_ADDRESS",
+        value_parser = parse_portal_address
+    )]
     pub portal_address: Address,
 
     /// Block building interval in milliseconds.
@@ -528,6 +532,16 @@ fn parse_l1_rpc_url(l1_rpc_url: &str) -> Result<String, String> {
     Ok(l1_rpc_url.to_owned())
 }
 
+fn parse_portal_address(value: &str) -> Result<Address, String> {
+    let address = value
+        .parse::<Address>()
+        .map_err(|err| format!("invalid --l1.portal-address: {err}"))?;
+    if address.is_zero() {
+        return Err("--l1.portal-address must be nonzero".to_owned());
+    }
+    Ok(address)
+}
+
 #[cfg(test)]
 mod tests {
     use std::{io::Write as _, process::Command, thread, time::Duration};
@@ -536,7 +550,7 @@ mod tests {
 
     use super::{
         Role, ZoneArgs, ZoneCli, load_decryption_keys, load_sequencer_signer, parse_l1_rpc_url,
-        sequencer_enabled, validate_p2p_transaction_size_limit,
+        parse_portal_address, sequencer_enabled, validate_p2p_transaction_size_limit,
     };
     use zone_sequencer::MAX_WITHDRAWAL_BATCH_GAS;
 
@@ -558,6 +572,12 @@ mod tests {
     fn dev_is_parsed_by_the_top_level_cli() {
         let parsed = ZoneCli::try_parse_from(["tempo-zone", "dev"]).unwrap();
         assert!(matches!(parsed, ZoneCli::Dev(_)));
+    }
+
+    #[test]
+    fn portal_address_must_be_nonzero() {
+        assert!(parse_portal_address("0x0000000000000000000000000000000000000000").is_err());
+        assert!(parse_portal_address("0x1111111111111111111111111111111111111111").is_ok());
     }
 
     #[test]

--- a/docs/ZONES.md
+++ b/docs/ZONES.md
@@ -683,6 +683,7 @@ cast code 0x5A4d000000000000000000000000000000000000 --rpc-url "$ETH_RPC_URL"
 |------|---------|-------------|
 | `--l1.rpc-url` | (required) | Certified Tempo follower WebSocket RPC URL |
 | `--l1.portal-address` | (from zone.json) | ZonePortal contract on L1 |
+| `--zone.id` | (deprecated) | Optional compatibility check against the zone ID encoded in the genesis chain ID. |
 | `--sequencer` | false | Enable sequencer mode for block production and withdrawal batch submission |
 | `--sequencer-key-file` | (required for sequencing) | Owner-readable file or FIFO containing the sequencer private key |
 | `--deposit-decryption-keys-file` | (optional) | File containing additional historical or pre-provisioned deposit decryption keys, one hex key per line |

--- a/docs/ZONES.md
+++ b/docs/ZONES.md
@@ -648,7 +648,6 @@ cast code 0x5A4d000000000000000000000000000000000000 --rpc-url "$ETH_RPC_URL"
 |------|---------|-------------|
 | `--l1.rpc-url` | (required) | Certified Tempo follower WebSocket RPC URL |
 | `--l1.portal-address` | (from zone.json) | ZonePortal contract on L1 |
-| `--zone.id` | (deprecated) | Optional compatibility check against the zone ID encoded in the genesis chain ID. |
 | `--sequencer` | false | Enable sequencer mode for block production and withdrawal batch submission |
 | `--sequencer-key-file` | (required for sequencing) | Owner-readable file or FIFO containing the sequencer private key |
 | `--deposit-decryption-keys-file` | (optional) | File containing additional historical or pre-provisioned deposit decryption keys, one hex key per line |


### PR DESCRIPTION
This PR moves node CLI validation into Clap parsers while preserving the deprecated `--zone.id` argument for backward compatibility.