### PR TITLE
refactor(checker): streamline startup and retries

### DIFF
--- a/crates/checker/README.md
+++ b/crates/checker/README.md
@@ -96,15 +96,22 @@ height.
 ## Failure behavior
 
 Temporary Tempo RPC or local-state acquisition failures retry without advancing
-or acknowledging the block. A deterministic mismatch records one durable
-finding, freezes the verified tip, and continues acknowledging subsequent
-notifications while recording how far the unchecked range extends. A finding
-remains active until the checker is rebuilt from authenticated genesis.
+or acknowledging the block. Each retry budget is bounded. Tempo retries use
+exponential backoff, while unavailable local Zone state retries once per second.
+Pruned state disables immediately because it cannot recover.
 
-An unrecoverable checker-local error disables the checker and drains ExEx
-notifications so it cannot terminate or stall Zone execution. Observe mode
-never changes block execution or consensus behavior; operators must alert on
-lag or an active divergence.
+A deterministic mismatch records one durable finding, freezes the verified tip,
+and continues acknowledging subsequent notifications while recording how far the
+unchecked range extends. A finding remains active until the checker is rebuilt
+from authenticated genesis.
+
+An exhausted retry budget or an unrecoverable checker-local error disables the
+checker and drains ExEx notifications so it cannot terminate or stall Zone
+execution. Verification then stays disabled for the life of the process; since
+the checker runs as an ExEx inside the node, restarting the node attempts to
+resume from the last durably verified Zone block. Observe mode never changes
+block execution or consensus behavior; operators must alert on lag or an active
+divergence.
 
 The node's existing metrics endpoint exports:
 

--- a/crates/checker/src/bootstrap.rs
+++ b/crates/checker/src/bootstrap.rs
@@ -1,4 +1,4 @@
-//! Authenticates Zone genesis and discovers its Portal creation on Tempo.
+//! Authenticates Zone genesis and its Portal creation on Tempo.
 
 use alloy_consensus::BlockHeader as _;
 use alloy_eips::{BlockId, BlockNumHash};
@@ -63,7 +63,7 @@ impl Bootstrap {
 }
 
 /// Discover and authenticate the identity encoded by local Zone genesis.
-pub(crate) async fn build<P>(
+pub(crate) async fn discover<P>(
     provider: &P,
     l1: &DynProvider<TempoNetwork>,
     config: &CheckerConfig,
@@ -72,7 +72,72 @@ where
     P: BlockNumReader + ChainSpecProvider + StateProviderFactory + ?Sized,
     P::ChainSpec: TempoHardforks,
 {
-    let portal = config.portal_address;
+    let context = read_context(provider, l1, config).await?;
+    let creation = discover_creation(l1, config, context.tempo.number).await?;
+    finish_bootstrap(context, l1, config, creation, CreationSource::Discovery).await
+}
+
+/// Authenticate the creation coordinate retained by an existing database.
+pub(crate) async fn authenticate<P>(
+    provider: &P,
+    l1: &DynProvider<TempoNetwork>,
+    config: &CheckerConfig,
+    identity: persistence::Identity,
+) -> Result<Bootstrap, AttemptError>
+where
+    P: BlockNumReader + ChainSpecProvider + StateProviderFactory + ?Sized,
+    P::ChainSpec: TempoHardforks,
+{
+    let context = read_context(provider, l1, config).await?;
+    if context.identity(config, identity.creation) != identity {
+        return Err(AttemptError::disable(eyre::eyre!(
+            "checker database identity does not match the configured Zone"
+        )));
+    }
+    finish_bootstrap(
+        context,
+        l1,
+        config,
+        identity.creation,
+        CreationSource::Persistence,
+    )
+    .await
+}
+
+/// Local genesis fields authenticated independently from Portal creation.
+struct BootstrapContext {
+    l1_chain_id: u64,
+    zone: persistence::BlockRef,
+    tempo: BlockNumHash,
+    initial_token: Address,
+}
+
+impl BootstrapContext {
+    const fn identity(
+        &self,
+        config: &CheckerConfig,
+        creation: persistence::BlockRef,
+    ) -> persistence::Identity {
+        persistence::Identity {
+            l1_chain_id: self.l1_chain_id,
+            zone_chain_id: config.zone_chain_id,
+            zone_id: config.zone_id,
+            portal: config.portal_address,
+            creation,
+        }
+    }
+}
+
+/// Authenticate configured chain identity and read local Zone genesis.
+async fn read_context<P>(
+    provider: &P,
+    l1: &DynProvider<TempoNetwork>,
+    config: &CheckerConfig,
+) -> Result<BootstrapContext, AttemptError>
+where
+    P: BlockNumReader + ChainSpecProvider + StateProviderFactory + ?Sized,
+    P::ChainSpec: TempoHardforks,
+{
     let zone_id = config.zone_id;
     let zone_chain_id = config.zone_chain_id;
     if zone_id == 0 {
@@ -95,29 +160,42 @@ where
         .ok_or_else(|| AttemptError::disable(eyre::eyre!("local Zone genesis is unavailable")))?;
     let (tempo, initial_token) =
         read_genesis(provider, zone_hash).map_err(AttemptError::disable)?;
-    let creation = discover_creation(l1, config, initial_token, tempo.number).await?;
-    if !is_canonical(l1, creation, "Portal creation").await? {
-        return Err(AttemptError::retry(eyre::eyre!(
-            "Portal creation changed during bootstrap"
-        )));
-    }
-    if !is_canonical(l1, tempo, "Zone genesis anchor").await? {
+
+    Ok(BootstrapContext {
+        l1_chain_id,
+        zone: persistence::BlockRef::new(GENESIS_BLOCK, zone_hash),
+        tempo,
+        initial_token,
+    })
+}
+
+/// Source determining whether a changed creation coordinate can be rediscovered.
+#[derive(Clone, Copy)]
+enum CreationSource {
+    Discovery,
+    Persistence,
+}
+
+/// Authenticate creation and the genesis anchor, then assemble bootstrap state.
+async fn finish_bootstrap(
+    context: BootstrapContext,
+    l1: &DynProvider<TempoNetwork>,
+    config: &CheckerConfig,
+    creation: persistence::BlockRef,
+    source: CreationSource,
+) -> Result<Bootstrap, AttemptError> {
+    authenticate_creation(l1, creation, config, context.initial_token, source).await?;
+    if !is_canonical(l1, context.tempo, "Zone genesis anchor").await? {
         return Err(AttemptError::disable(eyre::eyre!(
             "Zone genesis Tempo anchor is not canonical"
         )));
     }
 
     Ok(Bootstrap {
-        identity: persistence::Identity {
-            l1_chain_id,
-            zone_chain_id,
-            zone_id,
-            portal,
-            creation: creation.into(),
-        },
-        zone: persistence::BlockRef::new(GENESIS_BLOCK, zone_hash),
-        tempo: persistence::BlockRef::from(tempo),
-        initial_token,
+        identity: context.identity(config, creation),
+        zone: context.zone,
+        tempo: persistence::BlockRef::from(context.tempo),
+        initial_token: context.initial_token,
     })
 }
 
@@ -155,13 +233,12 @@ where
     ))
 }
 
-/// Use the RPC log index for discovery, then authenticate the matching receipt.
+/// Discover the unique creation coordinate from the RPC log index.
 async fn discover_creation(
     provider: &DynProvider<TempoNetwork>,
     config: &CheckerConfig,
-    initial_token: Address,
     anchor_number: u64,
-) -> Result<BlockNumHash, AttemptError> {
+) -> Result<persistence::BlockRef, AttemptError> {
     let head = provider
         .get_block_number()
         .await
@@ -184,18 +261,24 @@ async fn discover_creation(
     for page in pages {
         for log in page {
             if !log.removed {
-                candidates.push(log.block_hash.ok_or_else(|| {
+                let number = log.block_number.ok_or_else(|| {
+                    AttemptError::disable(eyre::eyre!(
+                        "ZoneCreated discovery result has no block number"
+                    ))
+                })?;
+                let hash = log.block_hash.ok_or_else(|| {
                     AttemptError::disable(eyre::eyre!(
                         "ZoneCreated discovery result has no block hash"
                     ))
-                })?);
+                })?;
+                candidates.push(persistence::BlockRef::new(number, hash));
             }
         }
     }
     candidates.sort_unstable();
     candidates.dedup();
-    let hash = match candidates.as_slice() {
-        [hash] => *hash,
+    let creation = match candidates.as_slice() {
+        [creation] => *creation,
         [] => {
             return Err(AttemptError::retry(eyre::eyre!(
                 "creation block is not yet available for Zone {} and Portal {} after genesis anchor {}",
@@ -213,34 +296,51 @@ async fn discover_creation(
             )));
         }
     };
-    authenticate_creation(provider, hash, config, initial_token).await
+    Ok(creation)
 }
 
 /// Require one matching `ZoneCreated` event with authenticated receipt provenance.
 async fn authenticate_creation(
     provider: &DynProvider<TempoNetwork>,
-    hash: B256,
+    creation: persistence::BlockRef,
     config: &CheckerConfig,
     initial_token: Address,
-) -> Result<BlockNumHash, AttemptError> {
+    source: CreationSource,
+) -> Result<(), AttemptError> {
     let block = provider
-        .get_block_by_hash(hash)
+        .get_block_by_number(creation.number.into())
         .hashes()
         .await
         .map_err(classify_rpc_error)?
         .ok_or_else(|| {
-            AttemptError::retry(eyre::eyre!("Portal creation block {hash} is unavailable"))
+            AttemptError::retry(eyre::eyre!(
+                "Portal creation block {} is unavailable",
+                creation.number
+            ))
         })?;
-    let coordinate = BlockNumHash::new(block.header().number(), hash);
+    let coordinate = persistence::BlockRef::new(block.header().number(), block.header().hash);
+    if coordinate != creation {
+        let error = eyre::eyre!(
+            "Portal creation coordinate changed from block {} ({}) to block {} ({})",
+            creation.number,
+            creation.hash,
+            coordinate.number,
+            coordinate.hash
+        );
+        return Err(match source {
+            CreationSource::Discovery => AttemptError::retry(error),
+            CreationSource::Persistence => AttemptError::disable(error),
+        });
+    }
     let receipts = provider
-        .get_block_receipts(BlockId::hash(hash))
+        .get_block_receipts(BlockId::hash(creation.hash))
         .await
         .map_err(classify_rpc_error)?
         .ok_or_else(|| {
             AttemptError::retry(eyre::eyre!("Portal creation receipts are unavailable"))
         })?;
     zone_l1::verify_receipts_against_header(
-        coordinate,
+        coordinate.into(),
         block.header().receipts_root(),
         block.header().logs_bloom(),
         &receipts,
@@ -254,7 +354,7 @@ async fn authenticate_creation(
         .filter(|log| log.address() == ZONE_FACTORY_ADDRESS)
         .filter(|log| log.topic0() == Some(&ZoneFactory::ZoneCreated::SIGNATURE_HASH))
         .map(|log| {
-            decode_event::<ZoneFactory::ZoneCreated>(&log.inner, "ZoneCreated", coordinate.number)
+            decode_event::<ZoneFactory::ZoneCreated>(&log.inner, "ZoneCreated", creation.number)
         })
         .collect::<eyre::Result<Vec<_>>>()
         .map_err(AttemptError::disable)?
@@ -275,7 +375,7 @@ async fn authenticate_creation(
             "Portal initial token does not match Zone genesis"
         )));
     }
-    Ok(coordinate)
+    Ok(())
 }
 
 async fn is_canonical(

--- a/crates/checker/src/bootstrap.rs
+++ b/crates/checker/src/bootstrap.rs
@@ -7,6 +7,7 @@ use alloy_primitives::{Address, B256, U256};
 use alloy_provider::{DynProvider, Provider as _};
 use alloy_rpc_types_eth::Filter;
 use alloy_sol_types::SolEvent as _;
+use futures::{StreamExt as _, TryStreamExt as _, stream};
 use reth_chainspec::{ChainSpecProvider, EthChainSpec};
 use reth_storage_api::{BlockNumReader, StateProviderFactory};
 use tempo_alloy::TempoNetwork;
@@ -24,13 +25,49 @@ use crate::{
 
 const GENESIS_BLOCK: u64 = 0;
 const LOG_QUERY_BLOCKS: u64 = 10_000;
+const LOG_QUERY_CONCURRENCY: usize = 8;
 
-/// Discover and authenticate the checkpoint encoded by local Zone genesis.
+/// Authenticated Zone genesis and Portal identity, without replayed accounting state.
+pub(crate) struct Bootstrap {
+    identity: persistence::Identity,
+    zone: persistence::BlockRef,
+    tempo: persistence::BlockRef,
+    initial_token: Address,
+}
+
+impl Bootstrap {
+    pub(crate) const fn identity(&self) -> persistence::Identity {
+        self.identity
+    }
+
+    pub(crate) const fn zone(&self) -> persistence::BlockRef {
+        self.zone
+    }
+
+    /// Replay the authenticated pre-genesis history only when a database must be created or reset.
+    pub(crate) async fn checkpoint(
+        &self,
+        provider: &DynProvider<TempoNetwork>,
+        config: &CheckerConfig,
+    ) -> Result<Checkpoint, AttemptError> {
+        let creation = BlockNumHash::from(self.identity.creation);
+        let tempo = BlockNumHash::from(self.tempo);
+        let state = initial_state(provider, config, creation, tempo, self.initial_token).await?;
+        Ok(Checkpoint {
+            identity: self.identity,
+            zone: self.zone,
+            tempo: self.tempo,
+            state,
+        })
+    }
+}
+
+/// Discover and authenticate the identity encoded by local Zone genesis.
 pub(crate) async fn build<P>(
     provider: &P,
     l1: &DynProvider<TempoNetwork>,
     config: &CheckerConfig,
-) -> Result<Checkpoint, AttemptError>
+) -> Result<Bootstrap, AttemptError>
 where
     P: BlockNumReader + ChainSpecProvider + StateProviderFactory + ?Sized,
     P::ChainSpec: TempoHardforks,
@@ -70,8 +107,7 @@ where
         )));
     }
 
