### PR TITLE
feat(node): build checkpoint-only Tempo imports

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -13872,6 +13872,7 @@ dependencies = [
  "tracing",
  "url",
  "zone-precompiles",
+ "zone-primitives",
 ]
 
 [[package]]

--- a/crates/evm/src/executor.rs
+++ b/crates/evm/src/executor.rs
@@ -23,7 +23,8 @@ use tempo_zone_contracts::IZoneOutbox;
 use zone_chainspec::ZoneChainSpec;
 use zone_l1::state::L1StateProvider;
 use zone_precompiles::{
-    ADVANCE_TEMPO_SELECTOR, L1StorageReader, is_finalize_withdrawal_batch_calldata,
+    ADVANCE_TEMPO_HEADERS_SELECTOR, ADVANCE_TEMPO_SELECTOR, L1StorageReader,
+    is_finalize_withdrawal_batch_calldata,
 };
 use zone_primitives::constants::{ZONE_INBOX_ADDRESS, ZONE_OUTBOX_ADDRESS};
 
@@ -36,6 +37,8 @@ enum ZoneBlockPhase {
     AwaitingAdvanceTempo,
     /// The block has committed `advanceTempo` and may execute ordinary transactions.
     Executing,
+    /// The block authenticated Tempo headers and must contain no further transactions.
+    CheckpointOnly,
     /// The block has finalized withdrawals and cannot accept any more transactions.
     WithdrawalsFinalized,
 }
@@ -53,6 +56,9 @@ impl ZoneBlockPhase {
 
         match (self, tx_kind) {
             (Self::AwaitingAdvanceTempo, ZoneTransactionKind::AdvanceTempo) => Ok(Self::Executing),
+            (Self::AwaitingAdvanceTempo, ZoneTransactionKind::AdvanceTempoHeaders) => {
+                Ok(Self::CheckpointOnly)
+            }
             (Self::AwaitingAdvanceTempo, _) => Err(BlockValidationError::msg(
                 "advanceTempo must be the first transaction in a zone block",
             )
@@ -61,6 +67,9 @@ impl ZoneBlockPhase {
                 "advanceTempo must only execute once per zone block",
             )
             .into()),
+            (Self::Executing, ZoneTransactionKind::AdvanceTempoHeaders) => Err(
+                BlockValidationError::msg("advanceTempoHeaders must only open a zone block").into(),
+            ),
             (Self::Executing, ZoneTransactionKind::Regular) => Ok(Self::Executing),
             (Self::Executing, ZoneTransactionKind::FinalizeWithdrawalBatch) => {
                 Ok(Self::WithdrawalsFinalized)
@@ -76,6 +85,10 @@ impl ZoneBlockPhase {
                 "finalizeWithdrawalBatch must be the last transaction in a zone block",
             )
             .into()),
+            (Self::CheckpointOnly, _) => Err(BlockValidationError::msg(
+                "advanceTempoHeaders must be the only transaction in a zone block",
+            )
+            .into()),
         }
     }
 
