### PR TITLE
Remove unused block interval CLI option

### DIFF
--- a/crates/node/src/cli.rs
+++ b/crates/node/src/cli.rs
@@ -105,7 +105,6 @@ fn run_node(mut cli: Cli<ZoneChainSpecParser, ZoneArgs>) -> eyre::Result<()> {
         info!(target: "reth::cli", "Launching Tempo Zone node");
 
         validate_l1_rpc_url(&args.l1_rpc_url)?;
-        validate_portal_address(args.portal_address)?;
         let zone_id = builder.config().chain.zone_id();
         validate_deprecated_zone_id(args.zone_id, zone_id)?;
 
@@ -292,7 +291,11 @@ pub struct ZoneArgs {
     pub l1_rpc_url: String,
 
     /// ZonePortal contract address on L1.
-    #[arg(long = "l1.portal-address", env = "L1_PORTAL_ADDRESS")]
+    #[arg(
+        long = "l1.portal-address",
+        env = "L1_PORTAL_ADDRESS",
+        value_parser = parse_portal_address
+    )]
     pub portal_address: Address,
 
     /// Path to a file or FIFO containing the shared sequencer private key.
@@ -522,12 +525,14 @@ fn validate_l1_rpc_url(l1_rpc_url: &str) -> eyre::Result<()> {
     Ok(())
 }
 