-    let state = initial_state(l1, config, creation, tempo, initial_token).await?;
-    Ok(Checkpoint {
+    Ok(Bootstrap {
         identity: persistence::Identity {
             l1_chain_id,
             zone_chain_id,
@@ -81,7 +117,7 @@ where
         },
         zone: persistence::BlockRef::new(GENESIS_BLOCK, zone_hash),
         tempo: persistence::BlockRef::from(tempo),
-        state,
+        initial_token,
     })
 }
 
@@ -130,22 +166,23 @@ async fn discover_creation(
         .get_block_number()
         .await
         .map_err(classify_rpc_error)?;
-    let mut candidates = Vec::new();
-    let mut start = 0;
-    while start <= head {
-        let end = start.saturating_add(LOG_QUERY_BLOCKS - 1).min(head);
-        let filter = Filter::new()
+    let filters = (0..=head).step_by(LOG_QUERY_BLOCKS as usize).map(|start| {
+        Filter::new()
             .address(ZONE_FACTORY_ADDRESS)
             .event_signature(ZoneFactory::ZoneCreated::SIGNATURE_HASH)
             .topic1(B256::from(U256::from(config.zone_id)))
             .topic2(config.portal_address.into_word())
             .from_block(start)
-            .to_block(end);
-        for log in provider
-            .get_logs(&filter)
-            .await
-            .map_err(classify_rpc_error)?
-        {
+            .to_block(start.saturating_add(LOG_QUERY_BLOCKS - 1).min(head))
+    });
+    let pages = stream::iter(filters)
+        .map(|filter| async move { provider.get_logs(&filter).await.map_err(classify_rpc_error) })
+        .buffer_unordered(LOG_QUERY_CONCURRENCY)
+        .try_collect::<Vec<_>>()
+        .await?;
+    let mut candidates = Vec::new();
+    for page in pages {
+        for log in page {
             if !log.removed {
                 candidates.push(log.block_hash.ok_or_else(|| {
                     AttemptError::disable(eyre::eyre!(
@@ -154,10 +191,6 @@ async fn discover_creation(
                 })?);
             }
         }
-        start = match end.checked_add(1) {
-            Some(next) => next,
-            None => break,
-        };
     }
     candidates.sort_unstable();
     candidates.dedup();

--- a/crates/checker/src/bootstrap.rs
+++ b/crates/checker/src/bootstrap.rs
@@ -1,5 +1,7 @@
 //! Authenticates Zone genesis and its Portal creation on Tempo.
 
+use std::collections::BTreeSet;
+
 use alloy_consensus::BlockHeader as _;
 use alloy_eips::{BlockId, BlockNumHash};
 use alloy_network::{BlockResponse as _, ReceiptResponse as _};
@@ -7,7 +9,7 @@ use alloy_primitives::{Address, B256, U256};
 use alloy_provider::{DynProvider, Provider as _};
 use alloy_rpc_types_eth::Filter;
 use alloy_sol_types::SolEvent as _;
-use futures::{StreamExt as _, TryStreamExt as _, stream};
+use futures::{StreamExt as _, stream};
 use reth_chainspec::{ChainSpecProvider, EthChainSpec};
 use reth_storage_api::{BlockNumReader, StateProviderFactory};
 use tempo_alloy::TempoNetwork;
@@ -252,13 +254,12 @@ async fn discover_creation(
             .from_block(start)
             .to_block(start.saturating_add(LOG_QUERY_BLOCKS - 1).min(head))
     });
-    let pages = stream::iter(filters)
+    let mut pages = stream::iter(filters)
         .map(|filter| async move { provider.get_logs(&filter).await.map_err(classify_rpc_error) })
-        .buffer_unordered(LOG_QUERY_CONCURRENCY)
-        .try_collect::<Vec<_>>()
-        .await?;
-    let mut candidates = Vec::new();
-    for page in pages {
+        .buffer_unordered(LOG_QUERY_CONCURRENCY);
+    let mut candidates = BTreeSet::new();
+    while let Some(page) = pages.next().await {
+        let page = page?;
         for log in page {
             if !log.removed {
                 let number = log.block_number.ok_or_else(|| {
@@ -271,32 +272,30 @@ async fn discover_creation(
                         "ZoneCreated discovery result has no block hash"
                     ))
                 })?;
-                candidates.push(persistence::BlockRef::new(number, hash));
+                candidates.insert(persistence::BlockRef::new(number, hash));
             }
         }
     }
-    candidates.sort_unstable();
-    candidates.dedup();
-    let creation = match candidates.as_slice() {
-        [creation] => *creation,
-        [] => {
-            return Err(AttemptError::retry(eyre::eyre!(
-                "creation block is not yet available for Zone {} and Portal {} after genesis anchor {}",
-                config.zone_id,
-                config.portal_address,
-                anchor_number,
-            )));
-        }
-        _ => {
-            return Err(AttemptError::disable(eyre::eyre!(
-                "expected one creation block for Zone {} and Portal {}, found {}",
-                config.zone_id,
-                config.portal_address,
-                candidates.len()
-            )));
-        }
-    };
-    Ok(creation)
+    if candidates.is_empty() {
+        return Err(AttemptError::retry(eyre::eyre!(
+            "creation block is not yet available for Zone {} and Portal {} after genesis anchor {}",
+            config.zone_id,
+            config.portal_address,
+            anchor_number,
+        )));
+    }
+    if candidates.len() != 1 {
+        return Err(AttemptError::disable(eyre::eyre!(
+            "expected one creation block for Zone {} and Portal {}, found {}",
+            config.zone_id,
+            config.portal_address,
+            candidates.len()
+        )));
+    }
+    Ok(candidates
+        .into_iter()
+        .next()
+        .expect("one creation coordinate was found"))
 }
 
 /// Require one matching `ZoneCreated` event with authenticated receipt provenance.

--- a/crates/checker/src/l1/events.rs
+++ b/crates/checker/src/l1/events.rs
@@ -47,12 +47,6 @@ pub(crate) enum L1PortalEvent {
     },
 }
 
-/// Ordered recognized Portal events for one L1 block.
-#[derive(Debug)]
-pub(super) struct L1Events {
-    pub(super) events: Vec<L1PortalEvent>,
-}
-
 /// Builds ordered event evidence while receipts are visited once.
 #[derive(Default)]
 pub(super) struct EventCollector {
@@ -99,10 +93,8 @@ impl EventCollector {
         Ok(())
     }
 
-    pub(super) fn finish(self) -> L1Events {
-        L1Events {
-            events: self.events,
-        }
+    pub(super) fn finish(self) -> Vec<L1PortalEvent> {
+        self.events
     }
 }
 
@@ -135,8 +127,7 @@ fn decode_portal_event(log: &Log, block: u64) -> eyre::Result<Option<L1PortalEve
             L1PortalEvent::TokenEnabled { token: e.token }
         }
         ZonePortal::BatchSubmitted::SIGNATURE_HASH => {
-            decode_event::<ZonePortal::BatchSubmitted>(log, "BatchSubmitted", block)?;
-            return Ok(None);
+            ignored!(ZonePortal::BatchSubmitted, "BatchSubmitted")
         }
         ZonePortal::WithdrawalProcessed::SIGNATURE_HASH => {
             let e =
@@ -378,7 +369,7 @@ mod tests {
         .encode_log_data())
     }
 
-    fn collect(receipts: &[TempoTransactionReceipt]) -> eyre::Result<L1Events> {
+    fn collect(receipts: &[TempoTransactionReceipt]) -> eyre::Result<Vec<L1PortalEvent>> {
         let mut collector = EventCollector::new(PORTAL);
         for receipt in receipts {
             collector.extract_receipt(receipt, BLOCK)?;
@@ -403,36 +394,30 @@ mod tests {
             ],
         )])
         .unwrap();
-        assert_eq!(events.events.len(), 7);
+        assert_eq!(events.len(), 7);
         assert!(matches!(
-            events.events[0],
+            events[0],
             L1PortalEvent::DepositMade {
                 deposit_number: 7,
                 ..
             }
         ));
+        assert!(matches!(events[1], L1PortalEvent::TokenEnabled { .. }));
         assert!(matches!(
-            events.events[1],
-            L1PortalEvent::TokenEnabled { .. }
-        ));
-        assert!(matches!(
-            events.events[2],
+            events[2],
             L1PortalEvent::WithdrawalProcessed { .. }
         ));
         assert!(matches!(
-            events.events[3],
+            events[3],
             L1PortalEvent::WithdrawalBounceBack { .. }
         ));
+        assert!(matches!(events[4], L1PortalEvent::DepositBounceBack { .. }));
         assert!(matches!(
-            events.events[4],
-            L1PortalEvent::DepositBounceBack { .. }
-        ));
-        assert!(matches!(
-            events.events[5],
+            events[5],
             L1PortalEvent::DepositBounceBackPending { .. }
         ));
         assert!(matches!(
-            events.events[6],
+            events[6],
             L1PortalEvent::RefundClaimed { amount: 42, .. }
         ));
     }
@@ -451,7 +436,7 @@ mod tests {
             receipt(false, B256::ZERO, vec![deposit()]),
         ])
         .unwrap();
-        assert!(events.events.is_empty());
+        assert!(events.is_empty());
     }
 
     #[test]
@@ -507,17 +492,14 @@ mod tests {
         }
         let events = collector.finish();
 
-        assert_eq!(events.events.len(), 3);
+        assert_eq!(events.len(), 3);
+        assert!(matches!(events[0], L1PortalEvent::DepositMade { .. }));
         assert!(matches!(
-            events.events[0],
-            L1PortalEvent::DepositMade { .. }
-        ));
-        assert!(matches!(
-            events.events[1],
+            events[1],
             L1PortalEvent::WithdrawalProcessed { .. }
         ));
         assert!(matches!(
-            events.events[2],
+            events[2],
             L1PortalEvent::TokenEnabled { token } if token == Address::repeat_byte(5)
         ));
     }

