### PR TITLE
feat(sequencer): distinguish remote prover outcomes

### DIFF
--- a/crates/sequencer/src/metrics.rs
+++ b/crates/sequencer/src/metrics.rs
@@ -41,6 +41,12 @@ pub(crate) struct ProverMetrics {
     /// Time spent establishing a TCP connection to the remote prover.
     pub(crate) spf_remote_connect_duration_seconds: Histogram,
 
+    /// Number of TCP connections successfully established with the remote prover.
+    pub(crate) spf_remote_connect_success_total: Counter,
+
+    /// Number of TCP connections that failed to establish with the remote prover.
+    pub(crate) spf_remote_connect_failure_total: Counter,
+
     /// Time spent serializing and sending a request to the remote prover.
     pub(crate) spf_remote_request_send_duration_seconds: Histogram,
 
@@ -49,6 +55,12 @@ pub(crate) struct ProverMetrics {
 
     /// Time from the first response byte until the response is fully read and decoded.
     pub(crate) spf_remote_response_receive_duration_seconds: Histogram,
+
+    /// Number of successful responses received from the remote prover.
+    pub(crate) spf_remote_response_success_total: Counter,
+
+    /// Number of error responses received from the remote prover.
+    pub(crate) spf_remote_response_failure_total: Counter,
 
     /// Time spent comparing SPF output with the finalized batch candidate.
     pub(crate) output_validation_duration_seconds: Histogram,

--- a/crates/sequencer/src/metrics.rs
+++ b/crates/sequencer/src/metrics.rs
@@ -47,6 +47,9 @@ pub(crate) struct ProverMetrics {
     /// Number of TCP connections that failed to establish with the remote prover.
     pub(crate) spf_remote_connect_failure_total: Counter,
 
+    /// Number of remote prover requests that failed because of connectivity.
+    pub(crate) spf_remote_connectivity_failure_total: Counter,
+
     /// Time spent serializing and sending a request to the remote prover.
     pub(crate) spf_remote_request_send_duration_seconds: Histogram,
 
@@ -66,6 +69,8 @@ pub(crate) struct ProverMetrics {
     pub(crate) output_validation_duration_seconds: Histogram,
 
     /// Number of finalized batch candidates that failed prover validation.
+    ///
+    /// Remote prover connectivity failures are excluded.
     pub(crate) validation_failure_total: Counter,
 
     /// Number of finalized batch candidates that passed prover validation.

--- a/crates/sequencer/src/prover.rs
+++ b/crates/sequencer/src/prover.rs
@@ -455,7 +455,16 @@ async fn verify_remotely(
     metrics
         .spf_remote_connect_duration_seconds
         .record(started.elapsed().as_secs_f64());
-    let stream = stream.wrap_err_with(|| format!("connect to remote prover at {address}"))?;
+    let stream = match stream {
+        Ok(stream) => {
+            metrics.spf_remote_connect_success_total.increment(1);
+            stream
+        }
+        Err(err) => {
+            metrics.spf_remote_connect_failure_total.increment(1);
+            return Err(err).wrap_err_with(|| format!("connect to remote prover at {address}"));
+        }
+    };
 
     let first_read_at = Arc::new(OnceLock::new());
     let stream = FirstReadTimed {
@@ -511,6 +520,7 @@ async fn verify_remotely(
                 "remote prover response request ID {request_id:?} does not match {:?}",
                 request.request_id
             );
+            metrics.spf_remote_response_success_total.increment(1);
             Ok(output)
         }
         VerifyResponse::Error {
@@ -530,6 +540,7 @@ async fn verify_remotely(
                     request.request_id
                 );
             }
+            metrics.spf_remote_response_failure_total.increment(1);
             bail!("remote prover rejected request ({code:?}): {message}")
         }
     }

--- a/crates/sequencer/src/prover.rs
+++ b/crates/sequencer/src/prover.rs
@@ -2,6 +2,7 @@
 
 use std::{
     collections::{BTreeMap, BTreeSet},
+    error::Error as StdError,
     fmt, io,
     pin::Pin,
     sync::{Arc, OnceLock},
@@ -33,7 +34,8 @@ use tracing::{debug, error, info};
 use zone_chainspec::ZoneChainSpec;
 use zone_l1::TempoStateExt as _;
 use zone_prover::{
-    DEFAULT_MAX_REQUEST_BYTES, PROTOCOL_VERSION, ProverConnection, VerifyRequest, VerifyResponse,
+    DEFAULT_MAX_REQUEST_BYTES, PROTOCOL_VERSION, ProverConnection, ProverConnectionError,
+    VerifyRequest, VerifyResponse,
 };
 use zone_rpc::{ZoneDebugApi, types::TempoStorageRead};
 use zone_spf::{
@@ -121,6 +123,24 @@ struct Anchor {
     number: u64,
     hash: B256,
     ancestry_headers: Vec<Bytes>,
+}
+
+/// Marks a remote prover transport failure so it can be excluded from validation alerts.
+#[derive(Debug)]
+struct RemoteProverConnectivityError(String);
+
+impl fmt::Display for RemoteProverConnectivityError {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter.write_str(&self.0)
+    }
+}
+
+impl StdError for RemoteProverConnectivityError {}
+
+fn is_remote_prover_connectivity_error(error: &eyre::Report) -> bool {
+    error
+        .downcast_ref::<RemoteProverConnectivityError>()
+        .is_some()
 }
 
 /// I/O wrapper that records when the first response byte is read.
@@ -233,7 +253,10 @@ pub(crate) fn spawn_shadow_prover<P: ZoneSequencerProvider>(
                     );
                 }
                 Err(err) => {
-                    metrics.validation_failure_total.increment(1);
+                    let connectivity_failure = is_remote_prover_connectivity_error(&err);
+                    if !connectivity_failure {
+                        metrics.validation_failure_total.increment(1);
+                    }
                     error!(
                         target: "zone::sequencer::prover",
                         zone_from = job.from,
@@ -241,6 +264,7 @@ pub(crate) fn spawn_shadow_prover<P: ZoneSequencerProvider>(
                         prev_block_hash = %job.batch.prev_block_hash,
                         next_block_hash = %job.batch.next_block_hash,
                         elapsed_ms = started.elapsed().as_millis(),
+                        connectivity_failure,
                         error = ?err,
                         "Shadow prover failed to validate finalized batch candidate"
                     );
@@ -462,7 +486,11 @@ async fn verify_remotely(
         }
         Err(err) => {
             metrics.spf_remote_connect_failure_total.increment(1);
-            return Err(err).wrap_err_with(|| format!("connect to remote prover at {address}"));
+            metrics.spf_remote_connectivity_failure_total.increment(1);
+            return Err(RemoteProverConnectivityError(format!(
+                "connect to remote prover at {address}: {err}"
+            ))
+            .into());
         }
     };
 
@@ -478,7 +506,16 @@ async fn verify_remotely(
     metrics
         .spf_remote_request_send_duration_seconds
         .record(started.elapsed().as_secs_f64());
-    send_result.wrap_err_with(|| format!("send request to remote prover at {address}"))?;
+    if let Err(err) = send_result {
+        if matches!(&err, ProverConnectionError::Io(_)) {
+            metrics.spf_remote_connectivity_failure_total.increment(1);
+            return Err(RemoteProverConnectivityError(format!(
+                "send request to remote prover at {address}: {err}"
+            ))
+            .into());
+        }
+        return Err(err).wrap_err_with(|| format!("send request to remote prover at {address}"));
+    }
 
     let response_started = Instant::now();
     let response_result = connection.receive();
@@ -501,9 +538,27 @@ async fn verify_remotely(
                 .as_secs_f64(),
         );
     }
-    let response: VerifyResponse = response_result
-        .wrap_err_with(|| format!("read response from remote prover at {address}"))?
-        .ok_or_else(|| eyre::eyre!("remote prover closed the connection without a response"))?;
+    let response: VerifyResponse = match response_result {
+        Ok(Some(response)) => response,
+        Ok(None) => {
+            metrics.spf_remote_connectivity_failure_total.increment(1);
+            return Err(RemoteProverConnectivityError(
+                "remote prover closed the connection without a response".into(),
+            )
+            .into());
+        }
+        Err(err) if matches!(&err, ProverConnectionError::Io(_)) => {
+            metrics.spf_remote_connectivity_failure_total.increment(1);
+            return Err(RemoteProverConnectivityError(format!(
+                "read response from remote prover at {address}: {err}"
+            ))
+            .into());
+        }
+        Err(err) => {
+            return Err(err)
+                .wrap_err_with(|| format!("read response from remote prover at {address}"));
+        }
+    };
 
     match response {
         VerifyResponse::Ok {
@@ -981,4 +1036,19 @@ fn witness_size(witness: &BatchWitness) -> usize {
                         .sum::<usize>()
             })
             .sum::<usize>()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn classifies_only_remote_connectivity_errors() {
+        let connectivity_error =
+            eyre::Report::new(RemoteProverConnectivityError("connection refused".into()));
+        assert!(is_remote_prover_connectivity_error(&connectivity_error));
+
+        let validation_error = eyre::eyre!("remote prover rejected request");
+        assert!(!is_remote_prover_connectivity_error(&validation_error));
+    }
 }


### PR DESCRIPTION
## Summary

- record successful and failed remote prover TCP connections separately
- record connectivity failures across connect, send, receive, and unexpected EOF
- exclude connectivity failures from `validation_failure_total` while preserving local validation and explicit prover response failures
- record successful and error prover responses separately

## Validation

- `cargo +nightly fmt --all -- --check`
- `cargo check -p zone-sequencer`
- `cargo test -p zone-sequencer --lib` (71 passed)
- `cargo +nightly clippy -p zone-sequencer --lib`

Prompted by: @shekhirin
