### PR TITLE
chore: bump workspace version to 0.2.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -11740,7 +11740,7 @@ dependencies = [
 
 [[package]]
 name = "tempo-vsock-proxy"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "clap",
  "libc",
@@ -11753,7 +11753,7 @@ dependencies = [
 
 [[package]]
 name = "tempo-xtask"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "alloy",
  "alloy-eips",
@@ -11793,7 +11793,7 @@ dependencies = [
 
 [[package]]
 name = "tempo-zone"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "reth-cli-util",
  "rustls",
@@ -11802,7 +11802,7 @@ dependencies = [
 
 [[package]]
 name = "tempo-zone-contracts"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "alloy-contract",
  "alloy-network",
@@ -11821,7 +11821,7 @@ dependencies = [
 
 [[package]]
 name = "tempo-zone-prover-enclave"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "alloy-consensus",
  "alloy-genesis",
@@ -11844,7 +11844,7 @@ dependencies = [
 
 [[package]]
 name = "tempo-zone-prover-utils"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -13697,7 +13697,7 @@ checksum = "29666d0abbfad1e3dc4dcf6144730dd3a3ab225bbbdac83319345b1b44ccfc1b"
 
 [[package]]
 name = "zone-chainspec"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "alloy-eips",
  "alloy-evm",
@@ -13717,7 +13717,7 @@ dependencies = [
 
 [[package]]
 name = "zone-evm"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "alloy-consensus",
  "alloy-evm",
@@ -13752,7 +13752,7 @@ dependencies = [
 
 [[package]]
 name = "zone-hardfork"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "alloy-hardforks",
  "paste",
@@ -13760,7 +13760,7 @@ dependencies = [
 
 [[package]]
 name = "zone-l1"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -13800,7 +13800,7 @@ dependencies = [
 
 [[package]]
 name = "zone-node"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "alloy",
  "alloy-chains",
@@ -13894,7 +13894,7 @@ dependencies = [
 
 [[package]]
 name = "zone-p2p"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "alloy-primitives",
  "alloy-signer-local",
@@ -13918,7 +13918,7 @@ dependencies = [
 
 [[package]]
 name = "zone-payload"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -13959,7 +13959,7 @@ dependencies = [
 
 [[package]]
 name = "zone-precompiles"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "aes-gcm",
  "alloy",
@@ -13990,7 +13990,7 @@ dependencies = [
 
 [[package]]
 name = "zone-primitives"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "alloy-primitives",
  "tempo-hardfork",
@@ -13999,7 +13999,7 @@ dependencies = [
 
 [[package]]
 name = "zone-prover"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -14018,7 +14018,7 @@ dependencies = [
 
 [[package]]
 name = "zone-rpc"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -14057,7 +14057,7 @@ dependencies = [
 
 [[package]]
 name = "zone-sequencer"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "alloy-chains",
  "alloy-consensus",
@@ -14103,7 +14103,7 @@ dependencies = [
 
 [[package]]
 name = "zone-spf"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,5 @@
 [workspace.package]
-version = "0.1.0"
+version = "0.2.0"
 edition = "2024"
 rust-version = "1.95.0"
 license = "MIT OR Apache-2.0"


### PR DESCRIPTION
## Summary

- bump the workspace package version from 0.1.0 to 0.2.0
- refresh workspace package versions in Cargo.lock

## Testing

- cargo metadata --locked --offline --format-version 1