### PR TITLE
fix(ci): backport release and action scan fixes

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -83,7 +83,7 @@ jobs:
       matrix:
         binary:
           - name: tempo-zone
-            features: "asm-keccak,jemalloc,otlp"
+            features: "asm-keccak,jemalloc"
         platform:
           - os: depot-ubuntu-latest-16
             target: x86_64-unknown-linux-gnu

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -35,7 +35,7 @@ jobs:
           submodules: recursive
       - name: Mint read-only Earn token
         id: earn-token
-        uses: tempoxyz/gh-actions/actions/github-sts@dd1014bf8244fded7a501e701cafab240a4f9f0e # main
+        uses: tempoxyz/gh-actions/actions/github-sts@92f7d8fd211faca8a38e892ebe84225d0ea2a0b3 # main
         with:
           scope: tempoxyz/earn
           policy: zones-read

--- a/.github/workflows/zones-benchmark.yml
+++ b/.github/workflows/zones-benchmark.yml
@@ -509,7 +509,7 @@ jobs:
 
       - name: Mint read-only Earn token
         id: earn-token
-        uses: tempoxyz/gh-actions/actions/github-sts@dd1014bf8244fded7a501e701cafab240a4f9f0e # main
+        uses: tempoxyz/gh-actions/actions/github-sts@92f7d8fd211faca8a38e892ebe84225d0ea2a0b3 # main
         with:
           scope: tempoxyz/earn
           policy: zones-read


### PR DESCRIPTION
## Summary

- remove the unsupported `otlp` feature from release binary builds
- refresh stale `github-sts` pins in the test and benchmark workflows
- backport all applicable fixes from #1271

The `sync-from-upstream.yml` pin change from #1271 is not applicable because `release/v0.2.0` predates the GitHub STS migration and still uses the GitHub App action.

## Validation

- `cargo check --locked --bin tempo-zone --features asm-keccak,jemalloc`
- `uvx zizmor .`

Prompted by: @grandizzy