### PR TITLE
refactor(checker): reuse authenticated L1 observations

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -13757,6 +13757,7 @@ dependencies = [
  "thiserror 2.0.18",
  "tokio",
  "tracing",
+ "zone-l1",
  "zone-precompiles",
  "zone-primitives",
 ]

--- a/crates/checker/Cargo.toml
+++ b/crates/checker/Cargo.toml
@@ -45,6 +45,7 @@ tempo-revm = { workspace = true, features = ["reth"] }
 tempo-zone-contracts = { workspace = true, features = ["rpc", "std"] }
 zone-precompiles.workspace = true
 zone-primitives.workspace = true
+zone-l1.workspace = true
 
 # misc
 eyre.workspace = true

--- a/crates/checker/DESIGN.md
+++ b/crates/checker/DESIGN.md
@@ -47,8 +47,9 @@ Protocol activity moves value between these buckets:
 
 For each canonical Zone block, the checker:
 
-1. Authenticates the imported Tempo blocks and decodes recognized events from
-   canonical Zone receipts.
+1. Reuses the node's receipt-authenticated Tempo evidence when retained (or
+   fetches and authenticates old evidence during recovery), then independently
+   decodes Portal events and canonical Zone receipts.
 2. Converts recognized protocol events into ordered accounting effects.
 3. Applies those effects to a copy of the last verified ghost state.
 4. Reads the exact Zone post-state and imported Tempo state.

--- a/crates/checker/README.md
+++ b/crates/checker/README.md
@@ -51,10 +51,13 @@ accounts forward and verifies their aggregate against total supply. It does not
 scan arbitrary Zone storage changes or reread every historical account balance
 on every block.
 
-Tempo consensus and execution are trust boundaries. Tempo evidence is bound to
-exact canonical block hashes and authenticated receipts, and the checker
-independently decodes the relevant Portal events. It does not re-execute Tempo.
-Zone post-state is read through Reth's exact-block storage provider.
+Tempo consensus and execution are trust boundaries. For live blocks, the checker
+reuses Portal logs whose receipts and headers the node's L1 subscriber already
+authenticated. It independently decodes those logs and verifies the exact block
+and parent coordinates. Bootstrap and old recovery ranges fall back to fetching
+and authenticating the same evidence from the configured archival Tempo RPC. It
+does not re-execute Tempo. Zone post-state is read through Reth's exact-block
+storage provider.
 
 ## Startup and recovery
 
@@ -173,15 +176,16 @@ ledger.
 | `observe` | Verify, persist findings, expose metrics, and leave Zone execution unchanged. |
 
 Use `--checker.mode observe` or `CHECKER_MODE=observe`. The checker reuses the
