### PR TITLE
fix(ci): sync release branches to private copies

### DIFF
--- a/.github/sts/sync-from-upstream.sts.yaml
+++ b/.github/sts/sync-from-upstream.sts.yaml
@@ -1,7 +1,7 @@
 # Allow the sync-from-upstream workflow in copies of this repo (scheduled and
 # manually dispatched runs on main) to mint a short-lived token to push the
-# synced main. `workflows: write` is required because the synced commits can
-# touch .github/workflows files.
+# synced main and `release/*` branches. `workflows: write` is required because
+# the synced commits can touch .github/workflows files.
 #
 # This file is mirrored into the copies by the sync itself, where it
 # authorizes tokens scoped to the copy: zones-private-fork mirrors main

--- a/.github/workflows/sync-from-upstream.yml
+++ b/.github/workflows/sync-from-upstream.yml
@@ -1,7 +1,7 @@
 # This workflow is intended for forks or private copies of tempoxyz/zones.
-# It keeps their main branch aligned with the upstream repository every hour.
+# It keeps their main and release branches aligned with upstream every hour.
 
-name: Sync main branch with upstream
+name: Sync main and release branches with upstream
 
 on:
   schedule:
@@ -29,12 +29,16 @@ jobs:
           fetch-depth: 0
           persist-credentials: false
 
-      - name: Sync main with upstream
+      - name: Sync main and release branches with upstream
         env:
           APP_TOKEN: ${{ steps.github-sts.outputs.token }}
         run: |
           git remote add upstream https://github.com/tempoxyz/zones.git
-          git fetch upstream main
+          git fetch upstream \
+            '+refs/heads/main:refs/remotes/upstream/main' \
+            '+refs/heads/release/*:refs/remotes/upstream/release/*'
           git checkout main
           git reset --hard upstream/main
-          git push "https://x-access-token:${APP_TOKEN}@github.com/${GITHUB_REPOSITORY}.git" main --force
+          git push "https://x-access-token:${APP_TOKEN}@github.com/${GITHUB_REPOSITORY}.git" \
+            '+refs/heads/main:refs/heads/main' \
+            '+refs/remotes/upstream/release/*:refs/heads/release/*'


### PR DESCRIPTION
Syncs `release/*` alongside `main` into private repository copies. The scoped refspec updates only those branches, preserving copy-only branches and leaving tags and upstream branch deletions untouched.