### PR TITLE
feat(prover): prove checkpoint-only Zone blocks

### DIFF
--- a/crates/node/src/engine.rs
+++ b/crates/node/src/engine.rs
@@ -60,10 +60,10 @@ use zone_l1::{DepositQueue, EncryptionKeyRing, FinalizedTarget, L1BlockDeposits,
 use zone_p2p::{LeadershipSchedule, P2pPeerId};
 use zone_payload::{TempoImport, ZonePayloadAttributes, ZonePayloadTypes};
 
-/// Block production permit backed by the effective leadership schedule.
+/// Full-block production permit backed by the effective leadership schedule.
 ///
-/// Blocks require the leader assigned to their first imported Tempo header, including checkpoint
-/// ranges that cross a leadership change. An optimistic override is open-ended until the next
+/// Full blocks require the leader assigned to their imported Tempo header. Checkpoint-only blocks
+/// are leader-neutral and bypass this permit. An optimistic override is open-ended until the next
 /// finalized portal transition supplies the ordinary-authority boundary.
 #[derive(Debug, Clone)]
 pub struct ProductionPermit {
@@ -80,7 +80,7 @@ impl ProductionPermit {
         }
     }
 
-    /// Decide whether this node may produce the zone block beginning at `tempo_anchor`.
+    /// Decide whether this node may produce the full zone block embedding `tempo_anchor`.
     ///
     /// `None` authorizes production; `Some(exit)` is the reason the engine must stop.
     pub fn check(&self, tempo_anchor: u64) -> Option<EngineExit> {
@@ -478,9 +478,11 @@ impl AvailableBlockDrain for ZoneEngine {
     }
 
     fn permit(&self, block: &Self::Block) -> Option<EngineExit> {
-        self.production_permit
-            .as_ref()
-            .and_then(|permit| permit.check(block.leader_anchor()))
+        self.production_permit.as_ref().and_then(|permit| {
+            block
+                .leader_anchor()
+                .and_then(|anchor| permit.check(anchor))
+        })
     }
 
     async fn advance_one(&mut self, block: Self::Block) -> eyre::Result<()> {
@@ -497,12 +499,12 @@ struct AvailableTempoImport {
 impl AvailableTempoImport {
     /// Tempo anchor whose leader must produce this Zone block.
     ///
-    /// The first imported header selects the leader even if later headers cross a handoff.
-    fn leader_anchor(&self) -> u64 {
+    /// Checkpoint-only blocks have no designated leader. A full block imports exactly one Tempo
+    /// header, whose effective leader supplies its production authority.
+    fn leader_anchor(&self) -> Option<u64> {
         self.checkpoint_headers
-            .first()
-            .unwrap_or(&self.l1_block.header)
-            .number()
+            .is_empty()
+            .then(|| self.l1_block.header.number())
     }
 }
 
@@ -639,18 +641,7 @@ mod tests {
     }
 
     #[test]
-    fn checkpoint_import_uses_first_header_leader() {
-        use commonware_cryptography::{Signer as _, ed25519::PrivateKey};
-        use zone_p2p::LeadershipState;
-
-        let outgoing = PrivateKey::from_seed(1).public_key();
-        let incoming = PrivateKey::from_seed(2).public_key();
-        let schedule = LeadershipSchedule::seeded(LeadershipState::new(1, outgoing.clone(), 0));
-        schedule
-            .publish(LeadershipState::new(2, incoming.clone(), 100))
-            .unwrap();
-        let outgoing_permit = ProductionPermit::new(schedule.clone(), outgoing);
-        let incoming_permit = ProductionPermit::new(schedule, incoming);
+    fn checkpoint_import_is_not_leader_restricted() {
         let available = AvailableTempoImport {
             l1_block: L1BlockDeposits {
                 header: header(90, 90),
@@ -659,35 +650,7 @@ mod tests {
             checkpoint_headers: (90..=110).map(|number| header(number, number)).collect(),
         };
 
-        assert_eq!(available.leader_anchor(), 90);
-        assert_eq!(outgoing_permit.check(available.leader_anchor()), None);
-        assert_eq!(
-            incoming_permit.check(available.leader_anchor()),
-            Some(EngineExit::Demoted {
-                tempo_anchor: 90,
-                epoch: 1
-            })
-        );
-
-        // The next range independently selects the incoming leader, as does a full import.
-        for checkpoint_headers in [vec![header(111, 111)], Vec::new()] {
-            let next = AvailableTempoImport {
-                l1_block: L1BlockDeposits {
-                    header: header(111, 111),
-                    events: Default::default(),
-                },
-                checkpoint_headers,
-            };
-            assert_eq!(next.leader_anchor(), 111);
-            assert_eq!(incoming_permit.check(next.leader_anchor()), None);
-            assert_eq!(
-                outgoing_permit.check(next.leader_anchor()),
-                Some(EngineExit::Demoted {
-                    tempo_anchor: 111,
-                    epoch: 2
-                })
-            );
-        }
+        assert_eq!(available.leader_anchor(), None);
     }
 
     #[test]

--- a/crates/node/src/replication.rs
+++ b/crates/node/src/replication.rs
@@ -707,9 +707,9 @@ pub(crate) async fn collect_follower_settlement_signatures<P>(
 
 /// Import live/backfilled blocks in canonical order on a follower.
 ///
-/// Live blocks are only imported when the sender equals the leader for their first imported Tempo
-/// header. This also applies to checkpoint-only ranges that cross a leadership change, resolving
-/// accidental split brain using the finalized schedule.
+/// Live full blocks are only imported when the sender equals the leader for their imported Tempo
+/// header. Checkpoint-only blocks have no designated leader and may be imported from any authorized
+/// P2P peer. The full-block check resolves accidental split brain using the finalized schedule.
 ///
 /// Backfilled blocks carry no producer claim and are judged by
 /// parent/anchor/execution/conflict validation alone. The loop exits when `stop` fires.
@@ -1198,9 +1198,10 @@ where
         }
         Err(PeerAnchorWaitError::Other(error)) => return Err(error),
     }
-    // Resolve production authority after observing the imported range, which may publish the
-    // leadership transition governing its first header. Backfilled blocks carry no producer claim.
-    validate_live_block_sender(
+    // Resolve live full-block production authority after observing its imported header, which may
+    // publish the leadership transition governing that same anchor. Checkpoint-only blocks are
+    // leader-neutral, and backfilled blocks carry no producer claim.
+    validate_live_import_sender(
         schedule,
         peer_block.live_sender.as_ref(),
         leader_anchor,
@@ -1278,6 +1279,18 @@ fn validate_live_block_sender(
              record governs",
         ),
     }
+}
+
+fn validate_live_import_sender(
+    schedule: &LeadershipSchedule,
+    live_sender: Option<&P2pPeerId>,
+    leader_anchor: Option<u64>,
+    block_number: u64,
+) -> eyre::Result<()> {
+    let Some(anchor_number) = leader_anchor else {
+        return Ok(());
+    };
+    validate_live_block_sender(schedule, live_sender, anchor_number, block_number)
 }
 
 fn reconcile_canonical_import(
@@ -1491,12 +1504,13 @@ impl DecodedTempoImport {
 
     /// Tempo anchor whose leader must produce this Zone block.
     ///
-    /// The first imported header selects the leader even if later headers cross a handoff.
-    fn leader_anchor(&self) -> u64 {
-        self.headers()
-            .first()
-            .expect("decoded nonempty Tempo import")
-            .number()
+    /// Checkpoint-only blocks have no designated leader. A full block imports exactly one Tempo
+    /// header, whose effective leader supplies its production authority.
+    fn leader_anchor(&self) -> Option<u64> {
+        match self {
+            Self::Full { header, .. } => Some(header.number()),
+            Self::CheckpointOnly { .. } => None,
+        }
     }
 }
 
@@ -1980,7 +1994,7 @@ mod tests {
     }
 
     #[test]
-    fn checkpoint_live_producer_uses_first_header_leader() {
+    fn checkpoint_live_producer_is_not_leader_restricted() {
         use commonware_cryptography::{Signer as _, ed25519::PrivateKey};
         use reth_primitives_traits::SealedHeader;
         use tempo_primitives::TempoHeader;
@@ -2006,11 +2020,9 @@ mod tests {
         let tempo_import = super::DecodedTempoImport::CheckpointOnly { headers };
 
         let leader_anchor = tempo_import.leader_anchor();
-        assert_eq!(leader_anchor, 90);
-        super::validate_live_block_sender(&schedule, Some(&outgoing), leader_anchor, 7).unwrap();
-        let error = super::validate_live_block_sender(&schedule, Some(&incoming), leader_anchor, 7)
-            .expect_err("a crossed handoff must not change the catch-up producer");
-        assert!(error.to_string().contains(&outgoing.to_string()));
+        assert_eq!(leader_anchor, None);
+        super::validate_live_import_sender(&schedule, Some(&outgoing), leader_anchor, 7).unwrap();
+        super::validate_live_import_sender(&schedule, Some(&incoming), leader_anchor, 7).unwrap();
 
         let full_import = super::DecodedTempoImport::Full {
             header: Box::new(SealedHeader::seal_slow(TempoHeader {
@@ -2024,10 +2036,11 @@ mod tests {
             enabled_tokens: Vec::new(),
         };
         let leader_anchor = full_import.leader_anchor();
-        assert_eq!(leader_anchor, 110);
-        super::validate_live_block_sender(&schedule, Some(&incoming), leader_anchor, 8).unwrap();
-        let error = super::validate_live_block_sender(&schedule, Some(&outgoing), leader_anchor, 8)
-            .expect_err("the final full block must be produced by its effective leader");
+        assert_eq!(leader_anchor, Some(110));
+        super::validate_live_import_sender(&schedule, Some(&incoming), leader_anchor, 8).unwrap();
+        let error =
+            super::validate_live_import_sender(&schedule, Some(&outgoing), leader_anchor, 8)
+                .expect_err("the final full block must be produced by its effective leader");
         assert!(error.to_string().contains(&incoming.to_string()));
     }
 

--- a/crates/spf/src/lib.rs
+++ b/crates/spf/src/lib.rs
@@ -430,9 +430,11 @@ fn validate_tempo_anchor(
 }
 
 fn validate_batch_block_shape(block: &ZoneBlock, is_last: bool) -> Result<(), Error> {
-    let valid = match &block.tempo_import {
-        TempoImport::CheckpointOnly { .. } => !is_last,
-        TempoImport::Full { .. } => is_last && block.finalize_withdrawal_batch_count.is_some(),
+    let valid = match (&block.tempo_import, is_last) {
+        (TempoImport::CheckpointOnly { .. }, false) => true,
+        (TempoImport::Full { .. }, false) => block.finalize_withdrawal_batch_count.is_none(),
+        (TempoImport::Full { .. }, true) => block.finalize_withdrawal_batch_count.is_some(),
+        (TempoImport::CheckpointOnly { .. }, true) => false,
     };
     if !valid {
         return Err(Error::InvalidBatchShape);
@@ -515,8 +517,8 @@ pub enum Error {
     /// A full block exceeded a protocol-wide outstanding portal-work bound.
     #[error("zone block {block_index} exceeds portal-work capacity")]
     PortalWorkCapacityExceeded { block_index: usize },
-    /// A batch must contain exactly one full operational block at the end, optionally preceded
-    /// by checkpoint-only blocks.
+    /// A batch must end in a full operational block that finalizes withdrawals. Intermediate
+    /// blocks may use either Tempo import variant, but must not finalize withdrawals.
     #[error("invalid batch shape")]
     InvalidBatchShape,
     /// The witness identifies a Zone other than the verifier-selected chain specification.
@@ -831,7 +833,7 @@ mod tests {
     }
 
     #[test]
-    fn batch_shape_rejects_multiple_full_blocks() {
+    fn batch_shape_rejects_intermediate_finalization() {
         let mut witness = minimal_batch_witness();
         for number in 1..=2 {
             witness.zone_blocks.push(ZoneBlock {
@@ -851,6 +853,24 @@ mod tests {
             validate_batch_block_shape(&witness.zone_blocks[0], false),
             Err(Error::InvalidBatchShape)
         );
+    }
+
+    #[test]
+    fn batch_shape_accepts_intermediate_full_block_without_finalization() {
+        let block = ZoneBlock {
+            number: 1,
+            parent_hash: B256::ZERO,
+            timestamp: 100,
+            timestamp_millis_part: 0,
+            beneficiary: Address::ZERO,
+            tempo_import: full_import(Bytes::from([0x01])),
+            finalize_withdrawal_batch_count: None,
+            finalize_withdrawal_batch_encrypted_senders: Vec::new(),
+            transactions: Vec::new(),
+        };
+
+        validate_system_inputs(&block, 0).unwrap();
+        assert_eq!(validate_batch_block_shape(&block, false), Ok(()));
     }
 
     #[test]


### PR DESCRIPTION
Extends the Zone SPF and shadow prover to validate T12 batches containing checkpoint-only blocks.

- Proves consecutive checkpoint-only Tempo header ranges.
- Enforces portal-work capacity across the batch.
- Requires the T12 portion of a batch to end with exactly one full operational block and withdrawal-finalization boundary.