### PR TITLE
tests(node): Chaos tests for L1 disconnect/catchup and P2P network

### DIFF
--- a/.config/nextest.toml
+++ b/.config/nextest.toml
@@ -6,5 +6,5 @@ test-threads = "num-cpus"
 # Integration tests spin up full reth nodes — limit concurrency to avoid
 # resource contention and flaky timeouts on CI runners.
 [[profile.ci.overrides]]
-filter = "test(/^(e2e|earn_zone_e2e|l1_e2e|network_chaos_e2e|restart_e2e|handoff_e2e)::/) | test(advance_tempo)"
+filter = "test(/^(e2e|earn_zone_e2e|l1_e2e|network_chaos_e2e|network_chaos_p2p_e2e|restart_e2e|handoff_e2e)::/) | test(advance_tempo)"
 threads-required = 8

--- a/.config/nextest.toml
+++ b/.config/nextest.toml
@@ -6,5 +6,5 @@ test-threads = "num-cpus"
 # Integration tests spin up full reth nodes — limit concurrency to avoid
 # resource contention and flaky timeouts on CI runners.
 [[profile.ci.overrides]]
-filter = "test(/^(e2e|earn_zone_e2e|l1_e2e|restart_e2e|handoff_e2e)::/) | test(advance_tempo)"
+filter = "test(/^(e2e|earn_zone_e2e|l1_e2e|network_chaos_e2e|restart_e2e|handoff_e2e)::/) | test(advance_tempo)"
 threads-required = 8

--- a/crates/node/tests/it/main.rs
+++ b/crates/node/tests/it/main.rs
@@ -8,6 +8,7 @@ mod enable_token;
 mod handoff_e2e;
 mod l1_e2e;
 mod network_chaos_e2e;
+mod network_chaos_p2p_e2e;
 mod precompiles;
 mod redacted_rpc;
 mod redacted_rpc_e2e;

--- a/crates/node/tests/it/main.rs
+++ b/crates/node/tests/it/main.rs
@@ -7,6 +7,7 @@ mod earn_zone_e2e;
 mod enable_token;
 mod handoff_e2e;
 mod l1_e2e;
+mod network_chaos_e2e;
 mod precompiles;
 mod redacted_rpc;
 mod redacted_rpc_e2e;

--- a/crates/node/tests/it/network_chaos_e2e.rs
+++ b/crates/node/tests/it/network_chaos_e2e.rs
@@ -182,7 +182,7 @@ async fn test_three_sequencers_reconnect_and_catch_up_after_l1_network_outage() 
         .wait_for_connections_after(0, 3, NETWORK_TIMEOUT)
         .await?;
     let portal = ZonePortal::new(cluster.portal_address, cluster.l1.provider());
-    let batches_before_outage = poll_until(
+    poll_until(
         NETWORK_TIMEOUT,
         POLL_INTERVAL,
         "an initial settled batch before the network outage",
@@ -232,7 +232,6 @@ async fn test_three_sequencers_reconnect_and_catch_up_after_l1_network_outage() 
             "node {index} reached outage target {outage_target} without an L1 connection"
         );
     }
-    let batches_at_resume = batch_count(&portal).await?.max(batches_before_outage);
 
     // Restoring the listeners must result in new TCP connections, not reuse of the sockets that
     // were alive before the fault. Catch-up then proves those connections carry valid RPC traffic.
@@ -267,8 +266,8 @@ async fn test_three_sequencers_reconnect_and_catch_up_after_l1_network_outage() 
         || {
             let portal = &portal;
             async move {
-                let count = batch_count(portal).await?;
-                Ok((count > batches_at_resume).then_some(count))
+                let settled_height = portal.zoneHeight().call().await?;
+                Ok((settled_height >= U256::from(recovered_height)).then_some(settled_height))
             }
         },
     )
@@ -372,8 +371,6 @@ async fn test_asymmetric_l1_outages_recover_followers_then_leader() -> eyre::Res
             index + 1
         );
     }
-    let batches_at_resume = batch_count(&portal).await?;
-
     for proxy in [&follower_one_proxy, &follower_two_proxy] {
         proxy.resume();
     }
@@ -408,8 +405,8 @@ async fn test_asymmetric_l1_outages_recover_followers_then_leader() -> eyre::Res
         || {
             let portal = &portal;
             async move {
-                let count = batch_count(portal).await?;
-                Ok((count > batches_at_resume).then_some(count))
+                let settled_height = portal.zoneHeight().call().await?;
+                Ok((settled_height >= U256::from(recovered_height)).then_some(settled_height))
             }
         },
     )
@@ -466,8 +463,6 @@ async fn test_asymmetric_l1_outages_recover_followers_then_leader() -> eyre::Res
             "node {index} advanced zone state without a connected leader"
         );
     }
-    let batches_before_leader_resume = batch_count(&portal).await?;
-
     leader_proxy.resume();
     leader_proxy
         .wait_for_connections_after(leader_accepted_before_outage, 1, NETWORK_TIMEOUT)
@@ -496,8 +491,9 @@ async fn test_asymmetric_l1_outages_recover_followers_then_leader() -> eyre::Res
         || {
             let portal = &portal;
             async move {
-                let count = batch_count(portal).await?;
-                Ok((count > batches_before_leader_resume).then_some(count))
+                let settled_height = portal.zoneHeight().call().await?;
+                Ok((settled_height >= U256::from(phase_two_recovered_height))
+                    .then_some(settled_height))
             }
         },
     )
@@ -511,7 +507,6 @@ async fn test_asymmetric_l1_outages_recover_followers_then_leader() -> eyre::Res
         .wait_all_at(phase_three_baseline, NETWORK_TIMEOUT)
         .await?;
     cluster.assert_same_block(phase_three_baseline).await?;
-    let batches_before_single_follower_outage = batch_count(&portal).await?;
     let isolated_accepted_before_outage = follower_one_proxy.accepted_connections();
     follower_one_proxy.disconnect();
     follower_one_proxy
@@ -549,8 +544,8 @@ async fn test_asymmetric_l1_outages_recover_followers_then_leader() -> eyre::Res
         || {
             let portal = &portal;
             async move {
-                let count = batch_count(portal).await?;
-                Ok((count > batches_before_single_follower_outage).then_some(count))
+                let settled_height = portal.zoneHeight().call().await?;
+                Ok((settled_height > U256::from(phase_three_baseline)).then_some(settled_height))
             }
         },
     )

