### PR TITLE
chore: ignore root .envrc

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -1,1 +1,0 @@
-export AMP_TOOLBOX=".amp/tools"

--- a/.gitignore
+++ b/.gitignore
@@ -12,7 +12,6 @@ profile.json.gz
 .idea
 **/.env
 **/.envrc
-!.envrc
 localnet/**
 generated/
 /earn/


### PR DESCRIPTION
## Summary

- stop tracking the repository-root `.envrc`
- allow the existing `**/.envrc` rule to ignore it

Prompted by: @shekhirin
