### PR TITLE
ci: ship reproducible zone binaries

### DIFF
--- a/.github/workflows/docker-profiling.yml
+++ b/.github/workflows/docker-profiling.yml
@@ -2,11 +2,6 @@ name: Docker Build (Profiling)
 
 on:
   workflow_dispatch:
-    inputs:
-      tag:
-        description: "Tag for the profiling image (e.g., profiling-latest)"
-        type: string
-        default: "profiling"
 
 env:
   REGISTRY: ghcr.io/tempoxyz
@@ -34,8 +29,8 @@ jobs:
           images: ${{ env.REGISTRY }}/tempo-zone
           bake-target: tempo-zone
           tags: |
-            type=raw,value=${{ github.event.inputs.tag }}
-            type=sha,prefix=${{ github.event.inputs.tag }}-sha-
+            type=raw,value=profiling
+            type=sha,prefix=profiling-sha-
 
       - name: Log in to Container Registry
         uses: docker/login-action@650006c6eb7dba73a995cc03b0b2d7f5ca915bee # v4.2.0

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -43,6 +43,7 @@ permissions:
 
 env:
   REGISTRY: ghcr.io/tempoxyz
+  STAGING_REPOSITORY: ghcr.io/tempoxyz/tempo-zone-staging
   TEMPO_DEVNET_GENESIS_URL: ${{ inputs.tempo_genesis_url || 'https://devnet-assets.tempoxyz.dev/tempo-devnet-nextfork.json' }}
 
 jobs:
@@ -482,8 +483,6 @@ jobs:
       VERSION: ${{ needs.resolve-production-build-inputs.outputs.version }}
       VERGEN_GIT_SHA: ${{ needs.resolve-production-build-inputs.outputs.commit_sha }}
       VERGEN_GIT_SHA_SHORT: ${{ needs.resolve-production-build-inputs.outputs.short_sha }}
-    outputs:
-      tempo_zone_tags: ${{ steps.meta-tempo-zone.outputs.tags }}
     steps:
       - name: Check out resolved commit
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
@@ -588,9 +587,9 @@ jobs:
           project: 0c6tg19qsp
           push: true
           set: |
-            tempo-zone.tags=${{ env.REGISTRY }}/tempo-zone:${{ needs.resolve-production-build-inputs.outputs.staging_tag }}
+            tempo-zone.tags=${{ env.STAGING_REPOSITORY }}:${{ needs.resolve-production-build-inputs.outputs.staging_tag }}
 
-      - name: Build and push non-production Docker images
+      - name: Build non-production tempo-zone without publishing it
         if: >-
           !(github.repository == 'tempoxyz/zones' &&
             github.event_name == 'push' &&
@@ -600,8 +599,23 @@ jobs:
           files: |
             docker/docker-bake.hcl
             ${{ steps.meta-tempo-zone.outputs.bake-file }}
+          targets: tempo-zone
+          project: 0c6tg19qsp
+          push: false
+          no-cache: ${{ github.event_name == 'schedule' }}
+          pull: ${{ github.event_name == 'schedule' }}
+
+      - name: Build and push non-production tempo-zone-xtask
+        if: >-
+          !(github.repository == 'tempoxyz/zones' &&
+            github.event_name == 'push' &&
+            (github.ref == 'refs/heads/main' || github.ref_type == 'tag'))
+        uses: depot/bake-action@1d58c2668346981089b088b7ef36755b206b20e9 # v1.13.0
+        with:
+          files: |
+            docker/docker-bake.hcl
             ${{ steps.meta-tempo-zone-xtask.outputs.bake-file }}
-          targets: default
+          targets: tempo-zone-xtask
           project: 0c6tg19qsp
           push: ${{ github.repository == 'tempoxyz/zones' && github.event_name != 'pull_request' }}
           no-cache: ${{ github.event_name == 'schedule' }}
@@ -700,6 +714,8 @@ jobs:
       contents: read
     outputs:
       clean_sha256: ${{ steps.hash.outputs.sha256 }}
+      clean_runtime_config_sha256: ${{ steps.hash.outputs.runtime_config_sha256 }}
+      clean_ca_bundle_sha256: ${{ steps.hash.outputs.ca_bundle_sha256 }}
     steps:
       - name: Check out resolved commit
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
@@ -715,6 +731,7 @@ jobs:
           SOURCE_DATE_EPOCH: ${{ needs.resolve-production-build-inputs.outputs.source_date_epoch }}
           VERSION: ${{ needs.resolve-production-build-inputs.outputs.version }}
           NO_CACHE: "1"
+          RUNTIME_IMAGE: tempo-zone-clean:${{ github.run_id }}
         run: |
           set -euo pipefail
           docker builder prune --all --force
@@ -723,17 +740,42 @@ jobs:
       - name: Hash clean rebuild
         id: hash
         shell: bash
+        env:
+          RUNTIME_IMAGE: tempo-zone-clean:${{ github.run_id }}
         run: |
           set -euo pipefail
+
           sha256="$(sha256sum out/tempo-zone | awk '{print $1}')"
           [[ "$sha256" =~ ^[0-9a-f]{64}$ ]] || {
             echo "Invalid clean-build SHA-256: $sha256" >&2
             exit 1
           }
-          echo "sha256=$sha256" >> "$GITHUB_OUTPUT"
+
+          runtime_config="$(docker image inspect "$RUNTIME_IMAGE" --format '{{json .Config}}' | \
+            jq -cS '{Entrypoint, Cmd, Env, WorkingDir, User, ExposedPorts, Volumes, Healthcheck, StopSignal}')"
+          runtime_config_sha256="$(printf '%s' "$runtime_config" | sha256sum | awk '{print $1}')"
+          [[ "$runtime_config_sha256" =~ ^[0-9a-f]{64}$ ]] || {
+            echo "Invalid clean runtime-config SHA-256: $runtime_config_sha256" >&2
+            exit 1
+          }
+
+          container_id="$(docker create "$RUNTIME_IMAGE")"
+          trap 'docker rm -f "$container_id" >/dev/null 2>&1 || true' EXIT
+          docker cp "$container_id:/etc/ssl/certs/ca-certificates.crt" "$RUNNER_TEMP/ca-certificates.crt"
+          ca_bundle_sha256="$(sha256sum "$RUNNER_TEMP/ca-certificates.crt" | awk '{print $1}')"
+          [[ "$ca_bundle_sha256" =~ ^[0-9a-f]{64}$ ]] || {
+            echo "Invalid clean CA-bundle SHA-256: $ca_bundle_sha256" >&2
+            exit 1
+          }
+
+          {
+            echo "sha256=$sha256"
+            echo "runtime_config_sha256=$runtime_config_sha256"
+            echo "ca_bundle_sha256=$ca_bundle_sha256"
+          } >> "$GITHUB_OUTPUT"
 
   production-reproducible-verify:
-    name: Verify staged production tempo-zone binary
+    name: Verify staged tempo-zone binary and runtime inputs
     needs:
       - resolve-production-build-inputs
       - build-and-push
@@ -756,16 +798,18 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Resolve the staged digest, extract the binary, and compare
+      - name: Resolve the staged digest and compare runtime inputs
         id: compare
         shell: bash
         env:
           COMMIT_SHA: ${{ needs.resolve-production-build-inputs.outputs.commit_sha }}
           SOURCE_DATE_EPOCH: ${{ needs.resolve-production-build-inputs.outputs.source_date_epoch }}
           VERSION: ${{ needs.resolve-production-build-inputs.outputs.version }}
-          IMAGE_REPOSITORY: ${{ env.REGISTRY }}/tempo-zone
+          IMAGE_REPOSITORY: ${{ env.STAGING_REPOSITORY }}
           IMAGE_TAG: ${{ needs.resolve-production-build-inputs.outputs.staging_tag }}
           CLEAN_SHA256: ${{ needs.production-reproducible-clean-rebuild.outputs.clean_sha256 }}
+          CLEAN_RUNTIME_CONFIG_SHA256: ${{ needs.production-reproducible-clean-rebuild.outputs.clean_runtime_config_sha256 }}
+          CLEAN_CA_BUNDLE_SHA256: ${{ needs.production-reproducible-clean-rebuild.outputs.clean_ca_bundle_sha256 }}
           BINARY_PATH: /usr/local/bin/tempo-zone
           CONTRACT_NAME: tempo-zone-linux-x86_64-reproducible
           CONTRACT_VERSION: "1"
@@ -775,6 +819,8 @@ jobs:
 
           image_digest=""
           image_sha256=""
+          image_runtime_config_sha256=""
+          image_ca_bundle_sha256=""
           comparison_result="failed"
           failure=""
           container_id=""
@@ -790,8 +836,12 @@ jobs:
               --arg image_digest "$image_digest" \
               --arg binary_path "$BINARY_PATH" \
               --arg image_sha256 "$image_sha256" \
+              --arg image_runtime_config_sha256 "$image_runtime_config_sha256" \
+              --arg image_ca_bundle_sha256 "$image_ca_bundle_sha256" \
               --arg clean_build_sha256 "$CLEAN_SHA256" \
-              --arg comparison_result "$comparison_result" \
+              --arg clean_runtime_config_sha256 "$CLEAN_RUNTIME_CONFIG_SHA256" \
+              --arg clean_ca_bundle_sha256 "$CLEAN_CA_BUNDLE_SHA256" \
+              --arg binary_comparison_result "$comparison_result" \
               --arg failure "$failure" \
               '{
                 commit_sha: $commit_sha,
@@ -803,14 +853,19 @@ jobs:
                   cargo_profile: "reproducible",
                   cargo_features: ["jemalloc"]
                 },
-                image: {
+                verification_scope: "tempo-zone binary, runtime execution config, and CA bundle",
+                candidate_image: {
                   repository: $image_repository,
                   digest: $image_digest,
                   binary_path: $binary_path,
-                  binary_sha256: $image_sha256
+                  binary_sha256: $image_sha256,
+                  runtime_config_sha256: $image_runtime_config_sha256,
+                  ca_bundle_sha256: $image_ca_bundle_sha256
                 },
                 clean_build_sha256: $clean_build_sha256,
-                comparison_result: $comparison_result,
+                clean_runtime_config_sha256: $clean_runtime_config_sha256,
+                clean_ca_bundle_sha256: $clean_ca_bundle_sha256,
+                binary_comparison_result: $binary_comparison_result,
                 failure: $failure
               }' > "$MANIFEST"
           }
@@ -852,12 +907,31 @@ jobs:
             exit 1
           }
 
-          if [[ "$image_sha256" == "$CLEAN_SHA256" ]]; then
+          image_runtime_config="$(docker image inspect "$immutable_image" --format '{{json .Config}}' | \
+            jq -cS '{Entrypoint, Cmd, Env, WorkingDir, User, ExposedPorts, Volumes, Healthcheck, StopSignal}')"
+          image_runtime_config_sha256="$(printf '%s' "$image_runtime_config" | sha256sum | awk '{print $1}')"
+          docker cp "$container_id:/etc/ssl/certs/ca-certificates.crt" "$RUNNER_TEMP/ca-certificates.crt"
+          image_ca_bundle_sha256="$(sha256sum "$RUNNER_TEMP/ca-certificates.crt" | awk '{print $1}')"
+
+          [[ "$image_runtime_config_sha256" =~ ^[0-9a-f]{64}$ ]] || {
+            failure="invalid image runtime-config SHA-256"
+            echo "Invalid image runtime-config SHA-256: $image_runtime_config_sha256" >&2
+            exit 1
+          }
+          [[ "$image_ca_bundle_sha256" =~ ^[0-9a-f]{64}$ ]] || {
+            failure="invalid image CA-bundle SHA-256"
+            echo "Invalid image CA-bundle SHA-256: $image_ca_bundle_sha256" >&2
+            exit 1
+          }
+
+          if [[ "$image_sha256" == "$CLEAN_SHA256" && \
+              "$image_runtime_config_sha256" == "$CLEAN_RUNTIME_CONFIG_SHA256" && \
+              "$image_ca_bundle_sha256" == "$CLEAN_CA_BUNDLE_SHA256" ]]; then
             comparison_result="success"