--- a/crates/node/tests/it/network_chaos_e2e.rs
+++ b/crates/node/tests/it/network_chaos_e2e.rs
@@ -20,7 +20,7 @@ use crate::utils::{
 const NETWORK_TIMEOUT: Duration = Duration::from_secs(60);
 const SUBMISSION_TIMEOUT: Duration = Duration::from_secs(15);
 const POLL_INTERVAL: Duration = Duration::from_millis(200);
-const L1_BLOCK_TIME: Duration = Duration::from_millis(100);
+const L1_BLOCK_TIME: Duration = Duration::from_millis(250);
 const OUTAGE_BLOCK_GAP: u64 = 8;
 const INITIAL_DEPOSIT: u128 = 10_000_000;
 const OUTAGE_DEPOSIT: u128 = 1_000_000;

--- a/crates/node/tests/it/network_chaos_e2e.rs
+++ b/crates/node/tests/it/network_chaos_e2e.rs
@@ -1,0 +1,581 @@
+//! End-to-end tests for recovery from real TCP-level network failures.
+//!
+//! Unlike the restart tests, every node and background task remains alive. All nodes reach the real
+//! Tempo L1 through one controlled TCP proxy, so disconnecting it closes every established RPC
+//! socket and exercises the production reconnect and finalized backfill path.
+
+use std::time::Duration;
+
+use alloy::{primitives::U256, providers::Provider as _};
+use alloy_network::ReceiptResponse as _;
+use tempo_precompiles::PATH_USD_ADDRESS;
+use tempo_primitives::transaction::calc_gas_balance_spending;
+use tempo_zone_contracts::{IZoneOutbox, ZONE_OUTBOX_ADDRESS, ZONE_TOKEN_ADDRESS, ZonePortal};
+
+use crate::utils::{
+    RealP2pCluster, ZoneAccount, poll_until, start_real_p2p_cluster_with_l1_proxy,
+    start_real_p2p_cluster_with_per_node_l1_proxies,
+};
+
+const NETWORK_TIMEOUT: Duration = Duration::from_secs(60);
+const SUBMISSION_TIMEOUT: Duration = Duration::from_secs(15);
+const POLL_INTERVAL: Duration = Duration::from_millis(200);
+const L1_BLOCK_TIME: Duration = Duration::from_millis(100);
+const OUTAGE_BLOCK_GAP: u64 = 8;
+const INITIAL_DEPOSIT: u128 = 10_000_000;
+const OUTAGE_DEPOSIT: u128 = 1_000_000;
+const OUTAGE_WITHDRAWAL: u128 = 250_000;
+
+struct OutageAssetFlow {
+    phase: &'static str,
+    l2_balance_before: U256,
+    l1_balance_before_withdrawal: U256,
+    deposit_block: u64,
+    withdrawal_hash: alloy::primitives::B256,
+    withdrawal_fee: u128,
+}
+
+async fn batch_count(
+    portal: &ZonePortal::ZonePortalInstance<alloy::providers::DynProvider>,
+) -> eyre::Result<usize> {
+    Ok(portal
+        .BatchSubmitted_filter()
+        .from_block(0)
+        .query()
+        .await?
+        .len())
+}
+
+async fn submit_outage_asset_flow(
+    cluster: &RealP2pCluster,
+    account: &mut ZoneAccount,
+    phase: &'static str,
+    outage_start: u64,
+) -> eyre::Result<OutageAssetFlow> {
+    let l2_balance_before = cluster.nodes[0]
+        .balance_of(ZONE_TOKEN_ADDRESS, account.address())
+        .await?;
+    let deposit_block =
+        tokio::time::timeout(SUBMISSION_TIMEOUT, account.submit_deposit(OUTAGE_DEPOSIT))
+            .await
+            .map_err(|_| eyre::eyre!("{phase} deposit submission timed out"))??;
+    eyre::ensure!(
+        deposit_block >= outage_start,
+        "{phase} deposit landed before the L1 outage began"
+    );
+
+    let withdrawal_fee = IZoneOutbox::new(ZONE_OUTBOX_ADDRESS, cluster.nodes[0].provider())
+        .calculateWithdrawalFee(0)
+        .call()
+        .await?;
+    let l1_balance_before_withdrawal = cluster
+        .l1
+        .balance_of(PATH_USD_ADDRESS, account.address())
+        .await?;
+    let withdrawal_hash = tokio::time::timeout(
+        SUBMISSION_TIMEOUT,
+        account.submit_withdrawal(OUTAGE_WITHDRAWAL),
+    )
+    .await
+    .map_err(|_| eyre::eyre!("{phase} withdrawal submission timed out"))??;
+
+    Ok(OutageAssetFlow {
+        phase,
+        l2_balance_before,
+        l1_balance_before_withdrawal,
+        deposit_block,
+        withdrawal_hash,
+        withdrawal_fee,
+    })
+}
+
+async fn assert_outage_asset_flow(
+    cluster: &RealP2pCluster,
+    account: &ZoneAccount,
+    flow: OutageAssetFlow,
+) -> eyre::Result<()> {
+    let receipt = poll_until(
+        NETWORK_TIMEOUT,
+        POLL_INTERVAL,
+        &format!(
+            "{} withdrawal to be included after reconnection",
+            flow.phase
+        ),
+        || {
+            let provider = cluster.nodes[0].provider();
+            async move {
+                Ok(provider
+                    .get_transaction_receipt(flow.withdrawal_hash)
+                    .await?)
+            }
+        },
+    )
+    .await?;
+    eyre::ensure!(receipt.status(), "{} withdrawal reverted", flow.phase);
+
+    cluster
+        .l1
+        .wait_for_withdrawal_on_l1(
+            cluster.portal_address,
+            account.address(),
+            flow.l1_balance_before_withdrawal,
+            OUTAGE_WITHDRAWAL,
+            NETWORK_TIMEOUT,
+        )
+        .await?;
+    let l1_balance_after = cluster
+        .l1
+        .balance_of(PATH_USD_ADDRESS, account.address())
+        .await?;
+    assert_eq!(
+        l1_balance_after,
+        flow.l1_balance_before_withdrawal + U256::from(OUTAGE_WITHDRAWAL),
+        "{} produced the wrong L1 balance after withdrawal",
+        flow.phase
+    );
+
+    for node in &cluster.nodes {
+        node.wait_for_tempo_block_number(flow.deposit_block, NETWORK_TIMEOUT)
+            .await?;
+    }
+    let inclusion_block = receipt
+        .block_number
+        .ok_or_else(|| eyre::eyre!("{} withdrawal receipt has no block", flow.phase))?;
+    cluster
+        .wait_all_at(inclusion_block, NETWORK_TIMEOUT)
+        .await?;
+
+    let transaction_fee = calc_gas_balance_spending(receipt.gas_used, receipt.effective_gas_price);
+    let expected_l2_balance = flow.l2_balance_before + U256::from(OUTAGE_DEPOSIT)
+        - U256::from(OUTAGE_WITHDRAWAL)
+        - U256::from(flow.withdrawal_fee)
+        - transaction_fee;
+    for (index, node) in cluster.nodes.iter().enumerate() {
+        let balance = node
+            .balance_of(ZONE_TOKEN_ADDRESS, account.address())
+            .await?;
+        assert_eq!(
+            balance, expected_l2_balance,
+            "{} produced the wrong L2 balance on node {index}",
+            flow.phase
+        );
+    }
+    Ok(())
+}
+
+/// All three sequencers lose their established L1 connections, remain running while L1 advances,
+/// reconnect through the same endpoint, backfill the finalized gap, and converge again.
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn test_three_sequencers_reconnect_and_catch_up_after_l1_network_outage() -> eyre::Result<()>
+{
+    reth_tracing::init_test_tracing();
+
+    let (cluster, proxy) = start_real_p2p_cluster_with_l1_proxy(4, L1_BLOCK_TIME).await?;
+    eyre::ensure!(
+        cluster.nodes.len() == 3,
+        "network-chaos fixture must start three nodes"
+    );
+
+    // Establish a healthy baseline: nodes have connected through the shared proxy and all hold
+    // the same leader-produced chain, and the quorum has submitted at least one batch to L1.
+    proxy
+        .wait_for_connections_after(0, 3, NETWORK_TIMEOUT)
+        .await?;
+    let portal = ZonePortal::new(cluster.portal_address, cluster.l1.provider());
+    let batches_before_outage = poll_until(
+        NETWORK_TIMEOUT,
+        POLL_INTERVAL,
+        "an initial settled batch before the network outage",
+        || {
+            let portal = &portal;
+            async move {
+                let count = batch_count(portal).await?;
+                Ok((count > 0).then_some(count))
+            }
+        },
+    )
+    .await?;
+    let baseline_height = cluster.nodes[0].provider().get_block_number().await?;
+    cluster
+        .wait_all_at(baseline_height, NETWORK_TIMEOUT)
+        .await?;
+    cluster.assert_same_block(baseline_height).await?;
+
+    let accepted_before_outage = proxy.accepted_connections();
+    proxy.disconnect();
+    proxy.wait_for_no_connections(NETWORK_TIMEOUT).await?;
+    eyre::ensure!(
+        proxy.active_connections() == 0,
+        "disconnect did not close every established L1 socket through {}",
+        proxy.listen_addr()
+    );
+
+    // Build a gap that cannot have been prefetched before the sockets were closed.
+    let outage_start = cluster.l1.provider().get_block_number().await?;
+    let outage_target = outage_start + OUTAGE_BLOCK_GAP;
+    poll_until(
+        NETWORK_TIMEOUT,
+        POLL_INTERVAL,
+        "L1 to advance while every sequencer link is disconnected",
+        || {
+            let provider = cluster.l1.provider();
+            async move {
+                let height = provider.get_block_number().await?;
+                Ok((height >= outage_target).then_some(height))
+            }
+        },
+    )
+    .await?;
+    for (index, node) in cluster.nodes.iter().enumerate() {
+        eyre::ensure!(
+            node.tempo_block_number().await? < outage_target,
+            "node {index} reached outage target {outage_target} without an L1 connection"
+        );
+    }
+    let batches_at_resume = batch_count(&portal).await?.max(batches_before_outage);
+
+    // Restoring the listeners must result in new TCP connections, not reuse of the sockets that
+    // were alive before the fault. Catch-up then proves those connections carry valid RPC traffic.
+    proxy.resume();
+    proxy
+        .wait_for_connections_after(accepted_before_outage, 3, NETWORK_TIMEOUT)
+        .await?;
+    for node in &cluster.nodes {
+        node.wait_for_tempo_block_number(outage_target, NETWORK_TIMEOUT)
+            .await?;
+    }
+
+    // Compare a fixed recovered height so continued L1 production cannot move the assertion's
+    // target while nodes are being sampled.
+    let mut recovered_height = u64::MAX;
+    for node in &cluster.nodes {
+        recovered_height = recovered_height.min(node.provider().get_block_number().await?);
+    }
+    eyre::ensure!(
+        recovered_height > baseline_height,
+        "nodes did not advance beyond their pre-outage zone height"
+    );
+    cluster
+        .wait_all_at(recovered_height, NETWORK_TIMEOUT)
+        .await?;
+    cluster.assert_same_block(recovered_height).await?;
+
+    poll_until(
+        NETWORK_TIMEOUT,
+        POLL_INTERVAL,
+        "batch settlement to resume after L1 reconnection",
+        || {
+            let portal = &portal;
+            async move {
+                let count = batch_count(portal).await?;
+                Ok((count > batches_at_resume).then_some(count))
+            }
+        },
+    )
+    .await?;
+
+    Ok(())
+}
+
+/// Exercise three asymmetric L1 outages: both followers, the leader, then one follower. Each
+/// restored side must backfill its missed anchors, process a deposit and withdrawal submitted
+/// during the outage, and converge before the next phase. The final phase also proves that one
+/// healthy follower preserves 2-of-3 settlement.
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn test_asymmetric_l1_outages_recover_followers_then_leader() -> eyre::Result<()> {
+    reth_tracing::init_test_tracing();
+
+    let (cluster, [leader_proxy, follower_one_proxy, follower_two_proxy]) =
+        start_real_p2p_cluster_with_per_node_l1_proxies(4, L1_BLOCK_TIME).await?;
+    eyre::ensure!(
+        cluster.nodes.len() == 3,
+        "network-chaos fixture must start one leader and two followers"
+    );
+    for proxy in [&follower_one_proxy, &follower_two_proxy] {
+        proxy
+            .wait_for_connections_after(0, 1, NETWORK_TIMEOUT)
+            .await?;
+    }
+
+    let portal = ZonePortal::new(cluster.portal_address, cluster.l1.provider());
+    poll_until(
+        NETWORK_TIMEOUT,
+        POLL_INTERVAL,
+        "an initial settled batch before disconnecting the followers",
+        || {
+            let portal = &portal;
+            async move {
+                let count = batch_count(portal).await?;
+                Ok((count > 0).then_some(count))
+            }
+        },
+    )
+    .await?;
+
+    // Seed one account before introducing faults so every outage can carry both a new L1 deposit
+    // and an L2 withdrawal. Approval is also completed up front: during the leader outage the
+    // withdrawal request itself may enter the pool, but no approval block can be produced.
+    let mut account =
+        ZoneAccount::from_l1_and_zone(&cluster.l1, &cluster.nodes[0], cluster.portal_address);
+    cluster
+        .l1
+        .fund_user(
+            account.address(),
+            INITIAL_DEPOSIT + 3 * OUTAGE_DEPOSIT + 10_000_000,
+        )
+        .await?;
+    let initial_balance = account
+        .deposit(INITIAL_DEPOSIT, NETWORK_TIMEOUT, &cluster.nodes[0])
+        .await?;
+    assert_eq!(initial_balance, U256::from(INITIAL_DEPOSIT));
+    for node in &cluster.nodes {
+        node.wait_for_balance(
+            ZONE_TOKEN_ADDRESS,
+            account.address(),
+            initial_balance,
+            NETWORK_TIMEOUT,
+        )
+        .await?;
+    }
+    account.approve_outbox(ZONE_TOKEN_ADDRESS).await?;
+
+    let baseline_height = cluster.nodes[0].provider().get_block_number().await?;
+    cluster
+        .wait_all_at(baseline_height, NETWORK_TIMEOUT)
+        .await?;
+    cluster.assert_same_block(baseline_height).await?;
+
+    let follower_accepted_before_outage = [
+        follower_one_proxy.accepted_connections(),
+        follower_two_proxy.accepted_connections(),
+    ];
+    for proxy in [&follower_one_proxy, &follower_two_proxy] {
+        proxy.disconnect();
+    }
+    for proxy in [&follower_one_proxy, &follower_two_proxy] {
+        proxy.wait_for_no_connections(NETWORK_TIMEOUT).await?;
+    }
+
+    let outage_start = cluster.l1.provider().get_block_number().await?;
+    let follower_outage_assets =
+        submit_outage_asset_flow(&cluster, &mut account, "both-follower outage", outage_start)
+            .await?;
+    let outage_target =
+        (outage_start + OUTAGE_BLOCK_GAP).max(follower_outage_assets.deposit_block + 1);
+    cluster.nodes[0]
+        .wait_for_tempo_block_number(outage_target, NETWORK_TIMEOUT)
+        .await?;
+    for (index, follower) in cluster.nodes[1..].iter().enumerate() {
+        eyre::ensure!(
+            follower.tempo_block_number().await? < outage_target,
+            "follower {} reached outage target {outage_target} without an L1 connection",
+            index + 1
+        );
+    }
+    let batches_at_resume = batch_count(&portal).await?;
+
+    for proxy in [&follower_one_proxy, &follower_two_proxy] {
+        proxy.resume();
+    }
+    for (proxy, accepted) in [&follower_one_proxy, &follower_two_proxy]
+        .into_iter()
+        .zip(follower_accepted_before_outage)
+    {
+        proxy
+            .wait_for_connections_after(accepted, 1, NETWORK_TIMEOUT)
+            .await?;
+    }
+    for follower in &cluster.nodes[1..] {
+        follower
+            .wait_for_tempo_block_number(outage_target, NETWORK_TIMEOUT)
+            .await?;
+    }
+
+    let recovered_height = cluster.nodes[0].provider().get_block_number().await?;
+    eyre::ensure!(
+        recovered_height > baseline_height,
+        "leader did not continue producing during the follower outage"
+    );
+    cluster
+        .wait_all_at(recovered_height, NETWORK_TIMEOUT)
+        .await?;
+    cluster.assert_same_block(recovered_height).await?;
+
+    poll_until(
+        NETWORK_TIMEOUT,
+        POLL_INTERVAL,
+        "quorum settlement to resume after both followers catch up",
+        || {
+            let portal = &portal;
+            async move {
+                let count = batch_count(portal).await?;
+                Ok((count > batches_at_resume).then_some(count))
+            }
+        },
+    )
+    .await?;
+    assert_outage_asset_flow(&cluster, &account, follower_outage_assets).await?;
+
+    // Phase 2 reverses the fault. Followers keep their L1 sockets and independently observe the
+    // advancing finalized chain, but cannot advance zone state without leader-produced blocks.
+    let phase_two_baseline = cluster.nodes[0].provider().get_block_number().await?;
+    cluster
+        .wait_all_at(phase_two_baseline, NETWORK_TIMEOUT)
+        .await?;
+    cluster.assert_same_block(phase_two_baseline).await?;
+    leader_proxy
+        .wait_for_connections_after(0, 1, NETWORK_TIMEOUT)
+        .await?;
+    let leader_accepted_before_outage = leader_proxy.accepted_connections();
+    leader_proxy.disconnect();
+    leader_proxy
+        .wait_for_no_connections(NETWORK_TIMEOUT)
+        .await?;
+
+    let leader_outage_start = cluster.l1.provider().get_block_number().await?;
+    let leader_outage_assets =
+        submit_outage_asset_flow(&cluster, &mut account, "leader outage", leader_outage_start)
+            .await?;
+    let leader_outage_target =
+        (leader_outage_start + OUTAGE_BLOCK_GAP).max(leader_outage_assets.deposit_block + 1);
+    for (index, follower) in cluster.nodes[1..].iter().enumerate() {
+        poll_until(
+            NETWORK_TIMEOUT,
+            POLL_INTERVAL,
+            &format!(
+                "follower {} to observe L1 during the leader outage",
+                index + 1
+            ),
+            || async {
+                Ok(follower
+                    .l1_block_tracker()
+                    .latest()
+                    .filter(|block| block.number >= leader_outage_target)
+                    .map(|block| block.number))
+            },
+        )
+        .await?;
+    }
+    eyre::ensure!(
+        follower_one_proxy.active_connections() > 0 && follower_two_proxy.active_connections() > 0,
+        "a follower L1 proxy lost connectivity during the leader-only outage"
+    );
+    for (index, node) in cluster.nodes.iter().enumerate() {
+        eyre::ensure!(
+            node.tempo_block_number().await? < leader_outage_target,
+            "node {index} advanced zone state without a connected leader"
+        );
+    }
+    let batches_before_leader_resume = batch_count(&portal).await?;
+
+    leader_proxy.resume();
+    leader_proxy
+        .wait_for_connections_after(leader_accepted_before_outage, 1, NETWORK_TIMEOUT)
+        .await?;
+    for node in &cluster.nodes {
+        node.wait_for_tempo_block_number(leader_outage_target, NETWORK_TIMEOUT)
+            .await?;
+    }
+
+    let phase_two_recovered_height = cluster.nodes[0].provider().get_block_number().await?;
+    eyre::ensure!(
+        phase_two_recovered_height > phase_two_baseline,
+        "leader did not produce the anchors missed during its L1 outage"
+    );
+    cluster
+        .wait_all_at(phase_two_recovered_height, NETWORK_TIMEOUT)
+        .await?;
+    cluster
+        .assert_same_block(phase_two_recovered_height)
+        .await?;
+
+    poll_until(
+        NETWORK_TIMEOUT,
+        POLL_INTERVAL,
+        "quorum settlement to resume after the leader catches up",
+        || {
+            let portal = &portal;
+            async move {
+                let count = batch_count(portal).await?;
+                Ok((count > batches_before_leader_resume).then_some(count))
+            }
+        },
+    )
+    .await?;
+    assert_outage_asset_flow(&cluster, &account, leader_outage_assets).await?;
+
+    // Phase 3 isolates one follower. The leader and other follower must keep producing and
+    // settling as a 2-of-3 quorum; the isolated follower then reconnects and rejoins the chain.
+    let phase_three_baseline = cluster.nodes[0].provider().get_block_number().await?;
+    cluster
+        .wait_all_at(phase_three_baseline, NETWORK_TIMEOUT)
+        .await?;
+    cluster.assert_same_block(phase_three_baseline).await?;
+    let batches_before_single_follower_outage = batch_count(&portal).await?;
+    let isolated_accepted_before_outage = follower_one_proxy.accepted_connections();
+    follower_one_proxy.disconnect();
+    follower_one_proxy
+        .wait_for_no_connections(NETWORK_TIMEOUT)
+        .await?;
+
+    let single_follower_outage_start = cluster.l1.provider().get_block_number().await?;
+    let single_follower_outage_assets = submit_outage_asset_flow(
+        &cluster,
+        &mut account,
+        "single-follower outage",
+        single_follower_outage_start,
+    )
+    .await?;
+    let single_follower_outage_target = (single_follower_outage_start + OUTAGE_BLOCK_GAP)
+        .max(single_follower_outage_assets.deposit_block + 1);
+    cluster.nodes[0]
+        .wait_for_tempo_block_number(single_follower_outage_target, NETWORK_TIMEOUT)
+        .await?;
+    cluster.nodes[2]
+        .wait_for_tempo_block_number(single_follower_outage_target, NETWORK_TIMEOUT)
+        .await?;
+    eyre::ensure!(
+        cluster.nodes[1].tempo_block_number().await? < single_follower_outage_target,
+        "isolated follower reached outage target without an L1 connection"
+    );
+    eyre::ensure!(
+        leader_proxy.active_connections() > 0 && follower_two_proxy.active_connections() > 0,
+        "healthy quorum member lost L1 connectivity during the single-follower outage"
+    );
+    poll_until(
+        NETWORK_TIMEOUT,
+        POLL_INTERVAL,
+        "2-of-3 settlement to continue with one follower disconnected from L1",
+        || {
+            let portal = &portal;
+            async move {
+                let count = batch_count(portal).await?;
+                Ok((count > batches_before_single_follower_outage).then_some(count))
+            }
+        },
+    )
+    .await?;
+
+    follower_one_proxy.resume();
+    follower_one_proxy
+        .wait_for_connections_after(isolated_accepted_before_outage, 1, NETWORK_TIMEOUT)
+        .await?;
+    cluster.nodes[1]
+        .wait_for_tempo_block_number(single_follower_outage_target, NETWORK_TIMEOUT)
+        .await?;
+
+    let phase_three_recovered_height = cluster.nodes[0].provider().get_block_number().await?;
+    eyre::ensure!(
+        phase_three_recovered_height > phase_three_baseline,
+        "healthy quorum did not advance during the single-follower outage"
+    );
+    cluster
+        .wait_all_at(phase_three_recovered_height, NETWORK_TIMEOUT)
+        .await?;
+    cluster
+        .assert_same_block(phase_three_recovered_height)
+        .await?;
+    assert_outage_asset_flow(&cluster, &account, single_follower_outage_assets).await?;
+
+    Ok(())
+}

--- a/crates/node/tests/it/network_chaos_p2p_e2e.rs
+++ b/crates/node/tests/it/network_chaos_p2p_e2e.rs
@@ -206,8 +206,8 @@ async fn test_follower_keeps_up_with_high_p2p_latency() -> eyre::Result<()> {
     Ok(())
 }
 
-/// Delayed L1 RPC responses cannot make a follower accept blocks before observing their anchors;
-/// the follower eventually observes those anchors and converges with the healthy nodes.
+/// A follower does not import leader blocks while their L1 anchors are withheld. Once responses
+/// resume with substantial latency, it observes the anchors and converges with the healthy nodes.
 #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
 async fn test_follower_keeps_up_with_high_l1_latency() -> eyre::Result<()> {
     reth_tracing::init_test_tracing();
@@ -215,14 +215,38 @@ async fn test_follower_keeps_up_with_high_l1_latency() -> eyre::Result<()> {
     let (cluster, _network, [_leader_l1, follower_l1, _other_follower_l1]) =
         start_cluster().await?;
     synchronized_head(&cluster).await?;
+    let follower_anchor = cluster.nodes[1].tempo_block_number().await?;
+    let highest_observed_anchor = cluster.nodes[1]
+        .l1_block_tracker()
+        .latest()
+        .map_or(follower_anchor, |anchor| anchor.number);
+    let target_anchor = highest_observed_anchor + RECOVERY_GAP;
+
     follower_l1.set_client_to_upstream_latency(L1_LATENCY);
     follower_l1.set_upstream_to_client_latency(L1_LATENCY);
+    follower_l1.pause_upstream_to_client(true);
 
-    let target = cluster.nodes[0].provider().get_block_number().await? + RECOVERY_GAP;
     cluster.nodes[0]
-        .wait_for_block_number(target, NETWORK_TIMEOUT)
+        .wait_for_tempo_block_number(target_anchor, NETWORK_TIMEOUT)
         .await?;
-    cluster.wait_all_at(target, NETWORK_TIMEOUT).await?;
-    cluster.assert_same_block(target).await?;
+    let target_head = cluster.nodes[0].provider().get_block_number().await?;
+    eyre::ensure!(
+        cluster.nodes[1].tempo_block_number().await? < target_anchor,
+        "follower imported anchor {target_anchor} while its L1 responses were paused"
+    );
+    eyre::ensure!(
+        cluster.nodes[1]
+            .l1_block_tracker()
+            .latest()
+            .is_none_or(|anchor| anchor.number < target_anchor),
+        "follower observed anchor {target_anchor} while its L1 responses were paused"
+    );
+
+    follower_l1.pause_upstream_to_client(false);
+    cluster.nodes[1]
+        .wait_for_tempo_block_number(target_anchor, NETWORK_TIMEOUT)
+        .await?;
+    cluster.wait_all_at(target_head, NETWORK_TIMEOUT).await?;
+    cluster.assert_same_block(target_head).await?;
     Ok(())
 }

--- a/crates/node/tests/it/network_chaos_p2p_e2e.rs
+++ b/crates/node/tests/it/network_chaos_p2p_e2e.rs
@@ -15,7 +15,7 @@ use crate::utils::{
 
 const NETWORK_TIMEOUT: Duration = Duration::from_secs(60);
 const POLL_INTERVAL: Duration = Duration::from_millis(200);
-const L1_BLOCK_TIME: Duration = Duration::from_millis(100);
+const L1_BLOCK_TIME: Duration = Duration::from_millis(250);
 const P2P_LATENCY: Duration = Duration::from_millis(400);
 const L1_LATENCY: Duration = Duration::from_millis(500);
 const RECOVERY_GAP: u64 = 6;

--- a/crates/node/tests/it/network_chaos_p2p_e2e.rs
+++ b/crates/node/tests/it/network_chaos_p2p_e2e.rs
@@ -1,0 +1,228 @@
+//! End-to-end coverage for P2P link failures and latency.
+//!
+//! Every peer-to-peer connection crosses a controllable TCP proxy. Unlike restart tests, the
+//! nodes, their transaction pools, and their role generations stay alive while links fail.
+
+use std::time::Duration;
+
+use alloy::{primitives::U256, providers::Provider as _};
+use alloy_network::ReceiptResponse as _;
+use tempo_zone_contracts::ZONE_TOKEN_ADDRESS;
+
+use crate::utils::{
+    P2pChaosNetwork, RealP2pCluster, ZoneAccount, poll_until, start_real_p2p_network_chaos_cluster,
+};
+
+const NETWORK_TIMEOUT: Duration = Duration::from_secs(60);
+const POLL_INTERVAL: Duration = Duration::from_millis(200);
+const L1_BLOCK_TIME: Duration = Duration::from_millis(100);
+const P2P_LATENCY: Duration = Duration::from_millis(400);
+const L1_LATENCY: Duration = Duration::from_millis(500);
+const RECOVERY_GAP: u64 = 6;
+const INITIAL_DEPOSIT: u128 = 10_000_000;
+const WITHDRAWAL_AMOUNT: u128 = 250_000;
+
+async fn start_cluster() -> eyre::Result<(
+    RealP2pCluster,
+    P2pChaosNetwork,
+    [crate::utils::TcpChaosProxy; 3],
+)> {
+    let fixture = start_real_p2p_network_chaos_cluster(4, L1_BLOCK_TIME).await?;
+    let cluster = &fixture.0;
+    eyre::ensure!(
+        cluster.nodes.len() == 3,
+        "P2P network-chaos fixture must start three nodes"
+    );
+
+    // The bootstrap leader waits for peer tip evidence before promotion. Reaching a common block
+    // proves the proxy mesh carries authenticated traffic before a fault is introduced.
+    cluster.nodes[0]
+        .wait_for_block_number(1, NETWORK_TIMEOUT)
+        .await?;
+    let head = cluster.nodes[0].provider().get_block_number().await?;
+    cluster.wait_all_at(head, NETWORK_TIMEOUT).await?;
+    cluster.assert_same_block(head).await?;
+    Ok(fixture)
+}
+
+async fn synchronized_head(cluster: &RealP2pCluster) -> eyre::Result<u64> {
+    let head = cluster.nodes[0].provider().get_block_number().await?;
+    cluster.wait_all_at(head, NETWORK_TIMEOUT).await?;
+    cluster.assert_same_block(head).await?;
+    Ok(head)
+}
+
+async fn assert_isolation_recovers(
+    cluster: &RealP2pCluster,
+    network: &P2pChaosNetwork,
+    isolated: &[usize],
+) -> eyre::Result<()> {
+    synchronized_head(cluster).await?;
+    network.disconnect_nodes(isolated);
+    network
+        .wait_for_nodes_disconnected(isolated, NETWORK_TIMEOUT)
+        .await?;
+
+    let outage_start = cluster.nodes[0].provider().get_block_number().await?;
+    let target = outage_start + RECOVERY_GAP;
+    cluster.nodes[0]
+        .wait_for_block_number(target, NETWORK_TIMEOUT)
+        .await?;
+
+    // The leader produces independently of P2P. When it is isolated, both followers fall behind;
+    // when the followers are isolated, those followers fall behind instead.
+    let lagging: &[usize] = if isolated.contains(&0) {
+        &[1, 2]
+    } else {
+        isolated
+    };
+    for index in lagging {
+        eyre::ensure!(
+            cluster.nodes[*index].provider().get_block_number().await? < target,
+            "isolated node {index} reached block {target} without a P2P connection"
+        );
+    }
+
+    network.resume_nodes(isolated);
+    cluster.wait_all_at(target, NETWORK_TIMEOUT).await?;
+    cluster.assert_same_block(target).await?;
+    Ok(())
+}
+
+/// Disconnect every P2P path involving the leader. The leader continues producing from L1 while
+/// both followers stop, then the followers backfill the missed blocks after reconnection.
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn test_followers_catch_up_after_leader_p2p_disconnect() -> eyre::Result<()> {
+    reth_tracing::init_test_tracing();
+
+    let (cluster, network, _l1_proxies) = start_cluster().await?;
+    assert_isolation_recovers(&cluster, &network, &[0]).await
+}
+
+/// Disconnect both followers from P2P while the leader continues producing, then verify both
+/// followers backfill and converge on the leader's canonical chain.
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn test_followers_catch_up_after_their_p2p_disconnect() -> eyre::Result<()> {
+    reth_tracing::init_test_tracing();
+
+    let (cluster, network, _l1_proxies) = start_cluster().await?;
+    assert_isolation_recovers(&cluster, &network, &[1, 2]).await
+}
+
+/// A transaction admitted to an isolated follower's pool remains pending locally. Once P2P is
+/// restored, reconciliation forwards it to the leader, which includes it in a canonical block.
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn test_follower_mempool_transaction_propagates_after_reconnect() -> eyre::Result<()> {
+    reth_tracing::init_test_tracing();
+
+    let (cluster, network, _l1_proxies) = start_cluster().await?;
+    let mut account =
+        ZoneAccount::from_l1_and_zone(&cluster.l1, &cluster.nodes[1], cluster.portal_address);
+    cluster
+        .l1
+        .fund_user(account.address(), INITIAL_DEPOSIT + 10_000_000)
+        .await?;
+    account
+        .deposit(INITIAL_DEPOSIT, NETWORK_TIMEOUT, &cluster.nodes[1])
+        .await?;
+    for node in &cluster.nodes {
+        node.wait_for_balance(
+            ZONE_TOKEN_ADDRESS,
+            account.address(),
+            U256::from(INITIAL_DEPOSIT),
+            NETWORK_TIMEOUT,
+        )
+        .await?;
+    }
+    account.approve_outbox(ZONE_TOKEN_ADDRESS).await?;
+
+    let baseline = synchronized_head(&cluster).await?;
+    network.disconnect_nodes(&[1]);
+    network
+        .wait_for_nodes_disconnected(&[1], NETWORK_TIMEOUT)
+        .await?;
+    cluster.nodes[0]
+        .wait_for_block_number(baseline + 2, NETWORK_TIMEOUT)
+        .await?;
+
+    let transaction_hash = account.submit_withdrawal(WITHDRAWAL_AMOUNT).await?;
+    eyre::ensure!(
+        cluster.nodes[0]
+            .provider()
+            .get_transaction_by_hash(transaction_hash)
+            .await?
+            .is_none(),
+        "leader received the follower transaction while all P2P links were disconnected"
+    );
+
+    network.resume_nodes(&[1]);
+    poll_until(
+        NETWORK_TIMEOUT,
+        POLL_INTERVAL,
+        "reconnected follower transaction to reach the leader",
+        || {
+            let provider = cluster.nodes[0].provider();
+            async move { Ok(provider.get_transaction_by_hash(transaction_hash).await?) }
+        },
+    )
+    .await?;
+    let receipt = poll_until(
+        NETWORK_TIMEOUT,
+        POLL_INTERVAL,
+        "forwarded follower transaction to be included by the leader",
+        || {
+            let provider = cluster.nodes[0].provider();
+            async move { Ok(provider.get_transaction_receipt(transaction_hash).await?) }
+        },
+    )
+    .await?;
+    eyre::ensure!(receipt.status(), "forwarded withdrawal reverted");
+    let inclusion_block = receipt
+        .block_number
+        .ok_or_else(|| eyre::eyre!("forwarded withdrawal receipt has no block number"))?;
+    cluster
+        .wait_all_at(inclusion_block, NETWORK_TIMEOUT)
+        .await?;
+    cluster.assert_same_block(inclusion_block).await?;
+    Ok(())
+}
+
+/// A follower remains able to import and validate the leader's chain while every P2P stream
+/// involving that follower carries substantial latency.
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn test_follower_keeps_up_with_high_p2p_latency() -> eyre::Result<()> {
+    reth_tracing::init_test_tracing();
+
+    let (cluster, network, _l1_proxies) = start_cluster().await?;
+    synchronized_head(&cluster).await?;
+    network.set_nodes_latency(&[1], P2P_LATENCY);
+
+    let target = cluster.nodes[0].provider().get_block_number().await? + RECOVERY_GAP;
+    cluster.nodes[0]
+        .wait_for_block_number(target, NETWORK_TIMEOUT)
+        .await?;
+    cluster.wait_all_at(target, NETWORK_TIMEOUT).await?;
+    cluster.assert_same_block(target).await?;
+    Ok(())
+}
+
+/// Delayed L1 RPC responses cannot make a follower accept blocks before observing their anchors;
+/// the follower eventually observes those anchors and converges with the healthy nodes.
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn test_follower_keeps_up_with_high_l1_latency() -> eyre::Result<()> {
+    reth_tracing::init_test_tracing();
+
+    let (cluster, _network, [_leader_l1, follower_l1, _other_follower_l1]) =
+        start_cluster().await?;
+    synchronized_head(&cluster).await?;
+    follower_l1.set_client_to_upstream_latency(L1_LATENCY);
+    follower_l1.set_upstream_to_client_latency(L1_LATENCY);
+
+    let target = cluster.nodes[0].provider().get_block_number().await? + RECOVERY_GAP;
+    cluster.nodes[0]
+        .wait_for_block_number(target, NETWORK_TIMEOUT)
+        .await?;
+    cluster.wait_all_at(target, NETWORK_TIMEOUT).await?;
+    cluster.assert_same_block(target).await?;
+    Ok(())
+}

--- a/crates/node/tests/it/utils.rs
+++ b/crates/node/tests/it/utils.rs
@@ -83,7 +83,7 @@ pub(crate) use auth_tokens::{
     build_signed_token_blob, now_secs, sign_keychain_signature, sign_p256_signature,
     sign_webauthn_signature,
 };
-pub(crate) use network::TcpChaosProxy;
+pub(crate) use network::{P2pChaosNetwork, TcpChaosProxy};
 
 /// Atomic counter for unique zone IDs across concurrent tests.
 static NEXT_ZONE_ID: AtomicU64 = AtomicU64::new(71_000);
@@ -3851,9 +3851,10 @@ pub(crate) async fn start_real_p2p_cluster_with_active_nodes(
         active_nodes,
         L1ProxyMode::Direct,
         None,
+        false,
     )
     .await?
-    .0)
+    .cluster)
 }
 
 /// Start the full three-member real-L1 cluster with one shared, controllable L1 proxy. Existing
