### PR TITLE
feat: mirror Tempo TIP-20 pause state on Zones

### DIFF
--- a/crates/evm/src/database.rs
+++ b/crates/evm/src/database.rs
@@ -14,6 +14,7 @@ use revm::{
     primitives::{AddressMap, StorageKey, StorageValue},
     state::{Account, AccountInfo, Bytecode},
 };
+use tempo_precompiles::tip20::{is_tip20_prefix, tip20_slots};
 use thiserror::Error;
 use zone_precompiles::{
     TIP403_REGISTRY_ADDRESS,
@@ -87,7 +88,7 @@ impl<DB: Database, L1: L1StorageReader> L1OverlayDB<DB, L1> {
         Ok(anchor)
     }
 
-    /// Rejects writes to the L1-mirrored TIP-403 registry.
+    /// Rejects writes to L1-mirrored TIP-403 and TIP-20 pause state.
     pub fn sanitize_state(
         &mut self,
         state: &mut AddressMap<Account>,
@@ -113,6 +114,24 @@ impl<DB: Database, L1: L1StorageReader> L1OverlayDB<DB, L1> {
             state.remove(&TIP403_REGISTRY_ADDRESS);
         }
 
+        for (address, account) in state.iter_mut() {
+            if !is_tip20_prefix(*address) {
+                continue;
+            }
+
+            if let Some(value) = account.storage.get(&tip20_slots::PAUSED)
+                && value.is_changed()
+            {
+                return Err(ZoneDbError::L1Write {
+                    address: *address,
+                    slot: tip20_slots::PAUSED,
+                });
+            }
+
+            // Do not persist a mirrored L1 value merely because the slot was read by TIP-20.
+            account.storage.remove(&tip20_slots::PAUSED);
+        }
+
         Ok(())
     }
 }
