### PR TITLE
ci: use GitHub STS for sync-from-upstream instead of app credentials

### DIFF
--- a/.github/sts/sync-from-upstream.sts.yaml
+++ b/.github/sts/sync-from-upstream.sts.yaml
@@ -1,0 +1,13 @@
+# Allow the sync-from-upstream workflow in zones-private-fork (scheduled and
+# manually dispatched runs on main) to mint a short-lived token to force-push
+# main. `workflows: write` is required because the synced commits touch
+# .github/workflows files.
+#
+# This file is mirrored into zones-private-fork by the sync itself, where it
+# authorizes tokens scoped to the fork. Note that its presence in this repo
+# also lets the fork's main-branch workflows mint a token scoped to
+# tempoxyz/zones, since a fork of this repo carries identical contents.
+subject: repo:tempoxyz@211589300/zones-private-fork@1329742643:ref:refs/heads/main
+permissions:
+  contents: write
+  workflows: write

--- a/.github/workflows/sync-from-upstream.yml
+++ b/.github/workflows/sync-from-upstream.yml
@@ -14,25 +14,24 @@ jobs:
   sync:
     if: ${{ github.repository != 'tempoxyz/zones' }}
     runs-on: ubuntu-latest
+    permissions:
+      id-token: write
     steps:
-      - name: Generate GitHub App token
-        id: app-token
-        uses: actions/create-github-app-token@1b10c78c7865c340bc4f6099eb2f838309f1e8c3 # v3.1.1
+      - name: Fetch GitHub token via STS
+        id: github-sts
+        uses: tempoxyz/gh-actions/actions/github-sts@dd1014bf8244fded7a501e701cafab240a4f9f0e # main
         with:
-          client-id: ${{ vars.SYNC_APP_ID }}
-          private-key: ${{ secrets.SYNC_APP_PRIVATE_KEY }}
-          permission-contents: write
-          permission-workflows: write
+          policy: sync-from-upstream
 
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
-          token: ${{ steps.app-token.outputs.token }}
+          token: ${{ steps.github-sts.outputs.token }}
           fetch-depth: 0
           persist-credentials: false
 
       - name: Sync main with upstream
         env:
-          APP_TOKEN: ${{ steps.app-token.outputs.token }}
+          APP_TOKEN: ${{ steps.github-sts.outputs.token }}
         run: |
           git remote add upstream https://github.com/tempoxyz/zones.git
           git fetch upstream main


### PR DESCRIPTION
## Summary

Same change as tempoxyz/tempo#7277, for zones: replaces the "Tempo Private Fork Syncer" GitHub App (app ID 2942696, `vars.SYNC_APP_ID` / `secrets.SYNC_APP_PRIVATE_KEY`) with a [github-sts](https://github.com/tempoxyz/gh-actions/tree/main/actions/github-sts) token exchange in the `sync-from-upstream` workflow.

- **`.github/workflows/sync-from-upstream.yml`** — drops the `create-github-app-token` step and stored credentials; the job now grants `id-token: write` and exchanges its OIDC token via STS (policy `sync-from-upstream`, default scope = the repo the workflow runs in, i.e. `zones-private-fork`). Same github-sts pin the other zones workflows use.
- **`.github/sts/sync-from-upstream.sts.yaml`** — trust policy granting `contents: write` and `workflows: write` to workflows running on `zones-private-fork`'s `main` branch. `workflows: write` is required because force-pushing upstream `main` includes changes to `.github/workflows` files. The policy reaches the fork via the sync itself, so the first sync after this lands still runs with the old app credentials and bootstraps the STS version.