### PR TITLE
docs(contracts): correct finalizeTempo timestamp semantics

### DIFF
--- a/crates/contracts/src/runtime/interfaces/IZone.sol
+++ b/crates/contracts/src/runtime/interfaces/IZone.sol
@@ -990,7 +990,7 @@ interface ITempoState {
     function tempoBlockNumber() external view returns (uint64);
 
     /// @notice Finalize a Tempo block header. Only callable by ZoneInbox.
-    /// @dev Validates chain continuity and exact timestamp alignment with the Zone block.
+    /// @dev Validates chain continuity and requires the Zone block timestamp to be at or after the Tempo timestamp.
     ///      Called by ZoneInbox.advanceTempo(). Executor enforces ZoneInbox-only access.
     /// @param header RLP-encoded Tempo header
     function finalizeTempo(bytes calldata header) external;


### PR DESCRIPTION
## Summary

- Correct the `finalizeTempo` interface documentation to match the implementation
- Clarify that Tempo timestamps must not exceed the executing Zone block timestamp

## Testing

- `git diff --check`

Prompted by: @shekhirin