@@ -131,7 +150,10 @@ impl<DB: Database, L1: L1StorageReader> RevmDatabase for L1OverlayDB<DB, L1> {
     }
 
     fn storage(&mut self, address: Address, slot: StorageKey) -> Result<StorageValue, Self::Error> {
-        if address != TIP403_REGISTRY_ADDRESS {
+        let mirrors_tip20_pause = is_tip20_prefix(address)
+            && slot == tip20_slots::PAUSED
+            && !self.l1.uses_local_tip20_pause();
+        if address != TIP403_REGISTRY_ADDRESS && !mirrors_tip20_pause {
             return self
                 .inner
                 .storage(address, slot)
@@ -139,7 +161,8 @@ impl<DB: Database, L1: L1StorageReader> RevmDatabase for L1OverlayDB<DB, L1> {
         }
 
         let anchor = self.anchor()?;
-        // REVM already charges this TIP-403 SLOAD; the host-side L1 fetch must not be charged again.
+        // REVM already charges this mirrored SLOAD; the host-side L1 fetch must not be charged
+        // again.
         self.l1
             .read_l1_storage_unmetered(address, B256::from(slot), anchor)
             .map(Into::into)
@@ -182,6 +205,7 @@ impl<E: DBErrorMarker> ZoneDbError<E> {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use alloy_primitives::address;
     use revm::{
         database::{CacheDB, EmptyDB},
         database_interface::DatabaseCommit,
@@ -212,6 +236,50 @@ mod tests {
 
         assert_eq!(db.storage(TIP403_REGISTRY_ADDRESS, slot).unwrap(), expected);
         assert_eq!(db.l1_state().get_anchor(), Some(anchor));
+    }
+
+    #[test]
+    fn overlays_tip20_pause_but_keeps_other_token_storage_local() {
+        let anchor = 42;
+        let token = address!("20C0000000000000000000000000000000000999");
+        let local_slot = U256::from(7);
+        let local_value = U256::from(99);
+        let l1 = TestL1::default();
+        l1.insert(token, tip20_slots::PAUSED, anchor, U256::ONE);
+        let mut inner = test_db(anchor);
+        inner
+            .insert_account_storage(token, tip20_slots::PAUSED, U256::ZERO)
+            .unwrap();
+        inner
+            .insert_account_storage(token, local_slot, local_value)
+            .unwrap();
+        let mut db = L1OverlayDB::new(inner, l1, Address::ZERO);
+
+        assert_eq!(db.storage(token, tip20_slots::PAUSED).unwrap(), U256::ONE);
+        assert_eq!(db.storage(token, local_slot).unwrap(), local_value);
+    }
+
+    #[test]
+    fn inbox_pause_exception_uses_local_tip20_pause() {
+        let anchor = 42;
+        let token = address!("20C0000000000000000000000000000000000999");
+        let l1 = TestL1::default();
+        l1.insert(token, tip20_slots::PAUSED, anchor, U256::ONE);
+        let mut inner = test_db(anchor);
+        inner
+            .insert_account_storage(token, tip20_slots::PAUSED, U256::ZERO)
+            .unwrap();
+        let mut db = L1OverlayDB::new(inner, l1, Address::ZERO);
+        let l1_state = db.l1_state().clone();
+
+        assert_eq!(db.storage(token, tip20_slots::PAUSED).unwrap(), U256::ONE);
+        assert_eq!(
+            l1_state
+                .with_local_tip20_pause(|| db.storage(token, tip20_slots::PAUSED))
+                .unwrap(),
+            U256::ZERO
+        );
+        assert_eq!(db.storage(token, tip20_slots::PAUSED).unwrap(), U256::ONE);
     }
 
     #[test]
@@ -272,6 +340,43 @@ mod tests {
         let mut inner = db.into_inner();
         inner.commit(state);
         assert_eq!(inner.storage(TIP403_REGISTRY_ADDRESS, slot).unwrap(), local);
+    }
+
+    #[test]
+    fn tip20_pause_overlay_cannot_be_persisted_or_changed() {
+        let token = address!("20C0000000000000000000000000000000000999");
+        let mut db = L1OverlayDB::new(test_db(42), TestL1::default(), Address::ZERO);
+        let mut unchanged = Account::default();
+        unchanged.mark_touch();
+        unchanged.storage.insert(
+            tip20_slots::PAUSED,
+            EvmStorageSlot {
+                original_value: U256::ONE,
+                present_value: U256::ONE,
+                ..Default::default()
+            },
+        );
+        let mut state = AddressMap::from_iter([(token, unchanged)]);
+
+        db.sanitize_state(&mut state).unwrap();
+        assert!(!state[&token].storage.contains_key(&tip20_slots::PAUSED));
+
+        let mut changed = Account::default();
+        changed.mark_touch();
+        changed.storage.insert(
+            tip20_slots::PAUSED,
+            EvmStorageSlot {
+                original_value: U256::ZERO,
+                present_value: U256::ONE,
+                ..Default::default()
+            },
+        );
+        let mut state = AddressMap::from_iter([(token, changed)]);
+        assert!(matches!(
+            db.sanitize_state(&mut state),
+            Err(ZoneDbError::L1Write { address, slot })
+                if address == token && slot == tip20_slots::PAUSED
+        ));
     }
 
     #[test]

--- a/crates/l1/src/subscriber.rs
+++ b/crates/l1/src/subscriber.rs
@@ -1,7 +1,10 @@
 use super::*;
 use eyre::WrapErr as _;
 use std::collections::HashSet;
-use tempo_contracts::precompiles::{ITIP20::TransferPolicyUpdate, TIP403_REGISTRY_ADDRESS};
+use tempo_contracts::precompiles::{
+    ITIP20::{PauseStateUpdate, TransferPolicyUpdate},
+    TIP403_REGISTRY_ADDRESS,
+};
 use tempo_primitives::is_tip20_prefix;
 
 use std::collections::BTreeMap;
@@ -335,9 +338,16 @@ type L1ProcessedEvents = (
 );
 
 fn cache_invalidation_address(address: Address, topic0: Option<&B256>) -> Option<Address> {
-    (address == TIP403_REGISTRY_ADDRESS
-        || (is_tip20_prefix(address) && topic0 == Some(&TransferPolicyUpdate::SIGNATURE_HASH)))
-    .then_some(TIP403_REGISTRY_ADDRESS)
+    let tip20 = is_tip20_prefix(address);
+    if address == TIP403_REGISTRY_ADDRESS
+        || (tip20 && topic0 == Some(&TransferPolicyUpdate::SIGNATURE_HASH))
+    {
+        Some(TIP403_REGISTRY_ADDRESS)
+    } else if tip20 && topic0 == Some(&PauseStateUpdate::SIGNATURE_HASH) {
+        Some(address)
+    } else {
+        None
+    }
 }
 
 fn portal_event_cache_invalidation_address(topic0: Option<&B256>) -> Option<Address> {
@@ -1064,6 +1074,16 @@ mod tests {
         assert_eq!(
             cache_invalidation_address(token, Some(&TransferPolicyUpdate::SIGNATURE_HASH)),
             Some(TIP403_REGISTRY_ADDRESS)
+        );
+    }
+
+    #[test]
+    fn token_pause_updates_invalidate_the_token() {
+        let token = address!("20C0000000000000000000000000000000000999");
+
+        assert_eq!(
+            cache_invalidation_address(token, Some(&PauseStateUpdate::SIGNATURE_HASH)),
+            Some(token)
         );
     }
 

--- a/crates/precompiles/src/inbox/dispatch.rs
+++ b/crates/precompiles/src/inbox/dispatch.rs
@@ -45,7 +45,7 @@ impl ZoneInbox {
                        self.view_refund(l1, msg_sender, call.token, call.owner)
                     }),
                     claimRefund(call) => crate::dispatch::mutate(call, msg_sender, |caller, call| {
-                        self.claim_refund(caller, call.token)
+                        self.claim_refund(l1, caller, call.token)
                     }),
                     advanceTempo(call) => {
                         if self.storage.is_static() {

--- a/crates/precompiles/src/inbox/mod.rs
+++ b/crates/precompiles/src/inbox/mod.rs
@@ -126,7 +126,7 @@ impl ZoneInbox {
 
             match queued {
                 DecodedQueuedDeposit::WithdrawalBounceBack(deposit) => {
-                    self.process_withdrawal_bounce_back(&mut outbox, deposit)
+                    self.process_withdrawal_bounce_back(l1, &mut outbox, deposit)
                 }
                 DecodedQueuedDeposit::Deposit(deposit) => {
                     let Some(decryption) = decryptions.next() else {
@@ -134,6 +134,7 @@ impl ZoneInbox {
                     };
                     let key = read_encryption_key(l1, deposit.keyIndex)?;
                     self.process_deposit(
+                        l1,
                         &mut outbox,
                         portal,
                         current_hash,
@@ -209,8 +210,9 @@ impl ZoneInbox {
         Ok(())
     }
 
-    fn process_deposit(
+    fn process_deposit<P: L1StorageReader>(
         &mut self,
+        l1: &L1State<P>,
         outbox: &mut ZoneOutbox,
         portal: Address,
         current_hash: B256,
@@ -223,7 +225,7 @@ impl ZoneInbox {
             return self.fail_deposit(outbox, current_hash, deposit);
         };
 
-        if self.try_mint(deposit.token, to, deposit.amount)? {
+        if self.try_mint(l1, deposit.token, to, deposit.amount)? {
             self.emit_event(deposit.processed_event(current_hash, to, memo))?;
         } else {
             self.fail_deposit(outbox, current_hash, deposit)?;
@@ -249,8 +251,9 @@ impl ZoneInbox {
         Ok(())
     }
 
-    fn process_withdrawal_bounce_back(
+    fn process_withdrawal_bounce_back<P: L1StorageReader>(
         &mut self,
+        l1: &L1State<P>,
         outbox: &mut ZoneOutbox,
         deposit: WithdrawalBounceBackDeposit,
     ) -> ZoneResult<()> {
@@ -260,7 +263,7 @@ impl ZoneInbox {
                 .expect("address suffix is eight bytes"),
         );
         let recipient = outbox.consume_fallback_recipient(ZONE_INBOX_ADDRESS, fallback_nonce)?;
-        if self.try_mint(deposit.token, recipient, deposit.amount)? {
+        if self.try_mint(l1, deposit.token, recipient, deposit.amount)? {
             self.emit_event(deposit.withdrawal_bounce_back_processed_event(recipient))?;
         } else {
             let slot = self.withdrawal_bounce_backs[deposit.token][recipient].slot();
@@ -272,7 +275,13 @@ impl ZoneInbox {
 
     /// Mint with Solidity `try/catch` semantics: ordinary reverts are caught while fatal and
     /// out-of-gas failures abort the outer Inbox call.
-    fn try_mint(&mut self, token: Address, to: Address, amount: u128) -> ZoneResult<bool> {
+    fn try_mint<P: L1StorageReader>(
+        &mut self,
+        l1: &L1State<P>,
+        token: Address,
+        to: Address,
+        amount: u128,
+    ) -> ZoneResult<bool> {
         let ensure_logic_err = |err: TempoPrecompileError| {
             if err.is_system_error() {
                 Err(err)
@@ -292,15 +301,17 @@ impl ZoneInbox {
         }
 
         let checkpoint = self.storage.checkpoint();
-        let success = TIP20Token::from_address(token)
-            .and_then(|mut token| {
-                token.mint(
-                    ZONE_INBOX_ADDRESS,
-                    ITIP20::mintCall {
-                        to,
-                        amount: U256::from(amount),
-                    },
-                )
+        let success = l1
+            .with_local_tip20_pause(|| {
+                TIP20Token::from_address(token).and_then(|mut token| {
+                    token.mint(
+                        ZONE_INBOX_ADDRESS,
+                        ITIP20::mintCall {
+                            to,
+                            amount: U256::from(amount),
+                        },
+                    )
+                })
             })
             .map(|_| true)
             .or_else(ensure_logic_err)?;
@@ -312,9 +323,14 @@ impl ZoneInbox {
         Ok(success)
     }
 
-    fn claim_refund(&mut self, caller: Address, token: Address) -> ZoneResult<u128> {
+    fn claim_refund<P: L1StorageReader>(
+        &mut self,
+        l1: &L1State<P>,
+        caller: Address,
+        token: Address,
+    ) -> ZoneResult<u128> {
         let amount = self.withdrawal_bounce_backs[token][caller].read()?;
-        if !self.try_mint(token, caller, amount)? {
+        if !self.try_mint(l1, token, caller, amount)? {
             return Err(TempoPrecompileError::from(TIP20Error::policy_forbids()).into());
         }
 

--- a/crates/precompiles/src/storage.rs
+++ b/crates/precompiles/src/storage.rs
@@ -70,6 +70,11 @@ pub struct L1State<P> {
     /// when a subcall reverts, preserving charges for potentially incurred L1 fetch work and
     /// simplifying the accounting model.
     access_set: Rc<RefCell<HashSet<(Address, B256)>>>,
+    /// Whether a protocol-owned Inbox mint should observe Zone-local pause state.
+    ///
+    /// This is shared with the database overlay so deposits accepted on Tempo before a token was
+    /// paused can still be credited without disabling pause mirroring for user token movement.
+    local_tip20_pause: Rc<Cell<bool>>,
     /// Underlying cache/RPC-backed reader for storage at an explicit Tempo block number.
     provider: P,
     /// ZonePortal read through the L1 provider by explicit storage operations.
@@ -82,6 +87,7 @@ impl<P> L1State<P> {
         Self {
             anchor: Rc::new(Cell::new(None)),
             access_set: Rc::new(RefCell::new(HashSet::default())),
+            local_tip20_pause: Rc::new(Cell::new(false)),
             provider,
             portal_address,
         }
@@ -91,6 +97,7 @@ impl<P> L1State<P> {
     pub fn reset_transaction_state(&self) {
         self.anchor.set(None);
         self.access_set.borrow_mut().clear();
+        self.local_tip20_pause.set(false);
     }
 
     /// Returns the anchor selected for the current transaction, if any.
@@ -101,6 +108,29 @@ impl<P> L1State<P> {
     /// Returns the configured ZonePortal address.
     pub const fn portal(&self) -> Address {
         self.portal_address
+    }
+
+    /// Runs a protocol-owned operation against Zone-local TIP-20 pause state.
+    ///
+    /// This exception is reserved for Inbox mints that settle value already escrowed on Tempo.
+    /// All other TIP-20 operations continue to observe the finalized Tempo pause state.
+    pub fn with_local_tip20_pause<T>(&self, operation: impl FnOnce() -> T) -> T {
+        struct Restore(Rc<Cell<bool>>, bool);
+
+        impl Drop for Restore {
+            fn drop(&mut self) {
+                self.0.set(self.1);
+            }
+        }
+
+        let previous = self.local_tip20_pause.replace(true);
+        let _restore = Restore(Rc::clone(&self.local_tip20_pause), previous);
+        operation()
+    }
+
+    /// Returns whether the current protocol operation should use Zone-local TIP-20 pause state.
+    pub fn uses_local_tip20_pause(&self) -> bool {
+        self.local_tip20_pause.get()
     }
 
     fn set_anchor(&self, new: u64) -> Result<(), L1StateError> {


### PR DESCRIPTION
## Summary

- mirror each TIP-20 paused slot from the finalized Tempo anchor, matching the existing TIP-403 overlay model
- invalidate the token L1 cache when a PauseStateUpdate event is finalized
- keep Inbox mints live for deposits and bounce-backs already escrowed on Tempo, while leaving TIP-403 policy checks and all user token movement pause-gated
- reject or strip attempts to persist Tempo-owned pause state in Zone storage

## Why

Pausing a TIP-20 on Tempo should pause its Zone representation too. The settlement exception prevents funds accepted by the L1 Portal before the pause from becoming stranded during later Zone processing.

## Validation

- cargo test -p zone-precompiles --lib --locked
- cargo test -p zone-evm -p zone-l1 --lib --locked
- cargo clippy -p zone-evm -p zone-precompiles -p zone-l1 --all-targets --all-features --locked -- -D warnings
- cargo fmt --all