--- a/crates/checker/src/l1/mod.rs
+++ b/crates/checker/src/l1/mod.rs
@@ -15,8 +15,8 @@ use zone_l1::L1BlockTracker;
 
 use crate::AttemptError;
 
+use events::EventCollector;
 pub(crate) use events::L1PortalEvent;
-use events::{EventCollector, L1Events};
 
 /// Bound on concurrent Portal balance reads for one token set.
 const BALANCE_CONCURRENCY: usize = 8;
@@ -54,7 +54,7 @@ impl From<L1ReadError> for AttemptError {
 #[derive(Debug)]
 pub(crate) struct L1BlockEvidence {
     block: BlockNumHash,
-    events: L1Events,
+    events: Vec<L1PortalEvent>,
 }
 
 impl L1BlockEvidence {
@@ -64,7 +64,7 @@ impl L1BlockEvidence {
 
     /// Return authenticated Portal events in receipt order.
     pub(crate) fn portal_events(&self) -> impl Iterator<Item = &L1PortalEvent> {
-        self.events.events.iter()
+        self.events.iter()
     }
 }
 

--- a/crates/checker/src/persistence/mod.rs
+++ b/crates/checker/src/persistence/mod.rs
@@ -75,6 +75,16 @@ pub(crate) struct Store {
 }
 
 impl Store {
+    /// Read the identity bound to an existing checker database.
+    pub(crate) fn inspect_identity(path: &Path) -> Result<Identity, PersistenceError> {
+        let db = DatabaseEnv::open(path, DatabaseEnvKind::RO, DatabaseArguments::default())?;
+        let tx = db.tx()?;
+        validate_schema(&tx)?;
+        let identity = read_metadata(&tx)?.identity;
+        tx.commit()?;
+        Ok(identity)
+    }
+
     /// Open an existing database or atomically create it from an authenticated checkpoint.
     pub(crate) fn open_or_create(
         path: &Path,
@@ -178,20 +188,7 @@ impl Store {
     /// Load the active row state directly without replaying retained deltas.
     pub(crate) fn load(&self) -> Result<Snapshot, PersistenceError> {
         let tx = self.db.tx()?;
-        let version = match tx.get::<Meta>(MetaKey::Version)? {
-            Some(MetaValue::Version(version)) => version,
-            _ => {
-                return Err(PersistenceError::Invalid(
-                    "schema version is missing".into(),
-                ));
-            }
-        };
-        if version != SCHEMA_VERSION {
-            return Err(PersistenceError::Schema {
-                expected: SCHEMA_VERSION,
-                actual: version,
-            });
-        }
+        validate_schema(&tx)?;
         let metadata = read_metadata(&tx)?;
         if metadata.identity != self.identity {
             return Err(PersistenceError::Identity);
@@ -327,6 +324,24 @@ impl Store {
             state: Arc::clone(&prior.state),
         })
     }
+}
+
+fn validate_schema<T: DbTx>(tx: &T) -> Result<(), PersistenceError> {
+    let version = match tx.get::<Meta>(MetaKey::Version)? {
+        Some(MetaValue::Version(version)) => version,
+        _ => {
+            return Err(PersistenceError::Invalid(
+                "schema version is missing".into(),
+            ));
+        }
+    };
+    if version != SCHEMA_VERSION {
+        return Err(PersistenceError::Schema {
+            expected: SCHEMA_VERSION,
+            actual: version,
+        });
+    }
+    Ok(())
 }
 
 fn read_metadata<T: DbTx>(tx: &T) -> Result<Metadata, PersistenceError> {

--- a/crates/checker/src/persistence/tests.rs
+++ b/crates/checker/src/persistence/tests.rs
@@ -1,9 +1,15 @@
 use alloy_primitives::{Address, B256, U256};
+use reth_db::{
+    Database as _,
+    transaction::{DbTx as _, DbTxMut as _},
+};
 
 use crate::accounting::{AccountKey, BalanceChange, Effect, LiabilityKind, State, TokenState};
 
 use super::{
-    BlockRef, CandidateTransition, Checkpoint, Finding, Identity, PersistenceError, Status, Store,
+    BlockRef, CandidateTransition, Checkpoint, Finding, Identity, PersistenceError, SCHEMA_VERSION,
+    Status, Store,
+    schema::{Meta, MetaKey, MetaValue},
 };
 
 fn block(number: u64, byte: u8) -> BlockRef {
@@ -39,6 +45,7 @@ fn rows_survive_restart_and_clear_on_reset() {
         state,
     };
     let initial = Store::create_atomic(&path, &checkpoint).unwrap();
+    assert_eq!(Store::inspect_identity(&path).unwrap(), identity());
     let (store, reopened) = Store::open(&path, identity()).unwrap();
     assert_eq!(reopened, initial);
     assert_eq!(reopened.state.token(token), Some(TokenState::default()));
@@ -81,6 +88,30 @@ fn rows_survive_restart_and_clear_on_reset() {
     assert_eq!(reset.metadata.verified_zone, genesis);
     assert_eq!(reset.state.account(account), None);
     assert_eq!(reset.state.token(token), Some(TokenState::default()));
+}
+
+#[test]
+fn inspect_identity_validates_schema() {
+    let directory = tempfile::tempdir().unwrap();
+    let path = directory.path().join("checker");
+    let checkpoint = Checkpoint {
+        identity: identity(),
+        zone: block(0, 10),
+        tempo: block(20, 20),
+        state: Default::default(),
+    };
+    Store::create_atomic(&path, &checkpoint).unwrap();
+    let (store, _) = Store::open(&path, identity()).unwrap();
+    let tx = store.db.tx_mut().unwrap();
+    tx.put::<Meta>(MetaKey::Version, MetaValue::Version(SCHEMA_VERSION + 1))
+        .unwrap();
+    tx.commit().unwrap();
+    drop(store);
+
+    assert!(matches!(
+        Store::inspect_identity(&path),
+        Err(PersistenceError::Schema { .. })
+    ));
 }
 
 #[test]

--- a/crates/checker/src/runtime.rs
+++ b/crates/checker/src/runtime.rs
@@ -28,7 +28,7 @@ use crate::{
 };
 
 const RETRY_DELAY: Duration = Duration::from_secs(1);
-const MAX_STATE_ATTEMPTS: u32 = 30;
+const MAX_ACQUISITION_ATTEMPTS: u32 = 30;
 const MAX_WS_FRAME_AND_MESSAGE_SIZE: usize = 128 * 1024 * 1024;
 
 /// `NodePrimitives` whose transaction and receipt types the checker can process.
@@ -90,9 +90,9 @@ where
 
 /// Bootstrap or open durable state, then verify each append-only notification in turn.
 ///
-/// Transient acquisition failures are retried. An authenticated divergence is
-/// persisted until the checker is rebuilt, while deterministic checker failures
-/// return so the outer runtime can disable verification and drain.
+/// Transient acquisition failures are retried up to a fixed bound. An authenticated
+/// divergence is persisted until the checker is rebuilt, while exhausted or
+/// deterministic failures return so the outer runtime can disable and drain.
 async fn run_inner<Node>(
     config: CheckerConfig,
     ctx: &mut ExExContext<Node>,
@@ -108,7 +108,7 @@ where
     let l1 = connect(&config.l1_rpc_url).await?;
     let bootstrap = retry_transient(
         || bootstrap::build(ctx.provider(), &l1, &config),
-        "checker bootstrap failed",
+        "checker bootstrap",
     )
     .await?;
     let mut checkpoint = None;
@@ -214,7 +214,7 @@ async fn connect(url: &str) -> eyre::Result<DynProvider<TempoNetwork>> {
                 .connect_client(client)
                 .erased())
         },
-        "Tempo RPC unavailable",
+        "Tempo RPC connection",
     )
     .await?;
     Ok(provider)
@@ -230,7 +230,7 @@ async fn authenticated_checkpoint<'a>(
         *checkpoint = Some(
             retry_transient(
                 || bootstrap.checkpoint(l1, config),
-                "checker initial-state replay failed",
+                "checker initial-state replay",
             )
             .await?,
         );
@@ -248,17 +248,26 @@ fn rpc_connection_config() -> ConnectionConfig {
     )
 }
 
-/// Retry transient failure and return failures that disable the checker.
-async fn retry_transient<T, F, Fut>(mut attempt: F, message: &str) -> eyre::Result<T>
+/// Retry transient failures up to the acquisition bound.
+async fn retry_transient<T, F, Fut>(mut attempt: F, operation: &str) -> eyre::Result<T>
 where
     F: FnMut() -> Fut,
     Fut: Future<Output = Result<T, AttemptError>>,
 {
+    let mut attempts = 0;
     loop {
         match attempt().await {
             Ok(value) => return Ok(value),
             Err(AttemptError::Retry(error)) => {
-                tracing::warn!(target: "zone::checker", %error, "{message}; retrying");
+                record_retry_attempt(&mut attempts, &error, operation)?;
+                tracing::warn!(
+                    target: "zone::checker",
+                    %error,
+                    operation,
+                    attempt = attempts,
+                    max_attempts = MAX_ACQUISITION_ATTEMPTS,
+                    "checker acquisition failed; retrying"
+                );
                 tokio::time::sleep(RETRY_DELAY).await;
             }
             Err(AttemptError::Disable(error)) => return Err(error),
@@ -287,7 +296,7 @@ fn notification_tip<N: NodePrimitives>(notification: &ExExNotification<N>) -> Op
 enum BlockError {
     /// Authenticated divergence to persist as a finding.
     Finding { zone: BlockRef, error: eyre::Report },
-    /// Deterministic checker failure that cannot be resolved by retrying.
+    /// Failure that cannot be resolved within the acquisition bound.
     Disable(eyre::Report),
 }
 
@@ -296,11 +305,15 @@ struct VerificationContext<'a> {
     metrics: &'a CheckerMetrics,
 }
 
-fn record_state_attempt(attempts: &mut u32, error: eyre::Report) -> eyre::Result<()> {
+fn record_retry_attempt(
+    attempts: &mut u32,
+    error: &eyre::Report,
+    operation: &str,
+) -> eyre::Result<()> {
     *attempts = attempts.saturating_add(1);
-    if *attempts >= MAX_STATE_ATTEMPTS {
+    if *attempts >= MAX_ACQUISITION_ATTEMPTS {
         return Err(eyre::eyre!(
-            "local Zone state remained unavailable after {attempts} attempts; checker requires unpruned state for notified blocks: {error:#}"
+            "{operation} retry budget exhausted after {attempts} failed attempts: {error:#}"
         ));
     }
     Ok(())
@@ -384,16 +397,10 @@ where
     let tempo = BlockNumHash::new(anchor.block_number(), anchor.block_hash());
     let tempo_parent = BlockNumHash::from(prior.metadata.imported_tempo);
     validate_tempo_advance(tempo_parent.number, tempo.number).map_err(fail)?;
-    let tempo_block = collect_l1_block_with_retry(
-        l1,
-        &config.l1_block_tracker,
-        config.portal_address,
-        tempo_parent,
-        tempo,
-        zone,
-        metrics,
-    )
-    .await?;
+    let mut l1_attempts = 0;
+    let tempo_block =
+        collect_l1_block_with_retry(l1, tempo_parent, tempo, zone, context, &mut l1_attempts)
+            .await?;
     let mut block_effects = effects::from_tempo(&tempo_block);
     block_effects.extend(effects::from_zone(&l2));
     let candidate = CandidateTransition::derive(
@@ -422,13 +429,18 @@ where
             Ok(observed) => break observed,
             Err(AccountingStateError::Unavailable(error)) => {
                 metrics.acquisition_retries_total.increment(1);
-                record_state_attempt(&mut state_attempts, error).map_err(BlockError::Disable)?;
+                record_retry_attempt(
+                    &mut state_attempts,
+                    &error,
+                    "local Zone state acquisition (checker requires unpruned state for notified blocks)",
+                )
+                .map_err(BlockError::Disable)?;
                 tracing::warn!(
                     target: "zone::checker",
                     zone_block = zone.number,
                     zone_hash = %zone.hash,
                     attempt = state_attempts,
-                    max_attempts = MAX_STATE_ATTEMPTS,
+                    max_attempts = MAX_ACQUISITION_ATTEMPTS,
                     "checker local state unavailable; retrying"
                 );
                 tokio::time::sleep(RETRY_DELAY).await;
@@ -457,16 +469,20 @@ where
         {
             Ok(balances) => break balances,
             Err(L1ReadError::Unavailable(error)) => {
-                record_l1_retry(metrics, &error);
+                record_l1_retry(
+                    metrics,
+                    &mut l1_attempts,
+                    &error,
+                    "Portal balance acquisition",
+                )?;
                 tokio::time::sleep(RETRY_DELAY).await;
                 collect_l1_block_with_retry(
                     l1,
-                    &config.l1_block_tracker,
-                    config.portal_address,
                     tempo_parent,
                     tempo,
                     zone,
-                    metrics,
+                    context,
+                    &mut l1_attempts,
                 )
                 .await?;
             }
@@ -494,18 +510,26 @@ fn classify_block_l1_error(error: L1ReadError, zone: BlockRef) -> BlockError {
 
 async fn collect_l1_block_with_retry(
     l1: &DynProvider<TempoNetwork>,
-    tracker: &zone_l1::L1BlockTracker,
-    portal: alloy_primitives::Address,
     parent: BlockNumHash,
     expected: BlockNumHash,
     zone: BlockRef,
-    metrics: &CheckerMetrics,
+    context: &VerificationContext<'_>,
+    attempts: &mut u32,
 ) -> Result<crate::l1::L1BlockEvidence, BlockError> {
+    let VerificationContext { config, metrics } = context;
     loop {
-        match collect_l1_block_at(l1, tracker, portal, parent, expected).await {
+        match collect_l1_block_at(
+            l1,
+            &config.l1_block_tracker,
+            config.portal_address,
+            parent,
+            expected,
+        )
+        .await
+        {
             Ok(block) => return Ok(block),
             Err(L1ReadError::Unavailable(error)) => {
-                record_l1_retry(metrics, &error);
+                record_l1_retry(metrics, attempts, &error, "Tempo block acquisition")?;
                 tokio::time::sleep(RETRY_DELAY).await;
             }
             Err(error) => return Err(classify_block_l1_error(error, zone)),
@@ -513,13 +537,23 @@ async fn collect_l1_block_with_retry(
     }
 }
 
-fn record_l1_retry(metrics: &CheckerMetrics, error: &eyre::Report) {
+fn record_l1_retry(
+    metrics: &CheckerMetrics,
+    attempts: &mut u32,
+    error: &eyre::Report,
+    operation: &str,
+) -> Result<(), BlockError> {
     metrics.acquisition_retries_total.increment(1);
+    record_retry_attempt(attempts, error, "L1 acquisition").map_err(BlockError::Disable)?;
     tracing::warn!(
         target: "zone::checker",
         %error,
-        "checker block acquisition failed; retrying"
+        operation,
+        attempt = *attempts,
+        max_attempts = MAX_ACQUISITION_ATTEMPTS,
+        "checker L1 acquisition failed; retrying"
     );
+    Ok(())
 }
 
 fn validate_tempo_advance(parent: u64, tip: u64) -> eyre::Result<()> {
@@ -547,7 +581,7 @@ mod tests {
                     "invalid genesis"
                 ))))
             },
-            "operation failed",
+            "operation",
         )
         .await;
 
@@ -565,14 +599,15 @@ mod tests {
     }
 
     #[test]
-    fn local_state_retries_are_bounded() {
+    fn acquisition_retries_are_bounded() {
         let mut attempts = 0;
-        for _ in 1..MAX_STATE_ATTEMPTS {
-            record_state_attempt(&mut attempts, eyre::eyre!("state unavailable")).unwrap();
+        let error = eyre::eyre!("state unavailable");
+        for _ in 1..MAX_ACQUISITION_ATTEMPTS {
+            record_retry_attempt(&mut attempts, &error, "local state acquisition").unwrap();
         }
-        let error = record_state_attempt(&mut attempts, eyre::eyre!("state unavailable"))
+        let error = record_retry_attempt(&mut attempts, &error, "local state acquisition")
             .expect_err("the final attempt must disable the checker");
-        assert_eq!(attempts, MAX_STATE_ATTEMPTS);
-        assert!(error.to_string().contains("remained unavailable"));
+        assert_eq!(attempts, MAX_ACQUISITION_ATTEMPTS);
+        assert!(error.to_string().contains("retry budget exhausted"));
     }
 }

--- a/crates/checker/src/runtime.rs
+++ b/crates/checker/src/runtime.rs
@@ -28,7 +28,12 @@ use crate::{
 };
 
 const RETRY_DELAY: Duration = Duration::from_secs(1);
-const MAX_ACQUISITION_ATTEMPTS: u32 = 30;
+/// Maximum delay between Tempo acquisition attempts.
+const MAX_RETRY_DELAY: Duration = Duration::from_secs(30);
+/// Retry bound for unavailable local Zone state.
+const MAX_STATE_ATTEMPTS: u32 = 30;
+/// Retry bound for Tempo acquisition.
+const MAX_L1_ATTEMPTS: u32 = 10;
 const MAX_WS_FRAME_AND_MESSAGE_SIZE: usize = 128 * 1024 * 1024;
 
 /// `NodePrimitives` whose transaction and receipt types the checker can process.
@@ -266,21 +271,21 @@ where
     F: FnMut() -> Fut,
     Fut: Future<Output = Result<T, AttemptError>>,
 {
-    let mut attempts = 0;
+    let mut backoff = Backoff::new();
     loop {
         match attempt().await {
             Ok(value) => return Ok(value),
             Err(AttemptError::Retry(error)) => {
-                record_retry_attempt(&mut attempts, &error, operation)?;
+                backoff.record(&error, operation)?;
                 tracing::warn!(
                     target: "zone::checker",
                     %error,
                     operation,
-                    attempt = attempts,
-                    max_attempts = MAX_ACQUISITION_ATTEMPTS,
+                    attempt = backoff.attempts,
+                    max_attempts = MAX_L1_ATTEMPTS,
                     "checker acquisition failed; retrying"
                 );
-                tokio::time::sleep(RETRY_DELAY).await;
+                backoff.wait().await;
             }
             Err(AttemptError::Disable(error)) => return Err(error),
         }
@@ -319,16 +324,43 @@ struct VerificationContext<'a> {
 
 fn record_retry_attempt(
     attempts: &mut u32,
+    max_attempts: u32,
     error: &eyre::Report,
     operation: &str,
 ) -> eyre::Result<()> {
     *attempts = attempts.saturating_add(1);
-    if *attempts >= MAX_ACQUISITION_ATTEMPTS {
+    if *attempts >= max_attempts {
         return Err(eyre::eyre!(
             "{operation} retry budget exhausted after {attempts} failed attempts: {error:#}"
         ));
     }
     Ok(())
+}
+
+/// Bounded backoff for Tempo acquisition.
+struct Backoff {
+    attempts: u32,
+    delay: Duration,
+}
+
+impl Backoff {
+    const fn new() -> Self {
+        Self {
+            attempts: 0,
+            delay: RETRY_DELAY,
+        }
+    }
+
+    /// Record one failed attempt.
+    fn record(&mut self, error: &eyre::Report, operation: &str) -> eyre::Result<()> {
+        record_retry_attempt(&mut self.attempts, MAX_L1_ATTEMPTS, error, operation)
+    }
+
+    /// Wait and increase the next delay.
+    async fn wait(&mut self) {
+        tokio::time::sleep(self.delay).await;
+        self.delay = self.delay.saturating_mul(2).min(MAX_RETRY_DELAY);
+    }
 }
 
 /// Verify one append-only notification's blocks.
@@ -409,9 +441,9 @@ where
     let tempo = BlockNumHash::new(anchor.block_number(), anchor.block_hash());
     let tempo_parent = BlockNumHash::from(prior.metadata.imported_tempo);
     validate_tempo_advance(tempo_parent.number, tempo.number).map_err(fail)?;
-    let mut l1_attempts = 0;
+    let mut l1_backoff = Backoff::new();
     let tempo_block =
-        collect_l1_block_with_retry(l1, tempo_parent, tempo, zone, context, &mut l1_attempts)
+        collect_l1_block_with_retry(l1, tempo_parent, tempo, zone, context, &mut l1_backoff)
             .await?;
     let mut block_effects = effects::from_tempo(&tempo_block);
     block_effects.extend(effects::from_zone(&l2));
@@ -443,6 +475,7 @@ where
                 metrics.acquisition_retries_total.increment(1);
                 record_retry_attempt(
                     &mut state_attempts,
+                    MAX_STATE_ATTEMPTS,
                     &error,
                     "local Zone state acquisition (checker requires unpruned state for notified blocks)",
                 )
@@ -452,7 +485,7 @@ where
                     zone_block = zone.number,
                     zone_hash = %zone.hash,
                     attempt = state_attempts,
-                    max_attempts = MAX_ACQUISITION_ATTEMPTS,
+                    max_attempts = MAX_STATE_ATTEMPTS,
                     "checker local state unavailable; retrying"
                 );
                 tokio::time::sleep(RETRY_DELAY).await;
@@ -483,20 +516,11 @@ where
             Err(L1ReadError::Unavailable(error)) => {
                 record_l1_retry(
                     metrics,
-                    &mut l1_attempts,
+                    &mut l1_backoff,
                     &error,
                     "Portal balance acquisition",
                 )?;
-                tokio::time::sleep(RETRY_DELAY).await;
-                collect_l1_block_with_retry(
-                    l1,
-                    tempo_parent,
-                    tempo,
-                    zone,
-                    context,
-                    &mut l1_attempts,
-                )
-                .await?;
+                l1_backoff.wait().await;
             }
             Err(error) => return Err(classify_block_l1_error(error, zone)),
         }
@@ -526,7 +550,7 @@ async fn collect_l1_block_with_retry(
     expected: BlockNumHash,
     zone: BlockRef,
     context: &VerificationContext<'_>,
-    attempts: &mut u32,
+    backoff: &mut Backoff,
 ) -> Result<crate::l1::L1BlockEvidence, BlockError> {
     let VerificationContext { config, metrics } = context;
     loop {
@@ -541,8 +565,8 @@ async fn collect_l1_block_with_retry(
         {
             Ok(block) => return Ok(block),
             Err(L1ReadError::Unavailable(error)) => {
-                record_l1_retry(metrics, attempts, &error, "Tempo block acquisition")?;
-                tokio::time::sleep(RETRY_DELAY).await;
+                record_l1_retry(metrics, backoff, &error, "Tempo block acquisition")?;
+                backoff.wait().await;
             }
             Err(error) => return Err(classify_block_l1_error(error, zone)),
         }
@@ -551,18 +575,20 @@ async fn collect_l1_block_with_retry(
 
 fn record_l1_retry(
     metrics: &CheckerMetrics,
-    attempts: &mut u32,
+    backoff: &mut Backoff,
     error: &eyre::Report,
     operation: &str,
 ) -> Result<(), BlockError> {
     metrics.acquisition_retries_total.increment(1);
-    record_retry_attempt(attempts, error, "L1 acquisition").map_err(BlockError::Disable)?;
+    backoff
+        .record(error, operation)
+        .map_err(BlockError::Disable)?;
     tracing::warn!(
         target: "zone::checker",
         %error,
         operation,
-        attempt = *attempts,
-        max_attempts = MAX_ACQUISITION_ATTEMPTS,
+        attempt = backoff.attempts,
+        max_attempts = MAX_L1_ATTEMPTS,
         "checker L1 acquisition failed; retrying"
     );
     Ok(())
@@ -614,12 +640,23 @@ mod tests {
     fn acquisition_retries_are_bounded() {
         let mut attempts = 0;
         let error = eyre::eyre!("state unavailable");
-        for _ in 1..MAX_ACQUISITION_ATTEMPTS {
-            record_retry_attempt(&mut attempts, &error, "local state acquisition").unwrap();
+        for _ in 1..MAX_STATE_ATTEMPTS {
+            record_retry_attempt(
+                &mut attempts,
+                MAX_STATE_ATTEMPTS,
+                &error,
+                "local state acquisition",
+            )
+            .unwrap();
         }
-        let error = record_retry_attempt(&mut attempts, &error, "local state acquisition")
-            .expect_err("the final attempt must disable the checker");
-        assert_eq!(attempts, MAX_ACQUISITION_ATTEMPTS);
+        let error = record_retry_attempt(
+            &mut attempts,
+            MAX_STATE_ATTEMPTS,
+            &error,
+            "local state acquisition",
+        )
+        .expect_err("the final attempt must disable the checker");
+        assert_eq!(attempts, MAX_STATE_ATTEMPTS);
         assert!(error.to_string().contains("retry budget exhausted"));
     }
 }

--- a/crates/checker/src/runtime.rs
+++ b/crates/checker/src/runtime.rs
@@ -21,7 +21,9 @@ use crate::{
     bootstrap,
     l1::{L1ReadError, classify_rpc_error, collect_l1_block_at, portal_balances},
     l2::{AccountingStateError, collect_l2_block_evidence, read_accounting_state},
-    persistence::{AppliedStatus, BlockRef, CandidateTransition, Finding, Snapshot, Status, Store},
+    persistence::{
+        AppliedStatus, BlockRef, CandidateTransition, Checkpoint, Finding, Snapshot, Status, Store,
+    },
     telemetry::{self, CheckerMetrics},
 };
 
@@ -104,12 +106,19 @@ where
 {
     tracing::info!(target: "zone::checker", "checker started");
     let l1 = connect(&config.l1_rpc_url).await?;
-    let checkpoint = retry_transient(
+    let bootstrap = retry_transient(
         || bootstrap::build(ctx.provider(), &l1, &config),
         "checker bootstrap failed",
     )
     .await?;
-    let (store, mut snapshot) = Store::open_or_create(&config.database_path, &checkpoint)?;
+    let mut checkpoint = None;
+    let (store, mut snapshot) = if config.database_path.exists() {
+        Store::open(&config.database_path, bootstrap.identity())?
+    } else {
+        let checkpoint =
+            authenticated_checkpoint(&mut checkpoint, &bootstrap, &l1, &config).await?;
+        Store::open_or_create(&config.database_path, checkpoint)?
+    };
     let verified = snapshot.metadata.verified_zone;
     if ctx.provider().block_hash(verified.number)? != Some(verified.hash) {
         tracing::warn!(
@@ -118,7 +127,9 @@ where
             zone_hash = %verified.hash,
             "checker tip is not in local Zone history; rebuilding"
         );
-        snapshot = store.reset(&checkpoint)?;
+        let checkpoint =
+            authenticated_checkpoint(&mut checkpoint, &bootstrap, &l1, &config).await?;
+        snapshot = store.reset(checkpoint)?;
         metrics.recovery_rebuilds_total.increment(1);
     }
     metrics.update(&snapshot);
@@ -128,10 +139,12 @@ where
 
     while let Some(notification) = ctx.notifications.try_next().await? {
         if !matches!(&notification, ExExNotification::ChainCommitted { .. }) {
-            snapshot = store.reset(&checkpoint)?;
+            let checkpoint =
+                authenticated_checkpoint(&mut checkpoint, &bootstrap, &l1, &config).await?;
+            snapshot = store.reset(checkpoint)?;
             metrics.recovery_rebuilds_total.increment(1);
             metrics.update(&snapshot);
-            ctx.catch_up_notifications_with_head(ExExHead::new(checkpoint.zone.into()))?;
+            ctx.catch_up_notifications_with_head(ExExHead::new(bootstrap.zone().into()))?;
             tracing::warn!(target: "zone::checker", "unexpected Zone revert; rebuilding from genesis");
             continue;
         }
@@ -146,72 +159,44 @@ where
         snapshot = store.observe(&snapshot, delivered_tip.into())?;
         metrics.update(&snapshot);
 
-        let mut state_retry = None;
-        loop {
-            let previous_verified = snapshot.metadata.verified_zone.number;
-            match process_notification(
-                &notification,
-                ctx.provider(),
-                &l1,
-                &store,
-                snapshot,
-                &config,
-            )
-            .await
-            {
-                Ok(next) => {
-                    let next = *next;
-                    let verified = next
-                        .metadata
-                        .verified_zone
-                        .number
-                        .saturating_sub(previous_verified);
-                    snapshot = next;
-                    metrics.verified_zone_blocks_total.increment(verified);
-                    metrics.update(&snapshot);
-                    ctx.send_finished_height(snapshot.metadata.verified_zone.into())?;
-                    break;
-                }
-                Err(BlockError::Finding { zone, error }) => {
-                    snapshot = store.load()?;
-                    tracing::error!(target: "zone::checker", %error, zone_block = zone.number, zone_hash = %zone.hash, "checker divergence");
-                    snapshot = store.record_finding(
-                        &snapshot,
-                        Finding {
-                            zone,
-                            summary: error.to_string(),
-                        },
-                    )?;
-                    metrics.update(&snapshot);
-                    ctx.send_finished_height(delivered_tip)?;
-                    break;
-                }
-                Err(BlockError::Retry(error)) => {
-                    snapshot = store.load()?;
-                    metrics.acquisition_retries_total.increment(1);
-                    metrics.update(&snapshot);
-                    tracing::warn!(target: "zone::checker", %error, "checker block processing failed; retrying");
-                    tokio::time::sleep(RETRY_DELAY).await;
-                }
-                Err(BlockError::StateUnavailable { zone, error }) => {
-                    metrics.acquisition_retries_total.increment(1);
-                    let attempts = state_attempts_for_block(&mut state_retry, zone);
-                    record_state_attempt(attempts, error)?;
-                    let attempt = *attempts;
-                    snapshot = store.load()?;
-                    metrics.update(&snapshot);
-                    tracing::warn!(
-                        target: "zone::checker",
-                        zone_block = zone.number,
-                        zone_hash = %zone.hash,
-                        attempt,
-                        max_attempts = MAX_STATE_ATTEMPTS,
-                        "checker local state unavailable; retrying"
-                    );
-                    tokio::time::sleep(RETRY_DELAY).await;
-                }
-                Err(BlockError::Disable(error)) => return Err(error),
+        let previous_verified = snapshot.metadata.verified_zone.number;
+        match process_notification(
+            &notification,
+            ctx.provider(),
+            &l1,
+            &store,
+            snapshot,
+            &config,
+            metrics,
+        )
+        .await
+        {
+            Ok(next) => {
+                let next = *next;
+                let verified = next
+                    .metadata
+                    .verified_zone
+                    .number
+                    .saturating_sub(previous_verified);
+                snapshot = next;
+                metrics.verified_zone_blocks_total.increment(verified);
+                metrics.update(&snapshot);
+                ctx.send_finished_height(snapshot.metadata.verified_zone.into())?;
             }
+            Err(BlockError::Finding { zone, error }) => {
+                snapshot = store.load()?;
+                tracing::error!(target: "zone::checker", %error, zone_block = zone.number, zone_hash = %zone.hash, "checker divergence");
+                snapshot = store.record_finding(
+                    &snapshot,
+                    Finding {
+                        zone,
+                        summary: error.to_string(),
+                    },
+                )?;
+                metrics.update(&snapshot);
+                ctx.send_finished_height(delivered_tip)?;
+            }
+            Err(BlockError::Disable(error)) => return Err(error),
         }
     }
     tracing::info!(target: "zone::checker", "checker notification stream closed");
@@ -233,6 +218,26 @@ async fn connect(url: &str) -> eyre::Result<DynProvider<TempoNetwork>> {
     )
     .await?;
     Ok(provider)
+}
+
+async fn authenticated_checkpoint<'a>(
+    checkpoint: &'a mut Option<Checkpoint>,
+    bootstrap: &bootstrap::Bootstrap,
+    l1: &DynProvider<TempoNetwork>,
+    config: &CheckerConfig,
+) -> eyre::Result<&'a Checkpoint> {
+    if checkpoint.is_none() {
+        *checkpoint = Some(
+            retry_transient(
+                || bootstrap.checkpoint(l1, config),
+                "checker initial-state replay failed",
+            )
+            .await?,
+        );
+    }
+    Ok(checkpoint
+        .as_ref()
+        .expect("checkpoint is initialized before it is returned"))
 }
 
 fn rpc_connection_config() -> ConnectionConfig {
@@ -280,21 +285,15 @@ fn notification_tip<N: NodePrimitives>(notification: &ExExNotification<N>) -> Op
 
 /// Failure processing one block.
 enum BlockError {
-    /// Transient failure; retry without advancing.
-    Retry(eyre::Report),
-    /// Local state is temporarily unavailable; retry only up to the configured safety bound.
-    StateUnavailable { zone: BlockRef, error: eyre::Report },
     /// Authenticated divergence to persist as a finding.
     Finding { zone: BlockRef, error: eyre::Report },
     /// Deterministic checker failure that cannot be resolved by retrying.
     Disable(eyre::Report),
 }
 
-fn state_attempts_for_block(retry: &mut Option<(BlockRef, u32)>, zone: BlockRef) -> &mut u32 {
-    if !matches!(retry, Some((failed, _)) if *failed == zone) {
-        *retry = Some((zone, 0));
-    }
-    &mut retry.as_mut().expect("retry state was initialized").1
+struct VerificationContext<'a> {
+    config: &'a CheckerConfig,
+    metrics: &'a CheckerMetrics,
 }
 
 fn record_state_attempt(attempts: &mut u32, error: eyre::Report) -> eyre::Result<()> {
@@ -315,6 +314,7 @@ async fn process_notification<N, P>(
     store: &Store,
     snapshot: Snapshot,
     config: &CheckerConfig,
+    metrics: &CheckerMetrics,
 ) -> Result<Box<Snapshot>, BlockError>
 where
     N: CheckedPrimitives,
@@ -330,12 +330,13 @@ where
             )));
         }
     };
+    let context = VerificationContext { config, metrics };
     for (block, receipts) in new.blocks_and_receipts() {
         if already_applied(&current, block.header().number(), block.hash())? {
             continue;
         }
         current =
-            verify_block::<N, _>(provider, l1, store, current, config, block, receipts).await?;
+            verify_block::<N, _>(provider, l1, store, current, &context, block, receipts).await?;
     }
     Ok(Box::new(current))
 }
@@ -362,7 +363,7 @@ async fn verify_block<N, P>(
     l1: &DynProvider<TempoNetwork>,
     store: &Store,
     prior: Snapshot,
-    config: &CheckerConfig,
+    context: &VerificationContext<'_>,
     block: &RecoveredBlock<N::Block>,
     receipts: &[N::Receipt],
 ) -> Result<Snapshot, BlockError>
@@ -371,6 +372,7 @@ where
     P: BlockNumReader + ChainSpecProvider + StateProviderFactory,
     P::ChainSpec: TempoHardforks,
 {
+    let VerificationContext { config, metrics } = context;
     let number = block.number();
     let hash = block.hash();
     let parent_hash = block.parent_hash();
@@ -382,15 +384,16 @@ where
     let tempo = BlockNumHash::new(anchor.block_number(), anchor.block_hash());
     let tempo_parent = BlockNumHash::from(prior.metadata.imported_tempo);
     validate_tempo_advance(tempo_parent.number, tempo.number).map_err(fail)?;
-    let tempo_block = collect_l1_block_at(
+    let tempo_block = collect_l1_block_with_retry(
         l1,
         &config.l1_block_tracker,
         config.portal_address,
         tempo_parent,
         tempo,
+        zone,
+        metrics,
     )
-    .await
-    .map_err(|error| classify_block_l1_error(error, zone))?;
+    .await?;
     let mut block_effects = effects::from_tempo(&tempo_block);
     block_effects.extend(effects::from_zone(&l2));
     let candidate = CandidateTransition::derive(
@@ -413,14 +416,28 @@ where
     let spec = provider
         .chain_spec()
         .tempo_hardfork_at(block.header().timestamp());
-    let observed = read_accounting_state(provider, &accounts, zone.into(), spec).map_err(
-        |error| match error {
-            AccountingStateError::Unavailable(error) => {
-                BlockError::StateUnavailable { zone, error }
+    let mut state_attempts = 0;
+    let observed = loop {
+        match read_accounting_state(provider, &accounts, zone.into(), spec) {
+            Ok(observed) => break observed,
+            Err(AccountingStateError::Unavailable(error)) => {
+                metrics.acquisition_retries_total.increment(1);
+                record_state_attempt(&mut state_attempts, error).map_err(BlockError::Disable)?;
+                tracing::warn!(
+                    target: "zone::checker",
+                    zone_block = zone.number,
+                    zone_hash = %zone.hash,
+                    attempt = state_attempts,
+                    max_attempts = MAX_STATE_ATTEMPTS,
+                    "checker local state unavailable; retrying"
+                );
+                tokio::time::sleep(RETRY_DELAY).await;
             }
-            AccountingStateError::Disable(error) => BlockError::Disable(error),
-        },
-    )?;
+            Err(AccountingStateError::Disable(error)) => {
+                return Err(BlockError::Disable(error));
+            }
+        }
+    };
     state
         .verify_zone_state(
             observed
@@ -429,9 +446,33 @@ where
         )
         .map_err(|error| fail(error.into()))?;
 
-    let balances = portal_balances(l1, config.portal_address, tokens, tempo.hash)
+    let balances = loop {
+        match portal_balances(
+            l1,
+            config.portal_address,
+            tokens.iter().copied(),
+            tempo.hash,
+        )
         .await
-        .map_err(|error| classify_block_l1_error(error, zone))?;
+        {
+            Ok(balances) => break balances,
+            Err(L1ReadError::Unavailable(error)) => {
+                record_l1_retry(metrics, &error);
+                tokio::time::sleep(RETRY_DELAY).await;
+                collect_l1_block_with_retry(
+                    l1,
+                    &config.l1_block_tracker,
+                    config.portal_address,
+                    tempo_parent,
+                    tempo,
+                    zone,
+                    metrics,
+                )
+                .await?;
+            }
+            Err(error) => return Err(classify_block_l1_error(error, zone)),
+        }
+    };
     state
         .verify_portal_balances(balances)
         .map_err(|error| fail(error.into()))?;
@@ -445,10 +486,40 @@ where
 
 fn classify_block_l1_error(error: L1ReadError, zone: BlockRef) -> BlockError {
     match error {
-        L1ReadError::Unavailable(error) => BlockError::Retry(error),
+        L1ReadError::Unavailable(error) => BlockError::Disable(error),
         L1ReadError::Finding(error) => BlockError::Finding { zone, error },
         L1ReadError::Disable(error) => BlockError::Disable(error),
     }
+}
+
+async fn collect_l1_block_with_retry(
+    l1: &DynProvider<TempoNetwork>,
+    tracker: &zone_l1::L1BlockTracker,
+    portal: alloy_primitives::Address,
+    parent: BlockNumHash,
+    expected: BlockNumHash,
+    zone: BlockRef,
+    metrics: &CheckerMetrics,
+) -> Result<crate::l1::L1BlockEvidence, BlockError> {
+    loop {
+        match collect_l1_block_at(l1, tracker, portal, parent, expected).await {
+            Ok(block) => return Ok(block),
+            Err(L1ReadError::Unavailable(error)) => {
+                record_l1_retry(metrics, &error);
+                tokio::time::sleep(RETRY_DELAY).await;
+            }
+            Err(error) => return Err(classify_block_l1_error(error, zone)),
+        }
+    }
+}
+
+fn record_l1_retry(metrics: &CheckerMetrics, error: &eyre::Report) {
+    metrics.acquisition_retries_total.increment(1);
+    tracing::warn!(
+        target: "zone::checker",
+        %error,
+        "checker block acquisition failed; retrying"
+    );
 }
 
 fn validate_tempo_advance(parent: u64, tip: u64) -> eyre::Result<()> {
@@ -495,29 +566,13 @@ mod tests {
 
     #[test]
     fn local_state_retries_are_bounded() {
-        let block_a = BlockRef::new(1, alloy_primitives::B256::repeat_byte(1));
-        let block_b = BlockRef::new(2, alloy_primitives::B256::repeat_byte(2));
-        let mut retry = None;
-        for _ in 0..20 {
-            record_state_attempt(
-                state_attempts_for_block(&mut retry, block_a),
-                eyre::eyre!("state unavailable"),
-            )
-            .unwrap();
-        }
+        let mut attempts = 0;
         for _ in 1..MAX_STATE_ATTEMPTS {
-            record_state_attempt(
-                state_attempts_for_block(&mut retry, block_b),
-                eyre::eyre!("state unavailable"),
-            )
-            .unwrap();
+            record_state_attempt(&mut attempts, eyre::eyre!("state unavailable")).unwrap();
         }
-        let error = record_state_attempt(
-            state_attempts_for_block(&mut retry, block_b),
-            eyre::eyre!("state unavailable"),
-        )
-        .expect_err("the final attempt must disable the checker");
-        assert_eq!(retry, Some((block_b, MAX_STATE_ATTEMPTS)));
+        let error = record_state_attempt(&mut attempts, eyre::eyre!("state unavailable"))
+            .expect_err("the final attempt must disable the checker");
+        assert_eq!(attempts, MAX_STATE_ATTEMPTS);
         assert!(error.to_string().contains("remained unavailable"));
     }
 }

--- a/crates/checker/src/runtime.rs
+++ b/crates/checker/src/runtime.rs
@@ -105,14 +105,26 @@ where
     <Node::Types as reth_node_api::NodeTypes>::Primitives: CheckedPrimitives,
 {
     tracing::info!(target: "zone::checker", "checker started");
+    let persisted_identity = config
+        .database_path
+        .exists()
+        .then(|| Store::inspect_identity(&config.database_path))
+        .transpose()?;
     let l1 = connect(&config.l1_rpc_url).await?;
     let bootstrap = retry_transient(
-        || bootstrap::build(ctx.provider(), &l1, &config),
+        || async {
+            match persisted_identity {
+                Some(identity) => {
+                    bootstrap::authenticate(ctx.provider(), &l1, &config, identity).await
+                }
+                None => bootstrap::discover(ctx.provider(), &l1, &config).await,
+            }
+        },
         "checker bootstrap",
     )
     .await?;
     let mut checkpoint = None;
-    let (store, mut snapshot) = if config.database_path.exists() {
+    let (store, mut snapshot) = if persisted_identity.is_some() {
         Store::open(&config.database_path, bootstrap.identity())?
     } else {
         let checkpoint =


### PR DESCRIPTION
Stacked on #1216.

## What changed

This keeps the checker behavior the same while avoiding repeated work:

- On a normal restart, reuse the accounting state already stored in the database. Rebuild the initial state only when creating or resetting the database.
- When an RPC or local state read briefly fails, retry that read in place instead of reloading the database and processing the whole notification again.
- Fetch the ZoneFactory creation logs a few pages at a time instead of waiting for every page one by one. The results are still sorted and checked in the same way.
- Use the L1 event list directly and share the existing helper for events that are decoded but intentionally ignored.

## Follow-up hardening

Review follow-ups added on top of the initial refactor:

- Bound transient RPC and local-state acquisition to 30 attempts. Exhaustion disables verification while the ExEx continues draining notifications.
- Reuse the persisted creation coordinate on restart, avoiding historical `ZoneCreated` discovery and initial-state replay unless the database is created or reset.
- Consume concurrent `ZoneCreated` log pages incrementally and retain only unique creation coordinates.
- Preserve the authenticated L1 observation reuse introduced by #1257.

Validation now passes 57 checker tests.

## Validation

- `cargo test -p zone-checker` (57 passed)
- `cargo clippy -p zone-checker --all-targets`
- `cargo fmt --all -- --check`
- `git diff --check`