@@ -88,6 +101,7 @@ impl ZoneBlockPhase {
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 enum ZoneTransactionKind {
     AdvanceTempo,
+    AdvanceTempoHeaders,
     Regular,
     FinalizeWithdrawalBatch,
     UnexpectedSystem,
@@ -103,6 +117,13 @@ impl ZoneTransactionKind {
             kind.to() == Some(&ZONE_INBOX_ADDRESS) && input.starts_with(&ADVANCE_TEMPO_SELECTOR)
         }) {
             return Self::AdvanceTempo;
+        }
+
+        if tx.calls().any(|(kind, input)| {
+            kind.to() == Some(&ZONE_INBOX_ADDRESS)
+                && input.starts_with(&ADVANCE_TEMPO_HEADERS_SELECTOR)
+        }) {
+            return Self::AdvanceTempoHeaders;
         }
 
         if tx.calls().any(|(kind, input)| {

--- a/crates/l1/Cargo.toml
+++ b/crates/l1/Cargo.toml
@@ -14,6 +14,7 @@ workspace = true
 # zones
 tempo-zone-contracts = { workspace = true, features = ["std", "serde", "rpc"] }
 zone-precompiles = { workspace = true, features = ["std"] }
+zone-primitives = { workspace = true }
 
 # tempo
 tempo-alloy.workspace = true

--- a/crates/l1/src/block.rs
+++ b/crates/l1/src/block.rs
@@ -10,6 +10,36 @@ pub struct L1BlockDeposits {
 }
 
 impl L1BlockDeposits {
+    /// Prepare portal work accumulated across checkpoint-only blocks for one full import.
+    pub async fn prepare_many(
+        blocks: Vec<Self>,
+        encryption_keys: &EncryptionKeyRing,
+        portal_address: Address,
+    ) -> eyre::Result<PreparedL1Block> {
+        let mut blocks = blocks.into_iter();
+        let first = blocks
+            .next()
+            .ok_or_else(|| eyre::eyre!("cannot prepare an empty L1 range"))?;
+        let mut prepared = first.prepare(encryption_keys, portal_address).await?;
+        for block in blocks {
+            let next = block.prepare(encryption_keys, portal_address).await?;
+            prepared.header = next.header;
+            prepared.queued_deposits.extend(next.queued_deposits);
+            prepared.decryptions.extend(next.decryptions);
+            prepared.enabled_tokens.extend(next.enabled_tokens);
+        }
+        eyre::ensure!(
+            prepared.queued_deposits.len() <= zone_primitives::constants::MAX_UNPROCESSED_DEPOSITS,
+            "outstanding deposit suffix exceeds protocol capacity"
+        );
+        eyre::ensure!(
+            prepared.enabled_tokens.len()
+                <= zone_primitives::constants::MAX_UNPROCESSED_TOKEN_ENABLEMENTS,
+            "outstanding token-enablement suffix exceeds protocol capacity"
+        );
+        Ok(prepared)
+    }
+
     /// Prepare all deposits for the payload builder.
     ///
     /// Decrypts deposits and ABI-encodes the types the `advanceTempo` call expects.

--- a/crates/l1/src/block.rs
+++ b/crates/l1/src/block.rs
@@ -16,7 +16,7 @@ impl L1BlockDeposits {
         encryption_keys: &EncryptionKeyRing,
         portal_address: Address,
     ) -> eyre::Result<PreparedL1Block> {
-        let follows_checkpoint_prefix = blocks.len() > 1;
+        let follows_checkpoint_blocks = blocks.len() > 1;
         let mut blocks = blocks.into_iter();
         let first = blocks
             .next()
@@ -38,7 +38,7 @@ impl L1BlockDeposits {
                 <= zone_primitives::constants::MAX_UNPROCESSED_TOKEN_ENABLEMENTS,
             "outstanding token-enablement suffix exceeds protocol capacity"
         );
-        prepared.follows_checkpoint_prefix = follows_checkpoint_prefix;
+        prepared.follows_checkpoint_blocks = follows_checkpoint_blocks;
         Ok(prepared)
     }
 
@@ -177,7 +177,7 @@ impl L1BlockDeposits {
             queued_deposits,
             decryptions,
             enabled_tokens,
-            follows_checkpoint_prefix: false,
+            follows_checkpoint_blocks: false,
         })
     }
 }
@@ -200,7 +200,7 @@ pub struct PreparedL1Block {
     #[serde(skip)]
     pub enabled_tokens: Vec<abi::EnabledToken>,
     /// Whether this is the first full import following checkpoint-only Zone blocks.
-    /// Such a block closes the settlement batch containing that prefix.
+    /// Such a block closes the settlement batch containing that prefix, and signals a batch boundary.
     #[serde(skip)]
-    pub follows_checkpoint_prefix: bool,
+    pub follows_checkpoint_blocks: bool,
 }

--- a/crates/l1/src/block.rs
+++ b/crates/l1/src/block.rs
@@ -16,6 +16,7 @@ impl L1BlockDeposits {
         encryption_keys: &EncryptionKeyRing,
         portal_address: Address,
     ) -> eyre::Result<PreparedL1Block> {
+        let follows_checkpoint_prefix = blocks.len() > 1;
         let mut blocks = blocks.into_iter();
         let first = blocks
             .next()
@@ -37,6 +38,7 @@ impl L1BlockDeposits {
                 <= zone_primitives::constants::MAX_UNPROCESSED_TOKEN_ENABLEMENTS,
             "outstanding token-enablement suffix exceeds protocol capacity"
         );
+        prepared.follows_checkpoint_prefix = follows_checkpoint_prefix;
         Ok(prepared)
     }
 
@@ -175,6 +177,7 @@ impl L1BlockDeposits {
             queued_deposits,
             decryptions,
             enabled_tokens,
+            follows_checkpoint_prefix: false,
         })
     }
 }
@@ -196,4 +199,8 @@ pub struct PreparedL1Block {
     /// Tokens newly enabled for bridging in this block.
     #[serde(skip)]
     pub enabled_tokens: Vec<abi::EnabledToken>,
+    /// Whether this is the first full import following checkpoint-only Zone blocks.
+    /// Such a block closes the settlement batch containing that prefix.
+    #[serde(skip)]
+    pub follows_checkpoint_prefix: bool,
 }

--- a/crates/node/src/engine.rs
+++ b/crates/node/src/engine.rs
@@ -57,7 +57,7 @@ use tracing::{error, info};
 use zone_chainspec::ZoneChainSpec;
 use zone_l1::{DepositQueue, EncryptionKeyRing, L1BlockDeposits, L1BlockTracker, PreparedL1Block};
 use zone_p2p::{LeadershipSchedule, P2pPeerId};
-use zone_payload::{ZonePayloadAttributes, ZonePayloadTypes};
+use zone_payload::{TempoImport, ZonePayloadAttributes, ZonePayloadTypes};
 
 /// Per-anchor production permit backed by the effective leadership schedule.
 ///