-node's Tempo RPC URL, Portal address, Zone ID, chain specification, and data
-directory. No checker-specific anchor, Portal, or database argument is needed.
+node's authenticated L1 observations, Tempo RPC URL, Portal address, Zone ID,
+chain specification, and data directory. No checker-specific anchor, Portal, or
+database argument is needed.
 
 ## Source organization
 
 ```text
 src/
   bootstrap.rs       genesis identity and authenticated Portal discovery
-  l1/                exact Tempo blocks, receipts, and Portal events
+  l1/                shared/fallback Tempo evidence and Portal event decoding
   l2/                Zone events and exact post-state reads
   accounting/        pure account and liability transitions
   persistence/       row-oriented MDBX state and exact verified coordinates

--- a/crates/checker/src/bootstrap.rs
+++ b/crates/checker/src/bootstrap.rs
@@ -17,7 +17,7 @@ use crate::{
     AttemptError, CheckerConfig,
     accounting::{State, effects},
     decode_event,
-    l1::{classify_rpc_error, collect_l1_block, portal_balances, validate_l1_receipts},
+    l1::{classify_rpc_error, collect_l1_block, portal_balances},
     l2::read_zone_genesis,
     persistence::{self, Checkpoint},
 };
@@ -206,9 +206,13 @@ async fn authenticate_creation(
         .ok_or_else(|| {
             AttemptError::retry(eyre::eyre!("Portal creation receipts are unavailable"))
         })?;
-    let transaction_hashes = block.transactions().hashes().collect::<Vec<_>>();
-    validate_l1_receipts(coordinate, &transaction_hashes, &receipts)
-        .map_err(AttemptError::disable)?;
+    zone_l1::verify_receipts_against_header(
+        coordinate,
+        block.header().receipts_root(),
+        block.header().logs_bloom(),
+        &receipts,
+    )
+    .map_err(AttemptError::disable)?;
 
     let mut creations = receipts
         .iter()

--- a/crates/checker/src/l1/events.rs
+++ b/crates/checker/src/l1/events.rs
@@ -84,11 +84,17 @@ impl EventCollector {
             return Ok(());
         }
         for log in receipt.logs() {
-            if log.address() == self.portal
-                && let Some(event) = decode_portal_event(&log.inner, block)?
-            {
-                self.events.push(event);
-            }
+            self.extract_log(&log.inner, block)?;
+        }
+        Ok(())
+    }
+
+    /// Decode one receipt-authenticated log when it was emitted by the configured Portal.
+    pub(super) fn extract_log(&mut self, log: &Log, block: u64) -> eyre::Result<()> {
+        if log.address == self.portal
+            && let Some(event) = decode_portal_event(log, block)?
+        {
+            self.events.push(event);
         }
         Ok(())
     }

--- a/crates/checker/src/l1/mod.rs
+++ b/crates/checker/src/l1/mod.rs
@@ -3,14 +3,15 @@
 mod events;
 
 use alloy_consensus::BlockHeader as _;
-use alloy_eips::{BlockId, BlockNumHash, NumHash};
-use alloy_network::{BlockResponse as _, ReceiptResponse as _, primitives::HeaderResponse as _};
+use alloy_eips::{BlockId, BlockNumHash};
+use alloy_network::{BlockResponse as _, primitives::HeaderResponse as _};
 use alloy_primitives::{Address, B256, U256};
 use alloy_provider::{DynProvider, Provider};
 use alloy_transport::{RpcError, TransportError, TransportErrorKind};
 use futures::{StreamExt as _, TryStreamExt as _, stream};
 use tempo_alloy::{TempoNetwork, rpc::TempoTransactionReceipt};
 use tempo_contracts::precompiles::ITIP20;
+use zone_l1::L1BlockTracker;
 
 use crate::AttemptError;
 
@@ -79,11 +80,47 @@ pub(crate) async fn collect_l1_block(
 /// Fetch the exact anchored Tempo block that extends `parent`.
 pub(crate) async fn collect_l1_block_at(
     provider: &DynProvider<TempoNetwork>,
+    tracker: &L1BlockTracker,
     portal: Address,
     parent: BlockNumHash,
     expected: BlockNumHash,
 ) -> Result<L1BlockEvidence, L1ReadError> {
+    if let Some(evidence) = tracker
+        .authenticated_portal_logs(expected)
+        .map_err(finding)?
+    {
+        return collect_tracked_l1_block_evidence(portal, parent, evidence);
+    }
     collect_l1_block_inner(provider, portal, parent, Some(expected)).await
+}
+
+fn collect_tracked_l1_block_evidence(
+    portal: Address,
+    parent: BlockNumHash,
+    evidence: zone_l1::AuthenticatedPortalLogs,
+) -> Result<L1BlockEvidence, L1ReadError> {
+    let expected_number = parent.number.checked_add(1).ok_or_else(|| {
+        disable(eyre::eyre!(
+            "Tempo block number overflow after {}",
+            parent.number
+        ))
+    })?;
+    if evidence.block.number != expected_number || evidence.parent_hash != parent.hash {
+        return Err(finding(eyre::eyre!(
+            "Tempo history is not contiguous at block {}",
+            evidence.block.number
+        )));
+    }
+    let mut collector = EventCollector::new(portal);
+    for log in &evidence.logs {
+        collector
+            .extract_log(log, evidence.block.number)
+            .map_err(finding)?;
+    }
+    Ok(L1BlockEvidence {
+        block: evidence.block,
+        events: collector.finish(),
+    })
 }
 
 async fn collect_l1_block_inner(
@@ -121,13 +158,24 @@ async fn collect_l1_block_inner(
             "Tempo history does not end at the Zone anchor"
         )));
     }
-    let transaction_hashes = block.transactions().as_hashes().ok_or_else(|| {
-        disable(eyre::eyre!(
-            "Tempo block {number} ({}) did not contain transaction hashes",
-            coordinate.hash
-        ))
-    })?;
-    collect_l1_block_evidence(provider, portal, coordinate, transaction_hashes).await
+    let receipts = provider
+        .get_block_receipts(BlockId::hash(coordinate.hash))
+        .await
+        .map_err(classify_rpc_error)?
+        .ok_or_else(|| {
+            unavailable(eyre::eyre!(
+                "no receipts for L1 block {number} ({})",
+                coordinate.hash
+            ))
+        })?;
+    zone_l1::verify_receipts_against_header(
+        coordinate,
+        block.header().receipts_root(),
+        block.header().logs_bloom(),
+        &receipts,
+    )
+    .map_err(disable)?;
+    collect_l1_block_evidence(portal, coordinate, &receipts)
 }
 
 /// Read Portal custody for one token at an exact canonical Tempo block.
@@ -163,24 +211,14 @@ pub(crate) async fn portal_balances(
 }
 
 /// Fetch receipts and collect Portal events for one authenticated L1 block.
-async fn collect_l1_block_evidence(
-    provider: &DynProvider<TempoNetwork>,
+fn collect_l1_block_evidence(
     portal: Address,
     block: BlockNumHash,
-    transaction_hashes: &[B256],
+    receipts: &[TempoTransactionReceipt],
 ) -> Result<L1BlockEvidence, L1ReadError> {
-    let hash = block.hash;
     let number = block.number;
-    let receipts = provider
-        .get_block_receipts(BlockId::hash(hash))
-        .await
-        .map_err(classify_rpc_error)?
-        .ok_or_else(|| unavailable(eyre::eyre!("no receipts for L1 block {number} ({hash})")))?;
-    validate_l1_receipts(NumHash::new(number, hash), transaction_hashes, &receipts)
-        .map_err(disable)?;
-
     let mut event_collector = EventCollector::new(portal);
-    for receipt in &receipts {
+    for receipt in receipts {
         event_collector
             .extract_receipt(receipt, number)
             .map_err(finding)?;
@@ -232,109 +270,59 @@ fn disable(error: impl Into<eyre::Report>) -> L1ReadError {
     L1ReadError::Disable(error.into())
 }
 
-/// Validate transaction and receipt correspondence from the trusted L1 RPC.
-pub(crate) fn validate_l1_receipts(
-    block: NumHash,
-    transaction_hashes: &[B256],
-    receipts: &[TempoTransactionReceipt],
-) -> eyre::Result<()> {
-    let block_number = block.number;
-    let block_hash = block.hash;
-    eyre::ensure!(
-        receipts.len() == transaction_hashes.len(),
-        "L1 block {block_number} ({block_hash}) has {} transactions but {} receipts",
-        transaction_hashes.len(),
-        receipts.len()
-    );
-    for (index, (transaction_hash, receipt)) in transaction_hashes.iter().zip(receipts).enumerate()
-    {
-        eyre::ensure!(
-            receipt.block_hash() == Some(block_hash),
-            "receipt {index} has wrong block hash in L1 block {block_number} ({block_hash})"
-        );
-        eyre::ensure!(
-            receipt.block_number() == Some(block_number),
-            "receipt {index} has wrong block number in L1 block {block_number} ({block_hash})"
-        );
-        eyre::ensure!(
-            receipt.transaction_index() == Some(index as u64),
-            "receipt {index} has wrong transaction index in L1 block {block_number} ({block_hash})"
-        );
-        eyre::ensure!(
-            receipt.transaction_hash() == *transaction_hash,
-            "receipt {index} has wrong transaction hash in L1 block {block_number} ({block_hash})"
-        );
-    }
-
-    Ok(())
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;
-    use alloy_consensus::ReceiptWithBloom;
-    use alloy_primitives::{B256, Bloom};
-    use alloy_rpc_types_eth::TransactionReceipt;
-    use tempo_alloy::rpc::TempoTransactionReceipt;
-    use tempo_primitives::{TempoReceipt, TempoTxType};
+    use alloy_eips::NumHash;
+    use alloy_primitives::{B256, Log};
+    use alloy_sol_types::SolEvent;
+    use tempo_zone_contracts::ZonePortal;
 
     const BLOCK: u64 = 100;
     const HASH: B256 = B256::repeat_byte(0x10);
 
-    fn receipt_with_logs(
-        success: bool,
-        logs: Vec<alloy_rpc_types_eth::Log>,
-    ) -> TempoTransactionReceipt {
-        let inner_receipt = TempoReceipt {
-            tx_type: TempoTxType::Legacy,
-            success,
-            cumulative_gas_used: 0,
-            logs,
+    #[test]
+    fn tracked_evidence_preserves_accounting_events_and_parent_link() {
+        let parent = BlockNumHash::new(BLOCK - 1, B256::repeat_byte(0x09));
+        let portal = Address::repeat_byte(0x20);
+        let token = Address::repeat_byte(0x21);
+        let log = Log {
+            address: portal,
+            data: ZonePortal::TokenEnabled {
+                token,
+                name: "Test".into(),
+                symbol: "TST".into(),
+                currency: "USD".into(),
+            }
+            .encode_log_data(),
         };
-        TempoTransactionReceipt {
-            inner: TransactionReceipt {
-                inner: ReceiptWithBloom::new(inner_receipt, Bloom::ZERO),
-                transaction_hash: B256::ZERO,
-                transaction_index: Some(0),
-                block_hash: Some(HASH),
-                block_number: Some(BLOCK),
-                gas_used: 0,
-                effective_gas_price: 0,
-                blob_gas_used: None,
-                blob_gas_price: None,
-                from: Address::ZERO,
-                to: Some(Address::ZERO),
-                contract_address: None,
-            },
-            fee_token: None,
-            fee_payer: Address::ZERO,
-        }
+        let tracked = zone_l1::AuthenticatedPortalLogs {
+            block: NumHash::new(BLOCK, HASH),
+            parent_hash: parent.hash,
+            logs: vec![log],
+        };
+
+        let evidence = collect_tracked_l1_block_evidence(portal, parent, tracked).unwrap();
+        assert_eq!(evidence.block(), BlockNumHash::new(BLOCK, HASH));
+        assert!(matches!(
+            evidence.portal_events().next(),
+            Some(L1PortalEvent::TokenEnabled { token: observed }) if *observed == token
+        ));
     }
 
     #[test]
-    fn validate_receipts_rejects_count_mismatch() {
-        let receipts = [receipt_with_logs(true, vec![])];
-        assert!(
-            validate_l1_receipts(
-                NumHash::new(BLOCK, HASH),
-                &[B256::ZERO, B256::repeat_byte(1)],
-                &receipts,
-            )
-            .is_err()
+    fn tracked_evidence_rejects_non_contiguous_parent() {
+        let tracked = zone_l1::AuthenticatedPortalLogs {
+            block: NumHash::new(BLOCK, HASH),
+            parent_hash: B256::repeat_byte(0xff),
+            logs: vec![],
+        };
+        let result = collect_tracked_l1_block_evidence(
+            Address::ZERO,
+            BlockNumHash::new(BLOCK - 1, B256::repeat_byte(0x09)),
+            tracked,
         );
-    }
-
-    #[test]
-    fn validate_receipts_rejects_wrong_transaction_metadata() {
-        let receipts = [receipt_with_logs(true, vec![])];
-        assert!(
-            validate_l1_receipts(
-                NumHash::new(BLOCK, HASH),
-                &[B256::repeat_byte(1)],
-                &receipts,
-            )
-            .is_err()
-        );
+        assert!(matches!(result, Err(L1ReadError::Finding(_))));
     }
 
     #[test]

--- a/crates/checker/src/lib.rs
+++ b/crates/checker/src/lib.rs
@@ -108,6 +108,8 @@ pub struct CheckerConfig {
     pub zone_chain_id: u64,
     /// Dedicated MDBX directory below the node data directory.
     pub database_path: PathBuf,
+    /// Receipt-authenticated Tempo observations shared with the Zone node.
+    pub l1_block_tracker: zone_l1::L1BlockTracker,
 }
 
 /// Observe-only checker execution extension.

--- a/crates/checker/src/runtime.rs
+++ b/crates/checker/src/runtime.rs
@@ -382,9 +382,15 @@ where
     let tempo = BlockNumHash::new(anchor.block_number(), anchor.block_hash());
     let tempo_parent = BlockNumHash::from(prior.metadata.imported_tempo);
     validate_tempo_advance(tempo_parent.number, tempo.number).map_err(fail)?;
-    let tempo_block = collect_l1_block_at(l1, config.portal_address, tempo_parent, tempo)
-        .await
-        .map_err(|error| classify_block_l1_error(error, zone))?;
+    let tempo_block = collect_l1_block_at(
+        l1,
+        &config.l1_block_tracker,
+        config.portal_address,
+        tempo_parent,
+        tempo,
+    )
+    .await
+    .map_err(|error| classify_block_l1_error(error, zone))?;
     let mut block_effects = effects::from_tempo(&tempo_block);
     block_effects.extend(effects::from_zone(&l2));
     let candidate = CandidateTransition::derive(

--- a/crates/l1/src/lib.rs
+++ b/crates/l1/src/lib.rs
@@ -18,7 +18,7 @@
 
 use alloy_consensus::BlockHeader as _;
 use alloy_eips::{BlockNumberOrTag, NumHash};
-use alloy_network::primitives::HeaderResponse as _;
+use alloy_network::{ReceiptResponse as _, primitives::HeaderResponse as _};
 use alloy_primitives::{Address, B256, Bloom, U256, keccak256};
 use alloy_provider::{DynProvider, Provider, ProviderBuilder};
 use alloy_rpc_client::RpcClient;
@@ -96,10 +96,11 @@ pub use ext::{ChainTempoStateExt, TempoStateExt};
 pub use queue::DepositQueue;
 pub use state::L1StateCache;
 pub use subscriber::{
-    L1BlockTracker, L1Subscriber, L1SubscriberConfig, LeadershipSink, MAX_L1_LOOKAHEAD_BLOCKS,
+    AuthenticatedPortalLogs, L1BlockTracker, L1Subscriber, L1SubscriberConfig, LeadershipSink,
+    MAX_L1_LOOKAHEAD_BLOCKS, verify_receipts_against_header,
 };
 
 #[cfg(test)]
 pub(crate) use queue::PendingDeposits;
 #[cfg(test)]
-pub(crate) use subscriber::{LocalTempoCheckpointReader, verify_receipts};
+pub(crate) use subscriber::LocalTempoCheckpointReader;

--- a/crates/l1/src/subscriber.rs
+++ b/crates/l1/src/subscriber.rs
@@ -13,6 +13,7 @@ pub const MAX_L1_LOOKAHEAD_BLOCKS: u64 = 7_200;
 #[derive(Debug, Default)]
 struct L1BlockTrackerState {
     observed: BTreeMap<u64, L1BlockObservation>,
+    recent_portal_evidence: BTreeMap<u64, AuthenticatedPortalLogs>,
     latest: Option<NumHash>,
     pruned_through: Option<u64>,
 }
@@ -21,7 +22,23 @@ struct L1BlockTrackerState {
 struct L1BlockObservation {
     hash: B256,
     portal_events: L1PortalEvents,
+    portal_evidence: Option<AuthenticatedPortalLogs>,
 }
+
+/// Receipt-root-authenticated Portal logs for one finalized Tempo block.
+#[derive(Debug, Clone)]
+pub struct AuthenticatedPortalLogs {
+    /// Exact finalized Tempo block containing the logs.
+    pub block: NumHash,
+    /// Parent hash from the authenticated Tempo header.
+    pub parent_hash: B256,
+    /// Portal logs in canonical receipt and log order.
+    pub logs: Vec<alloy_primitives::Log>,
+}
+
+/// Number of consumed Tempo blocks whose authenticated Portal logs remain available to
+/// asynchronous observers such as the checker ExEx.
+const RECENT_PORTAL_EVIDENCE_BLOCKS: u64 = 256;
 
 /// L1 blocks whose headers and receipts have been independently validated and
 /// whose derived state has been applied to the local caches.
@@ -158,9 +175,41 @@ impl L1BlockTracker {
         }
     }
 
+    /// Return retained receipt-authenticated Portal logs for an exact Tempo block.
+    ///
+    /// This is intentionally non-blocking. Callers replaying older history can fall back to an
+    /// archival provider when the bounded recent cache no longer contains the block.
+    pub fn authenticated_portal_logs(
+        &self,
+        block: NumHash,
+    ) -> eyre::Result<Option<AuthenticatedPortalLogs>> {
+        let state = self.state.read();
+        if let Some(observation) = state.observed.get(&block.number) {
+            eyre::ensure!(
+                observation.hash == block.hash,
+                "observed different L1 hash at block {}: expected {}, got {}",
+                block.number,
+                block.hash,
+                observation.hash
+            );
+            return Ok(observation.portal_evidence.clone());
+        }
+        if let Some(evidence) = state.recent_portal_evidence.get(&block.number) {
+            eyre::ensure!(
+                evidence.block.hash == block.hash,
+                "retained different L1 hash at block {}: expected {}, got {}",
+                block.number,
+                block.hash,
+                evidence.block.hash
+            );
+            return Ok(Some(evidence.clone()));
+        }
+        Ok(None)
+    }
+
     /// Record an independently validated and applied L1 anchor.
     pub fn record(&self, block: NumHash) -> eyre::Result<()> {
-        self.record_with_portal_events(block, L1PortalEvents::default())
+        self.record_observation(block, L1PortalEvents::default(), None)
     }
 
     /// Record an L1 anchor together with portal events decoded from its verified receipts.
@@ -168,6 +217,31 @@ impl L1BlockTracker {
         &self,
         block: NumHash,
         portal_events: L1PortalEvents,
+    ) -> eyre::Result<()> {
+        self.record_observation(block, portal_events, None)
+    }
+
+    /// Record an L1 anchor together with decoded events and authenticated raw Portal logs.
+    pub fn record_with_portal_evidence(
+        &self,
+        block: NumHash,
+        parent_hash: B256,
+        portal_events: L1PortalEvents,
+        logs: Vec<alloy_primitives::Log>,
+    ) -> eyre::Result<()> {
+        let evidence = AuthenticatedPortalLogs {
+            block,
+            parent_hash,
+            logs,
+        };
+        self.record_observation(block, portal_events, Some(evidence))
+    }
+
+    fn record_observation(
+        &self,
+        block: NumHash,
+        portal_events: L1PortalEvents,
+        portal_evidence: Option<AuthenticatedPortalLogs>,
     ) -> eyre::Result<()> {
         let mut state = self.state.write();
         if let Some(observation) = state.observed.get(&block.number) {
@@ -214,6 +288,7 @@ impl L1BlockTracker {
             L1BlockObservation {
                 hash: block.hash,
                 portal_events,
+                portal_evidence,
             },
         );
         state.latest = Some(block);
@@ -228,7 +303,22 @@ impl L1BlockTracker {
     /// only after successfully consuming the matching finalized L1 work.
     pub fn prune_through(&self, number: u64) {
         let mut state = self.state.write();
+        let consumed = state
+            .observed
+            .range(..=number)
+            .filter_map(|(_, observation)| {
+                observation
+                    .portal_evidence
+                    .clone()
+                    .map(|evidence| (evidence.block.number, evidence))
+            })
+            .collect::<Vec<_>>();
+        state.recent_portal_evidence.extend(consumed);
         state.observed.retain(|height, _| *height > number);
+        let retain_after = number.saturating_sub(RECENT_PORTAL_EVIDENCE_BLOCKS);
+        state
+            .recent_portal_evidence
+            .retain(|height, _| *height > retain_after);
         state.pruned_through = Some(state.pruned_through.map_or(number, |old| old.max(number)));
         drop(state);
         self.changed.send_replace(());
@@ -238,7 +328,7 @@ impl L1BlockTracker {
 /// Poll interval for the HTTP block filter fallback (500ms, matching L1 block time).
 const HTTP_POLL_INTERVAL: std::time::Duration = std::time::Duration::from_millis(500);
 
-type L1ProcessedEvents = (L1PortalEvents, HashSet<Address>);
+type L1ProcessedEvents = (L1PortalEvents, HashSet<Address>, Vec<alloy_primitives::Log>);
 
 fn cache_invalidation_address(address: Address, topic0: Option<&B256>) -> Option<Address> {
     (address == TIP403_REGISTRY_ADDRESS
@@ -669,16 +759,18 @@ impl L1Subscriber {
             // Decoding fails closed: a decode failure of a recognized portal log aborts this
             // block before anything is enqueued or any cache advances. Ingestion halts here (fenced)
             // instead of continuing under a partial event view.
-            let (events, invalidated) =
-                self.extract_events(block_number, &receipts)
-                    .map_err(|err| {
-                        self.subscriber_metrics.decode_fence_failures.increment(1);
-                        FencedIngestionError::new(block_number, "portal event decoding", err)
-                    })?;
+            let processed_events = self
+                .extract_events(block_number, &receipts)
+                .map_err(|err| {
+                    self.subscriber_metrics.decode_fence_failures.increment(1);
+                    FencedIngestionError::new(block_number, "portal event decoding", err)
+                })?;
+            let (events, invalidated, portal_logs) = processed_events;
             self.record_seen_block(block_number, to.saturating_sub(block_number));
 
             let sealed = SealedHeader::seal_slow(header);
             let anchor = sealed.num_hash();
+            let parent_hash = sealed.parent_hash();
             // Publish the leadership transition _before_ the activation block becomes
             // consumable.
             if let Some(sink) = &self.config.leadership_sink {
@@ -718,9 +810,12 @@ impl L1Subscriber {
                 .wrap_err_with(|| {
                     format!("unexpected discontinuity while enqueueing L1 block {block_number}")
                 })?;
-            self.config
-                .block_tracker
-                .record_with_portal_events(anchor, events.clone())?;
+            self.config.block_tracker.record_with_portal_evidence(
+                anchor,
+                parent_hash,
+                events.clone(),
+                portal_logs,
+            )?;
             // Publish derived L1 state only after the header has been admitted to every
             // configured retention sink and the contiguous observation tracker.
             self.apply_enabled_token_events(&events);
@@ -785,12 +880,17 @@ impl L1Subscriber {
         let portal_address = self.config.portal_address;
         let mut portal_events = L1PortalEvents::default();
         let mut invalidated = HashSet::new();
+        let mut portal_logs = Vec::new();
 
         for receipt in receipts {
+            let successful = receipt.status();
             for log in receipt.logs() {
                 let address = log.address();
 
                 if address == portal_address {
+                    if successful {
+                        portal_logs.push(log.inner.clone());
+                    }
                     invalidated.insert(address);
                     if let Some(address) =
                         portal_event_cache_invalidation_address(log.topics().first())
@@ -813,7 +913,7 @@ impl L1Subscriber {
             invalidated.extend([event.token, TIP403_REGISTRY_ADDRESS]);
         }
         self.record_portal_event_metrics(&portal_events);
-        Ok((portal_events, invalidated))
+        Ok((portal_events, invalidated, portal_logs))
     }
 
     fn record_seen_block(&self, block_number: u64, lag_blocks: u64) {
@@ -895,7 +995,7 @@ async fn fetch_and_verify_receipts_for_header(
         .get_block_receipts(BlockId::hash(block_hash))
         .await?
         .ok_or_else(|| eyre::eyre!("no receipts for block {block_number} ({block_hash})"))?;
-    verify_receipts(
+    verify_receipts_against_header(
         block,
         expected_receipts_root,
         expected_logs_bloom,
@@ -904,7 +1004,8 @@ async fn fetch_and_verify_receipts_for_header(
     Ok(receipts)
 }
 
-pub(crate) fn verify_receipts(
+/// Verify that RPC receipts reproduce an authenticated Tempo header's receipt root and log bloom.
+pub fn verify_receipts_against_header(
     block: NumHash,
     expected_receipts_root: B256,
     expected_logs_bloom: Bloom,

--- a/crates/l1/src/tests.rs
+++ b/crates/l1/src/tests.rs
@@ -209,6 +209,42 @@ async fn l1_block_tracker_returns_receipt_authenticated_portal_events() {
 }
 
 #[test]
+fn l1_block_tracker_retains_authenticated_portal_logs_after_consumption() {
+    let tracker = L1BlockTracker::default();
+    let anchor = NumHash::new(10, B256::with_last_byte(0x10));
+    let parent_hash = B256::with_last_byte(0x09);
+    let portal = address!("0x0000000000000000000000000000000000000ABC");
+    let log = alloy_primitives::Log::new_unchecked(
+        portal,
+        vec![B256::with_last_byte(1)],
+        Default::default(),
+    );
+    tracker
+        .record_with_portal_evidence(
+            anchor,
+            parent_hash,
+            L1PortalEvents::default(),
+            vec![log.clone()],
+        )
+        .unwrap();
+
+    let observed = tracker.authenticated_portal_logs(anchor).unwrap().unwrap();
+    assert_eq!(observed.parent_hash, parent_hash);
+    assert_eq!(observed.logs, vec![log.clone()]);
+
+    tracker.prune_through(anchor.number);
+    assert_eq!(tracker.observed_hash(anchor.number), None);
+    assert_eq!(
+        tracker
+            .authenticated_portal_logs(anchor)
+            .unwrap()
+            .unwrap()
+            .logs,
+        vec![log]
+    );
+}
+
+#[test]
 fn observed_portal_events_require_complete_advance_tempo_inputs() {
     let events = L1PortalEvents {
         deposits: vec![
@@ -508,7 +544,7 @@ fn verify_receipts_accepts_matching_root_and_logs_bloom() {
     ];
     let receipts_root = calculate_test_receipts_root(&receipts);
 
-    verify_receipts(block, receipts_root, Bloom::ZERO, &receipts)
+    verify_receipts_against_header(block, receipts_root, Bloom::ZERO, &receipts)
         .expect("matching receipts root should validate");
 }
 
@@ -527,8 +563,9 @@ fn verify_receipts_rejects_receipts_root_mismatch() {
         Bloom::ZERO,
     )];
 
-    let err = verify_receipts(block, B256::with_last_byte(0xff), Bloom::ZERO, &receipts)
-        .expect_err("mismatched receipts root should fail");
+    let err =
+        verify_receipts_against_header(block, B256::with_last_byte(0xff), Bloom::ZERO, &receipts)
+            .expect_err("mismatched receipts root should fail");
 
     assert!(
         err.to_string().contains("receipt root mismatch"),
@@ -554,7 +591,7 @@ fn verify_receipts_rejects_changed_receipt_bloom() {
     let mut tampered_receipts = receipts;
     tampered_receipts[0].inner.inner.logs_bloom = Bloom::repeat_byte(0x01);
 
-    let err = verify_receipts(block, receipts_root, Bloom::ZERO, &tampered_receipts)
+    let err = verify_receipts_against_header(block, receipts_root, Bloom::ZERO, &tampered_receipts)
         .expect_err("tampered receipt bloom should fail");
 
     assert!(
@@ -579,7 +616,7 @@ fn verify_receipts_rejects_logs_bloom_mismatch() {
     )];
     let receipts_root = calculate_test_receipts_root(&receipts);
 
-    let err = verify_receipts(block, receipts_root, Bloom::ZERO, &receipts)
+    let err = verify_receipts_against_header(block, receipts_root, Bloom::ZERO, &receipts)
         .expect_err("mismatched header logs bloom should fail");
 
     assert!(
@@ -1641,9 +1678,10 @@ fn extract_events_fails_closed_on_corrupt_recognized_portal_log() {
         ..Default::default()
     };
     let receipt = make_receipt_with_logs(10, B256::with_last_byte(0x10), vec![unknown]);
-    let (events, _) = subscriber.extract_events(10, &[receipt]).unwrap();
+    let (events, _, portal_logs) = subscriber.extract_events(10, &[receipt]).unwrap();
     assert!(events.deposits.is_empty());
     assert!(events.leader_transitions.is_empty());
+    assert_eq!(portal_logs.len(), 1);
 }
 
 #[test]
@@ -1678,7 +1716,7 @@ fn pause_events_invalidate_cached_portal_storage() {
     ];
     let receipt = make_receipt_with_logs(1, B256::with_last_byte(0x10), logs);
 
-    let (_, invalidated) = subscriber.extract_events(1, &[receipt]).unwrap();
+    let (_, invalidated, _) = subscriber.extract_events(1, &[receipt]).unwrap();
     assert!(invalidated.contains(&portal));
     subscriber.update_l1_state_anchor(1, &invalidated);
     assert_eq!(

--- a/crates/node/src/cli.rs
+++ b/crates/node/src/cli.rs
@@ -237,6 +237,7 @@ fn run_node(mut cli: Cli<ZoneChainSpecParser, ZoneArgs>) -> eyre::Result<()> {
         if let Some(config) = p2p_config {
             node = node.with_p2p(config);
         }
+        let checker_l1_block_tracker = node.l1_block_tracker();
 
         // Install or skip the checker ExEx based on the configured mode.
         match args.checker_mode {
@@ -255,6 +256,7 @@ fn run_node(mut cli: Cli<ZoneChainSpecParser, ZoneArgs>) -> eyre::Result<()> {
                     zone_id: checker_zone_id,
                     zone_chain_id: checker_zone_chain_id,
                     database_path: checker_database_path,
+                    l1_block_tracker: checker_l1_block_tracker,
                 });
                 builder
                     .node(node)


### PR DESCRIPTION
Stacked on #1216.

## Summary
- retain receipt-root-authenticated Portal logs in the node L1 tracker for asynchronous checker consumption
- have live checker verification reuse those exact block/hash/parent-bound observations instead of refetching Tempo receipts
- keep the archival RPC fallback for bootstrap and recovery beyond the bounded recent cache
- reuse the node L1 receipt-root/log-bloom verifier for fallback and bootstrap receipt authentication

## Behavior
Checker accounting, strict Portal decoding, parent/hash validation, persistence, findings, and observe-only behavior remain unchanged. The tracker retains the latest 256 consumed Tempo observations; older recovery ranges fall back to the existing archival provider.

## Validation
- `cargo test -p zone-l1 -p zone-checker` (132 passed)
- `cargo test -p zone-node --lib --features cli checker_mode` (3 passed)
- `cargo clippy -p zone-l1 -p zone-checker -p zone-node --features zone-node/cli --all-targets -- -D warnings`
- `cargo fmt --all -- --check`