@@ -3862,16 +3863,18 @@ pub(crate) async fn start_real_p2p_cluster_with_l1_proxy(
     withdrawal_batch_interval_blocks: u64,
     l1_block_time: Duration,
 ) -> eyre::Result<(RealP2pCluster, TcpChaosProxy)> {
-    let (cluster, mut proxies) = start_real_p2p_cluster_inner(
+    let mut parts = start_real_p2p_cluster_inner(
         withdrawal_batch_interval_blocks,
         3,
         L1ProxyMode::All,
         Some(l1_block_time),
+        false,
     )
     .await?;
     Ok((
-        cluster,
-        proxies
+        parts.cluster,
+        parts
+            .l1_proxies
             .pop()
             .expect("proxied cluster constructor must return its L1 proxy"),
     ))
@@ -3882,17 +3885,46 @@ pub(crate) async fn start_real_p2p_cluster_with_per_node_l1_proxies(
     withdrawal_batch_interval_blocks: u64,
     l1_block_time: Duration,
 ) -> eyre::Result<(RealP2pCluster, [TcpChaosProxy; 3])> {
-    let (cluster, proxies) = start_real_p2p_cluster_inner(
+    let parts = start_real_p2p_cluster_inner(
         withdrawal_batch_interval_blocks,
         3,
         L1ProxyMode::PerNode,
         Some(l1_block_time),
+        false,
     )
     .await?;
-    let proxies: [TcpChaosProxy; 3] = proxies
+    let proxies: [TcpChaosProxy; 3] = parts
+        .l1_proxies
         .try_into()
         .map_err(|_| eyre::eyre!("per-node proxy constructor must return three L1 proxies"))?;
-    Ok((cluster, proxies))
+    Ok((parts.cluster, proxies))
+}
+
+/// Start a full three-member cluster with independently controllable P2P links and one
+/// controllable L1 proxy per node.
+pub(crate) async fn start_real_p2p_network_chaos_cluster(
+    withdrawal_batch_interval_blocks: u64,
+    l1_block_time: Duration,
+) -> eyre::Result<(RealP2pCluster, P2pChaosNetwork, [TcpChaosProxy; 3])> {
+    let parts = start_real_p2p_cluster_inner(
+        withdrawal_batch_interval_blocks,
+        3,
+        L1ProxyMode::PerNode,
+        Some(l1_block_time),
+        true,
+    )
+    .await?;
+    let proxies = parts
+        .l1_proxies
+        .try_into()
+        .map_err(|_| eyre::eyre!("network-chaos cluster must return three L1 proxies"))?;
+    Ok((
+        parts.cluster,
+        parts
+            .p2p_network
+            .expect("network-chaos cluster must return its P2P proxy mesh"),
+        proxies,
+    ))
 }
 
 #[derive(Clone, Copy)]
@@ -3902,12 +3934,19 @@ enum L1ProxyMode {
     PerNode,
 }
 
+struct RealP2pClusterParts {
+    cluster: RealP2pCluster,
+    l1_proxies: Vec<TcpChaosProxy>,
+    p2p_network: Option<P2pChaosNetwork>,
+}
+
 async fn start_real_p2p_cluster_inner(
     withdrawal_batch_interval_blocks: u64,
     active_nodes: usize,
     proxy_mode: L1ProxyMode,
     l1_block_time: Option<Duration>,
-) -> eyre::Result<(RealP2pCluster, Vec<TcpChaosProxy>)> {
+    proxy_p2p: bool,
+) -> eyre::Result<RealP2pClusterParts> {
     eyre::ensure!(
         (2..=3).contains(&active_nodes),
         "real P2P test cluster requires two or three active nodes, got {active_nodes}"
@@ -3950,6 +3989,12 @@ async fn start_real_p2p_cluster_inner(
         available_address()?,
         available_address()?,
     ];
+    let (p2p_network, manifest_addresses) = if proxy_p2p {
+        let (network, manifest_addresses) = P2pChaosNetwork::start(addresses).await?;
+        (Some(network), manifest_addresses)
+    } else {
+        (None, [addresses; 3])
+    };
     let identities = [
         Ed25519PrivateKey::from_seed(301),
         Ed25519PrivateKey::from_seed(302),
@@ -3998,27 +4043,24 @@ async fn start_real_p2p_cluster_inner(
         next_unique_chain_id()
     ));
     std::fs::create_dir_all(&config_dir)?;
-    let manifest_path = config_dir.join("manifest.toml");
-    let mut manifest = format!(
-        "zone_id = {zone_id}\nsequencer_set_version = 0\nleader_ed25519_public_key = \"{}\"\n",
-        const_hex::encode_prefixed(public_keys[0].as_ref())
-    );
-    for (index, ((public_key, signer), address)) in public_keys
-        .iter()
-        .zip(&attestation_signers)
-        .zip(addresses)
-        .enumerate()
-    {
-        manifest.push_str(&format!(
-            "\n[[nodes]]\nname = \"node-{index}\"\ned25519_public_key = \"{}\"\nsecp256k1_address = \"{}\"\naddress = \"{address}\"\n",
-            const_hex::encode_prefixed(public_key.as_ref()),
-            signer.address(),
-        ));
-    }
-    std::fs::write(&manifest_path, manifest)?;
-
     let mut configs = Vec::with_capacity(3);
     for (index, role) in [(0, Role::Leader), (1, Role::Follower), (2, Role::Follower)] {
+        let manifest_path = config_dir.join(format!("manifest-{index}.toml"));
+        let mut manifest = format!(
+            "zone_id = {zone_id}\nsequencer_set_version = 0\nleader_ed25519_public_key = \"{}\"\n",
+            const_hex::encode_prefixed(public_keys[0].as_ref())
+        );
+        for (peer_index, (public_key, signer)) in
+            public_keys.iter().zip(&attestation_signers).enumerate()
+        {
+            let address = manifest_addresses[index][peer_index];
+            manifest.push_str(&format!(
+                "\n[[nodes]]\nname = \"node-{peer_index}\"\ned25519_public_key = \"{}\"\nsecp256k1_address = \"{}\"\naddress = \"{address}\"\n",
+                const_hex::encode_prefixed(public_key.as_ref()),
+                signer.address(),
+            ));
+        }
+        std::fs::write(&manifest_path, manifest)?;
         let key_path = config_dir.join(format!("node-{index}.key"));
         std::fs::write(
             &key_path,
@@ -4061,15 +4103,16 @@ async fn start_real_p2p_cluster_inner(
         );
     }
 
-    Ok((
-        RealP2pCluster {
+    Ok(RealP2pClusterParts {
+        cluster: RealP2pCluster {
             l1,
             portal_address,
             nodes,
             attestation_signers: attestation_signers.to_vec(),
         },
         l1_proxies,
-    ))
+        p2p_network,
+    })
 }
 
 /// Start a three-node multi-sequencer cluster with identical genesis state and authenticated

--- a/crates/node/tests/it/utils.rs
+++ b/crates/node/tests/it/utils.rs
@@ -77,11 +77,13 @@ use zone_primitives::constants::{ZONE_INBOX_ADDRESS, zone_chain_id as derive_zon
 
 #[path = "../../../rpc/test-utils/auth_tokens.rs"]
 mod auth_tokens;
+mod network;
 
 pub(crate) use auth_tokens::{
     build_signed_token_blob, now_secs, sign_keychain_signature, sign_p256_signature,
     sign_webauthn_signature,
 };
+pub(crate) use network::TcpChaosProxy;
 
 /// Atomic counter for unique zone IDs across concurrent tests.
 static NEXT_ZONE_ID: AtomicU64 = AtomicU64::new(71_000);
@@ -3163,6 +3165,16 @@ impl ZoneAccount {
         self.deposit_to(self.address, amount, timeout, zone).await
     }
 
+    /// Submit a pathUSD deposit on L1 without waiting for the zone to process it.
+    ///
+    /// Returns the L1 block containing the deposit. This is useful for tests that deliberately
+    /// prevent a zone node from observing L1 and need to restore connectivity before awaiting the
+    /// corresponding mint.
+    pub(crate) async fn submit_deposit(&mut self, amount: u128) -> eyre::Result<u64> {
+        self.submit_deposit_with_memo(amount, self.address, B256::ZERO)
+            .await
+    }
+
     /// Simulate an encrypted deposit without submitting a transaction.
     pub(crate) async fn simulate_deposit(
         &self,
@@ -3298,37 +3310,13 @@ impl ZoneAccount {
         timeout: Duration,
         zone: &ZoneTestNode,
     ) -> eyre::Result<(u64, U256)> {
-        use tempo_contracts::precompiles::ITIP20;
-        use tempo_precompiles::PATH_USD_ADDRESS;
-        use tempo_zone_contracts::{ZONE_TOKEN_ADDRESS, ZonePortal};
-
-        let portal_address = self.portal_address;
-
-        // Approve portal if needed
-        if !self.l1_portal_approved {
-            ITIP20::new(PATH_USD_ADDRESS, &self.l1_provider)
-                .approve(portal_address, U256::MAX)
-                .send()
-                .await?
-                .get_receipt()
-                .await?;
-            self.l1_portal_approved = true;
-        }
-
-        let portal = ZonePortal::new(portal_address, &self.l1_provider);
-        let (key_index, encrypted) = self.prepare_deposit(recipient, memo).await?;
+        use tempo_zone_contracts::ZONE_TOKEN_ADDRESS;
 
         // Snapshot balance before deposit
         let balance_before = zone.balance_of(ZONE_TOKEN_ADDRESS, recipient).await?;
-
-        // Call deposit on portal
-        let receipt = portal
-            .deposit(PATH_USD_ADDRESS, amount, key_index, encrypted, self.address)
-            .send()
-            .await?
-            .get_receipt()
+        let block_number = self
+            .submit_deposit_with_memo(amount, recipient, memo)
             .await?;
-        eyre::ensure!(receipt.status(), "L1 deposit tx failed");
 
         // Wait for the zone to process the encrypted deposit and mint to recipient
         let balance = zone
@@ -3340,11 +3328,42 @@ impl ZoneAccount {
             )
             .await?;
 
-        let block_number = receipt
-            .block_number
-            .ok_or_else(|| eyre::eyre!("deposit receipt missing block number"))?;
-
         Ok((block_number, balance))
+    }
+
+    async fn submit_deposit_with_memo(
+        &mut self,
+        amount: u128,
+        recipient: Address,
+        memo: B256,
+    ) -> eyre::Result<u64> {
+        use tempo_contracts::precompiles::ITIP20;
+        use tempo_precompiles::PATH_USD_ADDRESS;
+        use tempo_zone_contracts::ZonePortal;
+
+        let portal_address = self.portal_address;
+        if !self.l1_portal_approved {
+            let receipt = ITIP20::new(PATH_USD_ADDRESS, &self.l1_provider)
+                .approve(portal_address, U256::MAX)
+                .send()
+                .await?
+                .get_receipt()
+                .await?;
+            eyre::ensure!(receipt.status(), "L1 portal approval failed");
+            self.l1_portal_approved = true;
+        }
+
+        let (key_index, encrypted) = self.prepare_deposit(recipient, memo).await?;
+        let receipt = ZonePortal::new(portal_address, &self.l1_provider)
+            .deposit(PATH_USD_ADDRESS, amount, key_index, encrypted, self.address)
+            .send()
+            .await?
+            .get_receipt()
+            .await?;
+        eyre::ensure!(receipt.status(), "L1 deposit tx failed");
+        receipt
+            .block_number
+            .ok_or_else(|| eyre::eyre!("deposit receipt missing block number"))
     }
 
     async fn prepare_deposit(
@@ -3391,6 +3410,35 @@ impl ZoneAccount {
     /// Skips approval if already approved in this session.
     pub(crate) async fn withdraw(&mut self, amount: u128) -> eyre::Result<()> {
         self.withdraw_with(WithdrawalArgs::new(amount)).await
+    }
+
+    /// Submit a simple withdrawal to the L2 transaction pool without waiting for inclusion.
+    ///
+    /// The outbox must already be approved with [`Self::approve_outbox`]. Keeping approval
+    /// separate makes it possible to submit this transaction while block production is paused.
+    pub(crate) async fn submit_withdrawal(&self, amount: u128) -> eyre::Result<B256> {
+        use tempo_zone_contracts::{IZoneOutbox, ZONE_OUTBOX_ADDRESS, ZONE_TOKEN_ADDRESS};
+
+        eyre::ensure!(
+            self.l2_outbox_approved_tokens.contains(&ZONE_TOKEN_ADDRESS),
+            "zone outbox must be approved before submitting a non-blocking withdrawal"
+        );
+        let args = WithdrawalArgs::new(amount);
+        let pending = IZoneOutbox::new(ZONE_OUTBOX_ADDRESS, &self.l2_provider)
+            .requestWithdrawal(
+                ZONE_TOKEN_ADDRESS,
+                self.address,
+                args.amount,
+                args.memo,
+                args.gas_limit,
+                self.address,
+                args.data,
+                args.reveal_to,
+            )
+            .gas(WITHDRAWAL_TX_GAS)
+            .send()
+            .await?;
+        Ok(*pending.tx_hash())
     }
 
     /// Approve the ZoneOutbox, then request a withdrawal on L2 with custom args.
@@ -3798,6 +3846,68 @@ pub(crate) async fn start_real_p2p_cluster_with_active_nodes(
     withdrawal_batch_interval_blocks: u64,
     active_nodes: usize,
 ) -> eyre::Result<RealP2pCluster> {
+    Ok(start_real_p2p_cluster_inner(
+        withdrawal_batch_interval_blocks,
+        active_nodes,
+        L1ProxyMode::Direct,
+        None,
+    )
+    .await?
+    .0)
+}
+
+/// Start the full three-member real-L1 cluster with one shared, controllable L1 proxy. Existing
+/// cluster constructors intentionally retain their direct-connect behavior.
+pub(crate) async fn start_real_p2p_cluster_with_l1_proxy(
+    withdrawal_batch_interval_blocks: u64,
+    l1_block_time: Duration,
+) -> eyre::Result<(RealP2pCluster, TcpChaosProxy)> {
+    let (cluster, mut proxies) = start_real_p2p_cluster_inner(
+        withdrawal_batch_interval_blocks,
+        3,
+        L1ProxyMode::All,
+        Some(l1_block_time),
+    )
+    .await?;
+    Ok((
+        cluster,
+        proxies
+            .pop()
+            .expect("proxied cluster constructor must return its L1 proxy"),
+    ))
+}
+
+/// Start the full three-member cluster with one independently controllable L1 proxy per node.
+pub(crate) async fn start_real_p2p_cluster_with_per_node_l1_proxies(
+    withdrawal_batch_interval_blocks: u64,
+    l1_block_time: Duration,
+) -> eyre::Result<(RealP2pCluster, [TcpChaosProxy; 3])> {
+    let (cluster, proxies) = start_real_p2p_cluster_inner(
+        withdrawal_batch_interval_blocks,
+        3,
+        L1ProxyMode::PerNode,
+        Some(l1_block_time),
+    )
+    .await?;
+    let proxies: [TcpChaosProxy; 3] = proxies
+        .try_into()
+        .map_err(|_| eyre::eyre!("per-node proxy constructor must return three L1 proxies"))?;
+    Ok((cluster, proxies))
+}
+
+#[derive(Clone, Copy)]
+enum L1ProxyMode {
+    Direct,
+    All,
+    PerNode,
+}
+
+async fn start_real_p2p_cluster_inner(
+    withdrawal_batch_interval_blocks: u64,
+    active_nodes: usize,
+    proxy_mode: L1ProxyMode,
+    l1_block_time: Option<Duration>,
+) -> eyre::Result<(RealP2pCluster, Vec<TcpChaosProxy>)> {
     eyre::ensure!(
         (2..=3).contains(&active_nodes),
         "real P2P test cluster requires two or three active nodes, got {active_nodes}"
@@ -3808,7 +3918,33 @@ pub(crate) async fn start_real_p2p_cluster_with_active_nodes(
         Ok(listener.local_addr()?)
     }
 
-    let l1 = L1TestNode::start().await?;
+    let l1 = match l1_block_time {
+        Some(block_time) => {
+            L1TestNode::start_with(|config| config.dev.block_time = Some(block_time)).await?
+        }
+        None => L1TestNode::start().await?,
+    };
+    let direct_url = l1.ws_url().to_string();
+    let (l1_proxies, l1_rpc_urls) = match proxy_mode {
+        L1ProxyMode::Direct => (Vec::new(), vec![direct_url; active_nodes]),
+        L1ProxyMode::All => {
+            let upstream = TcpChaosProxy::upstream_addr(l1.ws_url())?;
+            let proxy = TcpChaosProxy::start(upstream).await?;
+            let proxy_url = proxy.proxy_url(l1.ws_url())?.to_string();
+            (vec![proxy], vec![proxy_url; active_nodes])
+        }
+        L1ProxyMode::PerNode => {
+            let upstream = TcpChaosProxy::upstream_addr(l1.ws_url())?;
+            let mut proxies = Vec::with_capacity(active_nodes);
+            let mut urls = Vec::with_capacity(active_nodes);
+            for _ in 0..active_nodes {
+                let proxy = TcpChaosProxy::start(upstream).await?;
+                urls.push(proxy.proxy_url(l1.ws_url())?.to_string());
+                proxies.push(proxy);
+            }
+            (proxies, urls)
+        }
+    };
     let addresses = [
         available_address()?,
         available_address()?,
@@ -3911,7 +4047,7 @@ pub(crate) async fn start_real_p2p_cluster_with_active_nodes(
         };
         nodes.push(
             ZoneTestNode::launch_with_genesis_and_withdrawal_batch_interval_and_decryption_keys(
-                l1.ws_url().to_string(),
+                l1_rpc_urls[index].clone(),
                 portal_address,
                 chain_id,
                 Some(genesis.clone()),
@@ -3925,12 +4061,15 @@ pub(crate) async fn start_real_p2p_cluster_with_active_nodes(
         );
     }
 
-    Ok(RealP2pCluster {
-        l1,
-        portal_address,
-        nodes,
-        attestation_signers: attestation_signers.to_vec(),
-    })
+    Ok((
+        RealP2pCluster {
+            l1,
+            portal_address,
+            nodes,
+            attestation_signers: attestation_signers.to_vec(),
+        },
+        l1_proxies,
+    ))
 }
 
 /// Start a three-node multi-sequencer cluster with identical genesis state and authenticated

--- a/crates/node/tests/it/utils/network.rs
+++ b/crates/node/tests/it/utils/network.rs
@@ -411,6 +411,15 @@ where
             return writer.shutdown().await;
         }
 
+        // `paused` may change while `read` is pending. Recheck it before forwarding the bytes so
+        // enabling a pause cannot leak the chunk that wakes the read.
+        while conditions.borrow().paused {
+            tokio::select! {
+                _ = cancel.cancelled() => return Ok(()),
+                changed = conditions.changed() => if changed.is_err() { return Ok(()) },
+            }
+        }
+
         let condition = *conditions.borrow();
         let throttle = condition.bytes_per_second.map_or(Duration::ZERO, |rate| {
             Duration::from_secs_f64(read as f64 / rate.get() as f64)
@@ -420,6 +429,15 @@ where
             tokio::select! {
                 _ = cancel.cancelled() => return Ok(()),
                 _ = tokio::time::sleep(delay) => {},
+            }
+        }
+
+        // The pause can also be enabled while the latency or bandwidth delay is pending.
+        // Recheck immediately before forwarding so that delayed chunks cannot leak through.
+        while conditions.borrow().paused {
+            tokio::select! {
+                _ = cancel.cancelled() => return Ok(()),
+                changed = conditions.changed() => if changed.is_err() { return Ok(()) },
             }
         }
         tokio::select! {
@@ -495,13 +513,20 @@ mod tests {
     async fn directional_pause_latency_and_bandwidth_preserve_the_stream() -> eyre::Result<()> {
         let (upstream, shutdown) = start_echo_server().await?;
         let proxy = TcpChaosProxy::start(upstream).await?;
+        let mut client = TcpStream::connect(proxy.listen_addr()).await?;
+        client.write_all(b"ready!").await?;
+        let mut warmup = [0_u8; 6];
+        client.read_exact(&mut warmup).await?;
+        assert_eq!(&warmup, b"ready!");
+
+        // Pause an established stream after its forwarding loop has returned to `read`. This
+        // covers the race where the paused state changes while that read is pending.
         proxy.pause_client_to_upstream(true);
         proxy.pause_upstream_to_client(false);
         proxy.set_upstream_to_client_latency(Duration::from_millis(100));
         proxy.set_client_to_upstream_bandwidth(NonZeroU64::new(8 * 1024));
         proxy.set_upstream_to_client_bandwidth(None);
 
-        let mut client = TcpStream::connect(proxy.listen_addr()).await?;
         let payload = vec![0x5a; 4 * 1024];
         client.write_all(&payload).await?;
         let mut echoed = vec![0_u8; payload.len()];
@@ -513,6 +538,15 @@ mod tests {
         );
 
         let started = tokio::time::Instant::now();
+        proxy.pause_client_to_upstream(false);
+        tokio::time::sleep(Duration::from_millis(100)).await;
+        proxy.pause_client_to_upstream(true);
+        assert!(
+            tokio::time::timeout(Duration::from_millis(800), client.read_exact(&mut echoed))
+                .await
+                .is_err(),
+            "pause enabled during the bandwidth delay leaked the pending payload"
+        );
         proxy.pause_client_to_upstream(false);
         client.read_exact(&mut echoed).await?;
         assert_eq!(echoed, payload);

--- a/crates/node/tests/it/utils/network.rs
+++ b/crates/node/tests/it/utils/network.rs
@@ -1,0 +1,448 @@
+//! Controllable TCP forwarding for network-chaos integration tests.
+
+use std::{
+    net::{SocketAddr, ToSocketAddrs as _},
+    num::NonZeroU64,
+    sync::{
+        Arc, Mutex,
+        atomic::{AtomicBool, AtomicU64, Ordering},
+    },
+    time::Duration,
+};
+
+use tokio::{
+    io::{AsyncRead, AsyncReadExt as _, AsyncWrite, AsyncWriteExt as _},
+    net::{TcpListener, TcpStream},
+    sync::{Notify, watch},
+};
+use tokio_util::sync::CancellationToken;
+
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
+struct DirectionCondition {
+    paused: bool,
+    latency: Duration,
+    bytes_per_second: Option<NonZeroU64>,
+}
+
+#[derive(Debug, Default)]
+struct ProxyStats {
+    accepted: AtomicU64,
+    active: AtomicU64,
+    closed: AtomicU64,
+    rejected_while_disconnected: AtomicU64,
+    client_to_upstream_bytes: AtomicU64,
+    upstream_to_client_bytes: AtomicU64,
+}
+
+#[derive(Debug)]
+struct ProxyInner {
+    enabled: AtomicBool,
+    generation: Mutex<CancellationToken>,
+    shutdown: CancellationToken,
+    stats: ProxyStats,
+    changed: Notify,
+    client_to_upstream: watch::Sender<DirectionCondition>,
+    upstream_to_client: watch::Sender<DirectionCondition>,
+}
+
+/// A stable local TCP endpoint whose live connections and forwarding behavior are test-controlled.
+///
+/// `disconnect` closes established sockets as well as rejecting new attempts. `resume` keeps the
+/// same listener address, forcing clients to exercise their normal reconnect path.
+#[derive(Debug)]
+pub(crate) struct TcpChaosProxy {
+    listen_addr: SocketAddr,
+    inner: Arc<ProxyInner>,
+    accept_task: tokio::task::JoinHandle<()>,
+}
+
+impl TcpChaosProxy {
+    pub(crate) async fn start(upstream: SocketAddr) -> eyre::Result<Self> {
+        let listener = TcpListener::bind("127.0.0.1:0").await?;
+        let listen_addr = listener.local_addr()?;
+        let (client_to_upstream, _) = watch::channel(DirectionCondition::default());
+        let (upstream_to_client, _) = watch::channel(DirectionCondition::default());
+        let inner = Arc::new(ProxyInner {
+            enabled: AtomicBool::new(true),
+            generation: Mutex::new(CancellationToken::new()),
+            shutdown: CancellationToken::new(),
+            stats: ProxyStats::default(),
+            changed: Notify::new(),
+            client_to_upstream,
+            upstream_to_client,
+        });
+        let task_inner = Arc::clone(&inner);
+        let accept_task = tokio::spawn(async move {
+            run_accept_loop(listener, upstream, task_inner).await;
+        });
+        Ok(Self {
+            listen_addr,
+            inner,
+            accept_task,
+        })
+    }
+
+    /// Resolve the TCP destination of an HTTP or WebSocket URL.
+    pub(crate) fn upstream_addr(url: &url::Url) -> eyre::Result<SocketAddr> {
+        let host = url
+            .host_str()
+            .ok_or_else(|| eyre::eyre!("RPC URL has no host: {url}"))?;
+        let port = url
+            .port_or_known_default()
+            .ok_or_else(|| eyre::eyre!("RPC URL has no port: {url}"))?;
+        (host, port)
+            .to_socket_addrs()?
+            .next()
+            .ok_or_else(|| eyre::eyre!("RPC URL host resolved to no addresses: {url}"))
+    }
+
+    /// Rewrite an RPC URL to this proxy while retaining its scheme and path.
+    pub(crate) fn proxy_url(&self, upstream_url: &url::Url) -> eyre::Result<url::Url> {
+        let mut url = upstream_url.clone();
+        url.set_ip_host(self.listen_addr.ip())
+            .map_err(|()| eyre::eyre!("failed setting proxy host"))?;
+        url.set_port(Some(self.listen_addr.port()))
+            .map_err(|()| eyre::eyre!("failed setting proxy port"))?;
+        Ok(url)
+    }
+
+    pub(crate) const fn listen_addr(&self) -> SocketAddr {
+        self.listen_addr
+    }
+
+    pub(crate) fn accepted_connections(&self) -> u64 {
+        self.inner.stats.accepted.load(Ordering::Acquire)
+    }
+
+    pub(crate) fn active_connections(&self) -> u64 {
+        self.inner.stats.active.load(Ordering::Acquire)
+    }
+
+    pub(crate) fn disconnect(&self) {
+        self.inner.enabled.store(false, Ordering::Release);
+        let mut generation = self.inner.generation.lock().expect("proxy lock poisoned");
+        generation.cancel();
+        *generation = CancellationToken::new();
+        drop(generation);
+        self.inner.changed.notify_waiters();
+    }
+
+    pub(crate) fn resume(&self) {
+        self.inner.enabled.store(true, Ordering::Release);
+        self.inner.changed.notify_waiters();
+    }
+
+    pub(crate) fn pause_client_to_upstream(&self, paused: bool) {
+        self.inner
+            .client_to_upstream
+            .send_modify(|condition| condition.paused = paused);
+    }
+
+    pub(crate) fn pause_upstream_to_client(&self, paused: bool) {
+        self.inner
+            .upstream_to_client
+            .send_modify(|condition| condition.paused = paused);
+    }
+
+    pub(crate) fn set_client_to_upstream_latency(&self, latency: Duration) {
+        self.inner
+            .client_to_upstream
+            .send_modify(|condition| condition.latency = latency);
+    }
+
+    pub(crate) fn set_upstream_to_client_latency(&self, latency: Duration) {
+        self.inner
+            .upstream_to_client
+            .send_modify(|condition| condition.latency = latency);
+    }
+
+    pub(crate) fn set_client_to_upstream_bandwidth(&self, bytes_per_second: Option<NonZeroU64>) {
+        self.inner
+            .client_to_upstream
+            .send_modify(|condition| condition.bytes_per_second = bytes_per_second);
+    }
+
+    pub(crate) fn set_upstream_to_client_bandwidth(&self, bytes_per_second: Option<NonZeroU64>) {
+        self.inner
+            .upstream_to_client
+            .send_modify(|condition| condition.bytes_per_second = bytes_per_second);
+    }
+
+    pub(crate) async fn wait_for_no_connections(&self, timeout: Duration) -> eyre::Result<()> {
+        self.wait_for(timeout, "all proxied connections to close", || {
+            self.active_connections() == 0
+        })
+        .await
+    }
+
+    pub(crate) async fn wait_for_connections_after(
+        &self,
+        previous_accepted: u64,
+        minimum_new_connections: u64,
+        timeout: Duration,
+    ) -> eyre::Result<u64> {
+        assert!(minimum_new_connections > 0);
+        let target = previous_accepted.saturating_add(minimum_new_connections);
+        self.wait_for(timeout, "fresh proxied connections", || {
+            self.accepted_connections() >= target
+        })
+        .await?;
+        Ok(self.accepted_connections())
+    }
+
+    async fn wait_for(
+        &self,
+        timeout: Duration,
+        description: &str,
+        condition: impl Fn() -> bool,
+    ) -> eyre::Result<()> {
+        tokio::time::timeout(timeout, async {
+            loop {
+                let notified = self.inner.changed.notified();
+                if condition() {
+                    return;
+                }
+                notified.await;
+            }
+        })
+        .await
+        .map_err(|_| eyre::eyre!("timed out after {timeout:?} waiting for {description}"))
+    }
+}
+
+impl Drop for TcpChaosProxy {
+    fn drop(&mut self) {
+        self.inner.shutdown.cancel();
+        self.inner
+            .generation
+            .lock()
+            .expect("proxy lock poisoned")
+            .cancel();
+        self.accept_task.abort();
+    }
+}
+
+async fn run_accept_loop(listener: TcpListener, upstream: SocketAddr, inner: Arc<ProxyInner>) {
+    loop {
+        let accepted = tokio::select! {
+            _ = inner.shutdown.cancelled() => return,
+            accepted = listener.accept() => accepted,
+        };
+        let Ok((client, _)) = accepted else {
+            return;
+        };
+        if !inner.enabled.load(Ordering::Acquire) {
+            inner
+                .stats
+                .rejected_while_disconnected
+                .fetch_add(1, Ordering::AcqRel);
+            drop(client);
+            inner.changed.notify_waiters();
+            continue;
+        }
+
+        let generation = inner
+            .generation
+            .lock()
+            .expect("proxy lock poisoned")
+            .child_token();
+        let connection_inner = Arc::clone(&inner);
+        tokio::spawn(async move {
+            run_connection(client, upstream, generation, connection_inner).await;
+        });
+    }
+}
+
+async fn run_connection(
+    client: TcpStream,
+    upstream: SocketAddr,
+    generation: CancellationToken,
+    inner: Arc<ProxyInner>,
+) {
+    let upstream_stream = tokio::select! {
+        _ = generation.cancelled() => return,
+        result = TcpStream::connect(upstream) => match result {
+            Ok(stream) => stream,
+            Err(_) => return,
+        },
+    };
+    if !inner.enabled.load(Ordering::Acquire) {
+        return;
+    }
+
+    inner.stats.accepted.fetch_add(1, Ordering::AcqRel);
+    inner.stats.active.fetch_add(1, Ordering::AcqRel);
+    inner.changed.notify_waiters();
+
+    let connection_cancel = generation.child_token();
+    let (client_read, client_write) = client.into_split();
+    let (upstream_read, upstream_write) = upstream_stream.into_split();
+    let client_to_upstream = pump(
+        client_read,
+        upstream_write,
+        inner.client_to_upstream.subscribe(),
+        connection_cancel.clone(),
+        &inner.stats.client_to_upstream_bytes,
+    );
+    let upstream_to_client = pump(
+        upstream_read,
+        client_write,
+        inner.upstream_to_client.subscribe(),
+        connection_cancel.clone(),
+        &inner.stats.upstream_to_client_bytes,
+    );
+    tokio::pin!(client_to_upstream, upstream_to_client);
+    tokio::select! {
+        _ = &mut client_to_upstream => {},
+        _ = &mut upstream_to_client => {},
+        _ = connection_cancel.cancelled() => {},
+    }
+    connection_cancel.cancel();
+    inner.stats.active.fetch_sub(1, Ordering::AcqRel);
+    inner.stats.closed.fetch_add(1, Ordering::AcqRel);
+    inner.changed.notify_waiters();
+}
+
+async fn pump<R, W>(
+    mut reader: R,
+    mut writer: W,
+    mut conditions: watch::Receiver<DirectionCondition>,
+    cancel: CancellationToken,
+    bytes: &AtomicU64,
+) -> std::io::Result<()>
+where
+    R: AsyncRead + Unpin,
+    W: AsyncWrite + Unpin,
+{
+    let mut buffer = vec![0_u8; 16 * 1024];
+    loop {
+        while conditions.borrow().paused {
+            tokio::select! {
+                _ = cancel.cancelled() => return Ok(()),
+                changed = conditions.changed() => if changed.is_err() { return Ok(()) },
+            }
+        }
+        let read = tokio::select! {
+            _ = cancel.cancelled() => return Ok(()),
+            result = reader.read(&mut buffer) => result?,
+        };
+        if read == 0 {
+            return writer.shutdown().await;
+        }
+
+        let condition = *conditions.borrow();
+        let throttle = condition.bytes_per_second.map_or(Duration::ZERO, |rate| {
+            Duration::from_secs_f64(read as f64 / rate.get() as f64)
+        });
+        let delay = condition.latency.saturating_add(throttle);
+        if !delay.is_zero() {
+            tokio::select! {
+                _ = cancel.cancelled() => return Ok(()),
+                _ = tokio::time::sleep(delay) => {},
+            }
+        }
+        tokio::select! {
+            _ = cancel.cancelled() => return Ok(()),
+            result = writer.write_all(&buffer[..read]) => result?,
+        }
+        bytes.fetch_add(read as u64, Ordering::Relaxed);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    async fn start_echo_server() -> eyre::Result<(SocketAddr, CancellationToken)> {
+        let listener = TcpListener::bind("127.0.0.1:0").await?;
+        let address = listener.local_addr()?;
+        let shutdown = CancellationToken::new();
+        let task_shutdown = shutdown.clone();
+        tokio::spawn(async move {
+            loop {
+                let accepted = tokio::select! {
+                    _ = task_shutdown.cancelled() => return,
+                    accepted = listener.accept() => accepted,
+                };
+                let Ok((mut stream, _)) = accepted else {
+                    return;
+                };
+                tokio::spawn(async move {
+                    let (mut read, mut write) = stream.split();
+                    let _ = tokio::io::copy(&mut read, &mut write).await;
+                });
+            }
+        });
+        Ok((address, shutdown))
+    }
+
+    #[tokio::test]
+    async fn disconnect_closes_live_socket_and_resume_accepts_a_fresh_connection()
+    -> eyre::Result<()> {
+        let (upstream, shutdown) = start_echo_server().await?;
+        let proxy = TcpChaosProxy::start(upstream).await?;
+        let mut first = TcpStream::connect(proxy.listen_addr()).await?;
+        first.write_all(b"before").await?;
+        let mut echoed = [0_u8; 6];
+        first.read_exact(&mut echoed).await?;
+        assert_eq!(&echoed, b"before");
+
+        let accepted = proxy.accepted_connections();
+        proxy.disconnect();
+        proxy
+            .wait_for_no_connections(Duration::from_secs(2))
+            .await?;
+        let closed = tokio::time::timeout(Duration::from_secs(2), first.read(&mut echoed)).await?;
+        assert!(
+            matches!(closed, Ok(0) | Err(_)),
+            "old connection still carried data after disconnect: {closed:?}"
+        );
+
+        proxy.resume();
+        let mut second = TcpStream::connect(proxy.listen_addr()).await?;
+        second.write_all(b"after!").await?;
+        second.read_exact(&mut echoed).await?;
+        assert_eq!(&echoed, b"after!");
+        proxy
+            .wait_for_connections_after(accepted, 1, Duration::from_secs(2))
+            .await?;
+        shutdown.cancel();
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn directional_pause_latency_and_bandwidth_preserve_the_stream() -> eyre::Result<()> {
+        let (upstream, shutdown) = start_echo_server().await?;
+        let proxy = TcpChaosProxy::start(upstream).await?;
+        proxy.pause_client_to_upstream(true);
+        proxy.pause_upstream_to_client(false);
+        proxy.set_upstream_to_client_latency(Duration::from_millis(100));
+        proxy.set_client_to_upstream_bandwidth(NonZeroU64::new(8 * 1024));
+        proxy.set_upstream_to_client_bandwidth(None);
+
+        let mut client = TcpStream::connect(proxy.listen_addr()).await?;
+        let payload = vec![0x5a; 4 * 1024];
+        client.write_all(&payload).await?;
+        let mut echoed = vec![0_u8; payload.len()];
+        assert!(
+            tokio::time::timeout(Duration::from_millis(100), client.read_exact(&mut echoed))
+                .await
+                .is_err(),
+            "paused direction unexpectedly forwarded the payload"
+        );
+
+        let started = tokio::time::Instant::now();
+        proxy.pause_client_to_upstream(false);
+        client.read_exact(&mut echoed).await?;
+        assert_eq!(echoed, payload);
+        assert!(
+            started.elapsed() >= Duration::from_millis(500),
+            "configured latency and bandwidth limit were not applied"
+        );
+
+        proxy.set_client_to_upstream_latency(Duration::ZERO);
+        proxy.set_upstream_to_client_latency(Duration::ZERO);
+        shutdown.cancel();
+        Ok(())
+    }
+}

--- a/crates/node/tests/it/utils/network.rs
+++ b/crates/node/tests/it/utils/network.rs
@@ -56,6 +56,85 @@ pub(crate) struct TcpChaosProxy {
     accept_task: tokio::task::JoinHandle<()>,
 }
 
+#[derive(Debug)]
+struct DirectedP2pProxy {
+    from: usize,
+    to: usize,
+    proxy: TcpChaosProxy,
+}
+
+/// A controllable proxy for every directed link in a three-node P2P cluster.
+///
+/// Commonware peers can establish a connection in either direction. Giving each node a distinct
+/// proxied view of every remote address lets tests isolate a member without depending on which
+/// side happened to dial the live connection.
+#[derive(Debug)]
+pub(crate) struct P2pChaosNetwork {
+    links: Vec<DirectedP2pProxy>,
+}
+
+impl P2pChaosNetwork {
+    /// Start one proxy for each directed peer link.
+    ///
+    /// Returns the per-node manifest addresses. Row `from`, column `to` is the address node
+    /// `from` should use for node `to`; diagonal entries retain the node's real listen address.
+    pub(crate) async fn start(
+        node_addresses: [SocketAddr; 3],
+    ) -> eyre::Result<(Self, [[SocketAddr; 3]; 3])> {
+        let mut manifest_addresses = [node_addresses; 3];
+        let mut links = Vec::with_capacity(6);
+        for from in 0..3 {
+            for to in 0..3 {
+                if from == to {
+                    continue;
+                }
+                let proxy = TcpChaosProxy::start(node_addresses[to]).await?;
+                manifest_addresses[from][to] = proxy.listen_addr();
+                links.push(DirectedP2pProxy { from, to, proxy });
+            }
+        }
+        Ok((Self { links }, manifest_addresses))
+    }
+
+    fn links_for<'a>(&'a self, nodes: &'a [usize]) -> impl Iterator<Item = &'a TcpChaosProxy> + 'a {
+        self.links
+            .iter()
+            .filter(|link| nodes.contains(&link.from) || nodes.contains(&link.to))
+            .map(|link| &link.proxy)
+    }
+
+    pub(crate) fn disconnect_nodes(&self, nodes: &[usize]) {
+        for proxy in self.links_for(nodes) {
+            proxy.disconnect();
+        }
+    }
+
+    pub(crate) fn resume_nodes(&self, nodes: &[usize]) {
+        for proxy in self.links_for(nodes) {
+            proxy.resume();
+        }
+    }
+
+    pub(crate) async fn wait_for_nodes_disconnected(
+        &self,
+        nodes: &[usize],
+        timeout: Duration,
+    ) -> eyre::Result<()> {
+        for proxy in self.links_for(nodes) {
+            proxy.wait_for_no_connections(timeout).await?;
+        }
+        Ok(())
+    }
+
+    /// Add symmetric latency to every P2P stream involving any of `nodes`.
+    pub(crate) fn set_nodes_latency(&self, nodes: &[usize], latency: Duration) {
+        for proxy in self.links_for(nodes) {
+            proxy.set_client_to_upstream_latency(latency);
+            proxy.set_upstream_to_client_latency(latency);
+        }
+    }
+}
+
 impl TcpChaosProxy {
     pub(crate) async fn start(upstream: SocketAddr) -> eyre::Result<Self> {
         let listener = TcpListener::bind("127.0.0.1:0").await?;

--- a/crates/node/tests/it/utils/network.rs
+++ b/crates/node/tests/it/utils/network.rs
@@ -83,13 +83,15 @@ impl P2pChaosNetwork {
     ) -> eyre::Result<(Self, [[SocketAddr; 3]; 3])> {
         let mut manifest_addresses = [node_addresses; 3];
         let mut links = Vec::with_capacity(6);
-        for from in 0..3 {
-            for to in 0..3 {
+        for (from, manifest_row) in manifest_addresses.iter_mut().enumerate() {
+            for (to, (manifest_address, &node_address)) in
+                manifest_row.iter_mut().zip(&node_addresses).enumerate()
+            {
                 if from == to {
                     continue;
                 }
-                let proxy = TcpChaosProxy::start(node_addresses[to]).await?;
-                manifest_addresses[from][to] = proxy.listen_addr();
+                let proxy = TcpChaosProxy::start(node_address).await?;
+                *manifest_address = proxy.listen_addr();
                 links.push(DirectedP2pProxy { from, to, proxy });
             }
         }


### PR DESCRIPTION
Adds end-to-end network failure tests for multi-sequencer using a controllable TCP proxy between Zone nodes and L1.

  This tests reconnection and backfill behavior.

  ## What this covers

  - All three sequencers losing their L1 connections, reconnecting, backfilling missed L1 blocks, and converging
  - Asymmetric outages affecting:
      - Both followers
      - The leader
      - A single follower

  - Continued block production and 2-of-3 settlement when a healthy quorum remains
  - Deposits and withdrawals submitted during outages being processed after recovery
  - Batch submission resuming after connectivity is restored

  ## Supporting changes

  - Adds a TCP chaos proxy capable of disconnecting active connections and restoring the same endpoint
  - Adds cluster fixtures supporting shared and per-node L1 proxies 