### PR TITLE
feat(bench): make chain gas limits configurable

### DIFF
--- a/.github/workflows/zones-benchmark.yml
+++ b/.github/workflows/zones-benchmark.yml
@@ -85,7 +85,7 @@ on:
         description: L1 callback gas requested by composable withdrawals (maximum 10000000).
         type: string
         required: true
-        default: "10000000"
+        default: "5000000"
       swap-liquidity:
         description: Untimed liquidity seeded into the selected swap mechanism.
         type: string
@@ -222,7 +222,7 @@ jobs:
           INPUT_WITHDRAWAL_AMOUNT: ${{ inputs.withdrawal-amount || '1000000' }}
           INPUT_SWAP_MECHANISM: direct-swap
           INPUT_RECIPIENT_MODE: ${{ inputs.recipient-mode || 'existing' }}
-          INPUT_CALLBACK_GAS_LIMIT: ${{ inputs.callback-gas-limit || '10000000' }}
+          INPUT_CALLBACK_GAS_LIMIT: ${{ inputs.callback-gas-limit || '5000000' }}
           INPUT_SWAP_LIQUIDITY: ${{ inputs.swap-liquidity || '10000000000' }}
           INPUT_L1_GAS_LIMIT: ${{ inputs.l1-gas-limit || '30000000' }}
           INPUT_L1_GENERAL_GAS_LIMIT: ${{ inputs.l1-general-gas-limit || '30000000' }}
@@ -339,7 +339,9 @@ jobs:
           planned_singleton_withdrawal_gas=0
           case "$neobank_preset" in
             encrypted-deposit) ;;