@@ -366,7 +366,7 @@ impl ZoneEngine {
                 target_gas_limit: None,
             },
             timestamp_millis_part,
-            l1_block,
+            tempo_import: TempoImport::Full(Box::new(l1_block)),
         };
 
         // Send FCU with payload attributes through the engine API to trigger

--- a/crates/node/src/replication.rs
+++ b/crates/node/src/replication.rs
@@ -1524,7 +1524,7 @@ mod tests {
             queued_deposits: vec![],
             decryptions: vec![],
             enabled_tokens: vec![],
-            follows_checkpoint_prefix: false,
+            follows_checkpoint_blocks: false,
         };
         let tx = zone_payload::build_advance_tempo_tx(&prepared, 1337);
         let block = SealedBlock::seal_slow(Block {
@@ -1617,7 +1617,7 @@ mod tests {
             queued_deposits: vec![],
             decryptions: vec![],
             enabled_tokens: vec![],
-            follows_checkpoint_prefix: false,
+            follows_checkpoint_blocks: false,
         };
         let TempoTxEnvelope::Legacy(system_tx) =
             zone_payload::build_advance_tempo_tx(&prepared, 1337).into_inner()

--- a/crates/node/src/replication.rs
+++ b/crates/node/src/replication.rs
@@ -1524,6 +1524,7 @@ mod tests {
             queued_deposits: vec![],
             decryptions: vec![],
             enabled_tokens: vec![],
+            follows_checkpoint_prefix: false,
         };
         let tx = zone_payload::build_advance_tempo_tx(&prepared, 1337);
         let block = SealedBlock::seal_slow(Block {
@@ -1616,6 +1617,7 @@ mod tests {
             queued_deposits: vec![],
             decryptions: vec![],
             enabled_tokens: vec![],
+            follows_checkpoint_prefix: false,
         };
         let TempoTxEnvelope::Legacy(system_tx) =
             zone_payload::build_advance_tempo_tx(&prepared, 1337).into_inner()

--- a/crates/payload/src/attrs.rs
+++ b/crates/payload/src/attrs.rs
@@ -26,6 +26,33 @@ pub enum TempoImport {
     CheckpointOnly(Vec<SealedHeader<TempoHeader>>),
 }
 
+impl TempoImport {
+    pub(crate) fn is_checkpoint_only(&self) -> bool {
+        matches!(self, Self::CheckpointOnly(_))
+    }
+
+    pub(crate) fn follows_checkpoint_blocks(&self) -> bool {
+        match self {
+            Self::Full(prepared) => prepared.follows_checkpoint_blocks,
+            Self::CheckpointOnly(_) => false,
+        }
+    }
+
+    pub(crate) fn total_deposits(&self) -> usize {
+        match self {
+            Self::Full(prepared) => prepared.queued_deposits.len(),
+            Self::CheckpointOnly(_) => 0,
+        }
+    }
+
+    pub(crate) fn enabled_tokens(&self) -> usize {
+        match self {
+            Self::Full(prepared) => prepared.enabled_tokens.len(),
+            Self::CheckpointOnly(_) => 0,
+        }
+    }
+}
+
 /// Zone RPC payload attributes — the type that flows through FCU.
 ///
 /// Carries standard Ethereum attributes, a millisecond timestamp portion, and

--- a/crates/payload/src/attrs.rs
+++ b/crates/payload/src/attrs.rs
@@ -12,12 +12,19 @@ use reth_node_api::{
     InvalidPayloadAttributesError, NewPayloadError, PayloadTypes, PayloadValidator,
 };
 use reth_payload_primitives::PayloadAttributes;
-use reth_primitives_traits::{AlloyBlockHeader, SealedBlock};
+use reth_primitives_traits::{AlloyBlockHeader, SealedBlock, SealedHeader};
 use serde::{Deserialize, Serialize};
 use tempo_node::engine::TempoEngineValidator;
 use tempo_payload_types::{TempoBuiltPayload, TempoExecutionData};
 use tempo_primitives::{Block, TempoHeader};
 use zone_l1::PreparedL1Block;
+
+/// Explicit opening Tempo system-call variant for a Zone payload.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub enum TempoImport {
+    Full(Box<PreparedL1Block>),
+    CheckpointOnly(Vec<SealedHeader<TempoHeader>>),
+}
 
 /// Zone RPC payload attributes — the type that flows through FCU.
 ///
@@ -38,7 +45,7 @@ pub struct ZonePayloadAttributes {
     /// processes exactly one L1 block via `advanceTempo`. Decryption and ABI
     /// encoding have already been performed by the engine; TIP-403 policy is
     /// enforced during `advanceTempo` when the deposits mint TIP-20 tokens.
-    pub l1_block: PreparedL1Block,
+    pub tempo_import: TempoImport,
 }
 
 impl reth_node_api::PayloadAttributes for ZonePayloadAttributes {
@@ -65,8 +72,8 @@ impl reth_node_api::PayloadAttributes for ZonePayloadAttributes {
 
 impl ZonePayloadAttributes {
     /// Returns a reference to the prepared L1 block data.
-    pub fn l1_block(&self) -> &PreparedL1Block {
-        &self.l1_block
+    pub fn tempo_import(&self) -> &TempoImport {
+        &self.tempo_import
     }
 
     /// Returns the extra data for the block header (always empty for zones).

--- a/crates/payload/src/builder.rs
+++ b/crates/payload/src/builder.rs
@@ -44,13 +44,13 @@ use tempo_transaction_pool::{
     StateAwareBestTransactions, TempoTransactionPool, transaction::TempoPooledTransaction,
 };
 use tracing::{error, info, warn};
-use zone_chainspec::ZoneChainSpec;
+use zone_chainspec::{ZoneChainSpec, ZoneHardforks as _};
 use zone_evm::ZoneEvmConfig;
 use zone_l1::{PreparedL1Block, TempoStateExt};
 use zone_precompiles::L1StateError;
 use zone_primitives::constants::MAX_RLP_BLOCK_SIZE;
 
-use crate::{ZonePayloadAttributes, ZonePayloadTypes};
+use crate::{TempoImport, ZonePayloadAttributes, ZonePayloadTypes};
 
 /// Default empty-batch cadence: every 120 zone blocks (~60 sec at Tempo's 500 ms block time).
 pub const DEFAULT_WITHDRAWAL_BATCH_INTERVAL_BLOCKS: u64 = 120;
@@ -172,19 +172,41 @@ where
         let start = Instant::now();
 
         let state_provider = self.provider.state_by_block_hash(parent_header.hash())?;
-        let prepared = attributes.l1_block();
-        validate_l1_continuity(state_provider.as_ref(), prepared)?;
+        let tempo_import = attributes.tempo_import();
+        let imported_headers = match tempo_import {
+            TempoImport::Full(prepared) => core::slice::from_ref(&prepared.header),
+            TempoImport::CheckpointOnly(headers) => headers.as_slice(),
+        };
+        validate_l1_continuity(state_provider.as_ref(), imported_headers)?;
+        let final_imported = imported_headers.last().expect("validated nonempty import");
+        let checkpoint_only = matches!(tempo_import, TempoImport::CheckpointOnly(_));
+        let total_deposits = match tempo_import {
+            TempoImport::Full(prepared) => prepared.queued_deposits.len(),
+            TempoImport::CheckpointOnly(_) => 0,
+        };
+        let enabled_tokens = match tempo_import {
+            TempoImport::Full(prepared) => prepared.enabled_tokens.len(),
+            TempoImport::CheckpointOnly(_) => 0,
+        };
 
-        let total_deposits = prepared.queued_deposits.len();
-
-        info!(
-            target: "zone::payload",
-            zone_block = parent_header.number() + 1,
-            l1_block = prepared.header.inner.number,
-            deposits = total_deposits,
-            enabled_tokens = prepared.enabled_tokens.len(),
-            "Including advanceTempo system tx (chain continuity OK)"
-        );
+        if checkpoint_only {
+            info!(
+                target: "zone::payload",
+                zone_block = parent_header.number() + 1,
+                l1_block = final_imported.inner.number,
+                header_count = imported_headers.len(),
+                "Including advanceTempoHeaders system tx (chain continuity OK)"
+            );
+        } else {
+            info!(
+                target: "zone::payload",
+                zone_block = parent_header.number() + 1,
+                l1_block = final_imported.inner.number,
+                deposits = total_deposits,
+                enabled_tokens,
+                "Including advanceTempo system tx (chain continuity OK)"
+            );
+        }
 
         let state = StateProviderDatabase::new(state_provider.as_ref());
         let mut db = State::builder()
@@ -235,51 +257,63 @@ where
         })?;
 
         // Execute advanceTempo system transaction — exactly one per zone block.
+        let opening_tx = match tempo_import {
+            TempoImport::Full(prepared) => build_advance_tempo_tx(prepared, chain_id),
+            TempoImport::CheckpointOnly(headers) => {
+                build_advance_tempo_headers_tx(headers, chain_id)?
+            }
+        };
         builder
-            .execute_transaction(build_advance_tempo_tx(prepared, chain_id))
+            .execute_transaction(opening_tx)
             .map(|_| ())
             .map_err(PayloadBuilderError::evm)
             .map_err(|err| {
                 error!(
                     ?err,
-                    l1_block = prepared.header.inner.number,
+                    l1_block = final_imported.inner.number,
                     deposits = total_deposits,
                     "advanceTempo system tx failed"
                 );
                 err
             })?;
 
-        // Execute pool transactions until either all of them fit or their packed RLP bytes reach
-        // the size budget
-        // The block executor owns gas-capacity accounting.
-        let pool_tx_size_budget = MAX_RLP_BLOCK_SIZE - BLOCK_SIZE_SAFETY_MARGIN;
-        let raw_best_txs = self
-            .pool
-            .best_transactions_with_attributes(BestTransactionsAttributes::new(base_fee, None));
-        let mut best_txs = StateAwareBestTransactions::new(raw_best_txs);
-        if execute_pool_transactions(
-            |tx, best_txs| {
-                builder
-                    .execute_transaction_with_result_closure(tx, |result| {
-                        best_txs.on_new_result(result);
-                    })
-                    .map(|_| ())
-            },
-            &mut best_txs,
-            &cancel,
-            pool_tx_size_budget,
-        )? == PoolExecutionOutcome::Cancelled
-        {
-            return Ok(BuildOutcome::Cancelled);
-        }
+        if !checkpoint_only {
+            // Execute pool transactions until either all of them fit or their packed RLP bytes reach
+            // the size budget
+            // The block executor owns gas-capacity accounting.
+            let pool_tx_size_budget = MAX_RLP_BLOCK_SIZE - BLOCK_SIZE_SAFETY_MARGIN;
+            let raw_best_txs = self
+                .pool
+                .best_transactions_with_attributes(BestTransactionsAttributes::new(base_fee, None));
+            let mut best_txs = StateAwareBestTransactions::new(raw_best_txs);
+            if execute_pool_transactions(
+                |tx, best_txs| {
+                    builder
+                        .execute_transaction_with_result_closure(tx, |result| {
+                            best_txs.on_new_result(result);
+                        })
+                        .map(|_| ())
+                },
+                &mut best_txs,
+                &cancel,
+                pool_tx_size_budget,
+            )? == PoolExecutionOutcome::Cancelled
+            {
+                return Ok(BuildOutcome::Cancelled);
+            }
 
-        finalize_withdrawal_batch_if_needed(
-            &mut builder,
-            block_number,
-            self.withdrawal_batch_interval_blocks,
-            self.withdrawal_reveal_encryptor.as_deref(),
-            chain_id,
-        )?;
+            finalize_withdrawal_batch_if_needed(
+                &mut builder,
+                block_number,
+                if chain_spec.zone_hardfork_at(attributes.timestamp()).is_z1() {
+                    1
+                } else {
+                    self.withdrawal_batch_interval_blocks
+                },
+                self.withdrawal_reveal_encryptor.as_deref(),
+                chain_id,
+            )?;
+        }
 
         let BlockBuilderOutcome {
             execution_result,
@@ -309,8 +343,8 @@ where
         let elapsed = start.elapsed();
         info!(
             number = sealed_block.number(),
-            l1_block = prepared.header.number(),
-            l1_hash = ?prepared.header.hash(),
+            l1_block = final_imported.number(),
+            l1_hash = ?final_imported.hash(),
             hash = ?sealed_block.hash(),
             gas_used = sealed_block.gas_used(),
             deposits = total_deposits,
@@ -378,7 +412,7 @@ where
 /// Validate that the prepared L1 block is the next block expected by TempoState.
 fn validate_l1_continuity(
     state_provider: &dyn StateProvider,
-    prepared: &PreparedL1Block,
+    headers: &[reth_primitives_traits::SealedHeader<TempoHeader>],
 ) -> Result<(), PayloadBuilderError> {
     let stored_l1 = state_provider
         .tempo_num_hash()
@@ -392,35 +426,50 @@ fn validate_l1_continuity(
         "TempoState current state"
     );
 
-    if prepared.header.inner.number != expected_block_number {
-        error!(
-            target: "zone::payload",
-            got = prepared.header.inner.number,
-            expected = expected_block_number,
-            "L1 block number mismatch — chain continuity broken"
-        );
+    if headers.is_empty() {
         return Err(PayloadBuilderError::Internal(reth_errors::RethError::msg(
-            format!(
-                "L1 block number mismatch: got {} expected {expected_block_number}",
-                prepared.header.inner.number
-            ),
+            "Tempo import contains no headers",
         )));
     }
+    let mut expected_number = expected_block_number;
+    let mut expected_hash = stored_l1.hash;
+    for header in headers {
+        if header.inner.number != expected_number {
+            error!(
+                target: "zone::payload",
+                got = header.inner.number,
+                expected = expected_number,
+                "L1 block number mismatch — chain continuity broken"
+            );
+            return Err(PayloadBuilderError::Internal(reth_errors::RethError::msg(
+                format!(
+                    "L1 block number mismatch: got {} expected {expected_block_number}",
+                    header.inner.number
+                ),
+            )));
+        }
 
-    if prepared.header.inner.parent_hash != stored_l1.hash {
-        error!(
-            target: "zone::payload",
-            got = %prepared.header.inner.parent_hash,
-            expected = %stored_l1.hash,
-            l1_block = prepared.header.inner.number,
-            "L1 parent hash mismatch — chain continuity broken"
-        );
-        return Err(PayloadBuilderError::Internal(reth_errors::RethError::msg(
-            format!(
-                "L1 parent hash mismatch at block {}: got {} expected {}",
-                prepared.header.inner.number, prepared.header.inner.parent_hash, stored_l1.hash
-            ),
-        )));
+        if header.inner.parent_hash != expected_hash {
+            error!(
+                target: "zone::payload",
+                got = %header.inner.parent_hash,
+                expected = %expected_hash,
+                l1_block = header.inner.number,
+                "L1 parent hash mismatch — chain continuity broken"
+            );
+            return Err(PayloadBuilderError::Internal(reth_errors::RethError::msg(
+                format!(
+                    "L1 parent hash mismatch at block {}: got {} expected {}",
+                    header.inner.number, header.inner.parent_hash, expected_hash
+                ),
+            )));
+        }
+        expected_number = expected_number.checked_add(1).ok_or_else(|| {
+            PayloadBuilderError::Internal(reth_errors::RethError::msg(
+                "Tempo block number overflow",
+            ))
+        })?;
+        expected_hash = header.hash();
     }
 
     Ok(())
@@ -715,10 +764,50 @@ pub fn build_advance_tempo_tx(
     )
 }
 
+/// Build a checkpoint-only `advanceTempoHeaders(headers)` system transaction.
+///
+/// The executor requires this transaction to be the complete body of its Zone block. Portal
+/// deposits and token enablements remain pending until a later full `advanceTempo` block.
+pub fn build_advance_tempo_headers_tx(
+    headers: &[reth_primitives_traits::SealedHeader<TempoHeader>],
+    chain_id: u64,
+) -> Result<Recovered<TempoTxEnvelope>, PayloadBuilderError> {
+    if headers.is_empty()
+        || headers.len() > zone_primitives::constants::MAX_TEMPO_HEADERS_PER_ZONE_BLOCK
+    {
+        return Err(PayloadBuilderError::Internal(reth_errors::RethError::msg(
+            "checkpoint-only Tempo header range is empty or oversized",
+        )));
+    }
+    let headers = headers
+        .iter()
+        .map(|header| {
+            let mut encoded = Vec::new();
+            header.header().encode(&mut encoded);
+            Bytes::from(encoded)
+        })
+        .collect();
+    let calldata = abi::IZoneInbox::advanceTempoHeadersCall { headers }.abi_encode();
+    let tx = TxLegacy {
+        chain_id: Some(chain_id),
+        nonce: 0,
+        gas_price: 0,
+        gas_limit: 0,
+        to: ZONE_INBOX_ADDRESS.into(),
+        value: U256::ZERO,
+        input: calldata.into(),
+    };
+    Ok(Recovered::new_unchecked(
+        TempoTxEnvelope::Legacy(Signed::new_unhashed(tx, TEMPO_SYSTEM_TX_SIGNATURE)),
+        TEMPO_SYSTEM_TX_SENDER,
+    ))
+}
+
 #[cfg(test)]
 mod tests {
     use alloy_consensus::{Header, Signed, TxLegacy};
     use alloy_primitives::{Address, B256, U256, address};
+    use alloy_rlp::Decodable;
     use alloy_sol_types::SolCall;
     use reth_primitives_traits::{Recovered, SealedHeader};
     use reth_revm::cancelled::CancelOnDrop;
@@ -753,6 +842,34 @@ mod tests {
             super::ZonePayloadFactory::new(0).withdrawal_batch_interval_blocks,
             1
         );
+    }
+
+    #[test]
+    fn builds_checkpoint_only_import_with_all_headers() {
+        let headers = [7, 8].map(|number| {
+            SealedHeader::seal_slow(TempoHeader {
+                inner: Header {
+                    number,
+                    ..Default::default()
+                },
+                ..Default::default()
+            })
+        });
+
+        let recovered = super::build_advance_tempo_headers_tx(&headers, 1337).unwrap();
+        let TempoTxEnvelope::Legacy(signed) = recovered.inner() else {
+            panic!("expected legacy transaction")
+        };
+        assert_eq!(signed.tx().chain_id, Some(1337));
+
+        let call = IZoneInbox::advanceTempoHeadersCall::abi_decode(&signed.tx().input).unwrap();
+        assert_eq!(call.headers.len(), 2);
+        for (encoded, expected) in call.headers.iter().zip(headers) {
+            let mut encoded = encoded.as_ref();
+            let decoded = TempoHeader::decode(&mut encoded).unwrap();
+            assert!(encoded.is_empty());
+            assert_eq!(decoded.inner.number, expected.inner.number);
+        }
     }
 
     /// A [`BestTransactions`] stream backed by a fixed queue that counts size-based rejections.

--- a/crates/payload/src/builder.rs
+++ b/crates/payload/src/builder.rs
@@ -180,20 +180,11 @@ where
         validate_l1_continuity(state_provider.as_ref(), imported_headers)?;
         let final_imported = imported_headers.last().expect("validated nonempty import");
         let checkpoint_only = matches!(tempo_import, TempoImport::CheckpointOnly(_));
-        let follows_checkpoint_prefix = match tempo_import {
-            TempoImport::Full(prepared) => prepared.follows_checkpoint_prefix,
-            TempoImport::CheckpointOnly(_) => false,
-        };
-        let total_deposits = match tempo_import {
-            TempoImport::Full(prepared) => prepared.queued_deposits.len(),
-            TempoImport::CheckpointOnly(_) => 0,
-        };
-        let enabled_tokens = match tempo_import {
-            TempoImport::Full(prepared) => prepared.enabled_tokens.len(),
-            TempoImport::CheckpointOnly(_) => 0,
-        };
+        let follows_checkpoint_blocks = tempo_import.follows_checkpoint_blocks();
+        let total_deposits = tempo_import.total_deposits();
+        let enabled_tokens = tempo_import.enabled_tokens();
 
-        if checkpoint_only {
+        if tempo_import.is_checkpoint_only() {
             info!(
                 target: "zone::payload",
                 zone_block = parent_header.number() + 1,
@@ -310,7 +301,7 @@ where
                 &mut builder,
                 block_number,
                 self.withdrawal_batch_interval_blocks,
-                follows_checkpoint_prefix,
+                follows_checkpoint_blocks,
                 self.withdrawal_reveal_encryptor.as_deref(),
                 chain_id,
             )?;
@@ -585,7 +576,7 @@ fn finalize_withdrawal_batch_if_needed<B>(
     builder: &mut B,
     block_number: u64,
     interval_blocks: u64,
-    follows_checkpoint_prefix: bool,
+    follows_checkpoint_blocks: bool,
     encryptor: Option<&dyn WithdrawalRevealEncryptor>,
     chain_id: u64,
 ) -> Result<(), PayloadBuilderError>
@@ -598,7 +589,7 @@ where
         !pending_withdrawals.is_empty(),
         block_number,
         interval_blocks,
-        follows_checkpoint_prefix,
+        follows_checkpoint_blocks,
     ) {
         return Ok(());
     }
@@ -651,11 +642,11 @@ fn should_finalize_withdrawal_batch(
     has_pending_withdrawals: bool,
     block_number: u64,
     interval_blocks: u64,
-    follows_checkpoint_prefix: bool,
+    follows_checkpoint_blocks: bool,
 ) -> bool {
     has_pending_withdrawals
         || block_number.is_multiple_of(interval_blocks)
-        || follows_checkpoint_prefix
+        || follows_checkpoint_blocks
 }
 
 /// Build the `finalizeWithdrawalBatch(count)` system transaction.
@@ -1061,7 +1052,7 @@ mod tests {
                 },
             }],
             enabled_tokens: vec![],
-            follows_checkpoint_prefix: false,
+            follows_checkpoint_blocks: false,
         };
 
         let recovered_tx = super::build_advance_tempo_tx(&prepared, 1337);

--- a/crates/payload/src/builder.rs
+++ b/crates/payload/src/builder.rs
@@ -44,7 +44,7 @@ use tempo_transaction_pool::{
     StateAwareBestTransactions, TempoTransactionPool, transaction::TempoPooledTransaction,
 };
 use tracing::{error, info, warn};
-use zone_chainspec::{ZoneChainSpec, ZoneHardforks as _};
+use zone_chainspec::ZoneChainSpec;
 use zone_evm::ZoneEvmConfig;
 use zone_l1::{PreparedL1Block, TempoStateExt};
 use zone_precompiles::L1StateError;
@@ -180,6 +180,10 @@ where
         validate_l1_continuity(state_provider.as_ref(), imported_headers)?;
         let final_imported = imported_headers.last().expect("validated nonempty import");
         let checkpoint_only = matches!(tempo_import, TempoImport::CheckpointOnly(_));
+        let follows_checkpoint_prefix = match tempo_import {
+            TempoImport::Full(prepared) => prepared.follows_checkpoint_prefix,
+            TempoImport::CheckpointOnly(_) => false,
+        };
         let total_deposits = match tempo_import {
             TempoImport::Full(prepared) => prepared.queued_deposits.len(),
             TempoImport::CheckpointOnly(_) => 0,
@@ -305,11 +309,8 @@ where
             finalize_withdrawal_batch_if_needed(
                 &mut builder,
                 block_number,
-                if chain_spec.zone_hardfork_at(attributes.timestamp()).is_z1() {
-                    1
-                } else {
-                    self.withdrawal_batch_interval_blocks
-                },
+                self.withdrawal_batch_interval_blocks,
+                follows_checkpoint_prefix,
                 self.withdrawal_reveal_encryptor.as_deref(),
                 chain_id,
             )?;
@@ -584,6 +585,7 @@ fn finalize_withdrawal_batch_if_needed<B>(
     builder: &mut B,
     block_number: u64,
     interval_blocks: u64,
+    follows_checkpoint_prefix: bool,
     encryptor: Option<&dyn WithdrawalRevealEncryptor>,
     chain_id: u64,
 ) -> Result<(), PayloadBuilderError>
@@ -592,7 +594,12 @@ where
 {
     let pending_withdrawals =
         read_pending_withdrawals_from_outbox(builder.evm_mut(), block_number)?;
-    if pending_withdrawals.is_empty() && !block_number.is_multiple_of(interval_blocks) {
+    if !should_finalize_withdrawal_batch(
+        !pending_withdrawals.is_empty(),
+        block_number,
+        interval_blocks,
+        follows_checkpoint_prefix,
+    ) {
         return Ok(());
     }
 
@@ -638,6 +645,17 @@ where
             );
             err
         })
+}
+
+fn should_finalize_withdrawal_batch(
+    has_pending_withdrawals: bool,
+    block_number: u64,
+    interval_blocks: u64,
+    follows_checkpoint_prefix: bool,
+) -> bool {
+    has_pending_withdrawals
+        || block_number.is_multiple_of(interval_blocks)
+        || follows_checkpoint_prefix
 }
 
 /// Build the `finalizeWithdrawalBatch(count)` system transaction.
@@ -827,13 +845,22 @@ mod tests {
     use zone_l1::PreparedL1Block;
 
     #[test]
-    fn withdrawal_batch_cadence_is_deterministic_from_block_number() {
+    fn withdrawal_batch_boundary_conditions() {
         let blocks = super::DEFAULT_WITHDRAWAL_BATCH_INTERVAL_BLOCKS;
 
         assert_eq!(blocks, 120);
-        assert_ne!(119 % blocks, 0);
-        assert_eq!(120 % blocks, 0);
-        assert_eq!(240 % blocks, 0);
+        assert!(!super::should_finalize_withdrawal_batch(
+            false, 119, blocks, false
+        ));
+        assert!(super::should_finalize_withdrawal_batch(
+            false, 120, blocks, false
+        ));
+        assert!(super::should_finalize_withdrawal_batch(
+            true, 121, blocks, false
+        ));
+        assert!(super::should_finalize_withdrawal_batch(
+            false, 150, blocks, true
+        ));
     }
 
     #[test]
@@ -1034,6 +1061,7 @@ mod tests {
                 },
             }],
             enabled_tokens: vec![],
+            follows_checkpoint_prefix: false,
         };
 
         let recovered_tx = super::build_advance_tempo_tx(&prepared, 1337);

--- a/crates/payload/src/lib.rs
+++ b/crates/payload/src/lib.rs
@@ -11,9 +11,9 @@ mod attrs;
 mod builder;
 mod withdrawal_reveal;
 
-pub use attrs::{ZonePayloadAttributes, ZonePayloadTypes};
+pub use attrs::{TempoImport, ZonePayloadAttributes, ZonePayloadTypes};
 pub use builder::{
     DEFAULT_WITHDRAWAL_BATCH_INTERVAL_BLOCKS, ZonePayloadBuilder, ZonePayloadFactory,
-    build_advance_tempo_tx,
+    build_advance_tempo_headers_tx, build_advance_tempo_tx,
 };
 pub use withdrawal_reveal::WithdrawalRevealEncryptor;

--- a/specs/spec.md
+++ b/specs/spec.md
@@ -701,7 +701,7 @@ The function writes `withdrawalQueueHash` and `withdrawalBatchIndex` to `lastBat
 
 A successful call emits `BatchFinalized(withdrawalQueueHash, withdrawalBatchIndex)`. This event is the authoritative zone-side batch boundary consumed by the sequencer; “finalized” means sealed on the zone and does not imply that the batch has been submitted to or accepted by Tempo. Acceptance on Tempo is indicated separately by the portal's `BatchSubmitted` event. For an empty batch, `withdrawalQueueHash` is zero while `withdrawalBatchIndex` still advances.
 
-Batch cadence is deterministic. It closes a batch when there are pending withdrawals or otherwise closes an empty batch at a block-number boundary. The default cadence is every 120th zone block (~1 minute at Tempo's expected 500 ms block interval), configurable as a block count. Intermediate zone blocks in the same batch do not call `finalizeWithdrawalBatch`.
+Batch cadence is deterministic, and only a full `advanceTempo` block can close a batch. A full block closes the batch when it contains pending withdrawals, when its zone block number is a multiple of the configured interval, or when it is the first full block following a nonempty prefix of `advanceTempoHeaders`-only blocks. The default interval is 120 zone blocks (~1 minute at Tempo's expected 500 ms block interval). An `advanceTempoHeaders`-only block never closes a batch, even when its number is an interval multiple; the following full block closes it instead. Other intermediate zone blocks do not call `finalizeWithdrawalBatch`.
 
 ### Withdrawal Queue
 


### PR DESCRIPTION
- Models Tempo imports as either a full operational import or a checkpoint-only header range.
- Builds `advanceTempoHeaders` system transactions from bounded, consecutive Tempo headers.
- Validates block-number and parent-hash continuity across imported header ranges.
- Keeps checkpoint-only Zone blocks system-only by excluding user transactions and withdrawal finalization.
- Aggregates deferred deposits and token enablements for the next full import while enforcing protocol capacity limits.
- Finalizes the withdrawal batch on the first full import following checkpoint-only blocks.
- Preserves normal `advanceTempo` and withdrawal-batch behavior when the Zone follows Tempo without a gap.