### PR TITLE
fix(seq): Filter out failed receipts

### DIFF
--- a/crates/evm/src/executor.rs
+++ b/crates/evm/src/executor.rs
@@ -279,15 +279,27 @@ mod tests {
     };
 
     use alloy_consensus::{Header, Signed, TxLegacy};
-    use alloy_evm::{EvmEnv, EvmFactory, block::BlockExecutor, eth::EthBlockExecutionCtx};
+    use alloy_evm::{
+        Evm, EvmEnv, EvmFactory,
+        block::BlockExecutor,
+        eth::{
+            EthBlockExecutionCtx,
+            receipt_builder::{ReceiptBuilder, ReceiptBuilderCtx},
+        },
+    };
     use alloy_primitives::{Address, B256, Bytes, Log, Signature, U256, keccak256};
     use alloy_rlp::Encodable as _;
     use alloy_sol_types::{SolCall, SolEvent};
     use reth_chainspec::EthChainSpec as _;
     use reth_primitives_traits::Recovered;
-    use revm::database::{CacheDB, EmptyDB};
+    use revm::{
+        bytecode::Bytecode,
+        context::result::ResultAndState,
+        database::{CacheDB, EmptyDB},
+        state::AccountInfo,
+    };
     use tempo_chainspec::spec::DEV;
-    use tempo_evm::TempoBlockExecutionCtx;
+    use tempo_evm::{TempoBlockExecutionCtx, TempoReceiptBuilder};
     use tempo_precompiles::{
         DEFAULT_FEE_TOKEN, TIP_FEE_MANAGER_ADDRESS,
         storage::{ContractStorage, Handler, StorageCtx, hashmap::HashMapStorageProvider},
@@ -364,6 +376,49 @@ mod tests {
                 data: event.encode_log_data(),
             }],
         }