-fn validate_portal_address(portal_address: Address) -> eyre::Result<()> {
-    eyre::ensure!(
-        !portal_address.is_zero(),
-        "--l1.portal-address must be nonzero"
-    );
-    Ok(())
+fn parse_portal_address(value: &str) -> Result<Address, String> {
+    let address = value
+        .parse::<Address>()
+        .map_err(|err| format!("invalid --l1.portal-address: {err}"))?;
+    if address.is_zero() {
+        return Err("--l1.portal-address must be nonzero".to_owned());
+    }
+    Ok(address)
 }
 
 fn validate_deprecated_zone_id(configured: Option<u32>, derived: u32) -> eyre::Result<()> {
@@ -547,9 +552,9 @@ mod tests {
     use clap::Parser as _;
 
     use super::{
-        Role, ZoneArgs, ZoneCli, load_decryption_keys, load_sequencer_signer, sequencer_enabled,
-        validate_deprecated_zone_id, validate_l1_rpc_url, validate_p2p_transaction_size_limit,
-        validate_portal_address,
+        Role, ZoneArgs, ZoneCli, load_decryption_keys, load_sequencer_signer, parse_portal_address,
+        sequencer_enabled, validate_deprecated_zone_id, validate_l1_rpc_url,
+        validate_p2p_transaction_size_limit,
     };
     use zone_sequencer::MAX_WITHDRAWAL_BATCH_GAS;
 
@@ -575,8 +580,8 @@ mod tests {
 
     #[test]
     fn portal_address_must_be_nonzero() {
-        assert!(validate_portal_address(alloy_primitives::Address::ZERO).is_err());
-        assert!(validate_portal_address(alloy_primitives::Address::repeat_byte(0x11)).is_ok());
+        assert!(parse_portal_address("0x0000000000000000000000000000000000000000").is_err());
+        assert!(parse_portal_address("0x1111111111111111111111111111111111111111").is_ok());
     }
 
     #[test]

--- a/crates/node/src/cli.rs
+++ b/crates/node/src/cli.rs
@@ -105,6 +105,7 @@ fn run_node(mut cli: Cli<ZoneChainSpecParser, ZoneArgs>) -> eyre::Result<()> {
         info!(target: "reth::cli", "Launching Tempo Zone node");
 
         validate_l1_rpc_url(&args.l1_rpc_url)?;
+        validate_portal_address(args.portal_address)?;
         let zone_id = builder.config().chain.zone_id();
         validate_deprecated_zone_id(args.zone_id, zone_id)?;
 
@@ -291,11 +292,7 @@ pub struct ZoneArgs {
     pub l1_rpc_url: String,
 
     /// ZonePortal contract address on L1.
-    #[arg(
-        long = "l1.portal-address",
-        env = "L1_PORTAL_ADDRESS",
-        value_parser = parse_portal_address
-    )]
+    #[arg(long = "l1.portal-address", env = "L1_PORTAL_ADDRESS")]
     pub portal_address: Address,
 
     /// Path to a file or FIFO containing the shared sequencer private key.
@@ -525,14 +522,12 @@ fn validate_l1_rpc_url(l1_rpc_url: &str) -> eyre::Result<()> {
     Ok(())
 }
 
-fn parse_portal_address(value: &str) -> Result<Address, String> {
-    let address = value
-        .parse::<Address>()
-        .map_err(|err| format!("invalid --l1.portal-address: {err}"))?;
-    if address.is_zero() {
-        return Err("--l1.portal-address must be nonzero".to_owned());
-    }
-    Ok(address)
+fn validate_portal_address(portal_address: Address) -> eyre::Result<()> {
+    eyre::ensure!(
+        !portal_address.is_zero(),
+        "--l1.portal-address must be nonzero"
+    );
+    Ok(())
 }
 
 fn validate_deprecated_zone_id(configured: Option<u32>, derived: u32) -> eyre::Result<()> {
@@ -552,9 +547,9 @@ mod tests {
     use clap::Parser as _;
 
     use super::{
-        Role, ZoneArgs, ZoneCli, load_decryption_keys, load_sequencer_signer, parse_portal_address,
-        sequencer_enabled, validate_deprecated_zone_id, validate_l1_rpc_url,
-        validate_p2p_transaction_size_limit,
+        Role, ZoneArgs, ZoneCli, load_decryption_keys, load_sequencer_signer, sequencer_enabled,
+        validate_deprecated_zone_id, validate_l1_rpc_url, validate_p2p_transaction_size_limit,
+        validate_portal_address,
     };
     use zone_sequencer::MAX_WITHDRAWAL_BATCH_GAS;
 
@@ -580,8 +575,8 @@ mod tests {
 
     #[test]
     fn portal_address_must_be_nonzero() {
-        assert!(parse_portal_address("0x0000000000000000000000000000000000000000").is_err());
-        assert!(parse_portal_address("0x1111111111111111111111111111111111111111").is_ok());
+        assert!(validate_portal_address(alloy_primitives::Address::ZERO).is_err());
+        assert!(validate_portal_address(alloy_primitives::Address::repeat_byte(0x11)).is_ok());
     }
 
     #[test]

--- a/crates/node/src/cli.rs
+++ b/crates/node/src/cli.rs
@@ -295,14 +295,6 @@ pub struct ZoneArgs {
     #[arg(long = "l1.portal-address", env = "L1_PORTAL_ADDRESS")]
     pub portal_address: Address,
 
-    /// Block building interval in milliseconds.
-    #[arg(
-        long = "block.interval-ms",
-        env = "BLOCK_INTERVAL_MS",
-        default_value_t = 250
-    )]
-    pub block_interval_ms: u64,
-
     /// Path to a file or FIFO containing the shared sequencer private key.
     ///
     /// Required by every node that can produce blocks. Requiredness is checked after the

--- a/docs/ZONES.md
+++ b/docs/ZONES.md
@@ -652,7 +652,6 @@ cast code 0x5A4d000000000000000000000000000000000000 --rpc-url "$ETH_RPC_URL"
 | `--sequencer` | false | Enable sequencer mode for block production and withdrawal batch submission |
 | `--sequencer-key-file` | (required for sequencing) | Owner-readable file or FIFO containing the sequencer private key |
 | `--deposit-decryption-keys-file` | (optional) | File containing additional historical or pre-provisioned deposit decryption keys, one hex key per line |
-| `--block.interval-ms` | 250 | Block building interval |
 | `--zone.batch-interval-blocks` | 120 | Zone blocks between empty withdrawal batch boundaries / L1 submissions (~1 minute at Tempo's 500 ms block time) |
 | `--zone.poll-interval-secs` | 1 | Fallback interval for reconciling the canonical Zone head when no native notification arrives |
 | `--withdrawal-poll-interval-secs` | 5 | How often (seconds) the withdrawal processor polls the L1 queue |


### PR DESCRIPTION
This PR removes the unused `block_interval_ms` cli arg.