-            *) planned_singleton_withdrawal_gas=$((500000 + 1750000 + 10#$INPUT_CALLBACK_GAS_LIMIT)) ;;
+            # Startup creates and retains an Earn anchor position with the full
+            # callback allowance before measured steady-state withdrawals.
+            *) planned_singleton_withdrawal_gas=$((500000 + 1750000 + 10000000)) ;;
           esac
           (( planned_singleton_withdrawal_gas == 0 ||
              planned_singleton_withdrawal_gas <= 10#$INPUT_L1_GENERAL_GAS_LIMIT )) \

--- a/.github/workflows/zones-benchmark.yml
+++ b/.github/workflows/zones-benchmark.yml
@@ -92,12 +92,12 @@ on:
         required: true
         default: "10000000000"
       l1-gas-limit:
-        description: Tempo L1 block gas limit.
+        description: Tempo L1 and Zone block gas limit.
         type: string
         required: true
         default: "30000000"
       l1-general-gas-limit:
-        description: Tempo L1 general transaction gas limit.
+        description: Tempo L1 per-block aggregate gas limit for general transactions.
         type: string
         required: true
         default: "30000000"
@@ -189,6 +189,7 @@ jobs:
       swap-liquidity: ${{ steps.config.outputs.swap-liquidity }}
       l1-gas-limit: ${{ steps.config.outputs.l1-gas-limit }}
       l1-general-gas-limit: ${{ steps.config.outputs.l1-general-gas-limit }}
+      zone-gas-limit: ${{ steps.config.outputs.zone-gas-limit }}
       withdrawal-max-batch-gas: ${{ steps.config.outputs.withdrawal-max-batch-gas }}
       withdrawal-max-in-flight-batches: ${{ steps.config.outputs.withdrawal-max-in-flight-batches }}
       zone-batch-interval-blocks: ${{ steps.config.outputs.zone-batch-interval-blocks }}
@@ -329,10 +330,6 @@ jobs:
           done
           (( 10#$INPUT_CALLBACK_GAS_LIMIT <= 10000000 )) \
             || { echo "::error::callback-gas-limit cannot exceed the 10000000 protocol cap"; exit 1; }
-          (( 10#$INPUT_L1_GAS_LIMIT <= 30000000 )) \
-            || { echo "::error::l1-gas-limit cannot exceed 30000000"; exit 1; }
-          (( 10#$INPUT_L1_GENERAL_GAS_LIMIT <= 30000000 )) \
-            || { echo "::error::l1-general-gas-limit cannot exceed 30000000"; exit 1; }
           (( 10#$INPUT_L1_GENERAL_GAS_LIMIT <= 10#$INPUT_L1_GAS_LIMIT )) \
             || { echo "::error::l1-general-gas-limit cannot exceed l1-gas-limit"; exit 1; }
           (( 10#$INPUT_WITHDRAWAL_MAX_BATCH_GAS <= 20000000 )) \
@@ -429,6 +426,7 @@ jobs:
             echo "swap-liquidity=$INPUT_SWAP_LIQUIDITY"
             echo "l1-gas-limit=$INPUT_L1_GAS_LIMIT"
             echo "l1-general-gas-limit=$INPUT_L1_GENERAL_GAS_LIMIT"
+            echo "zone-gas-limit=$INPUT_L1_GAS_LIMIT"
             echo "withdrawal-max-batch-gas=$INPUT_WITHDRAWAL_MAX_BATCH_GAS"
             echo "withdrawal-max-in-flight-batches=$INPUT_WITHDRAWAL_MAX_IN_FLIGHT_BATCHES"
             echo "zone-batch-interval-blocks=$INPUT_ZONE_BATCH_INTERVAL_BLOCKS"
@@ -468,6 +466,7 @@ jobs:
       ZONES_BENCH_SWAP_LIQUIDITY: ${{ needs.authorize.outputs.swap-liquidity }}
       ZONES_BENCH_L1_GAS_LIMIT: ${{ needs.authorize.outputs.l1-gas-limit }}
       ZONES_BENCH_L1_GENERAL_GAS_LIMIT: ${{ needs.authorize.outputs.l1-general-gas-limit }}
+      ZONES_BENCH_ZONE_GAS_LIMIT: ${{ needs.authorize.outputs.zone-gas-limit }}
       ZONES_BENCH_WITHDRAWAL_MAX_BATCH_GAS: ${{ needs.authorize.outputs.withdrawal-max-batch-gas }}
       ZONES_BENCH_WITHDRAWAL_MAX_IN_FLIGHT_BATCHES: ${{ needs.authorize.outputs.withdrawal-max-in-flight-batches }}
       ZONES_BENCH_ZONE_BATCH_INTERVAL_BLOCKS: ${{ needs.authorize.outputs.zone-batch-interval-blocks }}
@@ -798,7 +797,7 @@ jobs:
             L1_PORTAL_ADDRESS ZONES_BENCH_TOKEN \
             ZONES_BENCH_EXPECTED_L1_CHAIN_ID ZONES_BENCH_EXPECTED_ZONE_CHAIN_ID \
             ZONES_BENCH_EXPECTED_ZONE_ID ZONES_BENCH_TARGET_ID \
-            ZONES_BENCH_L1_GAS_LIMIT ZONES_BENCH_L1_GENERAL_GAS_LIMIT \
+            ZONES_BENCH_L1_GAS_LIMIT ZONES_BENCH_L1_GENERAL_GAS_LIMIT ZONES_BENCH_ZONE_GAS_LIMIT \
             ZONES_BENCH_L1_METRICS_URL ZONES_BENCH_ZONE_METRICS_URL \
             ZONES_BENCH_TOPOLOGY_DIR
           do
@@ -937,6 +936,7 @@ jobs:
             echo "- Earn revision: \`${ZONES_BENCH_EARN_REVISION:-unavailable}\`"
             echo "- Build: \`$ZONES_BENCH_BUILD_PROFILE\`, \`RUSTFLAGS=$RUSTFLAGS\`"
             echo "- L1 block/general gas limits: \`${ZONES_BENCH_L1_GAS_LIMIT:-unavailable}\` / \`${ZONES_BENCH_L1_GENERAL_GAS_LIMIT:-unavailable}\`"
+            echo "- Zone block gas limit: \`${ZONES_BENCH_ZONE_GAS_LIMIT:-unavailable}\`"
             echo "- Withdrawal scheduler (batch gas / in-flight / Zone blocks / poll): \`$ZONES_BENCH_WITHDRAWAL_MAX_BATCH_GAS\` / \`$ZONES_BENCH_WITHDRAWAL_MAX_IN_FLIGHT_BATCHES\` / \`$ZONES_BENCH_ZONE_BATCH_INTERVAL_BLOCKS\` / \`${ZONES_BENCH_WITHDRAWAL_POLL_INTERVAL_SECS}s\`"
           } >> "$summary"
           if [ -s "$ZONES_BENCH_SPF_SUMMARY" ]; then
@@ -996,6 +996,7 @@ jobs:
             --argjson l1StateBloatMiB "$((10#$ZONES_BENCH_BLOAT_GIB * 1000))" \
             --argjson l1BlockGasLimit "${ZONES_BENCH_L1_GAS_LIMIT:-0}" \
             --argjson l1GeneralGasLimit "${ZONES_BENCH_L1_GENERAL_GAS_LIMIT:-0}" \
+            --argjson zoneBlockGasLimit "${ZONES_BENCH_ZONE_GAS_LIMIT:-0}" \
             --argjson withdrawalMaxBatchGas "$((10#$ZONES_BENCH_WITHDRAWAL_MAX_BATCH_GAS))" \
             --argjson withdrawalMaxInFlightBatches "$((10#$ZONES_BENCH_WITHDRAWAL_MAX_IN_FLIGHT_BATCHES))" \
             --argjson zoneBatchIntervalBlocks "$((10#$ZONES_BENCH_ZONE_BATCH_INTERVAL_BLOCKS))" \
@@ -1051,6 +1052,7 @@ jobs:
               zoneStateBloatMiB: 0,
               l1BlockGasLimit: $l1BlockGasLimit,
               l1GeneralGasLimit: $l1GeneralGasLimit,
+              zoneBlockGasLimit: $zoneBlockGasLimit,
               withdrawalScheduler: {
                 maxBatchGas: $withdrawalMaxBatchGas,
                 maxInFlightBatches: $withdrawalMaxInFlightBatches,

--- a/.github/workflows/zones-benchmark.yml
+++ b/.github/workflows/zones-benchmark.yml
@@ -92,12 +92,12 @@ on:
         required: true
         default: "10000000000"
       l1-gas-limit:
-        description: Tempo L1 and Zone block gas limit.
+        description: Tempo L1 block gas limit.
         type: string
         required: true
         default: "30000000"
       l1-general-gas-limit:
-        description: Tempo L1 per-block aggregate gas limit for general transactions.
+        description: Tempo L1 general transaction gas limit.
         type: string
         required: true
         default: "30000000"

--- a/.github/workflows/zones-benchmark.yml
+++ b/.github/workflows/zones-benchmark.yml
@@ -339,7 +339,7 @@ jobs:
           planned_singleton_withdrawal_gas=0
           case "$neobank_preset" in
             encrypted-deposit) ;;
-            # Startup creates and retains an Earn anchor position with the full
+            # Startup creates and retains an Earn warmup position with the full
             # callback allowance before measured steady-state withdrawals.
             *) planned_singleton_withdrawal_gas=$((500000 + 1750000 + 10000000)) ;;
           esac

--- a/contrib/bench/l1-snapshot.sh
+++ b/contrib/bench/l1-snapshot.sh
@@ -207,6 +207,8 @@ l1_snapshot_load_config() {
         || l1_snapshot_die "benchmark accounts exceed the cached funded-account capacity"
     (( L1_SNAPSHOT_CHAIN_ID > 0 && L1_SNAPSHOT_GAS_LIMIT > 0 && L1_SNAPSHOT_GENERAL_GAS_LIMIT > 0 )) \
         || l1_snapshot_die "chain ID and gas limits must be greater than zero"
+    (( L1_SNAPSHOT_GENERAL_GAS_LIMIT <= L1_SNAPSHOT_GAS_LIMIT )) \
+        || l1_snapshot_die "ZONES_BENCH_L1_GENERAL_GAS_LIMIT cannot exceed ZONES_BENCH_L1_GAS_LIMIT"
     (( L1_SNAPSHOT_FORCE == 0 || L1_SNAPSHOT_FORCE == 1 )) \
         || l1_snapshot_die "ZONES_BENCH_FORCE_BLOAT must be 0 or 1"
 

--- a/contrib/bench/l1-snapshot.sh
+++ b/contrib/bench/l1-snapshot.sh
@@ -207,8 +207,6 @@ l1_snapshot_load_config() {
         || l1_snapshot_die "benchmark accounts exceed the cached funded-account capacity"
     (( L1_SNAPSHOT_CHAIN_ID > 0 && L1_SNAPSHOT_GAS_LIMIT > 0 && L1_SNAPSHOT_GENERAL_GAS_LIMIT > 0 )) \
         || l1_snapshot_die "chain ID and gas limits must be greater than zero"
-    (( L1_SNAPSHOT_GENERAL_GAS_LIMIT <= L1_SNAPSHOT_GAS_LIMIT )) \
-        || l1_snapshot_die "ZONES_BENCH_L1_GENERAL_GAS_LIMIT cannot exceed ZONES_BENCH_L1_GAS_LIMIT"
     (( L1_SNAPSHOT_FORCE == 0 || L1_SNAPSHOT_FORCE == 1 )) \
         || l1_snapshot_die "ZONES_BENCH_FORCE_BLOAT must be 0 or 1"
 

--- a/contrib/bench/neobank/swapped-redemption-position-scenario.yml
+++ b/contrib/bench/neobank/swapped-redemption-position-scenario.yml
@@ -50,7 +50,7 @@ scenario:
       with:
         sender: { var: account.ref }
         sender_address: { var: account.address }
-        recipient: { var: account.address }
+        recipient: ${ZONES_BENCH_POSITION_RECIPIENT}
         token: "${ZONES_BENCH_DLUSD}"
         fee_token: "${ZONES_BENCH_DLUSD}"
         amount: "${ZONES_BENCH_SWAPPED_REDEMPTION_ONRAMP_PER_ACCOUNT}"

--- a/contrib/bench/neobank/swapped-redemption-position-scenario.yml
+++ b/contrib/bench/neobank/swapped-redemption-position-scenario.yml
@@ -50,7 +50,7 @@ scenario:
       with:
         sender: { var: account.ref }
         sender_address: { var: account.address }
-        recipient: ${ZONES_BENCH_POSITION_RECIPIENT}
+        recipient: { var: account.address }
         token: "${ZONES_BENCH_DLUSD}"
         fee_token: "${ZONES_BENCH_DLUSD}"
         amount: "${ZONES_BENCH_SWAPPED_REDEMPTION_ONRAMP_PER_ACCOUNT}"
@@ -67,7 +67,7 @@ scenario:
       with:
         sender: { var: account.ref }
         sender_address: { var: account.address }
-        recipient: { var: account.address }
+        recipient: ${ZONES_BENCH_POSITION_RECIPIENT}
         input_token: "${ZONES_BENCH_DLUSD}"
         fee_token: "${ZONES_BENCH_DLUSD}"
         amount: "${ZONES_BENCH_SWAPPED_REDEMPTION_POSITION_PER_ACCOUNT}"

--- a/contrib/bench/provision-topology.sh
+++ b/contrib/bench/provision-topology.sh
@@ -554,6 +554,7 @@ provision_up() {
     local l1_chain_id="${ZONES_BENCH_L1_CHAIN_ID:-1337}"
     local l1_gas_limit="${ZONES_BENCH_L1_GAS_LIMIT:-30000000}"
     local l1_general_gas_limit="${ZONES_BENCH_L1_GENERAL_GAS_LIMIT:-$l1_gas_limit}"
+    local zone_gas_limit="${ZONES_BENCH_ZONE_GAS_LIMIT:-30000000}"
     local l1_max_fee_per_gas="${ZONES_BENCH_L1_MAX_FEE_PER_GAS:-12000000000}"
     local zone_max_fee_per_gas="${ZONES_BENCH_ZONE_MAX_FEE_PER_GAS:-10000000000}"
     local bloat_mib="${ZONES_BENCH_BLOAT_MIB:-1024}"
@@ -587,6 +588,7 @@ provision_up() {
     ZONES_BENCH_L1_CHAIN_ID="$l1_chain_id"
     ZONES_BENCH_L1_GAS_LIMIT="$l1_gas_limit"
     ZONES_BENCH_L1_GENERAL_GAS_LIMIT="$l1_general_gas_limit"
+    ZONES_BENCH_ZONE_GAS_LIMIT="$zone_gas_limit"
     ZONES_BENCH_L1_MAX_FEE_PER_GAS="$l1_max_fee_per_gas"
     ZONES_BENCH_ZONE_MAX_FEE_PER_GAS="$zone_max_fee_per_gas"
     ZONES_BENCH_BLOAT_MIB="$bloat_mib"
@@ -609,7 +611,7 @@ provision_up() {
     for name in \
         ZONES_BENCH_ACCOUNT_START ZONES_BENCH_ACCOUNTS ZONES_BENCH_ACCOUNT_CAPACITY \
         ZONES_BENCH_L1_CHAIN_ID \
-        ZONES_BENCH_L1_GAS_LIMIT ZONES_BENCH_L1_GENERAL_GAS_LIMIT \
+        ZONES_BENCH_L1_GAS_LIMIT ZONES_BENCH_L1_GENERAL_GAS_LIMIT ZONES_BENCH_ZONE_GAS_LIMIT \
         ZONES_BENCH_L1_MAX_FEE_PER_GAS ZONES_BENCH_ZONE_MAX_FEE_PER_GAS \
         ZONES_BENCH_BLOAT_MIB ZONES_BENCH_BLOAT_BALANCE \
         ZONES_BENCH_RPC_TIMEOUT_SECS ZONES_BENCH_ZONE_TIMEOUT_SECS \
@@ -627,6 +629,7 @@ provision_up() {
     l1_chain_id=$((10#$l1_chain_id))
     l1_gas_limit=$((10#$l1_gas_limit))
     l1_general_gas_limit=$((10#$l1_general_gas_limit))
+    zone_gas_limit=$((10#$zone_gas_limit))
     l1_max_fee_per_gas=$((10#$l1_max_fee_per_gas))
     zone_max_fee_per_gas=$((10#$zone_max_fee_per_gas))
     bloat_mib=$((10#$bloat_mib))
@@ -651,8 +654,7 @@ provision_up() {
     (( l1_gas_limit > 0 )) || die "ZONES_BENCH_L1_GAS_LIMIT must be greater than zero"
     (( l1_general_gas_limit > 0 )) \
         || die "ZONES_BENCH_L1_GENERAL_GAS_LIMIT must be greater than zero"
-    (( l1_gas_limit <= 30000000 )) \
-        || die "ZONES_BENCH_L1_GAS_LIMIT cannot exceed 30000000"
+    (( zone_gas_limit > 0 )) || die "ZONES_BENCH_ZONE_GAS_LIMIT must be greater than zero"
     (( l1_general_gas_limit <= l1_gas_limit )) \
         || die "ZONES_BENCH_L1_GENERAL_GAS_LIMIT cannot exceed ZONES_BENCH_L1_GAS_LIMIT"
     (( l1_max_fee_per_gas > 0 )) \
@@ -724,6 +726,7 @@ provision_up() {
 
     export ZONES_BENCH_ACCOUNT_START ZONES_BENCH_ACCOUNTS ZONES_BENCH_ACCOUNT_CAPACITY
     export ZONES_BENCH_L1_CHAIN_ID ZONES_BENCH_L1_GAS_LIMIT ZONES_BENCH_L1_GENERAL_GAS_LIMIT
+    export ZONES_BENCH_ZONE_GAS_LIMIT
     export ZONES_BENCH_L1_MAX_FEE_PER_GAS ZONES_BENCH_ZONE_MAX_FEE_PER_GAS
     export ZONES_BENCH_BLOAT_MIB ZONES_BENCH_BLOAT_BALANCE
     export ZONES_BENCH_SWAP_MECHANISM ZONES_BENCH_RECIPIENT_MODE ZONES_BENCH_SWAP_LIQUIDITY
@@ -892,6 +895,7 @@ provision_up() {
         --initial-token "$zone_token"
         --admin "$admin_address"
         --sequencer "$sequencer_address"
+        --gas-limit "$zone_gas_limit"
         --access-mode
     )
     # Access starts closed with an empty allowlist; untimed fixture setup applies the map.
@@ -973,10 +977,13 @@ provision_up() {
     wait_for_chain_advance "$zone_rpc" "Zone" "$zone_timeout"
     wait_for_zone_enabled_token "$zone_rpc" "$(jq -er '.earnToken' "$fixture_metadata")" "$zone_timeout"
     neobank_allowed_accounts+=("$(jq -er '.bridgeWallet' "$fixture_metadata")")
-    local queried_zone_chain_id
+    local queried_zone_chain_id queried_zone_gas_limit
     queried_zone_chain_id="$(hex_to_dec "$(rpc "$zone_rpc" eth_chainId)")"
     [[ "$queried_zone_chain_id" == "$zone_chain_id" ]] \
         || die "Zone RPC chain ID $queried_zone_chain_id does not match zone.json chain ID $zone_chain_id"
+    queried_zone_gas_limit="$(hex_to_dec "$(rpc "$zone_rpc" eth_getBlockByNumber '["latest",false]' | jq -er '.gasLimit')")"
+    [[ "$queried_zone_gas_limit" == "$zone_gas_limit" ]] \
+        || die "Zone RPC gas limit $queried_zone_gas_limit does not match configured gas limit $zone_gas_limit"
 
     local target_id="local-consensus-${genesis_a#0x}-zone-$zone_id"
     local -a env_pairs=(
@@ -1011,6 +1018,7 @@ provision_up() {
         ZONES_BENCH_ZONE_MAX_PRIORITY_FEE_PER_GAS 0 \
         ZONES_BENCH_L1_GAS_LIMIT "$l1_gas_limit" \
         ZONES_BENCH_L1_GENERAL_GAS_LIMIT "$l1_general_gas_limit" \
+        ZONES_BENCH_ZONE_GAS_LIMIT "$zone_gas_limit" \
         ZONES_BENCH_SWAP_MECHANISM "$swap_mechanism" \
         ZONES_BENCH_RECIPIENT_MODE "$recipient_mode" \
         ZONES_BENCH_SWAP_LIQUIDITY "$swap_liquidity" \

--- a/contrib/bench/provision-topology.sh
+++ b/contrib/bench/provision-topology.sh
@@ -704,7 +704,7 @@ provision_up() {
     local planned_singleton_withdrawal_gas=0
     case "$neobank_preset" in
         encrypted-deposit) ;;
-        # The untimed Earn anchor always uses the 10M protocol maximum.
+        # The untimed Earn warmup always uses the 10M protocol maximum.
         *) planned_singleton_withdrawal_gas=$((500000 + 1750000 + 10000000)) ;;
     esac
     (( planned_singleton_withdrawal_gas == 0 ||

--- a/contrib/bench/provision-topology.sh
+++ b/contrib/bench/provision-topology.sh
@@ -958,6 +958,7 @@ provision_up() {
         --http.api all \
         --ws --ws.addr 127.0.0.1 --ws.port 8546 \
         --ws.api all \
+        --rpc.max-connections 10000 \
         --metrics 127.0.0.1:9201 \
         --redacted-rpc.port 8544 \
         --zone.batch-interval-blocks "$zone_batch_interval_blocks" \

--- a/contrib/bench/provision-topology.sh
+++ b/contrib/bench/provision-topology.sh
@@ -567,7 +567,7 @@ provision_up() {
     local count="${ZONES_BENCH_COUNT:-100}"
     local max_concurrent="${ZONES_BENCH_MAX_CONCURRENT:-12}"
     local withdrawal_amount="${ZONES_BENCH_WITHDRAWAL_AMOUNT:-1000000}"
-    local callback_gas_limit="${ZONES_BENCH_CALLBACK_GAS_LIMIT:-10000000}"
+    local callback_gas_limit="${ZONES_BENCH_CALLBACK_GAS_LIMIT:-5000000}"
     local withdrawal_max_batch_gas="${ZONES_BENCH_WITHDRAWAL_MAX_BATCH_GAS:-20000000}"
     local withdrawal_max_in_flight_batches="${ZONES_BENCH_WITHDRAWAL_MAX_IN_FLIGHT_BATCHES:-12}"
     local zone_batch_interval_blocks="${ZONES_BENCH_ZONE_BATCH_INTERVAL_BLOCKS:-120}"
@@ -704,7 +704,8 @@ provision_up() {
     local planned_singleton_withdrawal_gas=0
     case "$neobank_preset" in
         encrypted-deposit) ;;
-        *) planned_singleton_withdrawal_gas=$((500000 + 1750000 + callback_gas_limit)) ;;
+        # The untimed Earn anchor always uses the 10M protocol maximum.
+        *) planned_singleton_withdrawal_gas=$((500000 + 1750000 + 10000000)) ;;
     esac
     (( planned_singleton_withdrawal_gas == 0 ||
        planned_singleton_withdrawal_gas <= l1_general_gas_limit )) \

--- a/contrib/bench/run-neobank-private-flow.sh
+++ b/contrib/bench/run-neobank-private-flow.sh
@@ -113,6 +113,7 @@ ZONES_BENCH_ACTIVITY_GAS_LIMIT="${ZONES_BENCH_ACTIVITY_GAS_LIMIT:-500000}"
 ZONES_BENCH_WITHDRAWAL_TX_GAS_LIMIT="${ZONES_BENCH_WITHDRAWAL_TX_GAS_LIMIT:-10000000}"
 ZONES_BENCH_APPROVAL_GAS_LIMIT="${ZONES_BENCH_APPROVAL_GAS_LIMIT:-2000000}"
 ZONES_BENCH_ADMISSION_SEED_AMOUNT="${ZONES_BENCH_ADMISSION_SEED_AMOUNT:-1}"
+ZONES_BENCH_ADMISSION_SEED_TPS="${ZONES_BENCH_ADMISSION_SEED_TPS:-200}"
 ZONES_BENCH_RECIPIENT_ACCOUNT_START="${ZONES_BENCH_RECIPIENT_ACCOUNT_START:-$ZONES_BENCH_ACCOUNT_START}"
 ZONES_BENCH_RECIPIENT_ACCOUNT_END="${ZONES_BENCH_RECIPIENT_ACCOUNT_END:-$ZONES_BENCH_ACCOUNT_END}"
 if [[ -z "${ZONES_BENCH_RECIPIENT_GENERATOR:-}" ]]; then
@@ -182,6 +183,7 @@ for name in ZONES_BENCH_CONTROL_ACCOUNT_INDEX ZONES_BENCH_ACCOUNT_START ZONES_BE
     ZONES_BENCH_RECIPIENT_ACCOUNT_END
 do uint "$name"; done
 positive_rate ZONES_BENCH_TPS
+positive_rate ZONES_BENCH_ADMISSION_SEED_TPS
 (( 10#$ZONES_BENCH_ACCOUNTS > 0 && 10#$ZONES_BENCH_COUNT > 0 )) || die "accounts and count must be positive"
 (( 10#$ZONES_BENCH_MAX_CONCURRENT > 0 )) || die "max concurrency must be positive"
 (( 10#$ZONES_BENCH_SAMPLE_INSTANCES > 0 )) ||
@@ -475,12 +477,13 @@ trap cleanup EXIT INT TERM
 
 run_setup_scenario() {
     local stage="$1" scenario="$2" count="$3" report="$4" context="${5:-}"
+    local starts_per_second="${6:-0}"
     local concurrency="$ZONES_BENCH_MAX_CONCURRENT"
     if (( 10#$concurrency > 10#$count )); then concurrency="$count"; fi
 
     echo "neobank stage=start run_id=$ZONES_BENCH_RUN_ID preset=$ZONES_BENCH_NEOBANK_PRESET stage=$stage${context:+ $context}"
     "$txgen_bin" scenario run \
-        --scenario "$scenario" --count "$count" --starts-per-second 0 \
+        --scenario "$scenario" --count "$count" --starts-per-second "$starts_per_second" \
         --max-in-flight "$concurrency" --max-rpc-in-flight "$concurrency" \
         --failure-policy fail-fast --step-timeout "$ZONES_BENCH_STEP_TIMEOUT" \
         --seed "$ZONES_BENCH_SEED" --report "$report"
@@ -490,15 +493,19 @@ run_setup_scenario() {
 
 # Zone transaction-pool admission requires every sender to hold a nonzero
 # balance of an enabled token. Run one exact encrypted onramp per benchmark
-# account before the untimed outbox approvals. This setup scenario uses account
-# leases, so count=accounts touches every account exactly once while respecting
-# the configured max-in-flight cap.
+# account before the untimed outbox approvals. Pace the deposits so a large
+# account pool is not packed into one L1 block and rejected by ZonePortal's
+# per-block deposit cap. This setup scenario uses account leases, so
+# count=accounts touches every account exactly once while respecting the
+# configured max-in-flight cap.
 seed_zone_admission_balances() {
     local seed_report="$ZONES_BENCH_OUTPUT/admission-seed-report.json"
     local total=$((10#$ZONES_BENCH_ACCOUNTS))
 
     run_setup_scenario \
-        zone_admission_seed "$admission_seed_scenario" "$total" "$seed_report"
+        zone_admission_seed "$admission_seed_scenario" "$total" "$seed_report" \
+        "starts_per_second=$ZONES_BENCH_ADMISSION_SEED_TPS" \
+        "$ZONES_BENCH_ADMISSION_SEED_TPS"
     echo "Zone admission seed verified: $total/$total exact encrypted deposits processed"
 }
 

--- a/contrib/bench/run-neobank-private-flow.sh
+++ b/contrib/bench/run-neobank-private-flow.sh
@@ -83,9 +83,7 @@ ZONES_BENCH_DEPOSIT_AMOUNT="${ZONES_BENCH_DEPOSIT_AMOUNT:-2000000}"
 ZONES_BENCH_ACTIVITY_AMOUNT="${ZONES_BENCH_ACTIVITY_AMOUNT:-1}"
 ZONES_BENCH_WITHDRAWAL_AMOUNT="${ZONES_BENCH_WITHDRAWAL_AMOUNT:-1000000}"
 ZONES_BENCH_BOOTSTRAP_DEPOSIT_AMOUNT="${ZONES_BENCH_BOOTSTRAP_DEPOSIT_AMOUNT:-10000000}"
-# The canonical Zone boundary e2e uses the full callback allowance: a gateway
-# callback can include a swap, vault action, and encrypted return deposit.
-ZONES_BENCH_CALLBACK_GAS_LIMIT="${ZONES_BENCH_CALLBACK_GAS_LIMIT:-10000000}"
+ZONES_BENCH_CALLBACK_GAS_LIMIT="${ZONES_BENCH_CALLBACK_GAS_LIMIT:-5000000}"
 ZONES_BENCH_OUTPUT="${ZONES_BENCH_OUTPUT:-target/zones-benchmark/neobank-e2e}"
 ZONES_BENCH_REPORT="${ZONES_BENCH_REPORT:-target/zones-benchmark/report-neobank-e2e.json}"
 ZONES_BENCH_RENDERED_SCENARIO="${ZONES_BENCH_RENDERED_SCENARIO:-$ZONES_BENCH_OUTPUT/scenario.rendered.yml}"
@@ -119,6 +117,7 @@ ZONES_BENCH_RECIPIENT_ACCOUNT_END="${ZONES_BENCH_RECIPIENT_ACCOUNT_END:-$ZONES_B
 if [[ -z "${ZONES_BENCH_RECIPIENT_GENERATOR:-}" ]]; then
     ZONES_BENCH_RECIPIENT_GENERATOR='{ pool: { pool: users, select: random } }'
 fi
+ZONES_BENCH_POSITION_RECIPIENT='{ var: account.address }'
 case "$ZONES_BENCH_RECIPIENT_MODE" in
     existing) ZONES_BENCH_PRIVATE_TRANSFER_RECIPIENT='{ var: recipient.address }' ;;
     random) ZONES_BENCH_PRIVATE_TRANSFER_RECIPIENT=random ;;
@@ -312,7 +311,7 @@ export ZONES_BENCH_DEPOSIT_GAS_LIMIT ZONES_BENCH_ACTIVITY_GAS_LIMIT
 export ZONES_BENCH_WITHDRAWAL_TX_GAS_LIMIT ZONES_BENCH_APPROVAL_GAS_LIMIT
 export ZONES_BENCH_ADMISSION_SEED_AMOUNT
 export ZONES_BENCH_RECIPIENT_ACCOUNT_START ZONES_BENCH_RECIPIENT_ACCOUNT_END
-export ZONES_BENCH_RECIPIENT_GENERATOR
+export ZONES_BENCH_RECIPIENT_GENERATOR ZONES_BENCH_POSITION_RECIPIENT
 export ZONES_BENCH_TOKEN ZONES_BENCH_DLUSD ZONES_BENCH_PATHUSD ZONES_BENCH_EARN_TOKEN
 export ZONES_BENCH_EARN_ROUTER ZONES_BENCH_EARN_VAULT
 export ZONES_BENCH_EARN_CONTRIBUTION_CONTROLLER ZONES_BENCH_BRIDGE_WALLET
@@ -565,6 +564,31 @@ if [[ "$ZONES_BENCH_NEOBANK_PRESET" != "encrypted-deposit" ]]; then
         "approval_round=base_and_earn"
 fi
 
+# Seed Earn before any setup or measured Earn callback: make one untimed deposit
+# with the full callback allowance and leave its returned EarnToken in an unrelated
+# Zone account. This keeps the EarnVault and engine nonempty, so the benchmark runs
+# steady-state deposit and redemption paths instead of empty-pool transitions.
+earn_anchor_amount="$ZONES_BENCH_WITHDRAWAL_AMOUNT"
+if [[ "$ZONES_BENCH_NEOBANK_PRESET" != "encrypted-deposit" ]]; then
+    readonly earn_anchor_callback_gas_limit=10000000
+    anchor_recipient_hash="$(cast keccak "zones-benchmark-earn-anchor:$ZONES_BENCH_SEED")"
+    earn_anchor_recipient="0x${anchor_recipient_hash: -40}"
+    ZONES_BENCH_CALLBACK_GAS_LIMIT="$earn_anchor_callback_gas_limit" \
+    ZONES_BENCH_SWAPPED_REDEMPTION_ONRAMP_PER_ACCOUNT="$ZONES_BENCH_DEPOSIT_AMOUNT" \
+    ZONES_BENCH_SWAPPED_REDEMPTION_POSITION_PER_ACCOUNT="$earn_anchor_amount" \
+    ZONES_BENCH_POSITION_RECIPIENT="\"$earn_anchor_recipient\"" run_setup_scenario \
+        earn_anchor "$neobank_specs/swapped-redemption-position-scenario.yml" 1 \
+        "$ZONES_BENCH_OUTPUT/earn-anchor-report.json" \
+        "callback_gas_limit=$earn_anchor_callback_gas_limit amount=$earn_anchor_amount"
+
+    anchor_share_supply_after="$(read_l1_uint "$ZONES_BENCH_EARN_VAULT" 'totalEarnShares()(uint256)')"
+    anchor_earn_supply_after="$(read_l1_uint "$ZONES_BENCH_EARN_TOKEN" 'totalSupply()(uint256)')"
+    [[ "$anchor_share_supply_after" == "$earn_anchor_amount" ]] ||
+        die "Earn anchor share supply $anchor_share_supply_after does not equal $earn_anchor_amount"
+    [[ "$anchor_earn_supply_after" == "$earn_anchor_amount" ]] ||
+        die "Earn anchor token supply $anchor_earn_supply_after does not equal $earn_anchor_amount"
+fi
+
 if [[ "$ZONES_BENCH_NEOBANK_PRESET" == "rewards-redemption" ]]; then
     initial_share_supply="$(read_l1_uint "$ZONES_BENCH_EARN_VAULT" 'totalEarnShares()(uint256)')"
     initial_earn_supply="$(read_l1_uint "$ZONES_BENCH_EARN_TOKEN" 'totalSupply()(uint256)')"
@@ -632,8 +656,9 @@ if [[ "$ZONES_BENCH_NEOBANK_PRESET" == "private-withdrawal" ||
       "$ZONES_BENCH_NEOBANK_PRESET" == "swapped-redemption" ]]; then
     initial_share_supply="$(read_l1_uint "$ZONES_BENCH_EARN_VAULT" 'totalEarnShares()(uint256)')"
     initial_earn_supply="$(read_l1_uint "$ZONES_BENCH_EARN_TOKEN" 'totalSupply()(uint256)')"
-    [[ "$initial_share_supply" == 0 && "$initial_earn_supply" == 0 ]] ||
-        die "$ZONES_BENCH_NEOBANK_PRESET position setup requires zero initial EarnToken supply"
+    [[ "$initial_share_supply" == "$earn_anchor_amount" &&
+       "$initial_earn_supply" == "$earn_anchor_amount" ]] ||
+        die "$ZONES_BENCH_NEOBANK_PRESET position setup requires only the startup Earn anchor position"
 
     stage_start redemption_position_setup
     position_concurrency="$ZONES_BENCH_MAX_CONCURRENT"
@@ -655,10 +680,11 @@ if [[ "$ZONES_BENCH_NEOBANK_PRESET" == "private-withdrawal" ||
     stage_start redemption_position_check
     positioned_share_supply="$(read_l1_uint "$ZONES_BENCH_EARN_VAULT" 'totalEarnShares()(uint256)')"
     positioned_earn_supply="$(read_l1_uint "$ZONES_BENCH_EARN_TOKEN" 'totalSupply()(uint256)')"
-    [[ "$positioned_share_supply" == "$swapped_redemption_total_position" ]] ||
-        die "$ZONES_BENCH_NEOBANK_PRESET share supply $positioned_share_supply does not equal $swapped_redemption_total_position"
-    [[ "$positioned_earn_supply" == "$swapped_redemption_total_position" ]] ||
-        die "$ZONES_BENCH_NEOBANK_PRESET EarnToken supply $positioned_earn_supply does not equal $swapped_redemption_total_position"
+    expected_redemption_position="$(bigint_eval "$swapped_redemption_total_position + $earn_anchor_amount")"
+    [[ "$positioned_share_supply" == "$expected_redemption_position" ]] ||
+        die "$ZONES_BENCH_NEOBANK_PRESET share supply $positioned_share_supply does not equal $expected_redemption_position"
+    [[ "$positioned_earn_supply" == "$expected_redemption_position" ]] ||
+        die "$ZONES_BENCH_NEOBANK_PRESET EarnToken supply $positioned_earn_supply does not equal $expected_redemption_position"
     verify_reward_zone_balances \
         seeded "$swapped_redemption_total_position" \
         "$swapped_redemption_position_per_account"
@@ -740,10 +766,11 @@ if [[ "$ZONES_BENCH_NEOBANK_PRESET" == "private-withdrawal" ||
     stage_start redemption_postcondition
     final_share_supply="$(read_l1_uint "$ZONES_BENCH_EARN_VAULT" 'totalEarnShares()(uint256)')"
     final_earn_supply="$(read_l1_uint "$ZONES_BENCH_EARN_TOKEN" 'totalSupply()(uint256)')"
-    [[ "$final_share_supply" == "$swapped_redemption_expected_remaining" ]] ||
-        die "terminal $ZONES_BENCH_NEOBANK_PRESET share supply $final_share_supply does not equal $swapped_redemption_expected_remaining"
-    [[ "$final_earn_supply" == "$swapped_redemption_expected_remaining" ]] ||
-        die "terminal $ZONES_BENCH_NEOBANK_PRESET EarnToken supply $final_earn_supply does not equal $swapped_redemption_expected_remaining"
+    expected_redemption_remaining="$(bigint_eval "$swapped_redemption_expected_remaining + $earn_anchor_amount")"
+    [[ "$final_share_supply" == "$expected_redemption_remaining" ]] ||
+        die "terminal $ZONES_BENCH_NEOBANK_PRESET share supply $final_share_supply does not equal $expected_redemption_remaining"
+    [[ "$final_earn_supply" == "$expected_redemption_remaining" ]] ||
+        die "terminal $ZONES_BENCH_NEOBANK_PRESET EarnToken supply $final_earn_supply does not equal $expected_redemption_remaining"
     verify_reward_zone_balances \
         distributed_remaining "$swapped_redemption_expected_remaining" \
         "$ZONES_BENCH_WITHDRAWAL_AMOUNT" \

--- a/contrib/bench/run-neobank-private-flow.sh
+++ b/contrib/bench/run-neobank-private-flow.sh
@@ -568,25 +568,25 @@ fi
 # with the full callback allowance and leave its returned EarnToken in an unrelated
 # Zone account. This keeps the EarnVault and engine nonempty, so the benchmark runs
 # steady-state deposit and redemption paths instead of empty-pool transitions.
-earn_anchor_amount="$ZONES_BENCH_WITHDRAWAL_AMOUNT"
+earn_warmup_amount="$ZONES_BENCH_WITHDRAWAL_AMOUNT"
 if [[ "$ZONES_BENCH_NEOBANK_PRESET" != "encrypted-deposit" ]]; then
-    readonly earn_anchor_callback_gas_limit=10000000
-    anchor_recipient_hash="$(cast keccak "zones-benchmark-earn-anchor:$ZONES_BENCH_SEED")"
-    earn_anchor_recipient="0x${anchor_recipient_hash: -40}"
-    ZONES_BENCH_CALLBACK_GAS_LIMIT="$earn_anchor_callback_gas_limit" \
+    readonly earn_warmup_callback_gas_limit=10000000
+    earn_warmup_recipient_hash="$(cast keccak "zones-benchmark-earn-warmup:$ZONES_BENCH_SEED")"
+    earn_warmup_recipient="0x${earn_warmup_recipient_hash: -40}"
+    ZONES_BENCH_CALLBACK_GAS_LIMIT="$earn_warmup_callback_gas_limit" \
     ZONES_BENCH_SWAPPED_REDEMPTION_ONRAMP_PER_ACCOUNT="$ZONES_BENCH_DEPOSIT_AMOUNT" \
-    ZONES_BENCH_SWAPPED_REDEMPTION_POSITION_PER_ACCOUNT="$earn_anchor_amount" \
-    ZONES_BENCH_POSITION_RECIPIENT="\"$earn_anchor_recipient\"" run_setup_scenario \
-        earn_anchor "$neobank_specs/swapped-redemption-position-scenario.yml" 1 \
-        "$ZONES_BENCH_OUTPUT/earn-anchor-report.json" \
-        "callback_gas_limit=$earn_anchor_callback_gas_limit amount=$earn_anchor_amount"
+    ZONES_BENCH_SWAPPED_REDEMPTION_POSITION_PER_ACCOUNT="$earn_warmup_amount" \
+    ZONES_BENCH_POSITION_RECIPIENT="\"$earn_warmup_recipient\"" run_setup_scenario \
+        earn_warmup "$neobank_specs/swapped-redemption-position-scenario.yml" 1 \
+        "$ZONES_BENCH_OUTPUT/earn-warmup-report.json" \
+        "callback_gas_limit=$earn_warmup_callback_gas_limit amount=$earn_warmup_amount"
 
-    anchor_share_supply_after="$(read_l1_uint "$ZONES_BENCH_EARN_VAULT" 'totalEarnShares()(uint256)')"
-    anchor_earn_supply_after="$(read_l1_uint "$ZONES_BENCH_EARN_TOKEN" 'totalSupply()(uint256)')"
-    [[ "$anchor_share_supply_after" == "$earn_anchor_amount" ]] ||
-        die "Earn anchor share supply $anchor_share_supply_after does not equal $earn_anchor_amount"
-    [[ "$anchor_earn_supply_after" == "$earn_anchor_amount" ]] ||
-        die "Earn anchor token supply $anchor_earn_supply_after does not equal $earn_anchor_amount"
+    warmup_share_supply_after="$(read_l1_uint "$ZONES_BENCH_EARN_VAULT" 'totalEarnShares()(uint256)')"
+    warmup_earn_supply_after="$(read_l1_uint "$ZONES_BENCH_EARN_TOKEN" 'totalSupply()(uint256)')"
+    [[ "$warmup_share_supply_after" == "$earn_warmup_amount" ]] ||
+        die "Earn warmup share supply $warmup_share_supply_after does not equal $earn_warmup_amount"
+    [[ "$warmup_earn_supply_after" == "$earn_warmup_amount" ]] ||
+        die "Earn warmup token supply $warmup_earn_supply_after does not equal $earn_warmup_amount"
 fi
 
 if [[ "$ZONES_BENCH_NEOBANK_PRESET" == "rewards-redemption" ]]; then
@@ -656,9 +656,9 @@ if [[ "$ZONES_BENCH_NEOBANK_PRESET" == "private-withdrawal" ||
       "$ZONES_BENCH_NEOBANK_PRESET" == "swapped-redemption" ]]; then
     initial_share_supply="$(read_l1_uint "$ZONES_BENCH_EARN_VAULT" 'totalEarnShares()(uint256)')"
     initial_earn_supply="$(read_l1_uint "$ZONES_BENCH_EARN_TOKEN" 'totalSupply()(uint256)')"
-    [[ "$initial_share_supply" == "$earn_anchor_amount" &&
-       "$initial_earn_supply" == "$earn_anchor_amount" ]] ||
-        die "$ZONES_BENCH_NEOBANK_PRESET position setup requires only the startup Earn anchor position"
+    [[ "$initial_share_supply" == "$earn_warmup_amount" &&
+       "$initial_earn_supply" == "$earn_warmup_amount" ]] ||
+        die "$ZONES_BENCH_NEOBANK_PRESET position setup requires only the startup Earn warmup position"
 
     stage_start redemption_position_setup
     position_concurrency="$ZONES_BENCH_MAX_CONCURRENT"
@@ -680,7 +680,7 @@ if [[ "$ZONES_BENCH_NEOBANK_PRESET" == "private-withdrawal" ||
     stage_start redemption_position_check
     positioned_share_supply="$(read_l1_uint "$ZONES_BENCH_EARN_VAULT" 'totalEarnShares()(uint256)')"
     positioned_earn_supply="$(read_l1_uint "$ZONES_BENCH_EARN_TOKEN" 'totalSupply()(uint256)')"
-    expected_redemption_position="$(bigint_eval "$swapped_redemption_total_position + $earn_anchor_amount")"
+    expected_redemption_position="$(bigint_eval "$swapped_redemption_total_position + $earn_warmup_amount")"
     [[ "$positioned_share_supply" == "$expected_redemption_position" ]] ||
         die "$ZONES_BENCH_NEOBANK_PRESET share supply $positioned_share_supply does not equal $expected_redemption_position"
     [[ "$positioned_earn_supply" == "$expected_redemption_position" ]] ||
@@ -766,7 +766,7 @@ if [[ "$ZONES_BENCH_NEOBANK_PRESET" == "private-withdrawal" ||
     stage_start redemption_postcondition
     final_share_supply="$(read_l1_uint "$ZONES_BENCH_EARN_VAULT" 'totalEarnShares()(uint256)')"
     final_earn_supply="$(read_l1_uint "$ZONES_BENCH_EARN_TOKEN" 'totalSupply()(uint256)')"
-    expected_redemption_remaining="$(bigint_eval "$swapped_redemption_expected_remaining + $earn_anchor_amount")"
+    expected_redemption_remaining="$(bigint_eval "$swapped_redemption_expected_remaining + $earn_warmup_amount")"
     [[ "$final_share_supply" == "$expected_redemption_remaining" ]] ||
         die "terminal $ZONES_BENCH_NEOBANK_PRESET share supply $final_share_supply does not equal $expected_redemption_remaining"
     [[ "$final_earn_supply" == "$expected_redemption_remaining" ]] ||

--- a/contrib/bench/scenario-reporting.sh
+++ b/contrib/bench/scenario-reporting.sh
@@ -19,6 +19,7 @@ build_scenario_report_args() {
         "bootstrap-deposit-amount:ZONES_BENCH_BOOTSTRAP_DEPOSIT_AMOUNT"
         "l1-gas-limit:ZONES_BENCH_L1_GAS_LIMIT"
         "l1-general-gas-limit:ZONES_BENCH_L1_GENERAL_GAS_LIMIT"
+        "zone-gas-limit:ZONES_BENCH_ZONE_GAS_LIMIT"
         "withdrawal-max-batch-gas:ZONES_BENCH_WITHDRAWAL_MAX_BATCH_GAS"
         "withdrawal-max-in-flight-batches:ZONES_BENCH_WITHDRAWAL_MAX_IN_FLIGHT_BATCHES"
         "zone-batch-interval-blocks:ZONES_BENCH_ZONE_BATCH_INTERVAL_BLOCKS"

--- a/xtask/src/deploy_neobank_fixtures.rs
+++ b/xtask/src/deploy_neobank_fixtures.rs
@@ -6,12 +6,17 @@ use alloy::{
     providers::{Provider, ProviderBuilder},
     rpc::types::TransactionRequest,
     signers::local::PrivateKeySigner,
-    sol_types::SolConstructor,
+    sol_types::{SolCall, SolConstructor},
 };
 use eyre::{Context as _, ensure, eyre};
 use serde::Serialize;
 use std::{fs, path::PathBuf};
-use tempo_alloy::{TempoNetwork, rpc::TempoCallBuilderExt as _};
+use tempo_alloy::{
+    TempoNetwork,
+    primitives::transaction::Call,
+    provider::TempoProviderBuilderExt as _,
+    rpc::{TempoCallBuilderExt as _, TempoTransactionRequest},
+};
 use tempo_contracts::precompiles::{IRolesAuth, ITIP20, ITIP20Factory};
 use tempo_precompiles::TIP20_FACTORY_ADDRESS;
 use tempo_zone_contracts::{ZonePortal, ZonePortal::Role as PortalRole};
@@ -118,6 +123,8 @@ alloy::sol! {
 }
 
 const DEFAULT_DEPLOYMENT_GAS_LIMIT: u64 = 30_000_000;
+// Tempo's transaction pool rejects AA transactions containing more than 32 calls.
+const MAX_PORTAL_ROLE_CALLS_PER_TX: usize = 32;
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Default, clap::ValueEnum, serde::Serialize)]
 #[serde(rename_all = "kebab-case")]
@@ -244,6 +251,7 @@ impl DeployNeobankFixtures {
             .await
             .wrap_err("failed connecting fixture deployer to Tempo L1")?;
         let admin_provider = ProviderBuilder::new_with_network::<TempoNetwork>()
+            .with_expiring_nonces()
             .wallet(EthereumWallet::from(portal_admin))
             .connect(&self.l1_rpc_url)
             .await
@@ -607,6 +615,7 @@ async fn configure_closed_loop_portal<P: Provider<TempoNetwork>>(
         "Configuring {} closed-loop ZonePortal roles...",
         assignments.len()
     );
+    let mut missing_role_calls = Vec::new();
     for (index, (account, expected_role)) in assignments.iter().enumerate() {
         if !portal
             .hasRole(*account, *expected_role)
@@ -614,39 +623,92 @@ async fn configure_closed_loop_portal<P: Provider<TempoNetwork>>(
             .await
             .wrap_err_with(|| format!("failed querying ZonePortal role at index {index}"))?
         {
-            let pending = match expected_role {
-                PortalRole::Account => {
-                    portal
-                        .setAllowedAccount(*account, true)
-                        .fee_token(fee_token)
-                        .send()
-                        .await
+            let input = match expected_role {
+                PortalRole::Account => ZonePortal::setAllowedAccountCall {
+                    account: *account,
+                    allowed: true,
                 }
-                PortalRole::CallbackGateway => {
-                    portal
-                        .setGateway(*account, true)
-                        .fee_token(fee_token)
-                        .send()
-                        .await
+                .abi_encode(),
+                PortalRole::CallbackGateway => ZonePortal::setGatewayCall {
+                    account: *account,
+                    allowed: true,
                 }
+                .abi_encode(),
                 unsupported => eyre::bail!(
                     "unsupported benchmark ZonePortal role {unsupported:?} at index {index}"
                 ),
-            }
-            .wrap_err_with(|| format!("failed assigning ZonePortal role at index {index}"))?;
-            let receipt = pending.get_receipt().await.wrap_err_with(|| {
-                format!("failed waiting for ZonePortal role receipt at index {index}")
-            })?;
-            check(&receipt, "assign ZonePortal benchmark role")?;
+            };
+            missing_role_calls.push(Call {
+                to: portal_address.into(),
+                value: Uint::<256, 4>::ZERO,
+                input: input.into(),
+            });
         }
         if (index + 1) % 10 == 0 || index + 1 == assignments.len() {
             println!(
-                "ZonePortal role setup progress: {}/{}",
+                "ZonePortal role discovery progress: {}/{}",
                 index + 1,
                 assignments.len()
             );
         }
     }
+
+    let batch_count = missing_role_calls
+        .len()
+        .div_ceil(MAX_PORTAL_ROLE_CALLS_PER_TX);
+    println!(
+        "Assigning {} missing ZonePortal roles in {} Tempo AA batches...",
+        missing_role_calls.len(),
+        batch_count
+    );
+    let receipt_results = futures::future::join_all(
+        missing_role_calls
+            .chunks(MAX_PORTAL_ROLE_CALLS_PER_TX)
+            .enumerate()
+            .map(|(batch_index, calls)| {
+                let request = TempoTransactionRequest {
+                    calls: calls.to_vec(),
+                    fee_token: Some(fee_token),
+                    ..Default::default()
+                };
+                async move {
+                    provider
+                        .send_transaction(request)
+                        .await
+                        .wrap_err_with(|| {
+                            format!(
+                                "failed submitting ZonePortal role batch {}/{batch_count}",
+                                batch_index + 1
+                            )
+                        })?
+                        .get_receipt()
+                        .await
+                        .wrap_err_with(|| {
+                            format!(
+                                "failed waiting for ZonePortal role batch {}/{batch_count}",
+                                batch_index + 1
+                            )
+                        })
+                }
+            }),
+    )
+    .await;
+    for (batch_index, receipt) in receipt_results.into_iter().enumerate() {
+        let receipt = receipt?;
+        check(
+            &receipt,
+            &format!(
+                "assign ZonePortal benchmark role batch {}/{batch_count}",
+                batch_index + 1
+            ),
+        )?;
+        println!(
+            "ZonePortal role batch progress: {}/{}",
+            batch_index + 1,
+            batch_count
+        );
+    }
+
     for (index, (account, expected_role)) in assignments.iter().enumerate() {
         ensure!(
             portal

--- a/xtask/src/deploy_neobank_fixtures.rs
+++ b/xtask/src/deploy_neobank_fixtures.rs
@@ -895,21 +895,24 @@ async fn deploy<P: Provider<TempoNetwork>>(
     bytecode: Vec<u8>,
     label: &str,
 ) -> eyre::Result<Address> {
-    let gas_limit = std::env::var("ZONES_BENCH_L1_GENERAL_GAS_LIMIT")
+    let general_gas_limit = std::env::var("ZONES_BENCH_L1_GENERAL_GAS_LIMIT")
         .unwrap_or_else(|_| DEFAULT_DEPLOYMENT_GAS_LIMIT.to_string())
         .parse::<u64>()
         .wrap_err("ZONES_BENCH_L1_GENERAL_GAS_LIMIT must be an unsigned integer")?;
     ensure!(
-        gas_limit > 0 && gas_limit <= DEFAULT_DEPLOYMENT_GAS_LIMIT,
-        "ZONES_BENCH_L1_GENERAL_GAS_LIMIT must be between 1 and {DEFAULT_DEPLOYMENT_GAS_LIMIT}"
+        general_gas_limit > 0,
+        "ZONES_BENCH_L1_GENERAL_GAS_LIMIT must be greater than zero"
     );
+    // The configured value is the aggregate general-transaction budget for an L1 block. Keep
+    // this individual deployment transaction within Tempo's protocol transaction gas cap.
+    let gas_limit = general_gas_limit.min(DEFAULT_DEPLOYMENT_GAS_LIMIT);
     let receipt = provider
         .send_transaction(
             TransactionRequest::default()
                 .with_kind(alloy::primitives::TxKind::Create)
                 // Fixture constructors can make contract calls that Tempo's generic
-                // estimator underestimates. Use the configured general-transaction
-                // cap so the setup transaction is admissible on the provisioned L1.
+                // estimator underestimates. Use as much of the configured general-transaction
+                // budget as Tempo's per-transaction cap allows.
                 .with_gas_limit(gas_limit)
                 .input(Bytes::from(bytecode).into())
                 .into(),


### PR DESCRIPTION
## Summary

- make L1 and Zone block gas limits configurable for high-throughput benchmark runs, while keeping individual fixture deployments within Tempo's transaction gas cap
- verify and report the configured Zone gas limit and raise the Zone RPC connection limit for load-test traffic
- pace admission-seed deposits to respect the ZonePortal per-block deposit cap
- batch ZonePortal role assignments into Tempo AA transactions to speed up large account-pool provisioning
- create and retain an untimed Earn warmup position so measured deposits and redemptions use steady-state contract paths
- lower the measured callback gas default to 5M while retaining the full 10M allowance for the cold warmup callback