-            echo "Staged production tempo-zone binary checksum matches clean rebuild"
+            echo "Staged tempo-zone binary and runtime inputs match the clean rebuild"
           else
-            failure="staged production image binary checksum does not match clean rebuild"
-            echo "::error::Staged production reproducible binary verification mismatch"
+            failure="staged binary or runtime input does not match clean rebuild"
+            echo "::error::Staged production reproducibility verification mismatch"
             exit 1
           fi
 
@@ -889,6 +963,10 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       packages: write
+    outputs:
+      image_digest: ${{ steps.promote.outputs.image_digest }}
+      binary_sha256: ${{ steps.promote.outputs.binary_sha256 }}
+      image_sha_tag: ${{ steps.promote.outputs.image_sha_tag }}
     steps:
       - name: Log in to Container Registry
         uses: docker/login-action@650006c6eb7dba73a995cc03b0b2d7f5ca915bee # v4.2.0
@@ -897,14 +975,29 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
+      - name: Docker metadata for promoted tempo-zone
+        id: meta-tempo-zone
+        uses: docker/metadata-action@80c7e94dd9b9319bd5eb7a0e0fe9291e23a2a2e9 # v6.1.0
+        with:
+          images: ${{ env.REGISTRY }}/tempo-zone
+          tags: |
+            type=semver,pattern={{version}}
+            type=semver,pattern={{major}}.{{minor}}
+            type=semver,pattern={{major}}
+            type=raw,value=stable,enable=${{ github.ref_type == 'tag' }}
+            type=raw,value=latest,enable={{is_default_branch}}
+            type=edge,branch=main
+            type=sha,prefix=sha-
+
       - name: Promote the verified manifest and recheck its binary
         id: promote
         shell: bash
         env:
           IMAGE_REPOSITORY: ${{ env.REGISTRY }}/tempo-zone
+          STAGING_REPOSITORY: ${{ env.STAGING_REPOSITORY }}
           STAGING_DIGEST: ${{ needs.production-reproducible-verify.outputs.image_digest }}
           VERIFIED_BINARY_SHA256: ${{ needs.production-reproducible-verify.outputs.image_sha256 }}
-          METADATA_TAGS: ${{ needs.build-and-push.outputs.tempo_zone_tags }}
+          METADATA_TAGS: ${{ steps.meta-tempo-zone.outputs.tags }}
           BINARY_PATH: /usr/local/bin/tempo-zone
         run: |
           set -Eeuo pipefail
@@ -921,6 +1014,7 @@ jobs:
           mapfile -t metadata_tags <<< "$METADATA_TAGS"
           tag_args=()
           tags=()
+          image_sha_tag=""
           for tag in "${metadata_tags[@]}"; do
             tag="${tag%$'\r'}"
             [[ -z "$tag" ]] && continue
@@ -930,13 +1024,24 @@ jobs:
             }
             tag_args+=(--tag "$tag")
             tags+=("$tag")
