### PR TITLE
tests(node): avoid withdrawal balance race in tests

### DIFF
--- a/crates/node/tests/it/demo_asset_swap.rs
+++ b/crates/node/tests/it/demo_asset_swap.rs
@@ -108,12 +108,14 @@ async fn test_multiasset_deposit_and_withdraw() -> eyre::Result<()> {
 
     // Withdraw AlphaUSD
     let alpha_withdrawal: u128 = 500_000; // 0.5 AlphaUSD
+    let alpha_balance_before = l1.balance_of(l1_alpha, account.address()).await?;
     account.withdraw_token(l2_alpha, alpha_withdrawal).await?;
 
     l1.wait_for_withdrawal_on_l1_token(
         portal_address,
         l1_alpha,
         account.address(),
+        alpha_balance_before,
         alpha_withdrawal,
         withdrawal_timeout,
     )
@@ -121,12 +123,14 @@ async fn test_multiasset_deposit_and_withdraw() -> eyre::Result<()> {
 
     // Withdraw BetaUSD
     let beta_withdrawal: u128 = 1_000_000; // 1 BetaUSD
+    let beta_balance_before = l1.balance_of(l1_beta, account.address()).await?;
     account.withdraw_token(l2_beta, beta_withdrawal).await?;
 
     l1.wait_for_withdrawal_on_l1_token(
         portal_address,
         l1_beta,
         account.address(),
+        beta_balance_before,
         beta_withdrawal,
         withdrawal_timeout,
     )

--- a/crates/node/tests/it/enable_token.rs
+++ b/crates/node/tests/it/enable_token.rs
@@ -301,6 +301,7 @@ async fn test_enable_token_via_real_l1() -> eyre::Result<()> {
     let withdrawal_timeout = std::time::Duration::from_secs(60);
 
     let alpha_withdrawal: u128 = 1_000_000; // 1 AlphaUSD
+    let alpha_balance_before = l1.balance_of(l1_alpha_usd, account.address()).await?;
     account
         .withdraw_token(l2_alpha_usd, alpha_withdrawal)
         .await?;
@@ -310,6 +311,7 @@ async fn test_enable_token_via_real_l1() -> eyre::Result<()> {
         portal_address,
         l1_alpha_usd,
         account.address(),
+        alpha_balance_before,
         alpha_withdrawal,
         withdrawal_timeout,
     )

--- a/crates/node/tests/it/l1_e2e.rs
+++ b/crates/node/tests/it/l1_e2e.rs
@@ -570,6 +570,7 @@ async fn test_deposit_via_real_l1() -> eyre::Result<()> {
 
     // Request withdrawal on L2
     let withdrawal_amount: u128 = 500_000; // 0.5 pathUSD
+    let l1_balance_before = l1.balance_of(PATH_USD_ADDRESS, account.address()).await?;
     account.withdraw(withdrawal_amount).await?;
 
     // Wait for the withdrawal to be fully processed on L1
@@ -577,6 +578,7 @@ async fn test_deposit_via_real_l1() -> eyre::Result<()> {
     l1.wait_for_withdrawal_on_l1(
         portal_address,
         account.address(),
+        l1_balance_before,
         withdrawal_amount,
         withdrawal_timeout,
     )
@@ -854,10 +856,14 @@ async fn test_open_mode_unlisted_account_roundtrip() -> eyre::Result<()> {
     let arbitrary_l1_recipient = l1.signer_at(5).address();
     let mut withdrawal = WithdrawalArgs::new(withdrawal_amount);
     withdrawal.to = Some(arbitrary_l1_recipient);
+    let l1_balance_before = l1
+        .balance_of(PATH_USD_ADDRESS, arbitrary_l1_recipient)
+        .await?;
     account.withdraw_with(withdrawal).await?;
     l1.wait_for_withdrawal_on_l1(
         portal_address,
         arbitrary_l1_recipient,
+        l1_balance_before,
         withdrawal_amount,
         Duration::from_secs(60),
     )
@@ -1972,11 +1978,13 @@ async fn test_multiasset_deposit_withdrawal() -> eyre::Result<()> {
 
     // Withdraw pathUSD
     let pathusd_withdrawal: u128 = 500_000; // 0.5 pathUSD
+    let pathusd_balance_before = l1.balance_of(PATH_USD_ADDRESS, account.address()).await?;
     account.withdraw(pathusd_withdrawal).await?;
 
     l1.wait_for_withdrawal_on_l1(
         portal_address,
         account.address(),
+        pathusd_balance_before,
         pathusd_withdrawal,
         withdrawal_timeout,
     )
@@ -1984,6 +1992,7 @@ async fn test_multiasset_deposit_withdrawal() -> eyre::Result<()> {
 
     // Withdraw ZoneUSD
     let zoneusd_withdrawal: u128 = 1_000_000; // 1 ZoneUSD
+    let zoneusd_balance_before = l1.balance_of(l1_zone_usd, account.address()).await?;
     account
         .withdraw_token(l2_zone_usd, zoneusd_withdrawal)
         .await?;
@@ -1992,6 +2001,7 @@ async fn test_multiasset_deposit_withdrawal() -> eyre::Result<()> {
         portal_address,
         l1_zone_usd,
         account.address(),
+        zoneusd_balance_before,
         zoneusd_withdrawal,
         withdrawal_timeout,
     )
@@ -2091,6 +2101,7 @@ async fn test_deposit_and_withdrawal() -> eyre::Result<()> {
         ZoneAccount::with_signer(recipient_signer, &l1, &zone, portal_address);
 
     let withdrawal_amount: u128 = 500_000; // 0.5 pathUSD
+    let l1_balance_before = l1.balance_of(PATH_USD_ADDRESS, recipient).await?;
     recipient_account.withdraw(withdrawal_amount).await?;
 
     // --- Step 6: Wait for the withdrawal to be fully processed on L1 ---
@@ -2098,6 +2109,7 @@ async fn test_deposit_and_withdrawal() -> eyre::Result<()> {
     l1.wait_for_withdrawal_on_l1(
         portal_address,
         recipient,
+        l1_balance_before,
         withdrawal_amount,
         withdrawal_timeout,
     )

--- a/crates/node/tests/it/restart_e2e.rs
+++ b/crates/node/tests/it/restart_e2e.rs
@@ -9,6 +9,7 @@
 
 use crate::utils::{L1TestNode, ZoneAccount, ZoneTestNode, spawn_sequencer};
 use alloy::primitives::{Address, U256};
+use tempo_precompiles::PATH_USD_ADDRESS;
 use tempo_zone_contracts::{IZoneOutbox, ZONE_OUTBOX_ADDRESS, ZONE_TOKEN_ADDRESS, ZonePortal};
 
 /// Longer timeout for real L1 tests.
@@ -104,10 +105,12 @@ async fn test_sequencer_restart_resumes_batch_submission() -> eyre::Result<()> {
     let seq_handle = spawn_sequencer(&l1, &zone, portal_address, l1.dev_signer()).await;
 
     let first_withdrawal: u128 = 500_000;
+    let l1_balance_before = l1.balance_of(PATH_USD_ADDRESS, account.address()).await?;
     account.withdraw(first_withdrawal).await?;
     l1.wait_for_withdrawal_on_l1(
         portal_address,
         account.address(),
+        l1_balance_before,
         first_withdrawal,
         WITHDRAWAL_TIMEOUT,
     )
@@ -135,10 +138,12 @@ async fn test_sequencer_restart_resumes_batch_submission() -> eyre::Result<()> {
 
     // --- Phase 3: Second withdrawal after restart ---
     let second_withdrawal: u128 = 300_000;
+    let l1_balance_before = l1.balance_of(PATH_USD_ADDRESS, account.address()).await?;
     account.withdraw(second_withdrawal).await?;
     l1.wait_for_withdrawal_on_l1(
         portal_address,
         account.address(),
+        l1_balance_before,
         second_withdrawal,
         WITHDRAWAL_TIMEOUT,
     )
@@ -255,10 +260,12 @@ async fn test_sequencer_restart_with_pending_withdrawal_queue() -> eyre::Result<
 
     // Request a NEW withdrawal after restart to verify normal operation continues.
     let second_withdrawal: u128 = 400_000;
+    let l1_balance_before = l1.balance_of(PATH_USD_ADDRESS, account.address()).await?;
     account.withdraw(second_withdrawal).await?;
     l1.wait_for_withdrawal_on_l1(
         portal_address,
         account.address(),
+        l1_balance_before,
         second_withdrawal,
         WITHDRAWAL_TIMEOUT,
     )
@@ -299,10 +306,12 @@ async fn test_double_sequencer_restart() -> eyre::Result<()> {
     // --- Cycle 1 ---
     let seq1 = spawn_sequencer(&l1, &zone, portal_address, l1.dev_signer()).await;
 
+    let l1_balance_before = l1.balance_of(PATH_USD_ADDRESS, account.address()).await?;
     account.withdraw(200_000).await?;
     l1.wait_for_withdrawal_on_l1(
         portal_address,
         account.address(),
+        l1_balance_before,
         200_000,
         WITHDRAWAL_TIMEOUT,
     )
@@ -315,10 +324,12 @@ async fn test_double_sequencer_restart() -> eyre::Result<()> {
     // --- Cycle 2 ---
     let seq2 = spawn_sequencer(&l1, &zone, portal_address, l1.dev_signer()).await;
 
+    let l1_balance_before = l1.balance_of(PATH_USD_ADDRESS, account.address()).await?;
     account.withdraw(300_000).await?;
     l1.wait_for_withdrawal_on_l1(
         portal_address,
         account.address(),
+        l1_balance_before,
         300_000,
         WITHDRAWAL_TIMEOUT,
     )
@@ -331,10 +342,12 @@ async fn test_double_sequencer_restart() -> eyre::Result<()> {
     // --- Cycle 3 (final) ---
     let _seq3 = spawn_sequencer(&l1, &zone, portal_address, l1.dev_signer()).await;
 
+    let l1_balance_before = l1.balance_of(PATH_USD_ADDRESS, account.address()).await?;
     account.withdraw(400_000).await?;
     l1.wait_for_withdrawal_on_l1(
         portal_address,
         account.address(),
+        l1_balance_before,
         400_000,
         WITHDRAWAL_TIMEOUT,
     )
@@ -455,6 +468,7 @@ async fn test_finalized_withdrawal_survives_sequencer_restart() -> eyre::Result<
     let seq_handle = spawn_sequencer(&l1, &zone, portal_address, l1.dev_signer()).await;
 
     let withdrawal_amount: u128 = 500_000;
+    let l1_balance_before = l1.balance_of(PATH_USD_ADDRESS, account.address()).await?;
     account.withdraw(withdrawal_amount).await?;
     let withdrawal_block =
         wait_for_withdrawal_requested(&zone, account.address(), withdrawal_amount).await?;
@@ -481,6 +495,7 @@ async fn test_finalized_withdrawal_survives_sequencer_restart() -> eyre::Result<
     l1.wait_for_withdrawal_on_l1(
         portal_address,
         account.address(),
+        l1_balance_before,
         withdrawal_amount,
         WITHDRAWAL_TIMEOUT,
     )

--- a/crates/node/tests/it/utils.rs
+++ b/crates/node/tests/it/utils.rs
@@ -1846,12 +1846,13 @@ impl L1TestNode {
     /// Wait for a withdrawal to be fully processed on L1 (pathUSD).
     ///
     /// Polls the account's L1 token balance until it increases by at least
-    /// `amount`, then asserts both `BatchSubmitted` and `WithdrawalProcessed`
-    /// events exist on the portal.
+    /// `amount` from the caller-provided pre-withdrawal balance, then asserts
+    /// both `BatchSubmitted` and `WithdrawalProcessed` events exist on the portal.
     pub(crate) async fn wait_for_withdrawal_on_l1(
         &self,
         portal_address: Address,
         account: Address,
+        balance_before: U256,
         amount: u128,
         timeout: Duration,
     ) -> eyre::Result<()> {
@@ -1860,6 +1861,7 @@ impl L1TestNode {
             portal_address,
             PATH_USD_ADDRESS,
             account,
+            balance_before,
             amount,
             timeout,
         )
@@ -1867,15 +1869,17 @@ impl L1TestNode {
     }
 
     /// Wait for a withdrawal of a specific token to be fully processed on L1.
+    ///
+    /// `balance_before` must be captured before submitting the withdrawal request.
     pub(crate) async fn wait_for_withdrawal_on_l1_token(
         &self,
         portal_address: Address,
         token: Address,
         account: Address,
+        balance_before: U256,
         amount: u128,
         timeout: Duration,
     ) -> eyre::Result<()> {
-        let balance_before = self.balance_of(token, account).await?;
         let expected = balance_before + U256::from(amount);
         self.wait_for_balance(token, account, expected, timeout)
             .await?;


### PR DESCRIPTION
## Summary

- require callers to pass a balance captured before submitting a withdrawal
- update all 15 withdrawal wait call sites across restart and L1 integration tests
- prevent fast L1 processing from making tests wait for a nonexistent second credit

## Testing

- `cargo +nightly fmt --all -- --check`
- `cargo check -p zone-node --tests`
- `cargo +nightly clippy -p zone-node --tests --no-deps`

Prompted by: aditya