### PR TITLE
refactor(checker): make metadata encoding fallible

### DIFF
--- a/crates/checker/src/persistence/codec.rs
+++ b/crates/checker/src/persistence/codec.rs
@@ -14,21 +14,13 @@ fn options() -> impl bincode::Options {
         .with_limit(MAX_VALUE_SIZE - 1)
 }
 
-/// Validate a dynamic value before passing it to MDBX's infallible codec interface.
-pub(super) fn validate<T: Serialize>(value: &T) -> Result<(), String> {
-    options()
-        .serialized_size(value)
-        .map(|_| ())
-        .map_err(|error| error.to_string())
-}
-
-fn encode<T: Serialize>(value: &T) -> Result<Vec<u8>, CodecError> {
+pub(super) fn encode<T: Serialize>(value: &T) -> Result<Vec<u8>, CodecError> {
     let mut encoded = vec![VERSION];
     options().serialize_into(&mut encoded, value).map_err(map)?;
     Ok(encoded)
 }
 
-fn decode<T: DeserializeOwned>(encoded: &[u8]) -> Result<T, CodecError> {
+pub(super) fn decode<T: DeserializeOwned>(encoded: &[u8]) -> Result<T, CodecError> {
     let (&version, value) = encoded.split_first().ok_or(CodecError::Empty)?;
     if version != VERSION {
         return Err(CodecError::Version(version));
@@ -64,11 +56,11 @@ macro_rules! values {
     )+};
 }
 
-values!(super::schema::MetaValue, super::schema::TokenValue);
+values!(super::schema::TokenValue);
 
 /// Invalid durable value envelope.
 #[derive(Debug, thiserror::Error)]
-enum CodecError {
+pub(super) enum CodecError {
     #[error("empty persistence value")]
     Empty,
     #[error("unsupported persistence value version {0}")]

--- a/crates/checker/src/persistence/mod.rs
+++ b/crates/checker/src/persistence/mod.rs
@@ -8,6 +8,7 @@ mod tests;
 
 use std::{fs, path::Path, sync::Arc};
 
+use alloy_primitives::Bytes;
 use reth_db::{
     Database, DatabaseEnv, DatabaseEnvKind,
     cursor::DbCursorRO,
@@ -143,7 +144,7 @@ impl Store {
             status: Status::Verifying,
         };
         let tx = store.db.tx_mut()?;
-        tx.put::<Meta>(MetaKey::Version, MetaValue::Version(SCHEMA_VERSION))?;
+        write_schema_version(&tx, SCHEMA_VERSION)?;
         write_metadata(&tx, &metadata)?;
         for (key, value) in checkpoint.state.accounts() {
             tx.put::<Accounts>(key, AccountValue(value))?;
@@ -178,14 +179,7 @@ impl Store {
     /// Load the active row state directly without replaying retained deltas.
     pub(crate) fn load(&self) -> Result<Snapshot, PersistenceError> {
         let tx = self.db.tx()?;
-        let version = match tx.get::<Meta>(MetaKey::Version)? {
-            Some(MetaValue::Version(version)) => version,
-            _ => {
-                return Err(PersistenceError::Invalid(
-                    "schema version is missing".into(),
-                ));
-            }
-        };
+        let version = read_schema_version(&tx)?;
         if version != SCHEMA_VERSION {
             return Err(PersistenceError::Schema {
                 expected: SCHEMA_VERSION,
@@ -329,8 +323,21 @@ impl Store {
     }
 }
 
+fn read_schema_version<T: DbTx>(tx: &T) -> Result<u32, PersistenceError> {
+    match read_meta_value(tx, MetaKey::Version)? {
+        Some(MetaValue::Version(version)) => Ok(version),
+        _ => Err(PersistenceError::Invalid(
+            "schema version is missing".into(),
+        )),
+    }
+}
+
+fn write_schema_version<T: DbTxMut>(tx: &T, version: u32) -> Result<(), PersistenceError> {
+    write_meta_value(tx, MetaKey::Version, &MetaValue::Version(version))
+}
+
 fn read_metadata<T: DbTx>(tx: &T) -> Result<Metadata, PersistenceError> {
-    match tx.get::<Meta>(MetaKey::Metadata)? {
+    match read_meta_value(tx, MetaKey::Metadata)? {
         Some(MetaValue::Metadata(metadata)) => Ok(*metadata),
         _ => Err(PersistenceError::Invalid("metadata is missing".into())),
     }
@@ -338,8 +345,27 @@ fn read_metadata<T: DbTx>(tx: &T) -> Result<Metadata, PersistenceError> {
 
 fn write_metadata<T: DbTxMut>(tx: &T, metadata: &Metadata) -> Result<(), PersistenceError> {
     let value = MetaValue::Metadata(Box::new(metadata.clone()));
-    codec::validate(&value).map_err(PersistenceError::Invalid)?;
-    tx.put::<Meta>(MetaKey::Metadata, value)?;
+    write_meta_value(tx, MetaKey::Metadata, &value)?;
+    Ok(())
+}
+
+fn read_meta_value<T: DbTx>(tx: &T, key: MetaKey) -> Result<Option<MetaValue>, PersistenceError> {
+    tx.get::<Meta>(key)?
+        .map(|value| {
+            codec::decode(&value).map_err(|error| PersistenceError::Invalid(error.to_string()))
+        })
+        .transpose()
+}
+
+fn write_meta_value<T: DbTxMut>(
+    tx: &T,
+    key: MetaKey,
+    value: &MetaValue,
+) -> Result<(), PersistenceError> {
+    let encoded = codec::encode(value)
+        .map(Bytes::from)
+        .map_err(|error| PersistenceError::Invalid(error.to_string()))?;
+    tx.put::<Meta>(key, encoded)?;
     Ok(())
 }
 

--- a/crates/checker/src/persistence/schema.rs
+++ b/crates/checker/src/persistence/schema.rs
@@ -1,6 +1,6 @@
 //! MDBX tables and fixed-width checker keys.
 
-use alloy_primitives::{Address, U256};
+use alloy_primitives::{Address, Bytes, U256};
 use reth_codecs::{Compress, Decompress, DecompressError};
 use reth_db::{
     DatabaseError, TableSet,
@@ -40,7 +40,7 @@ impl Decode for MetaKey {
     }
 }
 
-/// Versioned payload stored under a `MetaKey`.
+/// Versioned payload encoded under a [`MetaKey`].
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub(crate) enum MetaValue {
     Version(u32),
@@ -121,7 +121,7 @@ macro_rules! table {
     };
 }
 
-table!(Meta, MetaKey, MetaValue, "CheckerMeta");
+table!(Meta, MetaKey, Bytes, "CheckerMeta");
 table!(Accounts, AccountKey, AccountValue, "CheckerAccounts");
 table!(Tokens, Address, TokenValue, "CheckerTokens");
 

--- a/crates/checker/src/persistence/tests.rs
+++ b/crates/checker/src/persistence/tests.rs
@@ -127,6 +127,32 @@ fn finding_survives_restart_and_clears_on_reset() {
 }
 
 #[test]
+fn oversized_finding_is_rejected_without_panicking() {
+    let directory = tempfile::tempdir().unwrap();
+    let path = directory.path().join("checker");
+    let genesis = block(0, 10);
+    let checkpoint = Checkpoint {
+        identity: identity(),
+        zone: genesis,
+        tempo: block(20, 20),
+        state: Default::default(),
+    };
+    Store::create_atomic(&path, &checkpoint).unwrap();
+    let (store, snapshot) = Store::open(&path, identity()).unwrap();
+
+    let result = store.record_finding(
+        &snapshot,
+        Finding {
+            zone: block(1, 11),
+            summary: "x".repeat(16 * 1024 * 1024),
+        },
+    );
+
+    assert!(matches!(result, Err(PersistenceError::Invalid(_))));
+    assert_eq!(store.load().unwrap(), snapshot);
+}
+
+#[test]
 fn apply_rejects_stale_candidate_parent() {
     let directory = tempfile::tempdir().unwrap();
     let path = directory.path().join("checker");


### PR DESCRIPTION
## Summary

- store checker metadata as raw Reth `Bytes` and encode it fallibly before MDBX writes
- preserve the existing versioned bincode representation and strict decoding behavior
- keep schema-version and metadata rows behind type-specific helpers
- cover oversized divergence findings without a panic or partial write

## Why

The previous `MetaValue` database codec relied on callers validating dynamic metadata before Reth's infallible `Compress` implementation called `expect`. This moves the fallible boundary ahead of `put`, so serialization failures become ordinary persistence errors.

## Stack

Depends on #1216.

## Testing

- `rustup run nightly cargo fmt --all -- --check`
- `cargo test -p zone-checker --no-fail-fast` (57 passed)
- `cargo clippy -p zone-checker --all-targets`

Strict clippy with `-D warnings` remains blocked by pre-existing dead-code warnings in `zone-precompiles`.