+    }
+
+    fn emit_log_then_revert_bytecode(log: &Log) -> Bytes {
+        let data = &log.data.data;
+        let data_len = u16::try_from(data.len()).unwrap();
+        let [data_len_hi, data_len_lo] = data_len.to_be_bytes();
+
+        // Copy the ABI-encoded event data appended to this bytecode into memory.
+        let mut code = vec![
+            0x61,
+            data_len_hi,
+            data_len_lo, // PUSH2 data length
+            0x61,
+            0,
+            0, // PUSH2 data offset (filled below)
+            0x60,
+            0,    // PUSH1 memory offset
+            0x39, // CODECOPY
+        ];
+
+        for topic in log.topics().iter().rev() {
+            code.push(0x7f); // PUSH32
+            code.extend_from_slice(topic.as_slice());
+        }
+        code.extend_from_slice(&[
+            0x61,
+            data_len_hi,
+            data_len_lo, // PUSH2 data length
+            0x60,
+            0,                               // PUSH1 memory offset
+            0xa0 + log.topics().len() as u8, // LOGn
+            0x60,
+            0, // PUSH1 revert data length
+            0x60,
+            0,    // PUSH1 revert data offset
+            0xfd, // REVERT
+        ]);
+
+        let [data_offset_hi, data_offset_lo] = u16::try_from(code.len()).unwrap().to_be_bytes();
+        code[4] = data_offset_hi;
+        code[5] = data_offset_lo;
+        code.extend_from_slice(data);
+        code.into()
     }
 
     fn ordinary_tx(to: Address, input: Bytes) -> TempoTxEnvelope {
@@ -558,6 +613,43 @@ mod tests {
         executor
             .finish()
             .expect("reverted withdrawal request must not require finalization");
+    }
+
+    #[test]
+    fn reverted_execution_discards_withdrawal_requested_log() {
+        let emitter = Address::repeat_byte(0x44);
+        let expected_log = withdrawal_requested_receipt(emitter).logs.remove(0);
+        let code = emit_log_then_revert_bytecode(&expected_log);
+        let mut db = CacheDB::new(EmptyDB::default());
+        db.insert_account_info(
+            emitter,
+            AccountInfo {
+                code_hash: keccak256(&code),
+                code: Some(Bytecode::new_raw(code)),
+                nonce: 1,
+                ..Default::default()
+            },
+        );
+
+        let mut zone_genesis = DEV.genesis().clone();
+        zone_genesis.config.chain_id = zone_chain_id(DEV.chain().id(), 2).unwrap();
+        let chain_spec = std::sync::Arc::new(ZoneChainSpec::from_genesis(zone_genesis).unwrap());
+        let factory = ZoneEvmFactory::new(chain_spec, MockL1Reader::default(), Address::ZERO);
+        let mut evm = factory.create_evm(db, EvmEnv::default());
+        let ResultAndState { result, state } = evm
+            .transact_system_call(Address::repeat_byte(0x55), emitter, Bytes::new())
+            .expect("reverting transaction should execute");
+
+        let receipt = TempoReceiptBuilder::default().build_receipt(ReceiptBuilderCtx {
+            tx_type: TempoTxType::Legacy,
+            evm: &evm,
+            result,
+            state: &state,
+            cumulative_gas_used: 0,
+        });
+
+        assert!(!receipt.success);
+        assert!(receipt.logs.is_empty());
     }
 
     #[test]

--- a/crates/evm/src/executor.rs
+++ b/crates/evm/src/executor.rs
@@ -240,6 +240,7 @@ where
             .inner
             .receipts()
             .iter()
+            .filter(|receipt| receipt.status())
             .flat_map(|receipt| receipt.logs())
             .any(|log| {
                 log.address == ZONE_OUTBOX_ADDRESS
@@ -522,6 +523,41 @@ mod tests {
             "zone block with withdrawal requests is missing its finalizeWithdrawalBatch system \
              transaction"
         );
+    }
+
+    #[test]
+    fn reverted_withdrawal_requests_do_not_require_same_block_finalization() {
+        let mut zone_genesis = DEV.genesis().clone();
+        zone_genesis.config.chain_id = zone_chain_id(DEV.chain().id(), 2).unwrap();
+        let chain_spec = std::sync::Arc::new(ZoneChainSpec::from_genesis(zone_genesis).unwrap());
+        let factory =
+            ZoneEvmFactory::new(chain_spec.clone(), MockL1Reader::default(), Address::ZERO);
+        let evm = factory.create_evm(CacheDB::new(EmptyDB::default()), EvmEnv::default());
+        let ctx = TempoBlockExecutionCtx {
+            inner: EthBlockExecutionCtx {
+                parent_hash: B256::ZERO,
+                parent_beacon_block_root: None,
+                ommers: &[],
+                withdrawals: None,
+                extra_data: Bytes::new(),
+                tx_count_hint: Some(1),
+                slot_number: None,
+            },
+            general_gas_limit: 0,
+            shared_gas_limit: 0,
+            validator_set: None,
+            consensus_context: None,
+            subblock_fee_recipients: Default::default(),
+        };
+        let mut executor = ZoneBlockExecutor::new(evm, ctx, &chain_spec);
+        executor.phase = ZoneBlockPhase::Executing;
+        let mut receipt = withdrawal_requested_receipt(ZONE_OUTBOX_ADDRESS);
+        receipt.success = false;
+        executor.inner.receipts.push(receipt);
+
+        executor
+            .finish()
+            .expect("reverted withdrawal request must not require finalization");
     }
 
     #[test]

--- a/crates/sequencer/src/settlement.rs
+++ b/crates/sequencer/src/settlement.rs
@@ -1526,6 +1526,9 @@ pub(crate) fn read_zone_block_snapshot<P: ZoneSequencerProvider>(
     let mut processed_deposit_number = None;
 
     for receipt in receipts {
+        if !receipt.status() {
+            continue;
+        }
         for log in receipt.logs() {
             if log.address != inbox_address
                 || log.topics().first() != Some(&IZoneInbox::TempoAdvanced::SIGNATURE_HASH)
@@ -1598,6 +1601,9 @@ pub(crate) async fn fetch_finalized_batch<P: ZoneSequencerProvider>(
     let (block, receipts) = block_with_receipts(zone_provider, target.block_number)?;
     let mut requests = Vec::new();
     for (tx, receipt) in block.body.transactions.iter().zip(&receipts) {
+        if !receipt.status() {
+            continue;
+        }
         for log in receipt.logs() {
             if log.address != outbox_address
                 || log.topics().first() != Some(&IZoneOutbox::WithdrawalRequested::SIGNATURE_HASH)
@@ -1712,6 +1718,9 @@ fn fetch_finalized_batch_logs<P: ZoneSequencerProvider>(
             .zip(receipts.iter())
             .enumerate()
         {
+            if !receipt.status() {
+                continue;
+            }
             for (log_index, log) in receipt.logs().iter().enumerate() {
                 if log.address != outbox_address
                     || log.topics().first() != Some(&IZoneOutbox::BatchFinalized::SIGNATURE_HASH)
@@ -1744,16 +1753,18 @@ fn backward_log_query_start(hi: u64, floor: u64) -> u64 {
 mod tests {
     use super::*;
     use crate::abi;
-    use alloy_consensus::Header as ConsensusHeader;
-    use alloy_primitives::{B256, address};
+    use alloy_consensus::{Header as ConsensusHeader, Signed, TxLegacy};
+    use alloy_primitives::{B256, Log, Signature, address};
     use alloy_provider::ProviderBuilder;
     use alloy_rpc_types_eth::Header as RpcHeader;
-    use alloy_sol_types::SolValue;
+    use alloy_sol_types::{SolCall, SolEvent, SolValue};
     use alloy_transport::mock::Asserter;
     use proptest::prelude::*;
     use reth_provider::test_utils::MockEthProvider;
     use tempo_alloy::rpc::TempoHeaderResponse;
-    use tempo_primitives::{Block, TempoHeader, TempoPrimitives};
+    use tempo_primitives::{
+        Block, TempoHeader, TempoPrimitives, TempoReceipt, TempoTxEnvelope, TempoTxType,
+    };
 
     fn mock_l1(asserter: Asserter) -> DynProvider<TempoNetwork> {
         ProviderBuilder::new_with_network::<TempoNetwork>()
@@ -1847,6 +1858,139 @@ mod tests {
             err.to_string()
                 .contains("is not canonical in the Zone node")
         );
+    }
+
+    #[tokio::test]
+    async fn authoritative_zone_logs_ignore_reverted_receipts() {
+        let provider = MockEthProvider::<TempoPrimitives>::new();
+        let block_number = 7;
+        let inbox_address = Address::repeat_byte(0x11);
+        let outbox_address = Address::repeat_byte(0x22);
+
+        let transaction = |to: Address, input: Bytes| {
+            TempoTxEnvelope::Legacy(Signed::new_unhashed(
+                TxLegacy {
+                    to: to.into(),
+                    input,
+                    ..Default::default()
+                },
+                Signature::test_signature(),
+            ))
+        };
+        let receipt = |success: bool, address: Address, data| TempoReceipt {
+            tx_type: TempoTxType::Legacy,
+            success,
+            cumulative_gas_used: 0,
+            logs: vec![Log { address, data }],
+        };
+
+        let reverted_tempo_advanced = abi::IZoneInbox::TempoAdvanced {
+            tempoBlockHash: B256::repeat_byte(0x31),
+            tempoBlockNumber: 31,
+            depositsProcessed: U256::ZERO,
+            newProcessedDepositQueueHash: B256::repeat_byte(0x32),
+            lastProcessedDepositNumber: 31,
+        };
+        let tempo_advanced = abi::IZoneInbox::TempoAdvanced {
+            tempoBlockHash: B256::repeat_byte(0x41),
+            tempoBlockNumber: 41,
+            depositsProcessed: U256::ZERO,
+            newProcessedDepositQueueHash: B256::repeat_byte(0x42),
+            lastProcessedDepositNumber: 41,
+        };
+        let reverted_withdrawal = abi::IZoneOutbox::WithdrawalRequested {
+            withdrawalIndex: 0,
+            sender: Address::repeat_byte(0x51),
+            token: Address::repeat_byte(0x52),
+            to: Address::repeat_byte(0x53),
+            amount: 1,
+            fee: 0,
+            memo: B256::ZERO,
+            gasLimit: 0,
+            fallbackNonce: 1,
+            data: Bytes::new(),
+            revealTo: Bytes::new(),
+        };
+        let reverted_boundary = abi::IZoneOutbox::BatchFinalized {
+            withdrawalQueueHash: B256::repeat_byte(0x61),
+            withdrawalBatchIndex: 60,
+        };
+        let boundary = abi::IZoneOutbox::BatchFinalized {
+            withdrawalQueueHash: B256::ZERO,
+            withdrawalBatchIndex: 61,
+        };
+        let finalize_input = abi::IZoneOutbox::finalizeWithdrawalBatchCall {
+            count: U256::ZERO,
+            blockNumber: block_number,
+            encryptedSenders: Vec::new(),
+        }
+        .abi_encode()
+        .into();
+
+        let transactions = vec![
+            transaction(inbox_address, Bytes::from_static(b"reverted-tempo")),
+            transaction(inbox_address, Bytes::from_static(b"tempo")),
+            transaction(outbox_address, Bytes::from_static(b"reverted-withdrawal")),
+            transaction(outbox_address, Bytes::from_static(b"reverted-boundary")),
+            transaction(outbox_address, finalize_input),
+        ];
+        let receipts = vec![
+            receipt(
+                false,
+                inbox_address,
+                reverted_tempo_advanced.encode_log_data(),
+            ),
+            receipt(true, inbox_address, tempo_advanced.encode_log_data()),
+            receipt(false, outbox_address, reverted_withdrawal.encode_log_data()),
+            receipt(false, outbox_address, reverted_boundary.encode_log_data()),
+            receipt(true, outbox_address, boundary.encode_log_data()),
+        ];
+
+        let mut header = TempoHeader::default();
+        header.inner.number = block_number;
+        let block_hash = B256::repeat_byte(0x71);
+        provider.add_block(
+            block_hash,
+            Block {
+                header,
+                body: alloy_consensus::BlockBody {
+                    transactions,
+                    ..Default::default()
+                },
+            },
+        );
+        provider.add_receipts(block_number, receipts);
+
+        let snapshot = read_zone_block_snapshot(&provider, inbox_address, block_number).unwrap();
+        assert_eq!(snapshot.tempo_block_number, tempo_advanced.tempoBlockNumber);
+        assert_eq!(
+            snapshot.processed_deposit_hash,
+            tempo_advanced.newProcessedDepositQueueHash
+        );
+        assert_eq!(
+            snapshot.processed_deposit_number,
+            tempo_advanced.lastProcessedDepositNumber
+        );
+
+        let boundaries =
+            fetch_finalized_batch_boundaries(&provider, outbox_address, block_number, block_number)
+                .await
+                .unwrap();
+        assert_eq!(boundaries.len(), 1);
+        assert_eq!(
+            boundaries[0].withdrawal_batch_index,
+            boundary.withdrawalBatchIndex
+        );
+
+        let finalized = fetch_finalized_batch(&provider, outbox_address, &boundaries[0])
+            .await
+            .unwrap();
+        assert!(finalized.withdrawals.is_empty());
+
+        let restored = fetch_slot_withdrawals(&provider, outbox_address, block_number)
+            .await
+            .unwrap();
+        assert!(restored.is_empty());
     }
 
     fn abi_word(value: impl SolValue) -> Bytes {


### PR DESCRIPTION
Update the monitor-side withdrawal reconstruction logic in fetch_slot_withdrawals to verify the transaction receipt status of each fetched WithdrawalRequested log.

  - fetch_finalized_batch ignores failed receipts.
  - fetch_slot_withdrawals is protected through its filtered boundary scan and fetch_finalized_batch call.
  - Added receipt-status filtering to:
      - withdrawal detection  executor.rs:239
      - zone snapshot reconstruction in  settlement.rs:1528
      - finalized-boundary scanning in  settlement.rs:1713

  - Added regression tests covering reverted withdrawal, TempoAdvanced, and BatchFinalized logs.