+            if [[ "$tag" =~ :sha-[0-9a-f]{7}$ ]]; then
+              [[ -z "$image_sha_tag" ]] || {
+                echo "Multiple Docker SHA tags were generated" >&2
+                exit 1
+              }
+              image_sha_tag="$tag"
+            fi
           done
           (( ${#tags[@]} > 0 )) || {
             echo "No production tempo-zone tags were generated" >&2
             exit 1
           }
+          [[ -n "$image_sha_tag" ]] || {
+            echo "No Docker SHA tag was generated" >&2
+            exit 1
+          }
 
-          source_image="$IMAGE_REPOSITORY@$STAGING_DIGEST"
+          source_image="$STAGING_REPOSITORY@$STAGING_DIGEST"
           docker buildx imagetools create --prefer-index=false \
             "${tag_args[@]}" "$source_image"
 
@@ -977,6 +1082,7 @@ jobs:
           {
             echo "image_digest=$STAGING_DIGEST"
             echo "binary_sha256=$promoted_sha256"
+            echo "image_sha_tag=$image_sha_tag"
           } >> "$GITHUB_OUTPUT"
 
       - name: Publish Zones CI event
@@ -987,16 +1093,22 @@ jobs:
           EVENTS_CERT: ${{ secrets.EVENTS_CERT }}
           EVENTS_ARGS: ${{ secrets.EVENTS_ARGS }}
           COMMIT_SHA: ${{ needs.resolve-production-build-inputs.outputs.commit_sha }}
-          SHORT_SHA: ${{ needs.resolve-production-build-inputs.outputs.short_sha }}
           IMAGE_DIGEST: ${{ steps.promote.outputs.image_digest }}
+          IMAGE_SHA_TAG: ${{ steps.promote.outputs.image_sha_tag }}
         run: |
           set -euo pipefail
+
+          tag="${IMAGE_SHA_TAG##*:}"
+          [[ "$tag" =~ ^sha-[0-9a-f]{7}$ ]] || {
+            echo "Invalid promoted Docker SHA tag: $IMAGE_SHA_TAG" >&2
+            exit 1
+          }
 
           install -m 0700 -d "$RUNNER_TEMP/events"
           printf '%s' "$EVENTS_KEY" > "$RUNNER_TEMP/events/key.pem"
           printf '%s' "$EVENTS_CERT" > "$RUNNER_TEMP/events/cert.pem"
           payload=$(jq -cn \
-            --arg tag "sha-${SHORT_SHA}" \
+            --arg tag "$tag" \
             --arg sha "$COMMIT_SHA" \
             --arg branch "$GITHUB_REF_NAME" \
             --arg digest "$IMAGE_DIGEST" \

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -61,6 +61,7 @@ jobs:
       commit_sha: ${{ steps.commit.outputs.commit_sha }}
       short_sha: ${{ steps.commit.outputs.short_sha }}
       source_date_epoch: ${{ steps.commit.outputs.source_date_epoch }}
+      staging_tag: ${{ steps.commit.outputs.staging_tag }}
       version: ${{ steps.commit.outputs.version }}
     steps:
       - name: Check out workflow commit
@@ -94,6 +95,7 @@ jobs:
             echo "commit_sha=$commit_sha"
             echo "short_sha=$short_sha"
             echo "source_date_epoch=$source_date_epoch"
+            echo "staging_tag=verify-${commit_sha}-${GITHUB_RUN_ID}"
             echo "version=sha-$short_sha"
           } >> "$GITHUB_OUTPUT"
 
@@ -474,9 +476,14 @@ jobs:
       contents: read
       packages: write
       id-token: write
+    env:
+      GIT_SHA: ${{ needs.resolve-production-build-inputs.outputs.commit_sha }}
+      SOURCE_DATE_EPOCH: ${{ needs.resolve-production-build-inputs.outputs.source_date_epoch }}
+      VERSION: ${{ needs.resolve-production-build-inputs.outputs.version }}
+      VERGEN_GIT_SHA: ${{ needs.resolve-production-build-inputs.outputs.commit_sha }}
+      VERGEN_GIT_SHA_SHORT: ${{ needs.resolve-production-build-inputs.outputs.short_sha }}
     outputs:
-      production_repository: ${{ steps.production-image.outputs.repository }}
-      production_tag: ${{ steps.production-image.outputs.tag }}
+      tempo_zone_tags: ${{ steps.meta-tempo-zone.outputs.tags }}
     steps:
       - name: Check out resolved commit
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
@@ -549,16 +556,6 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Record immutable verification reference
-        id: production-image
-        shell: bash
-        env:
-          SHORT_SHA: ${{ needs.resolve-production-build-inputs.outputs.short_sha }}
-        run: |
-          set -euo pipefail
-          echo "repository=${REGISTRY}/tempo-zone" >> "$GITHUB_OUTPUT"
-          echo "tag=sha-${SHORT_SHA}" >> "$GITHUB_OUTPUT"
-
       - name: Download Tempo devnet genesis
         shell: bash
         run: |
@@ -575,7 +572,29 @@ jobs:
           genesis_sha=$(sha256sum .tempo-genesis/genesis.json | cut -d' ' -f1)
           echo "Embedding Tempo devnet genesis sha256:${genesis_sha}"
 
-      - name: Build and push Docker images
+      # Main and release-tag production tags are attached only after the staged
+      # image passes binary reproducibility verification.
+      - name: Build and stage production tempo-zone
+        if: >-
+          github.repository == 'tempoxyz/zones' &&
+          github.event_name == 'push' &&
+          (github.ref == 'refs/heads/main' || github.ref_type == 'tag')
+        uses: depot/bake-action@1d58c2668346981089b088b7ef36755b206b20e9 # v1.13.0
+        with:
+          files: |
+            docker/docker-bake.hcl
+            ${{ steps.meta-tempo-zone.outputs.bake-file }}
+          targets: tempo-zone
+          project: 0c6tg19qsp
+          push: true
+          set: |
+            tempo-zone.tags=${{ env.REGISTRY }}/tempo-zone:${{ needs.resolve-production-build-inputs.outputs.staging_tag }}
+
+      - name: Build and push non-production Docker images
+        if: >-
+          !(github.repository == 'tempoxyz/zones' &&
+            github.event_name == 'push' &&
+            (github.ref == 'refs/heads/main' || github.ref_type == 'tag'))
         uses: depot/bake-action@1d58c2668346981089b088b7ef36755b206b20e9 # v1.13.0
         with:
           files: |
@@ -585,17 +604,22 @@ jobs:
           targets: default
           project: 0c6tg19qsp
           push: ${{ github.repository == 'tempoxyz/zones' && github.event_name != 'pull_request' }}
-          # Scheduled builds refresh moving external tools and base images. All
-          # commit/tag/manual builds can safely reuse Depot's content-addressed
-          # layer cache and will still invalidate layers when inputs change.
           no-cache: ${{ github.event_name == 'schedule' }}
           pull: ${{ github.event_name == 'schedule' }}
-        env:
-          GIT_SHA: ${{ needs.resolve-production-build-inputs.outputs.commit_sha }}
-          SOURCE_DATE_EPOCH: ${{ needs.resolve-production-build-inputs.outputs.source_date_epoch }}
-          VERSION: ${{ needs.resolve-production-build-inputs.outputs.version }}
-          VERGEN_GIT_SHA: ${{ needs.resolve-production-build-inputs.outputs.commit_sha }}
-          VERGEN_GIT_SHA_SHORT: ${{ needs.resolve-production-build-inputs.outputs.short_sha }}
+
+      - name: Build and push production tempo-zone-xtask
+        if: >-
+          github.repository == 'tempoxyz/zones' &&
+          github.event_name == 'push' &&
+          (github.ref == 'refs/heads/main' || github.ref_type == 'tag')
+        uses: depot/bake-action@1d58c2668346981089b088b7ef36755b206b20e9 # v1.13.0
+        with:
+          files: |
+            docker/docker-bake.hcl
+            ${{ steps.meta-tempo-zone-xtask.outputs.bake-file }}
+          targets: tempo-zone-xtask
+          project: 0c6tg19qsp
+          push: true
 
       # Nitro CLI converts an image from the runner's local Docker image store.
       - name: Load tempo-zone-prover enclave payload
@@ -664,79 +688,6 @@ jobs:
           path: target/tempo-zone-prover-eif/measurements.json
           if-no-files-found: error
 
-      - name: Publish Zones CI event
-        if: >-
-          github.repository == 'tempoxyz/zones' &&
-          github.event_name == 'push' &&
-          github.ref == 'refs/heads/main'
-        shell: bash
-        env:
-          EVENTS_KEY: ${{ secrets.EVENTS_KEY }}
-          EVENTS_CERT: ${{ secrets.EVENTS_CERT }}
-          EVENTS_ARGS: ${{ secrets.EVENTS_ARGS }}
-          COMMIT_SHA: ${{ needs.resolve-production-build-inputs.outputs.commit_sha }}
-          SHORT_SHA: ${{ needs.resolve-production-build-inputs.outputs.short_sha }}
-        run: |
-          set -euo pipefail
-
-          image="${REGISTRY}/tempo-zone:sha-${SHORT_SHA}"
-          digest=""
-          for attempt in {1..12}; do
-            digest=$(docker buildx imagetools inspect "$image" \
-              --format '{{.Manifest.Digest}}' 2>/dev/null || true)
-            if [[ "$digest" =~ ^sha256:[0-9a-f]{64}$ ]]; then
-              break
-            fi
-            echo "Waiting for $image to become readable (attempt $attempt/12)"
-            sleep 5
-          done
-          [[ "$digest" =~ ^sha256:[0-9a-f]{64}$ ]] || {
-            echo "Could not resolve a valid digest for $image" >&2
-            exit 1
-          }
-
-          install -m 0700 -d "$RUNNER_TEMP/events"
-          printf '%s' "$EVENTS_KEY" > "$RUNNER_TEMP/events/key.pem"
-          printf '%s' "$EVENTS_CERT" > "$RUNNER_TEMP/events/cert.pem"
-          payload=$(jq -cn \
-            --arg tag "sha-${SHORT_SHA}" \
-            --arg sha "$COMMIT_SHA" \
-            --arg branch "$GITHUB_REF_NAME" \
-            --arg digest "$digest" \
-            '{
-              repository: "tempoxyz/zones",
-              event: "registry_package",
-              data: {
-                tag: $tag,
-                sha: $sha,
-                branch: $branch,
-                digest: $digest
-              }
-            }')
-          command -v python3 >/dev/null || {
-            echo "python3 is required to parse EVENTS_ARGS" >&2
-            exit 1
-          }
-          mapfile -t events_args < <(
-            python3 - "$EVENTS_ARGS" <<'PY'
-          import shlex
-          import sys
-
-          for argument in shlex.split(sys.argv[1]):
-              print(argument)
-          PY
-          )
-          (( ${#events_args[@]} > 0 )) || {
-            echo "EVENTS_ARGS is empty" >&2
-            exit 1
-          }
-          curl --fail-with-body --silent --show-error \
-            --key "$RUNNER_TEMP/events/key.pem" \
-            --cert "$RUNNER_TEMP/events/cert.pem" \
-            "${events_args[@]}" \
-            -H "Content-Type: application/json" \
-            -d "$payload"
-
   production-reproducible-clean-rebuild:
     name: Rebuild production contract without Docker cache
     needs: resolve-production-build-inputs
@@ -782,7 +733,7 @@ jobs:
           echo "sha256=$sha256" >> "$GITHUB_OUTPUT"
 
   production-reproducible-verify:
-    name: Verify production tempo-zone binary
+    name: Verify staged production tempo-zone binary
     needs:
       - resolve-production-build-inputs
       - build-and-push
@@ -794,6 +745,9 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       packages: read
+    outputs:
+      image_digest: ${{ steps.compare.outputs.image_digest }}
+      image_sha256: ${{ steps.compare.outputs.image_sha256 }}
     steps:
       - name: Log in to Container Registry
         uses: docker/login-action@650006c6eb7dba73a995cc03b0b2d7f5ca915bee # v4.2.0
@@ -802,14 +756,15 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Resolve the image digest, extract the binary, and compare
+      - name: Resolve the staged digest, extract the binary, and compare
+        id: compare
         shell: bash
         env:
           COMMIT_SHA: ${{ needs.resolve-production-build-inputs.outputs.commit_sha }}
           SOURCE_DATE_EPOCH: ${{ needs.resolve-production-build-inputs.outputs.source_date_epoch }}
           VERSION: ${{ needs.resolve-production-build-inputs.outputs.version }}
-          IMAGE_REPOSITORY: ${{ needs.build-and-push.outputs.production_repository }}
-          IMAGE_TAG: ${{ needs.build-and-push.outputs.production_tag }}
+          IMAGE_REPOSITORY: ${{ env.REGISTRY }}/tempo-zone
+          IMAGE_TAG: ${{ needs.resolve-production-build-inputs.outputs.staging_tag }}
           CLEAN_SHA256: ${{ needs.production-reproducible-clean-rebuild.outputs.clean_sha256 }}
           BINARY_PATH: /usr/local/bin/tempo-zone
           CONTRACT_NAME: tempo-zone-linux-x86_64-reproducible
@@ -881,7 +836,7 @@ jobs:
             sleep 5
           done
           if [[ ! "$image_digest" =~ ^sha256:[0-9a-f]{64}$ ]]; then
-            failure="could not resolve production image digest"
+            failure="could not resolve staged production image digest"
             echo "Could not resolve a valid digest for $tagged_image" >&2
             exit 1
           fi
@@ -899,12 +854,17 @@ jobs:
 
           if [[ "$image_sha256" == "$CLEAN_SHA256" ]]; then
             comparison_result="success"
-            echo "Production tempo-zone binary checksum matches clean rebuild"
+            echo "Staged production tempo-zone binary checksum matches clean rebuild"
           else
-            failure="production image binary checksum does not match clean rebuild"
-            echo "::error::Production reproducible binary verification mismatch"
+            failure="staged production image binary checksum does not match clean rebuild"
+            echo "::error::Staged production reproducible binary verification mismatch"
             exit 1
           fi
+
+          {
+            echo "image_digest=$image_digest"
+            echo "image_sha256=$image_sha256"
+          } >> "$GITHUB_OUTPUT"
 
       - name: Upload verification manifest
         if: always()
@@ -914,3 +874,162 @@ jobs:
           path: ${{ runner.temp }}/production-reproducible-image-verification.json
           if-no-files-found: warn
           retention-days: 7
+
+  promote-verified-tempo-zone:
+    name: Promote verified tempo-zone image
+    needs:
+      - resolve-production-build-inputs
+      - build-and-push
+      - production-reproducible-verify
+    if: >-
+      needs.production-reproducible-verify.result == 'success' &&
+      github.repository == 'tempoxyz/zones' &&
+      github.event_name == 'push' &&
+      (github.ref == 'refs/heads/main' || github.ref_type == 'tag')
+    runs-on: ubuntu-latest
+    permissions:
+      packages: write
+    steps:
+      - name: Log in to Container Registry
+        uses: docker/login-action@650006c6eb7dba73a995cc03b0b2d7f5ca915bee # v4.2.0
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Promote the verified manifest and recheck its binary
+        id: promote
+        shell: bash
+        env:
+          IMAGE_REPOSITORY: ${{ env.REGISTRY }}/tempo-zone
+          STAGING_DIGEST: ${{ needs.production-reproducible-verify.outputs.image_digest }}
+          VERIFIED_BINARY_SHA256: ${{ needs.production-reproducible-verify.outputs.image_sha256 }}
+          METADATA_TAGS: ${{ needs.build-and-push.outputs.tempo_zone_tags }}
+          BINARY_PATH: /usr/local/bin/tempo-zone
+        run: |
+          set -Eeuo pipefail
+
+          [[ "$STAGING_DIGEST" =~ ^sha256:[0-9a-f]{64}$ ]] || {
+            echo "Invalid staged image digest: $STAGING_DIGEST" >&2
+            exit 1
+          }
+          [[ "$VERIFIED_BINARY_SHA256" =~ ^[0-9a-f]{64}$ ]] || {
+            echo "Invalid verified binary SHA-256: $VERIFIED_BINARY_SHA256" >&2
+            exit 1
+          }
+
+          mapfile -t metadata_tags <<< "$METADATA_TAGS"
+          tag_args=()
+          tags=()
+          for tag in "${metadata_tags[@]}"; do
+            tag="${tag%$'\r'}"
+            [[ -z "$tag" ]] && continue
+            [[ "$tag" == "$IMAGE_REPOSITORY:"* ]] || {
+              echo "Unexpected tempo-zone tag: $tag" >&2
+              exit 1
+            }
+            tag_args+=(--tag "$tag")
+            tags+=("$tag")
+          done
+          (( ${#tags[@]} > 0 )) || {
+            echo "No production tempo-zone tags were generated" >&2
+            exit 1
+          }
+
+          source_image="$IMAGE_REPOSITORY@$STAGING_DIGEST"
+          docker buildx imagetools create --prefer-index=false \
+            "${tag_args[@]}" "$source_image"
+
+          for tag in "${tags[@]}"; do
+            tag_digest=""
+            for attempt in {1..12}; do
+              tag_digest="$(docker buildx imagetools inspect "$tag" \
+                --format '{{.Manifest.Digest}}' 2>/dev/null || true)"
+              if [[ "$tag_digest" =~ ^sha256:[0-9a-f]{64}$ ]]; then
+                break
+              fi
+              echo "Waiting for $tag to become readable (attempt $attempt/12)"
+              sleep 5
+            done
+            [[ "$tag_digest" == "$STAGING_DIGEST" ]] || {
+              echo "Promotion changed $tag from $STAGING_DIGEST to $tag_digest" >&2
+              exit 1
+            }
+          done
+
+          container_id=""
+          cleanup() {
+            if [[ -n "$container_id" ]]; then
+              docker rm -f "$container_id" >/dev/null 2>&1 || true
+            fi
+          }
+          trap cleanup EXIT
+
+          docker pull "$source_image"
+          container_id="$(docker create "$source_image")"
+          docker cp "$container_id:$BINARY_PATH" "$RUNNER_TEMP/tempo-zone"
+          promoted_sha256="$(sha256sum "$RUNNER_TEMP/tempo-zone" | awk '{print $1}')"
+          [[ "$promoted_sha256" == "$VERIFIED_BINARY_SHA256" ]] || {
+            echo "Promoted tempo-zone binary checksum changed" >&2
+            exit 1
+          }
+
+          {
+            echo "image_digest=$STAGING_DIGEST"
+            echo "binary_sha256=$promoted_sha256"
+          } >> "$GITHUB_OUTPUT"
+
+      - name: Publish Zones CI event
+        if: github.ref == 'refs/heads/main'
+        shell: bash
+        env:
+          EVENTS_KEY: ${{ secrets.EVENTS_KEY }}
+          EVENTS_CERT: ${{ secrets.EVENTS_CERT }}
+          EVENTS_ARGS: ${{ secrets.EVENTS_ARGS }}
+          COMMIT_SHA: ${{ needs.resolve-production-build-inputs.outputs.commit_sha }}
+          SHORT_SHA: ${{ needs.resolve-production-build-inputs.outputs.short_sha }}
+          IMAGE_DIGEST: ${{ steps.promote.outputs.image_digest }}
+        run: |
+          set -euo pipefail
+
+          install -m 0700 -d "$RUNNER_TEMP/events"
+          printf '%s' "$EVENTS_KEY" > "$RUNNER_TEMP/events/key.pem"
+          printf '%s' "$EVENTS_CERT" > "$RUNNER_TEMP/events/cert.pem"
+          payload=$(jq -cn \
+            --arg tag "sha-${SHORT_SHA}" \
+            --arg sha "$COMMIT_SHA" \
+            --arg branch "$GITHUB_REF_NAME" \
+            --arg digest "$IMAGE_DIGEST" \
+            '{
+              repository: "tempoxyz/zones",
+              event: "registry_package",
+              data: {
+                tag: $tag,
+                sha: $sha,
+                branch: $branch,
+                digest: $digest
+              }
+            }')
+          command -v python3 >/dev/null || {
+            echo "python3 is required to parse EVENTS_ARGS" >&2
+            exit 1
+          }
+          mapfile -t events_args < <(
+            python3 - "$EVENTS_ARGS" <<'PY'
+          import shlex
+          import sys
+
+          for argument in shlex.split(sys.argv[1]):
+              print(argument)
+          PY
+          )
+          (( ${#events_args[@]} > 0 )) || {
+            echo "EVENTS_ARGS is empty" >&2
+            exit 1
+          }
+          curl --fail-with-body --silent --show-error \
+            --key "$RUNNER_TEMP/events/key.pem" \
+            --cert "$RUNNER_TEMP/events/cert.pem" \
+            "${events_args[@]}" \
+            -H "Content-Type: application/json" \
+            -d "$payload"

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -46,6 +46,57 @@ env:
   TEMPO_DEVNET_GENESIS_URL: ${{ inputs.tempo_genesis_url || 'https://devnet-assets.tempoxyz.dev/tempo-devnet-nextfork.json' }}
 
 jobs:
+  resolve-production-build-inputs:
+    name: Resolve production Docker build inputs
+    # Private copies retain PR image builds, but must not publish shared images
+    # or run the upstream's scheduled refreshes.
+    if: >-
+      (github.event_name != 'workflow_dispatch' || inputs.reproducible_verify != true) &&
+      (github.repository == 'tempoxyz/zones' ||
+      (github.event_name != 'schedule' && github.event_name != 'push'))
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    outputs:
+      commit_sha: ${{ steps.commit.outputs.commit_sha }}
+      short_sha: ${{ steps.commit.outputs.short_sha }}
+      source_date_epoch: ${{ steps.commit.outputs.source_date_epoch }}
+      version: ${{ steps.commit.outputs.version }}
+    steps:
+      - name: Check out workflow commit
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          ref: ${{ github.sha }}
+          fetch-depth: 1
+          persist-credentials: false
+          submodules: recursive
+
+      - name: Record immutable build inputs
+        id: commit
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          commit_sha="$(git rev-parse HEAD)"
+          short_sha="$(git rev-parse --short=7 HEAD)"
+          source_date_epoch="$(git show -s --format=%ct HEAD)"
+
+          [[ "$commit_sha" =~ ^[0-9a-f]{40}$ ]] || {
+            echo "Resolved ref is not a full commit SHA: $commit_sha" >&2
+            exit 1
+          }
+          [[ "$source_date_epoch" =~ ^[0-9]+$ ]] || {
+            echo "Invalid SOURCE_DATE_EPOCH: $source_date_epoch" >&2
+            exit 1
+          }
+
+          {
+            echo "commit_sha=$commit_sha"
+            echo "short_sha=$short_sha"
+            echo "source_date_epoch=$source_date_epoch"
+            echo "version=sha-$short_sha"
+          } >> "$GITHUB_OUTPUT"
+
   reproducible-verify-resolve:
     name: Resolve reproducible verification commit
     if: >-
@@ -410,9 +461,11 @@ jobs:
 
   build-and-push:
     name: Build and Push Docker Images
+    needs: resolve-production-build-inputs
     # Private copies retain PR image builds, but must not publish shared images
     # or run the upstream's scheduled refreshes.
     if: >-
+      needs.resolve-production-build-inputs.result == 'success' &&
       (github.event_name != 'workflow_dispatch' || inputs.reproducible_verify != true) &&
       (github.repository == 'tempoxyz/zones' ||
       (github.event_name != 'schedule' && github.event_name != 'push'))
@@ -421,10 +474,14 @@ jobs:
       contents: read
       packages: write
       id-token: write
+    outputs:
+      production_repository: ${{ steps.production-image.outputs.repository }}
+      production_tag: ${{ steps.production-image.outputs.tag }}
     steps:
-      - name: Checkout repository
+      - name: Check out resolved commit
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
+          ref: ${{ needs.resolve-production-build-inputs.outputs.commit_sha }}
           persist-credentials: false
           submodules: recursive
 
@@ -492,8 +549,15 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
-      - id: shortsha
-        run: echo "shortsha=${GITHUB_SHA::7}" >> "$GITHUB_OUTPUT"
+      - name: Record immutable verification reference
+        id: production-image
+        shell: bash
+        env:
+          SHORT_SHA: ${{ needs.resolve-production-build-inputs.outputs.short_sha }}
+        run: |
+          set -euo pipefail
+          echo "repository=${REGISTRY}/tempo-zone" >> "$GITHUB_OUTPUT"
+          echo "tag=sha-${SHORT_SHA}" >> "$GITHUB_OUTPUT"
 
       - name: Download Tempo devnet genesis
         shell: bash
@@ -527,8 +591,11 @@ jobs:
           no-cache: ${{ github.event_name == 'schedule' }}
           pull: ${{ github.event_name == 'schedule' }}
         env:
-          VERGEN_GIT_SHA: ${{ github.sha }}
-          VERGEN_GIT_SHA_SHORT: ${{ steps.shortsha.outputs.shortsha }}
+          GIT_SHA: ${{ needs.resolve-production-build-inputs.outputs.commit_sha }}
+          SOURCE_DATE_EPOCH: ${{ needs.resolve-production-build-inputs.outputs.source_date_epoch }}
+          VERSION: ${{ needs.resolve-production-build-inputs.outputs.version }}
+          VERGEN_GIT_SHA: ${{ needs.resolve-production-build-inputs.outputs.commit_sha }}
+          VERGEN_GIT_SHA_SHORT: ${{ needs.resolve-production-build-inputs.outputs.short_sha }}
 
       # Nitro CLI converts an image from the runner's local Docker image store.
       - name: Load tempo-zone-prover enclave payload
@@ -593,7 +660,7 @@ jobs:
       - name: Upload tempo-zone-prover PCR measurements
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
-          name: tempo-zone-prover-measurements-${{ steps.shortsha.outputs.shortsha }}
+          name: tempo-zone-prover-measurements-${{ needs.resolve-production-build-inputs.outputs.short_sha }}
           path: target/tempo-zone-prover-eif/measurements.json
           if-no-files-found: error
 
@@ -607,7 +674,8 @@ jobs:
           EVENTS_KEY: ${{ secrets.EVENTS_KEY }}
           EVENTS_CERT: ${{ secrets.EVENTS_CERT }}
           EVENTS_ARGS: ${{ secrets.EVENTS_ARGS }}
-          SHORT_SHA: ${{ steps.shortsha.outputs.shortsha }}
+          COMMIT_SHA: ${{ needs.resolve-production-build-inputs.outputs.commit_sha }}
+          SHORT_SHA: ${{ needs.resolve-production-build-inputs.outputs.short_sha }}
         run: |
           set -euo pipefail
 
@@ -632,7 +700,7 @@ jobs:
           printf '%s' "$EVENTS_CERT" > "$RUNNER_TEMP/events/cert.pem"
           payload=$(jq -cn \
             --arg tag "sha-${SHORT_SHA}" \
-            --arg sha "$GITHUB_SHA" \
+            --arg sha "$COMMIT_SHA" \
             --arg branch "$GITHUB_REF_NAME" \
             --arg digest "$digest" \
             '{
@@ -668,3 +736,181 @@ jobs:
             "${events_args[@]}" \
             -H "Content-Type: application/json" \
             -d "$payload"
+
+  production-reproducible-clean-rebuild:
+    name: Rebuild production contract without Docker cache
+    needs: resolve-production-build-inputs
+    if: >-
+      github.repository == 'tempoxyz/zones' &&
+      github.event_name == 'push' &&
+      (github.ref == 'refs/heads/main' || github.ref_type == 'tag')
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    outputs:
+      clean_sha256: ${{ steps.hash.outputs.sha256 }}
+    steps:
+      - name: Check out resolved commit
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          ref: ${{ needs.resolve-production-build-inputs.outputs.commit_sha }}
+          fetch-depth: 1
+          persist-credentials: false
+          submodules: recursive
+
+      - name: Build production contract without Docker or BuildKit cache
+        env:
+          GIT_SHA: ${{ needs.resolve-production-build-inputs.outputs.commit_sha }}
+          SOURCE_DATE_EPOCH: ${{ needs.resolve-production-build-inputs.outputs.source_date_epoch }}
+          VERSION: ${{ needs.resolve-production-build-inputs.outputs.version }}
+          NO_CACHE: "1"
+        run: |
+          set -euo pipefail
+          docker builder prune --all --force
+          scripts/reproducible-build.sh
+
+      - name: Hash clean rebuild
+        id: hash
+        shell: bash
+        run: |
+          set -euo pipefail
+          sha256="$(sha256sum out/tempo-zone | awk '{print $1}')"
+          [[ "$sha256" =~ ^[0-9a-f]{64}$ ]] || {
+            echo "Invalid clean-build SHA-256: $sha256" >&2
+            exit 1
+          }
+          echo "sha256=$sha256" >> "$GITHUB_OUTPUT"
+
+  production-reproducible-verify:
+    name: Verify production tempo-zone binary
+    needs:
+      - resolve-production-build-inputs
+      - build-and-push
+      - production-reproducible-clean-rebuild
+    if: >-
+      github.repository == 'tempoxyz/zones' &&
+      github.event_name == 'push' &&
+      (github.ref == 'refs/heads/main' || github.ref_type == 'tag')
+    runs-on: ubuntu-latest
+    permissions:
+      packages: read
+    steps:
+      - name: Log in to Container Registry
+        uses: docker/login-action@650006c6eb7dba73a995cc03b0b2d7f5ca915bee # v4.2.0
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Resolve the image digest, extract the binary, and compare
+        shell: bash
+        env:
+          COMMIT_SHA: ${{ needs.resolve-production-build-inputs.outputs.commit_sha }}
+          SOURCE_DATE_EPOCH: ${{ needs.resolve-production-build-inputs.outputs.source_date_epoch }}
+          VERSION: ${{ needs.resolve-production-build-inputs.outputs.version }}
+          IMAGE_REPOSITORY: ${{ needs.build-and-push.outputs.production_repository }}
+          IMAGE_TAG: ${{ needs.build-and-push.outputs.production_tag }}
+          CLEAN_SHA256: ${{ needs.production-reproducible-clean-rebuild.outputs.clean_sha256 }}
+          BINARY_PATH: /usr/local/bin/tempo-zone
+          CONTRACT_NAME: tempo-zone-linux-x86_64-reproducible
+          CONTRACT_VERSION: "1"
+          MANIFEST: ${{ runner.temp }}/production-reproducible-image-verification.json
+        run: |
+          set -Eeuo pipefail
+
+          image_digest=""
+          image_sha256=""
+          comparison_result="failed"
+          failure=""
+          container_id=""
+
+          write_manifest() {
+            jq -n \
+              --arg commit_sha "$COMMIT_SHA" \
+              --arg source_date_epoch "$SOURCE_DATE_EPOCH" \
+              --arg version "$VERSION" \
+              --arg contract_name "$CONTRACT_NAME" \
+              --arg contract_version "$CONTRACT_VERSION" \
+              --arg image_repository "$IMAGE_REPOSITORY" \
+              --arg image_digest "$image_digest" \
+              --arg binary_path "$BINARY_PATH" \
+              --arg image_sha256 "$image_sha256" \
+              --arg clean_build_sha256 "$CLEAN_SHA256" \
+              --arg comparison_result "$comparison_result" \
+              --arg failure "$failure" \
+              '{
+                commit_sha: $commit_sha,
+                contract: {
+                  name: $contract_name,
+                  version: $contract_version,
+                  source_date_epoch: $source_date_epoch,
+                  target: "x86_64-unknown-linux-gnu",
+                  cargo_profile: "reproducible",
+                  cargo_features: ["jemalloc"]
+                },
+                image: {
+                  repository: $image_repository,
+                  digest: $image_digest,
+                  binary_path: $binary_path,
+                  binary_sha256: $image_sha256
+                },
+                clean_build_sha256: $clean_build_sha256,
+                comparison_result: $comparison_result,
+                failure: $failure
+              }' > "$MANIFEST"
+          }
+
+          cleanup() {
+            status=$?
+            if [[ -n "$container_id" ]]; then
+              docker rm -f "$container_id" >/dev/null 2>&1 || true
+            fi
+            write_manifest
+            exit "$status"
+          }
+          trap cleanup EXIT
+
+          tagged_image="$IMAGE_REPOSITORY:$IMAGE_TAG"
+          for attempt in {1..12}; do
+            image_digest="$(docker buildx imagetools inspect "$tagged_image" \
+              --format '{{.Manifest.Digest}}' 2>/dev/null || true)"
+            if [[ "$image_digest" =~ ^sha256:[0-9a-f]{64}$ ]]; then
+              break
+            fi
+            echo "Waiting for $tagged_image to become readable (attempt $attempt/12)"
+            sleep 5
+          done
+          if [[ ! "$image_digest" =~ ^sha256:[0-9a-f]{64}$ ]]; then
+            failure="could not resolve production image digest"
+            echo "Could not resolve a valid digest for $tagged_image" >&2
+            exit 1
+          fi
+
+          immutable_image="$IMAGE_REPOSITORY@$image_digest"
+          docker pull "$immutable_image"
+          container_id="$(docker create "$immutable_image")"
+          docker cp "$container_id:$BINARY_PATH" "$RUNNER_TEMP/tempo-zone"
+          image_sha256="$(sha256sum "$RUNNER_TEMP/tempo-zone" | awk '{print $1}')"
+          [[ "$image_sha256" =~ ^[0-9a-f]{64}$ ]] || {
+            failure="invalid image binary SHA-256"
+            echo "Invalid image binary SHA-256: $image_sha256" >&2
+            exit 1
+          }
+
+          if [[ "$image_sha256" == "$CLEAN_SHA256" ]]; then
+            comparison_result="success"
+            echo "Production tempo-zone binary checksum matches clean rebuild"
+          else
+            failure="production image binary checksum does not match clean rebuild"
+            echo "::error::Production reproducible binary verification mismatch"
+            exit 1
+          fi
+
+      - name: Upload verification manifest
+        if: always()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: production-reproducible-image-verification-${{ needs.resolve-production-build-inputs.outputs.short_sha }}
+          path: ${{ runner.temp }}/production-reproducible-image-verification.json
+          if-no-files-found: warn
+          retention-days: 7

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,7 +13,7 @@ on:
         required: true
         type: string
       dry_run:
-        description: "Dry run (build binaries without creating release)"
+        description: "Verify the canonical Linux x86_64 binary without publishing an image or release"
         default: false
         type: boolean
 
@@ -315,6 +315,9 @@ jobs:
   build-other-release:
     name: Build ${{ matrix.platform.target }} release binary
     needs: resolve-release
+    # Dry runs are a focused reproducible-contract test; full releases retain
+    # the ARM Linux and macOS artifact builds below.
+    if: github.event_name != 'workflow_dispatch' || inputs.dry_run == false
     runs-on: ${{ matrix.platform.os }}
     strategy:
       fail-fast: false

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,17 +9,9 @@ on:
   workflow_dispatch:
     inputs:
       tag:
-        description: "Tag to release (e.g., v0.1.0)"
+        description: "Tag or ref to release (e.g., v0.1.0)"
         required: true
         type: string
-      profile:
-        description: "Build profile"
-        default: "profiling"
-        type: choice
-        options:
-          - "release"
-          - "profiling"
-          - "maxperf"
       dry_run:
         description: "Dry run (build binaries without creating release)"
         default: false
@@ -31,158 +23,381 @@ permissions:
 env:
   CARGO_TERM_COLOR: always
   RUST_BACKTRACE: full
+  RUST_TOOLCHAIN: "1.96.0"
 
 jobs:
-  get-version:
-    name: Get Version
+  resolve-release:
+    name: Resolve release inputs
     runs-on: ubuntu-latest
     outputs:
-      version: ${{ steps.get_version.outputs.version }}
+      version: ${{ steps.release.outputs.version }}
+      commit_sha: ${{ steps.release.outputs.commit_sha }}
+      short_sha: ${{ steps.release.outputs.short_sha }}
+      source_date_epoch: ${{ steps.release.outputs.source_date_epoch }}
     steps:
-      - name: Get version from tag
-        id: get_version
+      - name: Check out release tag or ref
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          ref: ${{ inputs.tag || github.ref }}
+          fetch-depth: 1
+          persist-credentials: false
+          submodules: recursive
+
+      - name: Record immutable release inputs
+        id: release
+        shell: bash
         env:
           INPUT_TAG: ${{ inputs.tag }}
         run: |
-          if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
-            echo "version=${INPUT_TAG}" >> "$GITHUB_OUTPUT"
+          set -euo pipefail
+
+          if [[ "$GITHUB_EVENT_NAME" == "workflow_dispatch" ]]; then
+            version="$INPUT_TAG"
           else
-            echo "version=${GITHUB_REF#refs/tags/}" >> "$GITHUB_OUTPUT"
+            version="${GITHUB_REF#refs/tags/}"
           fi
+          commit_sha="$(git rev-parse HEAD)"
+          short_sha="$(git rev-parse --short=7 HEAD)"
+          source_date_epoch="$(git show -s --format=%ct HEAD)"
+
+          [[ -n "$version" ]] || {
+            echo "Release version is empty" >&2
+            exit 1
+          }
+          [[ "$commit_sha" =~ ^[0-9a-f]{40}$ ]] || {
+            echo "Resolved ref is not a full commit SHA: $commit_sha" >&2
+            exit 1
+          }
+          [[ "$source_date_epoch" =~ ^[0-9]+$ ]] || {
+            echo "Invalid SOURCE_DATE_EPOCH: $source_date_epoch" >&2
+            exit 1
+          }
+
+          {
+            echo "version=$version"
+            echo "commit_sha=$commit_sha"
+            echo "short_sha=$short_sha"
+            echo "source_date_epoch=$source_date_epoch"
+          } >> "$GITHUB_OUTPUT"
+
   check-version:
-    name: check version
+    name: Check version
     runs-on: ubuntu-latest
-    needs: get-version
+    needs: resolve-release
     if: ${{ github.event.inputs.dry_run != 'true' }}
     steps:
-      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+      - name: Check out resolved commit
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
+          ref: ${{ needs.resolve-release.outputs.commit_sha }}
           persist-credentials: false
+          submodules: recursive
+
       - uses: tempoxyz/gh-actions/actions/setup-rust-build@98b1081dcf34361b576aca2ab3041772708582ef
         with:
-          toolchain: stable
+          toolchain: ${{ env.RUST_TOOLCHAIN }}
           mold: "false"
           sccache: "false"
-      - name: Verify crate version matches tag
-        # Check that the Cargo version starts with the tag,
-        # so that Cargo version 1.4.8 can be matched against both v1.4.8 and v1.4.8-rc.1
-        env:
-          VERSION: ${{ needs.get-version.outputs.version }}
-        run: |
-          tag="$VERSION"
-          tag=${tag#v}
-          cargo_ver=$(cargo metadata --no-deps --format-version 1 | jq -r '.packages[0].version')
-          [[ "$tag" == "$cargo_ver"* ]] || { echo "Tag $tag doesn’t match the Cargo version $cargo_ver"; exit 1; }
 
-  build-release:
-    name: Build Release Binaries
-    needs: get-version
+      - name: Verify crate version matches tag
+        # Check that the Cargo version starts with the tag, so Cargo version
+        # 1.4.8 matches both v1.4.8 and v1.4.8-rc.1.
+        env:
+          VERSION: ${{ needs.resolve-release.outputs.version }}
+        run: |
+          set -euo pipefail
+          tag="${VERSION#v}"
+          cargo_ver="$(cargo metadata --locked --no-deps --format-version 1 | jq -r '.packages[0].version')"
+          [[ "$tag" == "$cargo_ver"* ]] || {
+            echo "Tag $tag does not match Cargo version $cargo_ver" >&2
+            exit 1
+          }
+
+  build-linux-x86_64-release:
+    name: Build canonical Linux x86_64 release binary
+    needs: resolve-release
+    runs-on: depot-ubuntu-latest-16
+    permissions:
+      contents: read
+    outputs:
+      binary_sha256: ${{ steps.hash.outputs.sha256 }}
+    steps:
+      - name: Check out resolved commit
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          ref: ${{ needs.resolve-release.outputs.commit_sha }}
+          fetch-depth: 1
+          persist-credentials: false
+          submodules: recursive
+
+      # Linux x86_64 is the canonical reproducible release contract.
+      - name: Build the canonical reproducible binary
+        env:
+          GIT_SHA: ${{ needs.resolve-release.outputs.commit_sha }}
+          SOURCE_DATE_EPOCH: ${{ needs.resolve-release.outputs.source_date_epoch }}
+          VERSION: ${{ needs.resolve-release.outputs.version }}
+        run: scripts/reproducible-build.sh
+
+      - name: Prepare release archive and checksums
+        id: prepare
+        shell: bash
+        env:
+          VERSION: ${{ needs.resolve-release.outputs.version }}
+        run: |
+          set -euo pipefail
+
+          target="x86_64-unknown-linux-gnu"
+          binary_name="tempo-zone-${VERSION}-${target}"
+          archive_name="${binary_name}.tar.gz"
+          binary_checksum_name="${binary_name}.sha256"
+
+          cp out/tempo-zone "$binary_name"
+          tar czf "$archive_name" "$binary_name"
+          shasum -a 256 "$archive_name" > "${archive_name}.sha256"
+          printf '%s  %s\n' "$(sha256sum out/tempo-zone | awk '{print $1}')" "$binary_name" \
+            > "$binary_checksum_name"
+
+          {
+            echo "archive_name=$archive_name"
+            echo "archive_checksum_name=${archive_name}.sha256"
+            echo "binary_checksum_name=$binary_checksum_name"
+          } >> "$GITHUB_OUTPUT"
+
+      - name: Hash canonical binary
+        id: hash
+        shell: bash
+        run: |
+          set -euo pipefail
+          sha256="$(sha256sum out/tempo-zone | awk '{print $1}')"
+          [[ "$sha256" =~ ^[0-9a-f]{64}$ ]] || {
+            echo "Invalid canonical-build SHA-256: $sha256" >&2
+            exit 1
+          }
+          echo "sha256=$sha256" >> "$GITHUB_OUTPUT"
+
+      - name: Upload canonical Linux x86_64 release assets
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: tempo-zone-x86_64-unknown-linux-gnu
+          path: |
+            ${{ steps.prepare.outputs.archive_name }}
+            ${{ steps.prepare.outputs.archive_checksum_name }}
+            ${{ steps.prepare.outputs.binary_checksum_name }}
+          if-no-files-found: error
+
+  rebuild-linux-x86_64-release:
+    name: Clean rebuild canonical Linux x86_64 binary
+    needs: resolve-release
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    outputs:
+      binary_sha256: ${{ steps.hash.outputs.sha256 }}
+    steps:
+      - name: Check out resolved commit
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          ref: ${{ needs.resolve-release.outputs.commit_sha }}
+          fetch-depth: 1
+          persist-credentials: false
+          submodules: recursive
+
+      - name: Rebuild the canonical reproducible binary without cache
+        env:
+          GIT_SHA: ${{ needs.resolve-release.outputs.commit_sha }}
+          SOURCE_DATE_EPOCH: ${{ needs.resolve-release.outputs.source_date_epoch }}
+          VERSION: ${{ needs.resolve-release.outputs.version }}
+          NO_CACHE: "1"
+        run: |
+          set -euo pipefail
+          docker builder prune --all --force
+          scripts/reproducible-build.sh
+
+      - name: Hash clean rebuild
+        id: hash
+        shell: bash
+        run: |
+          set -euo pipefail
+          sha256="$(sha256sum out/tempo-zone | awk '{print $1}')"
+          [[ "$sha256" =~ ^[0-9a-f]{64}$ ]] || {
+            echo "Invalid clean-build SHA-256: $sha256" >&2
+            exit 1
+          }
+          echo "sha256=$sha256" >> "$GITHUB_OUTPUT"
+
+  compare-linux-x86_64-release:
+    name: Verify canonical Linux x86_64 release binary
+    needs:
+      - resolve-release
+      - build-linux-x86_64-release
+      - rebuild-linux-x86_64-release
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - name: Compare raw binary hashes
+        shell: bash
+        env:
+          COMMIT_SHA: ${{ needs.resolve-release.outputs.commit_sha }}
+          SOURCE_DATE_EPOCH: ${{ needs.resolve-release.outputs.source_date_epoch }}
+          VERSION: ${{ needs.resolve-release.outputs.version }}
+          CANDIDATE_SHA256: ${{ needs.build-linux-x86_64-release.outputs.binary_sha256 }}
+          CLEAN_REBUILD_SHA256: ${{ needs.rebuild-linux-x86_64-release.outputs.binary_sha256 }}
+          CONTRACT_NAME: tempo-zone-linux-x86_64-reproducible
+          CONTRACT_VERSION: "1"
+          MANIFEST: ${{ runner.temp }}/tempo-zone-linux-x86_64-verification.json
+        run: |
+          set -Eeuo pipefail
+
+          comparison_result="failed"
+          failure=""
+
+          write_manifest() {
+            jq -n \
+              --arg commit_sha "$COMMIT_SHA" \
+              --arg version "$VERSION" \
+              --arg contract_name "$CONTRACT_NAME" \
+              --arg contract_version "$CONTRACT_VERSION" \
+              --argjson source_date_epoch "$SOURCE_DATE_EPOCH" \
+              --arg candidate_sha256 "$CANDIDATE_SHA256" \
+              --arg clean_rebuild_sha256 "$CLEAN_REBUILD_SHA256" \
+              --arg comparison_result "$comparison_result" \
+              --arg failure "$failure" \
+              '{
+                commit_sha: $commit_sha,
+                version: $version,
+                contract: {
+                  name: $contract_name,
+                  version: $contract_version,
+                  dockerfile: "docker/Dockerfile.reproducible",
+                  target: "x86_64-unknown-linux-gnu",
+                  cargo_profile: "reproducible",
+                  cargo_features: ["jemalloc"],
+                  source_date_epoch: $source_date_epoch
+                },
+                candidate_binary_sha256: $candidate_sha256,
+                clean_rebuild_binary_sha256: $clean_rebuild_sha256,
+                comparison_result: $comparison_result,
+                failure: $failure
+              }' > "$MANIFEST"
+          }
+
+          trap 'write_manifest' EXIT
+
+          [[ "$CANDIDATE_SHA256" =~ ^[0-9a-f]{64}$ ]] || {
+            failure="invalid candidate binary SHA-256"
+            echo "Invalid candidate binary SHA-256: $CANDIDATE_SHA256" >&2
+            exit 1
+          }
+          [[ "$CLEAN_REBUILD_SHA256" =~ ^[0-9a-f]{64}$ ]] || {
+            failure="invalid clean rebuild SHA-256"
+            echo "Invalid clean rebuild SHA-256: $CLEAN_REBUILD_SHA256" >&2
+            exit 1
+          }
+
+          if [[ "$CANDIDATE_SHA256" != "$CLEAN_REBUILD_SHA256" ]]; then
+            failure="canonical release binary checksum does not match clean rebuild"
+            echo "::error::Canonical Linux x86_64 reproducible binary verification mismatch"
+            exit 1
+          fi
+
+          comparison_result="success"
+          echo "Canonical Linux x86_64 release binary checksum matches clean rebuild"
+
+      - name: Upload release verification manifest
+        if: always()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: tempo-zone-linux-x86_64-reproducible-verification
+          path: ${{ runner.temp }}/tempo-zone-linux-x86_64-verification.json
+          if-no-files-found: warn
+
+  build-other-release:
+    name: Build ${{ matrix.platform.target }} release binary
+    needs: resolve-release
     runs-on: ${{ matrix.platform.os }}
     strategy:
       fail-fast: false
       matrix:
-        binary:
-          - name: tempo-zone
-            features: "asm-keccak,jemalloc"
         platform:
-          - os: depot-ubuntu-latest-16
-            target: x86_64-unknown-linux-gnu
+          # These release artifacts remain outside the reproducible contract.
           - os: depot-ubuntu-latest-arm-16
             target: aarch64-unknown-linux-gnu
           - os: depot-macos-15
             target: aarch64-apple-darwin
-
     steps:
-      - name: Checkout repository
+      - name: Check out resolved commit
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
+          ref: ${{ needs.resolve-release.outputs.commit_sha }}
           persist-credentials: false
+          submodules: recursive
 
       - name: Install Rust toolchain
         uses: tempoxyz/gh-actions/actions/setup-rust-build@98b1081dcf34361b576aca2ab3041772708582ef
         with:
-          toolchain: stable
+          toolchain: ${{ env.RUST_TOOLCHAIN }}
           targets: ${{ matrix.platform.target }}
           sccache: "false"
-
-      - name: Get build profile
-        id: profile
-        env:
-          INPUT_PROFILE: ${{ inputs.profile }}
-        run: |
-          if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
-            echo "profile=${INPUT_PROFILE}" >> "$GITHUB_OUTPUT"
-          else
-            echo "profile=maxperf" >> "$GITHUB_OUTPUT"
-          fi
-        shell: bash
 
       - name: Build binary
         env:
           CARGO_TARGET_DIR: target
-          BINARY_NAME: ${{ matrix.binary.name }}
-          FEATURES: ${{ matrix.binary.features }}
-          PROFILE: ${{ steps.profile.outputs.profile }}
           TARGET: ${{ matrix.platform.target }}
-        run: cargo build --bin "$BINARY_NAME" --features "$FEATURES" --profile "$PROFILE" --target "$TARGET"
+        run: >-
+          cargo build --locked --bin tempo-zone --features "asm-keccak,jemalloc"
+          --profile maxperf --target "$TARGET"
 
       - name: Prepare binary
         id: prepare
         shell: bash
         env:
-          BINARY: ${{ matrix.binary.name }}
           TARGET: ${{ matrix.platform.target }}
-          PROFILE: ${{ steps.profile.outputs.profile }}
-          VERSION: ${{ needs.get-version.outputs.version }}
+          VERSION: ${{ needs.resolve-release.outputs.version }}
         run: |
-          if [ "$PROFILE" = "dev" ]; then
-            PROFILE_DIR="debug"
-          else
-            PROFILE_DIR="$PROFILE"
-          fi
+          set -euo pipefail
 
-          BINARY_PATH="target/${TARGET}/${PROFILE_DIR}/${BINARY}"
-          BINARY_NAME="${BINARY}-${VERSION}-${TARGET}"
-          ARCHIVE_NAME="${BINARY}-${VERSION}-${TARGET}.tar.gz"
+          binary_name="tempo-zone-${VERSION}-${TARGET}"
+          archive_name="${binary_name}.tar.gz"
 
-          cp "$BINARY_PATH" "$BINARY_NAME"
-          tar czf "$ARCHIVE_NAME" "$BINARY_NAME"
+          cp "target/${TARGET}/maxperf/tempo-zone" "$binary_name"
+          tar czf "$archive_name" "$binary_name"
+          shasum -a 256 "$archive_name" > "${archive_name}.sha256"
 
           {
-            echo "archive_name=$ARCHIVE_NAME"
-            echo "archive_path=$ARCHIVE_NAME"
+            echo "archive_name=$archive_name"
+            echo "archive_checksum_name=${archive_name}.sha256"
           } >> "$GITHUB_OUTPUT"
 
-      - name: Generate checksums
-        shell: bash
-        env:
-          ARCHIVE_PATH: ${{ steps.prepare.outputs.archive_path }}
-          ARCHIVE_NAME: ${{ steps.prepare.outputs.archive_name }}
-        run: |
-          shasum -a 256 "$ARCHIVE_PATH" > "${ARCHIVE_NAME}.sha256"
-
-      - name: Upload artifacts
+      - name: Upload release assets
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
-          name: ${{ matrix.binary.name }}-${{ matrix.platform.target }}
+          name: tempo-zone-${{ matrix.platform.target }}
           path: |
-            ${{ steps.prepare.outputs.archive_path }}
-            ${{ steps.prepare.outputs.archive_name }}.sha256
+            ${{ steps.prepare.outputs.archive_name }}
+            ${{ steps.prepare.outputs.archive_checksum_name }}
           if-no-files-found: error
 
   create-release:
     name: Create Release
-    needs: [get-version, build-release]
+    needs:
+      - resolve-release
+      - check-version
+      - build-linux-x86_64-release
+      - rebuild-linux-x86_64-release
+      - compare-linux-x86_64-release
+      - build-other-release
     if: ${{ github.event_name == 'push' || (github.event_name == 'workflow_dispatch' && inputs.dry_run == false) }}
     runs-on: depot-ubuntu-latest
     permissions:
       contents: write
     steps:
-      # This is necessary for generating the changelog.
-      # It has to come before "Download Artifacts" or else it deletes the artifacts.
-      - name: Checkout repository
+      # This is necessary for generating the changelog. It has to come before
+      # downloading artifacts or else checkout deletes the artifacts.
+      - name: Check out resolved commit
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
+          ref: ${{ needs.resolve-release.outputs.commit_sha }}
           fetch-depth: 0
           persist-credentials: false
 
@@ -194,19 +409,19 @@ jobs:
       - name: Create Release
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          VERSION: ${{ needs.get-version.outputs.version }}
+          VERSION: ${{ needs.resolve-release.outputs.version }}
         run: |
-          # Determine if this is a prerelease
-          PRERELEASE=""
+          set -euo pipefail
+
+          prerelease=""
           if echo "$VERSION" | grep -qE '(alpha|beta|rc)'; then
-            PRERELEASE="--prerelease"
+            prerelease="--prerelease"
           fi
 
-          # Create draft release with all artifacts
           gh release create "$VERSION" \
             --repo ${{ github.repository }} \
             --title "Release $VERSION" \
             --draft \
             --notes "" \
-            $PRERELEASE \
+            $prerelease \
             artifacts/**/*

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,7 +9,7 @@ on:
   workflow_dispatch:
     inputs:
       tag:
-        description: "Tag or ref to release (e.g., v0.1.0)"
+        description: "Existing Git tag to release (e.g., v0.1.0)"
         required: true
         type: string
       dry_run:
@@ -35,11 +35,11 @@ jobs:
       short_sha: ${{ steps.release.outputs.short_sha }}
       source_date_epoch: ${{ steps.release.outputs.source_date_epoch }}
     steps:
-      - name: Check out release tag or ref
+      - name: Check out release tag
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
-          ref: ${{ inputs.tag || github.ref }}
-          fetch-depth: 1
+          ref: ${{ github.event_name == 'workflow_dispatch' && format('refs/tags/{0}', inputs.tag) || github.ref }}
+          fetch-depth: 0
           persist-credentials: false
           submodules: recursive
 
@@ -64,12 +64,24 @@ jobs:
             echo "Release version is empty" >&2
             exit 1
           }
+          git check-ref-format --allow-onelevel "refs/tags/$version" || {
+            echo "Release version is not a valid tag name: $version" >&2
+            exit 1
+          }
           [[ "$commit_sha" =~ ^[0-9a-f]{40}$ ]] || {
             echo "Resolved ref is not a full commit SHA: $commit_sha" >&2
             exit 1
           }
           [[ "$source_date_epoch" =~ ^[0-9]+$ ]] || {
             echo "Invalid SOURCE_DATE_EPOCH: $source_date_epoch" >&2
+            exit 1
+          }
+          tag_commit="$(git rev-parse --verify "refs/tags/$version^{commit}")" || {
+            echo "Release tag does not resolve to a commit: $version" >&2
+            exit 1
+          }
+          [[ "$tag_commit" == "$commit_sha" ]] || {
+            echo "Release tag $version resolves to $tag_commit, not $commit_sha" >&2
             exit 1
           }
 
@@ -120,7 +132,7 @@ jobs:
     permissions:
       contents: read
     outputs:
-      binary_sha256: ${{ steps.hash.outputs.sha256 }}
+      asset_artifact_id: ${{ steps.upload.outputs.artifact-id }}
     steps:
       - name: Check out resolved commit
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
@@ -163,19 +175,8 @@ jobs:
             echo "binary_checksum_name=$binary_checksum_name"
           } >> "$GITHUB_OUTPUT"
 
-      - name: Hash canonical binary
-        id: hash
-        shell: bash
-        run: |
-          set -euo pipefail
-          sha256="$(sha256sum out/tempo-zone | awk '{print $1}')"
-          [[ "$sha256" =~ ^[0-9a-f]{64}$ ]] || {
-            echo "Invalid canonical-build SHA-256: $sha256" >&2
-            exit 1
-          }
-          echo "sha256=$sha256" >> "$GITHUB_OUTPUT"
-
       - name: Upload canonical Linux x86_64 release assets
+        id: upload
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: tempo-zone-x86_64-unknown-linux-gnu
@@ -235,14 +236,21 @@ jobs:
     permissions:
       contents: read
     steps:
-      - name: Compare raw binary hashes
+      - name: Download canonical Linux x86_64 release assets
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          artifact-ids: ${{ needs.build-linux-x86_64-release.outputs.asset_artifact_id }}
+          path: ${{ runner.temp }}/canonical-linux-x86_64-assets
+
+      - name: Verify archived binary against clean rebuild
         shell: bash
         env:
           COMMIT_SHA: ${{ needs.resolve-release.outputs.commit_sha }}
           SOURCE_DATE_EPOCH: ${{ needs.resolve-release.outputs.source_date_epoch }}
           VERSION: ${{ needs.resolve-release.outputs.version }}
-          CANDIDATE_SHA256: ${{ needs.build-linux-x86_64-release.outputs.binary_sha256 }}
           CLEAN_REBUILD_SHA256: ${{ needs.rebuild-linux-x86_64-release.outputs.binary_sha256 }}
+          CANDIDATE_ARTIFACT_ID: ${{ needs.build-linux-x86_64-release.outputs.asset_artifact_id }}
+          CANDIDATE_ASSET_DIR: ${{ runner.temp }}/canonical-linux-x86_64-assets
           CONTRACT_NAME: tempo-zone-linux-x86_64-reproducible
           CONTRACT_VERSION: "1"
           MANIFEST: ${{ runner.temp }}/tempo-zone-linux-x86_64-verification.json
@@ -251,6 +259,8 @@ jobs:
 
           comparison_result="failed"
           failure=""
+          candidate_sha256=""
+          candidate_archive_sha256=""
 
           write_manifest() {
             jq -n \
@@ -259,7 +269,9 @@ jobs:
               --arg contract_name "$CONTRACT_NAME" \
               --arg contract_version "$CONTRACT_VERSION" \
               --argjson source_date_epoch "$SOURCE_DATE_EPOCH" \
-              --arg candidate_sha256 "$CANDIDATE_SHA256" \
+              --arg candidate_artifact_id "$CANDIDATE_ARTIFACT_ID" \
+              --arg candidate_archive_sha256 "$candidate_archive_sha256" \
+              --arg candidate_sha256 "$candidate_sha256" \
               --arg clean_rebuild_sha256 "$CLEAN_REBUILD_SHA256" \
               --arg comparison_result "$comparison_result" \
               --arg failure "$failure" \
@@ -275,6 +287,8 @@ jobs:
                   cargo_features: ["jemalloc"],
                   source_date_epoch: $source_date_epoch
                 },
+                candidate_artifact_id: $candidate_artifact_id,
+                candidate_archive_sha256: $candidate_archive_sha256,
                 candidate_binary_sha256: $candidate_sha256,
                 clean_rebuild_binary_sha256: $clean_rebuild_sha256,
                 comparison_result: $comparison_result,
@@ -284,9 +298,9 @@ jobs:
 
           trap 'write_manifest' EXIT
 
-          [[ "$CANDIDATE_SHA256" =~ ^[0-9a-f]{64}$ ]] || {
-            failure="invalid candidate binary SHA-256"
-            echo "Invalid candidate binary SHA-256: $CANDIDATE_SHA256" >&2
+          [[ "$CANDIDATE_ARTIFACT_ID" =~ ^[0-9]+$ ]] || {
+            failure="invalid candidate artifact ID"
+            echo "Invalid candidate artifact ID: $CANDIDATE_ARTIFACT_ID" >&2
             exit 1
           }
           [[ "$CLEAN_REBUILD_SHA256" =~ ^[0-9a-f]{64}$ ]] || {
@@ -295,7 +309,71 @@ jobs:
             exit 1
           }
 
-          if [[ "$CANDIDATE_SHA256" != "$CLEAN_REBUILD_SHA256" ]]; then
+          target="x86_64-unknown-linux-gnu"
+          binary_name="tempo-zone-${VERSION}-${target}"
+          archive_name="${binary_name}.tar.gz"
+          archive_checksum_name="${archive_name}.sha256"
+          binary_checksum_name="${binary_name}.sha256"
+          mapfile -t archive_paths < <(find "$CANDIDATE_ASSET_DIR" -type f -name "$archive_name" -print)
+          if [[ ${#archive_paths[@]} -ne 1 ]]; then
+            failure="candidate artifact does not contain exactly one $archive_name"
+            echo "$failure" >&2
+            exit 1
+          fi
+          archive_path="${archive_paths[0]}"
+          asset_dir="$(dirname "$archive_path")"
+
+          for asset in "$archive_path" \
+              "$asset_dir/$archive_checksum_name" \
+              "$asset_dir/$binary_checksum_name"; do
+            [[ -f "$asset" ]] || {
+              failure="candidate artifact is missing $(basename "$asset")"
+              echo "$failure" >&2
+              exit 1
+            }
+          done
+
+          (
+            cd "$asset_dir"
+            sha256sum --strict --check "$archive_checksum_name"
+          ) || {
+            failure="candidate archive checksum does not match its archive"
+            exit 1
+          }
+
+          mapfile -t archive_entries < <(tar -tzf "$archive_path")
+          if [[ ${#archive_entries[@]} -ne 1 || "${archive_entries[0]}" != "$binary_name" ]]; then
+            failure="candidate archive does not contain exactly $binary_name"
+            echo "$failure" >&2
+            exit 1
+          fi
+
+          extract_dir="$RUNNER_TEMP/canonical-linux-x86_64-extracted"
+          mkdir -p "$extract_dir"
+          tar -xzf "$archive_path" -C "$extract_dir"
+          candidate_binary="$extract_dir/$binary_name"
+          [[ -f "$candidate_binary" && ! -L "$candidate_binary" ]] || {
+            failure="candidate archive binary is missing or is a symlink"
+            echo "$failure" >&2
+            exit 1
+          }
+
+          candidate_sha256="$(sha256sum "$candidate_binary" | awk '{print $1}')"
+          candidate_archive_sha256="$(sha256sum "$archive_path" | awk '{print $1}')"
+          [[ "$candidate_sha256" =~ ^[0-9a-f]{64}$ ]] || {
+            failure="invalid archived candidate binary SHA-256"
+            echo "$failure" >&2
+            exit 1
+          }
+
+          read -r declared_binary_sha256 declared_binary_name < "$asset_dir/$binary_checksum_name"
+          if [[ "$declared_binary_sha256" != "$candidate_sha256" || "$declared_binary_name" != "$binary_name" ]]; then
+            failure="candidate bare-binary checksum does not match archived binary"
+            echo "$failure" >&2
+            exit 1
+          fi
+
+          if [[ "$candidate_sha256" != "$CLEAN_REBUILD_SHA256" ]]; then
             failure="canonical release binary checksum does not match clean rebuild"
             echo "::error::Canonical Linux x86_64 reproducible binary verification mismatch"
             exit 1
@@ -404,9 +482,23 @@ jobs:
           fetch-depth: 0
           persist-credentials: false
 
-      - name: Download artifacts
+      - name: Download verified canonical Linux x86_64 assets
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
+          artifact-ids: ${{ needs.build-linux-x86_64-release.outputs.asset_artifact_id }}
+          path: artifacts
+
+      - name: Download other release assets
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          pattern: tempo-zone-aarch64-*
+          path: artifacts
+          merge-multiple: true
+
+      - name: Download Linux x86_64 verification manifest
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          name: tempo-zone-linux-x86_64-reproducible-verification
           path: artifacts
 
       - name: Create Release
@@ -421,10 +513,17 @@ jobs:
             prerelease="--prerelease"
           fi
 
+          mapfile -d '' assets < <(find artifacts -type f -print0 | sort -z)
+          (( ${#assets[@]} > 0 )) || {
+            echo "No verified release assets were downloaded" >&2
+            exit 1
+          }
+
           gh release create "$VERSION" \
             --repo ${{ github.repository }} \
+            --verify-tag \
             --title "Release $VERSION" \
             --draft \
             --notes "" \
             $prerelease \
-            artifacts/**/*
+            "${assets[@]}"

--- a/docker/Dockerfile.reproducible
+++ b/docker/Dockerfile.reproducible
@@ -1,8 +1,6 @@
 # syntax=docker/dockerfile:1.7
 #
-# Reproducible build of the `tempo-zone` binary for x86_64-unknown-linux-gnu.
-# This is verification-only for now; release.yml and docker.yml still publish
-# through the existing release paths.
+# Reproducible build of the canonical Linux x86_64 `tempo-zone` binary.
 
 ARG RUST_TOOLCHAIN=1.96.0
 FROM rust:${RUST_TOOLCHAIN}-bookworm@sha256:64d9b7f60e3abb08d477cad983d0a3743acc53a19369ba4482510184c9c807e5 AS builder
@@ -54,9 +52,8 @@ RUN cargo build --locked --bin tempo-zone \
 FROM scratch AS artifacts
 COPY --from=builder /app/target/x86_64-unknown-linux-gnu/reproducible/tempo-zone /tempo-zone
 
-# Runtime image used only by the reproducible-image verification pilot. The
-# binary is intentionally copied from the reproducible builder above rather
-# than rebuilt in this stage.
+# The production runtime copies the canonical reproducible binary. Image layers
+# are not themselves part of this reproducibility contract.
 FROM debian:bookworm-slim@sha256:4724b8cc51e33e398f0e2e15e18d5ec2851ff0c2280647e1310bc1642182655d AS reproducible-runtime-base
 ARG DEBIAN_SNAPSHOT=20260501T000000Z
 RUN echo "deb [check-valid-until=no] http://snapshot.debian.org/archive/debian/${DEBIAN_SNAPSHOT}/ bookworm main" \

--- a/docker/Dockerfile.reproducible
+++ b/docker/Dockerfile.reproducible
@@ -1,4 +1,4 @@
-# syntax=docker/dockerfile:1.7
+# syntax=docker/dockerfile:1.7@sha256:a57df69d0ea827fb7266491f2813635de6f17269be881f696fbfdf2d83dda33e
 #
 # Reproducible build of the canonical Linux x86_64 `tempo-zone` binary.
 

--- a/docker/docker-bake-profiling.hcl
+++ b/docker/docker-bake-profiling.hcl
@@ -37,6 +37,7 @@ target "_common" {
 }
 
 target "tempo-zone" {
+  dockerfile = "docker/Dockerfile"
   inherits = ["_common", "docker-metadata"]
   target = "tempo-zone"
 }

--- a/docker/docker-bake.hcl
+++ b/docker/docker-bake.hcl
@@ -65,13 +65,20 @@ target "_common" {
 }
 
 target "tempo-zone" {
-  inherits = ["_common", "docker-metadata"]
-  target = "tempo-zone"
+  inherits = ["docker-metadata"]
+  dockerfile = "docker/Dockerfile.reproducible"
+  context = "."
+  target = "tempo-zone-reproducible"
+  args = {
+    SOURCE_DATE_EPOCH = "${SOURCE_DATE_EPOCH}"
+    GIT_SHA = "${GIT_SHA}"
+    VERSION = "${VERSION}"
+  }
+  platforms = ["linux/amd64"]
 }
 
-# Non-production candidate image for the manual reproducible-image
-# verification workflow. This uses Dockerfile.reproducible's dedicated build
-# profile and flags, rather than the normal Dockerfile with a profile override.
+# Non-production candidate image for the manual reproducible-image verification
+# workflow. The production target above uses the same binary build contract.
 target "tempo-zone-reproducible" {
   dockerfile = "docker/Dockerfile.reproducible"
   context = "."

--- a/docker/docker-bake.hcl
+++ b/docker/docker-bake.hcl
@@ -74,6 +74,10 @@ target "tempo-zone" {
     GIT_SHA = "${GIT_SHA}"
     VERSION = "${VERSION}"
   }
+  labels = {
+    "org.opencontainers.image.description" = "Production tempo-zone image; verification covers the tempo-zone binary, runtime execution config, and CA bundle."
+    "org.tempoxyz.reproducible.verification-scope" = "tempo-zone-binary-runtime-config-ca-bundle"
+  }
   platforms = ["linux/amd64"]
 }
 

--- a/scripts/reproducible-build.sh
+++ b/scripts/reproducible-build.sh
@@ -5,6 +5,8 @@
 # Inputs (env):
 #   VERSION         informational version baked into audit output (default: dev)
 #   OUT_DIR         where the built binary lands (default: ./out)
+#   GIT_SHA         full SHA of the checked-out commit (validated when set)
+#   SOURCE_DATE_EPOCH commit timestamp (validated when set)
 #   DEBIAN_SNAPSHOT pinned Debian apt snapshot override
 #   NO_CACHE        set to 1 to disable Docker/BuildKit layer cache
 #
@@ -18,14 +20,24 @@ VERSION="${VERSION:-dev}"
 OUT_DIR="${OUT_DIR:-./out}"
 DEBIAN_SNAPSHOT="${DEBIAN_SNAPSHOT:-}"
 NO_CACHE="${NO_CACHE:-0}"
+CHECKED_OUT_COMMIT="$(git rev-parse HEAD)"
+CHECKED_OUT_EPOCH="$(git log -1 --pretty=%ct)"
+COMMIT="${GIT_SHA:-$CHECKED_OUT_COMMIT}"
+SOURCE_DATE_EPOCH="${SOURCE_DATE_EPOCH:-$CHECKED_OUT_EPOCH}"
 
 [[ "$NO_CACHE" == "0" || "$NO_CACHE" == "1" ]] || {
   echo "NO_CACHE must be 0 or 1" >&2
   exit 1
 }
 
-SOURCE_DATE_EPOCH="$(git log -1 --pretty=%ct)"
-COMMIT="$(git rev-parse HEAD)"
+[[ "$COMMIT" =~ ^[0-9a-f]{40}$ && "$COMMIT" == "$CHECKED_OUT_COMMIT" ]] || {
+  echo "GIT_SHA must be the full SHA of the checked-out commit" >&2
+  exit 1
+}
+[[ "$SOURCE_DATE_EPOCH" =~ ^[0-9]+$ && "$SOURCE_DATE_EPOCH" == "$CHECKED_OUT_EPOCH" ]] || {
+  echo "SOURCE_DATE_EPOCH must be the checked-out commit timestamp" >&2
+  exit 1
+}
 
 echo "::group::Reproducible build inputs"
 printf '  commit              = %s\n' "$COMMIT"

--- a/scripts/reproducible-build.sh
+++ b/scripts/reproducible-build.sh
@@ -9,6 +9,7 @@
 #   SOURCE_DATE_EPOCH commit timestamp (validated when set)
 #   DEBIAN_SNAPSHOT pinned Debian apt snapshot override
 #   NO_CACHE        set to 1 to disable Docker/BuildKit layer cache
+#   RUNTIME_IMAGE   optional local tag for the final runtime image
 #
 # Output:
 #   $OUT_DIR/tempo-zone
@@ -20,6 +21,7 @@ VERSION="${VERSION:-dev}"
 OUT_DIR="${OUT_DIR:-./out}"
 DEBIAN_SNAPSHOT="${DEBIAN_SNAPSHOT:-}"
 NO_CACHE="${NO_CACHE:-0}"
+RUNTIME_IMAGE="${RUNTIME_IMAGE:-}"
 CHECKED_OUT_COMMIT="$(git rev-parse HEAD)"
 CHECKED_OUT_EPOCH="$(git log -1 --pretty=%ct)"
 COMMIT="${GIT_SHA:-$CHECKED_OUT_COMMIT}"
@@ -29,6 +31,11 @@ SOURCE_DATE_EPOCH="${SOURCE_DATE_EPOCH:-$CHECKED_OUT_EPOCH}"
   echo "NO_CACHE must be 0 or 1" >&2
   exit 1
 }
+
+if [[ -n "$RUNTIME_IMAGE" && "$RUNTIME_IMAGE" == *[[:space:]]* ]]; then
+  echo "RUNTIME_IMAGE must not contain whitespace" >&2
+  exit 1
+fi
 
 [[ "$COMMIT" =~ ^[0-9a-f]{40}$ && "$COMMIT" == "$CHECKED_OUT_COMMIT" ]] || {
   echo "GIT_SHA must be the full SHA of the checked-out commit" >&2
@@ -47,6 +54,7 @@ printf '  Dockerfile          = docker/Dockerfile.reproducible\n'
 printf '  out_dir             = %s\n' "$OUT_DIR"
 [[ -n "$DEBIAN_SNAPSHOT" ]] && printf '  DEBIAN_SNAPSHOT     = %s (override)\n' "$DEBIAN_SNAPSHOT"
 [[ "$NO_CACHE" == "1" ]] && printf '  cache               = disabled\n'
+[[ -n "$RUNTIME_IMAGE" ]] && printf '  runtime_image       = %s\n' "$RUNTIME_IMAGE"
 echo "::endgroup::"
 
 mkdir -p "$OUT_DIR"
@@ -65,14 +73,29 @@ if [[ "$NO_CACHE" == "1" ]]; then
   build_options+=( --no-cache )
 fi
 
-docker build \
-  --platform linux/amd64 \
-  "${build_options[@]}" \
-  "${build_args[@]}" \
-  -f docker/Dockerfile.reproducible \
-  --target artifacts \
-  --output "type=local,dest=$OUT_DIR" \
-  .
+if [[ -n "$RUNTIME_IMAGE" ]]; then
+  docker build \
+    --platform linux/amd64 \
+    "${build_options[@]}" \
+    "${build_args[@]}" \
+    -f docker/Dockerfile.reproducible \
+    --target tempo-zone-reproducible \
+    --tag "$RUNTIME_IMAGE" \
+    .
+
+  runtime_container="$(docker create "$RUNTIME_IMAGE")"
+  trap 'docker rm -f "$runtime_container" >/dev/null 2>&1 || true' EXIT
+  docker cp "$runtime_container:/usr/local/bin/tempo-zone" "$OUT_DIR/tempo-zone"
+else
+  docker build \
+    --platform linux/amd64 \
+    "${build_options[@]}" \
+    "${build_args[@]}" \
+    -f docker/Dockerfile.reproducible \
+    --target artifacts \
+    --output "type=local,dest=$OUT_DIR" \
+    .
+fi
 
 echo "Reproducible binary written to $OUT_DIR/tempo-zone"
 sha256sum "$OUT_DIR/tempo-zone"


### PR DESCRIPTION
Promotes the Debian `profile=reproducible` recipe to the canonical Linux x86_64 `tempo-zone` contract.

The normal image and Linux x86_64 archive now carry the same binary. Main and tag image builds independently rebuild the resolved commit, extract the binary from the pushed image by immutable digest, and publish verification manifests; draft creation waits for the equivalent raw-binary comparison.

ARM Linux and macOS archives continue to use the maxperf path and are not covered by this contract. The manual candidate-image verifier remains separate.