### PR TITLE
fix(sequencer): coordinate batch anchors in monitor

### DIFF
--- a/crates/node/src/replication.rs
+++ b/crates/node/src/replication.rs
@@ -626,10 +626,10 @@ where
         provider,
         height,
         attestation,
-        Some((
+        (
             signed.attestation.anchorBlockNumber,
             signed.attestation.anchorBlockHash,
-        )),
+        ),
     )
     .await?
     .ok_or_eyre("signed block is not a batch boundary")?;
@@ -830,7 +830,7 @@ pub(crate) async fn run_follower_block_sync<P>(
                                 &provider,
                                 height,
                                 &attestation,
-                                Some((proposal.anchorBlockNumber, proposal.anchorBlockHash)),
+                                (proposal.anchorBlockNumber, proposal.anchorBlockHash),
                             ).await?.ok_or_eyre("proposed block is not a batch boundary")?;
                             eyre::ensure!(proposal == expected, "settlement proposal does not match follower state");
 

--- a/crates/node/src/settlement_attestation.rs
+++ b/crates/node/src/settlement_attestation.rs
@@ -596,7 +596,9 @@ async fn propose_settlement<P>(
 where
     P: HeaderProvider<Header = TempoHeader> + ReceiptProvider,
 {
-    let commitments = block_commitments(provider, number)?;
+    let Some(commitments) = block_commitments(provider, number)? else {
+        return Ok(false);
+    };
     if commitments.withdrawal.is_none() {
         return Ok(false);
     }

--- a/crates/node/src/settlement_attestation.rs
+++ b/crates/node/src/settlement_attestation.rs
@@ -230,7 +230,7 @@ pub(crate) async fn build_settlement_attestation<P>(
     provider: &P,
     number: u64,
     context: &AttestationContext,
-    proposed_anchor: Option<(u64, B256)>,
+    anchor: (u64, B256),
 ) -> eyre::Result<Option<SettlementAttestation>>
 where
     P: HeaderProvider<Header = TempoHeader> + ReceiptProvider,
@@ -270,25 +270,7 @@ where
         "zone withdrawal batch index {withdrawal_batch_index} does not follow portal index {portal_batch_index}"
     );
 
-    let (anchor_block_number, anchor_block_hash) = if let Some(anchor) = proposed_anchor {
-        anchor
-    } else {
-        let l1_tip = context.l1_provider.get_block_number().await?;
-        let gap = l1_tip.saturating_sub(commitments.tempo_block_number);
-        if gap < context.anchor_config.effective_window() {
-            (commitments.tempo_block_number, commitments.tempo_block_hash)
-        } else {
-            let anchor_number = l1_tip.saturating_sub(context.anchor_config.safety_margin());
-            let header = context
-                .l1_provider
-                .get_header_by_number(anchor_number.into())
-                .await?
-                .ok_or_eyre(format!("missing L1 anchor header {anchor_number}"))?
-                .inner
-                .inner;
-            (anchor_number, header.hash_slow())
-        }
-    };
+    let (anchor_block_number, anchor_block_hash) = anchor;
     validate_settlement_anchor(
         context,
         commitments.tempo_block_number,
@@ -614,7 +596,24 @@ async fn propose_settlement<P>(
 where
     P: HeaderProvider<Header = TempoHeader> + ReceiptProvider,
 {
-    let Some(attestation) = build_settlement_attestation(provider, number, context, None).await?
+    let commitments = block_commitments(provider, number)?;
+    if commitments.withdrawal.is_none() {
+        return Ok(false);
+    }
+    let anchor = context
+        .store
+        .prepared_anchor(number)
+        .ok_or_else(|| eyre::eyre!("zone monitor has not prepared settlement boundary {number}"))?;
+    let Some(attestation) = build_settlement_attestation(
+        provider,
+        number,
+        context,
+        (
+            anchor.block_number(commitments.tempo_block_number),
+            anchor.block_hash(),
+        ),
+    )
+    .await?
     else {
         return Ok(false);
     };

--- a/crates/sequencer/src/attestation.rs
+++ b/crates/sequencer/src/attestation.rs
@@ -673,6 +673,7 @@ mod tests {
             anchorBlockHash: B256::repeat_byte(3),
             blockTransitionHash: B256::repeat_byte(4),
             depositQueueTransitionHash: B256::repeat_byte(5),
+            tokenEnablementTransitionHash: B256::ZERO,
             withdrawalQueueHash: B256::repeat_byte(6),
             verifierConfigHash: B256::repeat_byte(7),
         };

--- a/crates/sequencer/src/attestation.rs
+++ b/crates/sequencer/src/attestation.rs
@@ -12,8 +12,16 @@ use alloy_sol_types::{Eip712Domain, SolStruct as _, SolValue as _, eip712_domain
 use eyre::WrapErr as _;
 use tokio::sync::{Notify, watch};
 
+use crate::settlement::BatchAnchor;
+
 type SettlementSignatures =
     BTreeMap<u64, BTreeMap<B256, BTreeMap<Address, SignedSettlementAttestation>>>;
+
+#[derive(Debug, Default)]
+struct AttestationState {
+    settlements: SettlementSignatures,
+    prepared_anchors: BTreeMap<u64, BatchAnchor>,
+}
 
 sol! {
     /// Exact settlement statement verified by ZonePortal.
@@ -218,7 +226,7 @@ pub struct SettlementCertificate {
 /// Settlement certificates shared by P2P and batch submission.
 #[derive(Debug, Clone)]
 pub struct AttestationStore {
-    settlements: Arc<RwLock<SettlementSignatures>>,
+    state: Arc<RwLock<AttestationState>>,
     settlement_changed: Arc<Notify>,
     submitted_height: watch::Sender<u64>,
 }
@@ -227,7 +235,7 @@ impl Default for AttestationStore {
     fn default() -> Self {
         let (submitted_height, _) = watch::channel(0);
         Self {
-            settlements: Arc::default(),
+            state: Arc::default(),
             settlement_changed: Arc::default(),
             submitted_height,
         }
@@ -250,12 +258,14 @@ impl AttestationStore {
         let digest = domain.settlement_digest(&signed.attestation);
 
         let (inserted, signature_count) = {
-            let mut all = self
-                .settlements
-                .write()
-                .expect("attestation store lock poisoned");
+            let mut state = self.state.write().expect("attestation store lock poisoned");
 
-            let signatures = all.entry(height).or_default().entry(digest).or_default();
+            let signatures = state
+                .settlements
+                .entry(height)
+                .or_default()
+                .entry(digest)
+                .or_default();
             let inserted = signatures.insert(signer, signed).is_none();
             (inserted, signatures.len())
         };
@@ -275,11 +285,9 @@ impl AttestationStore {
         leader: Address,
         follower: Address,
     ) -> eyre::Result<()> {
-        let all = self
+        let state = self.state.read().expect("attestation store lock poisoned");
+        let signatures = state
             .settlements
-            .read()
-            .expect("attestation store lock poisoned");
-        let signatures = all
             .get(&height)
             .and_then(|by_digest| by_digest.get(&digest))
             .filter(|signatures| signatures.contains_key(&leader))
@@ -307,11 +315,9 @@ impl AttestationStore {
         let digest = domain.settlement_digest(&signed.attestation);
 
         let signature_count = {
-            let mut all = self
+            let mut state = self.state.write().expect("attestation store lock poisoned");
+            let signatures = state
                 .settlements
-                .write()
-                .expect("attestation store lock poisoned");
-            let signatures = all
                 .get_mut(&height)
                 .and_then(|by_digest| by_digest.get_mut(&digest))
                 .filter(|signatures| signatures.contains_key(&leader))
@@ -353,11 +359,9 @@ impl AttestationStore {
 
     /// Get the settlement certificate at the zone block height
     fn settlement_at(&self, height: u64, quorum: usize) -> Option<SettlementCertificate> {
-        let all = self
+        let state = self.state.read().expect("attestation store lock poisoned");
+        let (digest, signatures) = state
             .settlements
-            .read()
-            .expect("attestation store lock poisoned");
-        let (digest, signatures) = all
             .get(&height)?
             .iter()
             .find(|(_, signatures)| signatures.len() >= quorum)?;
@@ -377,24 +381,47 @@ impl AttestationStore {
 
     /// Remove one unusable certificate without discarding other anchor candidates.
     pub fn remove_settlement(&self, height: u64, digest: B256) {
-        let mut settlements = self
-            .settlements
-            .write()
-            .expect("attestation store lock poisoned");
-        if let Some(by_digest) = settlements.get_mut(&height) {
+        let mut state = self.state.write().expect("attestation store lock poisoned");
+        if let Some(by_digest) = state.settlements.get_mut(&height) {
             by_digest.remove(&digest);
             if by_digest.is_empty() {
-                settlements.remove(&height);
+                state.settlements.remove(&height);
             }
         }
     }
 
+    /// Publish the monitor-owned anchor for a height, invalidating signatures for any previous
+    /// anchor at that height.
+    pub fn replace_prepared_anchor(&self, height: u64, anchor: BatchAnchor) {
+        let mut state = self.state.write().expect("attestation store lock poisoned");
+        if state.prepared_anchors.get(&height) != Some(&anchor) {
+            state.settlements.remove(&height);
+            state.prepared_anchors.insert(height, anchor);
+            self.settlement_changed.notify_one();
+        }
+    }
+
+    /// Return the monitor-owned anchor for a Zone height.
+    pub fn prepared_anchor(&self, height: u64) -> Option<BatchAnchor> {
+        self.state
+            .read()
+            .expect("attestation store lock poisoned")
+            .prepared_anchors
+            .get(&height)
+            .cloned()
+    }
+
     /// Remove all attestations covered by a confirmed batch submission.
     pub fn remove_submitted(&self, height: u64) {
-        self.settlements
-            .write()
-            .expect("attestation store lock poisoned")
-            .retain(|settlement_height, _| *settlement_height > height);
+        {
+            let mut state = self.state.write().expect("attestation store lock poisoned");
+            state
+                .settlements
+                .retain(|settlement_height, _| *settlement_height > height);
+            state
+                .prepared_anchors
+                .retain(|anchor_height, _| *anchor_height > height);
+        }
         self.submitted_height.send_if_modified(|submitted| {
             if height > *submitted {
                 *submitted = height;
@@ -629,5 +656,45 @@ mod tests {
 
         store.remove_submitted(10);
         assert!(store.settlement_at(10, 1).is_none());
+    }
+
+    #[test]
+    fn replacing_prepared_anchor_discards_the_old_certificate() {
+        let store = AttestationStore::default();
+        let signer = PrivateKeySigner::random();
+        let attestation = SettlementAttestation {
+            zoneId: 7,
+            sequencerSetVersion: 3,
+            zoneHeight: U256::from(10),
+            withdrawalBatchIndex: U256::from(1),
+            verifier: Address::repeat_byte(2),
+            tempoBlockNumber: 100,
+            anchorBlockNumber: 100,
+            anchorBlockHash: B256::repeat_byte(3),
+            blockTransitionHash: B256::repeat_byte(4),
+            depositQueueTransitionHash: B256::repeat_byte(5),
+            withdrawalQueueHash: B256::repeat_byte(6),
+            verifierConfigHash: B256::repeat_byte(7),
+        };
+        let first = crate::BatchAnchor::Direct {
+            block_hash: B256::repeat_byte(3),
+        };
+        store.replace_prepared_anchor(10, first);
+        store.insert_settlement(
+            domain(),
+            signer.address(),
+            SignedSettlementAttestation::sign(attestation, domain(), &signer).unwrap(),
+        );
+        assert!(store.settlement_at(10, 1).is_some());
+
+        let replacement = crate::BatchAnchor::Ancestry {
+            block_number: 108,
+            block_hash: B256::repeat_byte(10),
+            ancestry_headers: vec![Bytes::from_static(&[1])],
+        };
+        store.replace_prepared_anchor(10, replacement.clone());
+
+        assert!(store.settlement_at(10, 1).is_none());
+        assert_eq!(store.prepared_anchor(10), Some(replacement));
     }
 }

--- a/crates/sequencer/src/lib.rs
+++ b/crates/sequencer/src/lib.rs
@@ -39,8 +39,7 @@ pub use monitor::{ZoneMonitorConfig, ZoneMonitorSharedState};
 pub use prover::ShadowProverConfig;
 pub use settlement::{
     BatchAnchor, BatchAnchorConfig, BatchData, BatchSubmitter, PortalZoneAnchor, PreparedBatch,
-    SettlementAbi,
-    resolve_portal_zone_anchor,
+    SettlementAbi, resolve_portal_zone_anchor,
 };
 pub use withdrawals::{
     DEFAULT_MAX_IN_FLIGHT_WITHDRAWAL_BATCHES, DEFAULT_MAX_WITHDRAWAL_BATCH_GAS,

--- a/crates/sequencer/src/lib.rs
+++ b/crates/sequencer/src/lib.rs
@@ -38,7 +38,8 @@ pub use encryption_key::{
 pub use monitor::{ZoneMonitorConfig, ZoneMonitorSharedState};
 pub use prover::ShadowProverConfig;
 pub use settlement::{
-    BatchAnchorConfig, BatchData, BatchSubmitter, PortalZoneAnchor, SettlementAbi,
+    BatchAnchor, BatchAnchorConfig, BatchData, BatchSubmitter, PortalZoneAnchor, PreparedBatch,
+    SettlementAbi,
     resolve_portal_zone_anchor,
 };
 pub use withdrawals::{
@@ -161,7 +162,6 @@ pub async fn spawn_zone_sequencer<P: ZoneSequencerProvider>(
         prover::spawn_shadow_prover(
             prover_config,
             config.portal_address,
-            config.batch_anchor_config,
             zone_provider.clone(),
             l1_provider.clone(),
         )

--- a/crates/sequencer/src/monitor.rs
+++ b/crates/sequencer/src/monitor.rs
@@ -530,7 +530,7 @@ impl<P: ZoneSequencerProvider> ZoneMonitor<P> {
                     warn!(
                         zone_from = from,
                         zone_to = to,
-                        anchor_block_number = prepared.anchor.block_number(batch_data.tempo_block_number),
+                        anchor_block_number = prepared.anchor_block_number(),
                         anchor_block_hash = %prepared.anchor.block_hash(),
                         error = %error,
                         "Prepared batch anchor expired or changed; rebuilding the settlement attempt"

--- a/crates/sequencer/src/monitor.rs
+++ b/crates/sequencer/src/monitor.rs
@@ -42,8 +42,8 @@ use crate::{
     resolve_portal_zone_anchor,
     settlement::{
         BatchAnchorConfig, BatchData, BatchSubmitError, BatchSubmitter, FinalizedBatchLog,
-        WithdrawalPage, ZoneBlockSnapshot, fetch_finalized_batch, fetch_finalized_batch_boundaries,
-        read_zone_block_snapshot,
+        PreparedBatch, WithdrawalPage, ZoneBlockSnapshot, fetch_finalized_batch,
+        fetch_finalized_batch_boundaries, read_zone_block_snapshot,
     },
     withdrawals::SharedWithdrawalStore,
 };
@@ -322,6 +322,14 @@ impl<P: ZoneSequencerProvider> ZoneMonitor<P> {
             Err(BatchSubmitError::PortalAdvanced) => {
                 unreachable!("portal advancement is reconciled by submit_batch_with_retry")
             }
+            Err(BatchSubmitError::PreparedAnchorInvalid(error)) => {
+                error!(
+                    from = scan_from,
+                    to = latest_zone_block,
+                    %error,
+                    "Prepared anchor invalidation escaped the rebuild loop; retrying on the next monitor tick"
+                );
+            }
             Err(BatchSubmitError::Other(error)) => {
                 error!(
                     from = scan_from,
@@ -497,11 +505,40 @@ impl<P: ZoneSequencerProvider> ZoneMonitor<P> {
             withdrawal_batch_index: finalized_batch.finalized_index,
         };
 
-        if let Some(prover) = &self.shadow_prover {
-            prover.try_enqueue(from, to, batch_data.clone());
+        loop {
+            let prepared = self
+                .batch_submitter
+                .prepare_batch(batch_data.clone())
+                .await?;
+            if let Some(store) = &self.config.attestation_store {
+                store.replace_prepared_anchor(to, prepared.anchor.clone());
+            }
+            if let Some(prover) = &self.shadow_prover {
+                prover.try_enqueue(from, to, prepared.clone());
+            }
+
+            match self
+                .submit_batch_with_retry(
+                    &prepared,
+                    to,
+                    finalized_batch.withdrawals.clone(),
+                    shutdown,
+                )
+                .await
+            {
+                Err(BatchSubmitError::PreparedAnchorInvalid(error)) => {
+                    warn!(
+                        zone_from = from,
+                        zone_to = to,
+                        anchor_block_number = prepared.anchor.block_number(batch_data.tempo_block_number),
+                        anchor_block_hash = %prepared.anchor.block_hash(),
+                        error = %error,
+                        "Prepared batch anchor expired or changed; rebuilding the settlement attempt"
+                    );
+                }
+                result => return result,
+            }
         }
-        self.submit_batch_with_retry(&batch_data, to, finalized_batch.withdrawals, shutdown)
-            .await
     }
 
     /// Submit a `submitBatch` transaction to the ZonePortal on L1 with exponential
@@ -521,11 +558,12 @@ impl<P: ZoneSequencerProvider> ZoneMonitor<P> {
     /// on-chain state.
     async fn submit_batch_with_retry(
         &mut self,
-        batch_data: &BatchData,
+        prepared: &PreparedBatch,
         last_zone_block: u64,
         withdrawals: Vec<abi::Withdrawal>,
         shutdown: &sync::CancellationToken,
     ) -> std::result::Result<(), BatchSubmitError> {
+        let batch_data = &prepared.batch;
         let mut delay = INITIAL_RETRY_DELAY;
 
         for attempt in 1..=MAX_RETRIES {
@@ -574,11 +612,7 @@ impl<P: ZoneSequencerProvider> ZoneMonitor<P> {
             }
 
             let submit_started = std::time::Instant::now();
-            match self
-                .batch_submitter
-                .submit_batch(batch_data, shutdown)
-                .await
-            {
+            match self.batch_submitter.submit_batch(prepared, shutdown).await {
                 Ok(event) => {
                     let portal_index = if event.withdrawalQueueIndex == NO_QUEUE_INDEX {
                         None
@@ -667,6 +701,7 @@ impl<P: ZoneSequencerProvider> ZoneMonitor<P> {
                     }
                     return Ok(());
                 }
+                Err(error @ BatchSubmitError::PreparedAnchorInvalid(_)) => return Err(error),
                 Err(BatchSubmitError::Other(e)) => {
                     self.metrics
                         .batch_submit_latency_seconds
@@ -1041,6 +1076,15 @@ mod tests {
         }
     }
 
+    fn prepared(batch: BatchData) -> PreparedBatch {
+        PreparedBatch {
+            anchor: crate::BatchAnchor::Direct {
+                block_hash: B256::ZERO,
+            },
+            batch,
+        }
+    }
+
     #[tokio::test]
     async fn leader_demotion_stops_batch_submission_waiting_for_settlement_quorum() {
         let l1 = Asserter::new();
@@ -1079,9 +1123,10 @@ mod tests {
 
         let shutdown = sync::CancellationToken::new();
         let submission_shutdown = shutdown.clone();
+        let prepared = prepared(batch_data.clone());
         let submission = tokio::spawn(async move {
             monitor
-                .submit_batch_with_retry(&batch_data, 71, Vec::new(), &submission_shutdown)
+                .submit_batch_with_retry(&prepared, 71, Vec::new(), &submission_shutdown)
                 .await
         });
 
@@ -1355,7 +1400,12 @@ mod tests {
         };
 
         monitor
-            .submit_batch_with_retry(&batch_data, 20, Vec::new(), &sync::CancellationToken::new())
+            .submit_batch_with_retry(
+                &prepared(batch_data.clone()),
+                20,
+                Vec::new(),
+                &sync::CancellationToken::new(),
+            )
             .await
             .unwrap();
 
@@ -1405,7 +1455,7 @@ mod tests {
 
         let error = monitor
             .submit_batch_with_retry(
-                &batch_data,
+                &prepared(batch_data),
                 pending_boundary,
                 Vec::new(),
                 &sync::CancellationToken::new(),
@@ -1449,7 +1499,12 @@ mod tests {
         };
 
         let error = monitor
-            .submit_batch_with_retry(&batch_data, 20, Vec::new(), &sync::CancellationToken::new())
+            .submit_batch_with_retry(
+                &prepared(batch_data),
+                20,
+                Vec::new(),
+                &sync::CancellationToken::new(),
+            )
             .await
             .unwrap_err();
 

--- a/crates/sequencer/src/prover.rs
+++ b/crates/sequencer/src/prover.rs
@@ -41,7 +41,7 @@ use zone_spf::{
     ZoneStateWitness, prove_zone_batch,
 };
 
-use crate::{BatchAnchorConfig, BatchData, ZoneSequencerProvider, metrics::ProverMetrics};
+use crate::{BatchAnchor, BatchData, PreparedBatch, ZoneSequencerProvider, metrics::ProverMetrics};
 
 /// Number of candidates allowed to wait behind the active validation.
 const SHADOW_PROVER_QUEUE_CAPACITY: usize = 2;
@@ -86,7 +86,7 @@ pub(crate) struct ShadowProver {
 struct ProverJob {
     from: u64,
     to: u64,
-    batch: BatchData,
+    prepared: PreparedBatch,
     enqueued_at: Instant,
 }
 
@@ -104,7 +104,6 @@ struct ValidationStats {
 struct ProverContext<P> {
     config: ShadowProverConfig,
     portal: Address,
-    anchor_config: BatchAnchorConfig,
     zone_provider: P,
     l1_provider: DynProvider<TempoNetwork>,
 }
@@ -115,12 +114,6 @@ struct ZoneInputs {
     checkpoint_by_zone_block: BTreeMap<u64, u64>,
     initial_tempo_number: u64,
     initial_tempo_hash: B256,
-}
-
-struct Anchor {
-    number: u64,
-    hash: B256,
-    ancestry_headers: Vec<Bytes>,
 }
 
 /// I/O wrapper that records when the first response byte is read.
@@ -166,7 +159,6 @@ impl<T: AsyncWrite + Unpin> AsyncWrite for FirstReadTimed<T> {
 pub(crate) fn spawn_shadow_prover<P: ZoneSequencerProvider>(
     config: ShadowProverConfig,
     portal: Address,
-    anchor_config: BatchAnchorConfig,
     zone_provider: P,
     l1_provider: DynProvider<TempoNetwork>,
 ) -> ShadowProver {
@@ -181,7 +173,6 @@ pub(crate) fn spawn_shadow_prover<P: ZoneSequencerProvider>(
     let context = ProverContext {
         config,
         portal,
-        anchor_config,
         zone_provider,
         l1_provider,
     };
@@ -219,8 +210,8 @@ pub(crate) fn spawn_shadow_prover<P: ZoneSequencerProvider>(
                         target: "zone::sequencer::prover",
                         zone_from = job.from,
                         zone_to = job.to,
-                        prev_block_hash = %job.batch.prev_block_hash,
-                        next_block_hash = %job.batch.next_block_hash,
+                        prev_block_hash = %job.prepared.batch.prev_block_hash,
+                        next_block_hash = %job.prepared.batch.next_block_hash,
                         elapsed_ms = started.elapsed().as_millis(),
                         witness_bytes = stats.witness_bytes,
                         blocks = stats.blocks,
@@ -238,8 +229,8 @@ pub(crate) fn spawn_shadow_prover<P: ZoneSequencerProvider>(
                         target: "zone::sequencer::prover",
                         zone_from = job.from,
                         zone_to = job.to,
-                        prev_block_hash = %job.batch.prev_block_hash,
-                        next_block_hash = %job.batch.next_block_hash,
+                        prev_block_hash = %job.prepared.batch.prev_block_hash,
+                        next_block_hash = %job.prepared.batch.next_block_hash,
                         elapsed_ms = started.elapsed().as_millis(),
                         error = ?err,
                         "Shadow prover failed to validate finalized batch candidate"
@@ -254,13 +245,14 @@ pub(crate) fn spawn_shadow_prover<P: ZoneSequencerProvider>(
 
 impl ShadowProver {
     /// Queue a candidate without waiting for validation or queue capacity.
-    pub(crate) fn try_enqueue(&self, from: u64, to: u64, batch: BatchData) {
+    pub(crate) fn try_enqueue(&self, from: u64, to: u64, prepared: PreparedBatch) {
         if let Err(err) = self.sender.try_send(ProverJob {
             from,
             to,
-            batch: batch.clone(),
+            prepared: prepared.clone(),
             enqueued_at: Instant::now(),
         }) {
+            let batch = &prepared.batch;
             error!(
                 target: "zone::sequencer::prover",
                 zone_from = from,
@@ -283,23 +275,24 @@ async fn validate_candidate<P: ZoneSequencerProvider>(
     job: &ProverJob,
     metrics: &ProverMetrics,
 ) -> Result<ValidationStats> {
+    let batch = &job.prepared.batch;
     ensure!(
-        job.batch.zone_height == job.to,
+        batch.zone_height == job.to,
         "candidate zone height {} does not match range end {}",
-        job.batch.zone_height,
+        batch.zone_height,
         job.to
     );
     ensure!(
-        job.from != 1 || job.batch.prev_block_hash.is_zero(),
+        job.from != 1 || batch.prev_block_hash.is_zero(),
         "first Zone batch must use the zero portal prev_block_hash sentinel, found {}",
-        job.batch.prev_block_hash
+        batch.prev_block_hash
     );
 
     let zone_provider = context.zone_provider.clone();
     let from = job.from;
     let to = job.to;
-    let expected_prev_hash = job.batch.prev_block_hash;
-    let expected_next_hash = job.batch.next_block_hash;
+    let expected_prev_hash = batch.prev_block_hash;
+    let expected_next_hash = batch.next_block_hash;
 
     let started = Instant::now();
     let zone_inputs = tokio::task::spawn_blocking(move || {
@@ -325,7 +318,7 @@ async fn validate_candidate<P: ZoneSequencerProvider>(
         .record(started.elapsed().as_secs_f64());
 
     let started = Instant::now();
-    let (initial_tempo_header, final_tempo_header, anchor) = async {
+    let (initial_tempo_header, final_tempo_header) = async {
         let initial_tempo_header =
             tempo_header(&context.l1_provider, zone_inputs.initial_tempo_number)
                 .await
@@ -345,20 +338,18 @@ async fn validate_candidate<P: ZoneSequencerProvider>(
             .transpose()?
             .unwrap_or_else(|| initial_tempo_header.clone());
         ensure!(
-            final_tempo_header.number() == job.batch.tempo_block_number,
+            final_tempo_header.number() == batch.tempo_block_number,
             "candidate Tempo block is {}, but the final advanceTempo header is {}",
-            job.batch.tempo_block_number,
+            batch.tempo_block_number,
             final_tempo_header.number()
         );
 
-        let anchor = resolve_anchor(
-            &context.l1_provider,
+        validate_prepared_anchor(
+            &job.prepared.anchor,
             final_tempo_header.number(),
             final_tempo_header.hash_slow(),
-            context.anchor_config,
-        )
-        .await?;
-        Ok::<_, eyre::Report>((initial_tempo_header, final_tempo_header, anchor))
+        )?;
+        Ok::<_, eyre::Report>((initial_tempo_header, final_tempo_header))
     }
     .await?;
     metrics
@@ -380,15 +371,15 @@ async fn validate_candidate<P: ZoneSequencerProvider>(
             zone_id: context.config.zone_id,
             portal: context.portal,
             tempo_block_number: final_tempo_header.number(),
-            anchor_block_number: anchor.number,
-            anchor_block_hash: anchor.hash,
-            expected_withdrawal_batch_index: job.batch.withdrawal_batch_index,
+            anchor_block_number: job.prepared.anchor.block_number(batch.tempo_block_number),
+            anchor_block_hash: job.prepared.anchor.block_hash(),
+            expected_withdrawal_batch_index: batch.withdrawal_batch_index,
         },
         parent_header: zone_inputs.parent_header,
         zone_blocks: zone_inputs.blocks,
         zone_state_witness,
         tempo_state_witness,
-        tempo_ancestry_headers: anchor.ancestry_headers,
+        tempo_ancestry_headers: job.prepared.anchor.ancestry_headers().to_vec(),
     };
 
     let started = Instant::now();
@@ -407,7 +398,7 @@ async fn validate_candidate<P: ZoneSequencerProvider>(
         .record(started.elapsed().as_secs_f64());
 
     let started = Instant::now();
-    compare_output(&output, &job.batch, witness.parent_header.hash_slow())?;
+    compare_output(&output, batch, witness.parent_header.hash_slow())?;
     metrics
         .output_validation_duration_seconds
         .record(started.elapsed().as_secs_f64());
@@ -446,7 +437,7 @@ async fn verify_remotely(
         version: PROTOCOL_VERSION,
         request_id: format!(
             "zone-{zone_id}-{}-{}-{}",
-            job.from, job.to, job.batch.next_block_hash
+            job.from, job.to, job.prepared.batch.next_block_hash
         ),
         witness: witness.clone(),
     };
@@ -851,48 +842,54 @@ async fn tempo_header(provider: &DynProvider<TempoNetwork>, number: u64) -> Resu
         .ok_or_eyre(format!("Tempo block {number} not found"))
 }
 
-async fn resolve_anchor(
-    provider: &DynProvider<TempoNetwork>,
+fn validate_prepared_anchor(
+    anchor: &BatchAnchor,
     checkpoint_number: u64,
     checkpoint_hash: B256,
-    config: BatchAnchorConfig,
-) -> Result<Anchor> {
-    let tip = provider.get_block_number().await?;
-    ensure!(
-        checkpoint_number <= tip,
-        "Tempo checkpoint {checkpoint_number} is not yet confirmed behind tip {tip}"
-    );
-    let gap = tip - checkpoint_number;
-    if gap < config.effective_window() {
-        return Ok(Anchor {
-            number: checkpoint_number,
-            hash: checkpoint_hash,
-            ancestry_headers: Vec::new(),
-        });
-    }
+) -> Result<()> {
+    let BatchAnchor::Ancestry {
+        block_number,
+        block_hash,
+        ancestry_headers,
+    } = anchor
+    else {
+        ensure!(
+            anchor.block_hash() == checkpoint_hash,
+            "direct Tempo anchor hash {} does not match checkpoint {checkpoint_hash}",
+            anchor.block_hash()
+        );
+        return Ok(());
+    };
 
-    let anchor_number = tip.saturating_sub(config.safety_margin());
     ensure!(
-        anchor_number > checkpoint_number,
-        "Tempo ancestry anchor {anchor_number} does not follow checkpoint {checkpoint_number}"
+        *block_number > checkpoint_number,
+        "Tempo ancestry anchor {block_number} does not follow checkpoint {checkpoint_number}"
+    );
+    ensure!(
+        ancestry_headers.len() == (*block_number - checkpoint_number) as usize,
+        "Tempo ancestry header count does not cover checkpoint {checkpoint_number} through anchor {block_number}"
     );
     let mut expected_parent = checkpoint_hash;
-    let mut ancestry_headers = Vec::with_capacity((anchor_number - checkpoint_number) as usize);
-    for number in checkpoint_number + 1..=anchor_number {
-        let header = tempo_header(provider, number).await?;
+    for (offset, encoded) in ancestry_headers.iter().enumerate() {
+        let number = checkpoint_number + 1 + offset as u64;
+        let header = decode_tempo_header(encoded)?;
+        ensure!(
+            header.number() == number,
+            "Tempo ancestry returned block {} at expected height {number}",
+            header.number()
+        );
         ensure!(
             header.parent_hash() == expected_parent,
             "Tempo ancestry broke at block {number}: expected parent {expected_parent}, found {}",
             header.parent_hash()
         );
         expected_parent = header.hash_slow();
-        ancestry_headers.push(Bytes::from(alloy_rlp::encode(&header)));
     }
-    Ok(Anchor {
-        number: anchor_number,
-        hash: expected_parent,
-        ancestry_headers,
-    })
+    ensure!(
+        expected_parent == *block_hash,
+        "Tempo ancestry ends at {expected_parent}, not prepared anchor hash {block_hash}"
+    );
+    Ok(())
 }
 
 fn compare_output(output: &BatchOutput, batch: &BatchData, expected_prev_hash: B256) -> Result<()> {
@@ -970,4 +967,54 @@ fn witness_size(witness: &BatchWitness) -> usize {
                         .sum::<usize>()
             })
             .sum::<usize>()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use alloy_consensus::Header as ConsensusHeader;
+
+    fn ancestry_header(number: u64, parent_hash: B256) -> (Bytes, B256) {
+        let header = TempoHeader {
+            inner: ConsensusHeader {
+                number,
+                parent_hash,
+                ..Default::default()
+            },
+            ..Default::default()
+        };
+        let hash = header.hash_slow();
+        (Bytes::from(alloy_rlp::encode(&header)), hash)
+    }
+
+    #[test]
+    fn prover_uses_the_prepared_ancestry_without_sampling_a_head() {
+        let checkpoint_number = 162_000;
+        let checkpoint_hash = B256::repeat_byte(0x11);
+        let (first, first_hash) = ancestry_header(checkpoint_number + 1, checkpoint_hash);
+        let (second, anchor_hash) = ancestry_header(checkpoint_number + 2, first_hash);
+        let anchor = BatchAnchor::Ancestry {
+            block_number: checkpoint_number + 2,
+            block_hash: anchor_hash,
+            ancestry_headers: vec![first, second],
+        };
+
+        validate_prepared_anchor(&anchor, checkpoint_number, checkpoint_hash).unwrap();
+    }
+
+    #[test]
+    fn prover_rejects_a_prepared_anchor_with_a_different_terminal_hash() {
+        let checkpoint_number = 162_000;
+        let checkpoint_hash = B256::repeat_byte(0x11);
+        let (header, _) = ancestry_header(checkpoint_number + 1, checkpoint_hash);
+        let anchor = BatchAnchor::Ancestry {
+            block_number: checkpoint_number + 1,
+            block_hash: B256::repeat_byte(0x22),
+            ancestry_headers: vec![header],
+        };
+
+        let error = validate_prepared_anchor(&anchor, checkpoint_number, checkpoint_hash)
+            .expect_err("terminal anchor mismatch must fail proving");
+        assert!(error.to_string().contains("not prepared anchor hash"));
+    }
 }

--- a/crates/sequencer/src/prover.rs
+++ b/crates/sequencer/src/prover.rs
@@ -371,7 +371,7 @@ async fn validate_candidate<P: ZoneSequencerProvider>(
             zone_id: context.config.zone_id,
             portal: context.portal,
             tempo_block_number: final_tempo_header.number(),
-            anchor_block_number: job.prepared.anchor.block_number(batch.tempo_block_number),
+            anchor_block_number: job.prepared.anchor_block_number(),
             anchor_block_hash: job.prepared.anchor.block_hash(),
             expected_withdrawal_batch_index: batch.withdrawal_batch_index,
         },

--- a/crates/sequencer/src/settlement.rs
+++ b/crates/sequencer/src/settlement.rs
@@ -4,7 +4,7 @@
 //! [`ZonePortal`](crate::abi::ZonePortal) contract deployed on L1. The sequencer
 //! signing key is used for every L1 transaction.
 //!
-//! [`BatchData`] is produced by the zone monitor and passed to the submitter.
+//! [`PreparedBatch`] is produced by the zone monitor and passed to the submitter.
 //!
 //! # POC limitations
 //!
@@ -19,7 +19,7 @@
 //! | < configured effective window | Direct | Portal reads hash from EIP-2935. |
 //! | ≥ configured effective window | Ancestry | Use a recent anchor and collect ancestry headers for the batch. |
 //!
-//! [`AnchorMode`] handles submissions whose `tempoBlockNumber` is outside the
+//! [`BatchAnchor`] handles submissions whose `tempoBlockNumber` is outside the
 //! configured direct window by falling back to ancestry mode — a recent anchor
 //! block plus a locally validated parent-hash header chain.
 
@@ -63,6 +63,7 @@ use crate::nonce_keys::SUBMIT_BATCH_NONCE_KEY;
 pub enum BatchSubmitError {
     Cancelled,
     PortalAdvanced,
+    PreparedAnchorInvalid(eyre::Report),
     Other(eyre::Report),
 }
 
@@ -79,6 +80,7 @@ impl fmt::Display for BatchSubmitError {
             Self::PortalAdvanced => {
                 formatter.write_str("portal advanced while waiting for settlement quorum")
             }
+            Self::PreparedAnchorInvalid(error) => error.fmt(formatter),
             Self::Other(error) => error.fmt(formatter),
         }
     }
@@ -314,9 +316,15 @@ impl BatchSubmitter {
         self.attestation_store = store;
     }
 
+    /// Resolve the single immutable anchor shared by proving, quorum, and submission.
+    pub async fn prepare_batch(&self, batch: BatchData) -> Result<PreparedBatch> {
+        let anchor = self.resolve_batch_anchor(batch.tempo_block_number).await?;
+        Ok(PreparedBatch { batch, anchor })
+    }
+
     /// Submit a batch to the ZonePortal on Tempo L1.
     ///
-    /// Resolves the anchor mode based on how old `tempo_block_number` is:
+    /// Uses the anchor already selected by the zone monitor:
     ///
     /// - **Direct** — `tempo_block_number` is within the configured effective window,
     ///   the portal reads its hash directly from EIP-2935.
@@ -332,18 +340,20 @@ impl BatchSubmitter {
     // TODO: pass real proof bytes once proof generation is implemented.
     #[instrument(skip_all, fields(
         portal = %self.portal_address,
-        tempo_block = batch.tempo_block_number,
-        prev_block_hash = %batch.prev_block_hash,
-        next_block_hash = %batch.next_block_hash,
-        withdrawal_queue_hash = %batch.withdrawal_queue_hash,
-        withdrawal_batch_index = batch.withdrawal_batch_index,
+        tempo_block = prepared.batch.tempo_block_number,
+        anchor_block = prepared.anchor.block_number(prepared.batch.tempo_block_number),
+        prev_block_hash = %prepared.batch.prev_block_hash,
+        next_block_hash = %prepared.batch.next_block_hash,
+        withdrawal_queue_hash = %prepared.batch.withdrawal_queue_hash,
+        withdrawal_batch_index = prepared.batch.withdrawal_batch_index,
     ))]
     pub async fn submit_batch(
         &self,
-        batch: &BatchData,
+        prepared: &PreparedBatch,
         shutdown: &sync::CancellationToken,
     ) -> std::result::Result<BatchSubmitted, BatchSubmitError> {
         let settlement_abi = SettlementAbi::from_l1(&self.l1_provider).await?;
+        let batch = &prepared.batch;
         let block_transition = BlockTransition {
             prevBlockHash: batch.prev_block_hash,
             nextBlockHash: batch.next_block_hash,
@@ -366,68 +376,52 @@ impl BatchSubmitter {
             .read_submission_metadata(signer.map_or(Address::ZERO, PrivateKeySigner::address))
             .await?;
         self.validate_submission_metadata(batch, metadata)?;
-        let (certificate, anchor_mode, current_l1_block) =
-            if let Some(store) = &self.attestation_store {
-                let threshold = metadata.sequencer_threshold as usize;
-                info!(
-                    zone_height = batch.zone_height,
-                    threshold, "Waiting for settlement quorum"
-                );
-                let certificate = self
-                    .wait_for_settlement_or_portal_progress(
-                        store,
-                        batch.zone_height,
-                        threshold,
-                        batch.prev_block_hash,
-                        shutdown,
-                    )
-                    .await?;
-                let anchor_mode = match self
-                    .validate_certificate(
-                        batch,
-                        settlement_abi,
-                        batch.zone_height,
-                        metadata,
-                        &certificate,
-                    )
-                    .await
-                {
-                    Ok(anchor_mode) => anchor_mode,
-                    Err(err) => {
-                        store.remove_settlement(batch.zone_height, certificate.digest);
-                        return Err(err.into());
-                    }
-                };
-                let current_l1_block = self
-                    .l1_provider
-                    .get_block_number()
-                    .await
-                    .map_err(|error| BatchSubmitError::Other(error.into()))?;
-                (Some(certificate), anchor_mode, current_l1_block)
-            } else {
-                let (anchor_mode, current_l1_block) =
-                    self.resolve_anchor_mode(batch.tempo_block_number).await?;
-                (None, anchor_mode, current_l1_block)
-            };
-        let recent_tempo_block_number = anchor_mode.recent_block_number();
+        let (certificate, current_l1_block) = if let Some(store) = &self.attestation_store {
+            let threshold = metadata.sequencer_threshold as usize;
+            info!(
+                zone_height = batch.zone_height,
+                threshold, "Waiting for settlement quorum"
+            );
+            let certificate = self
+                .wait_for_settlement_or_portal_progress(
+                    store,
+                    batch.zone_height,
+                    threshold,
+                    batch.prev_block_hash,
+                    prepared,
+                    shutdown,
+                )
+                .await?;
+            match self.validate_certificate(
+                prepared,
+                settlement_abi,
+                batch.zone_height,
+                metadata,
+                &certificate,
+            ) {
+                Ok(()) => {}
+                Err(err) => {
+                    store.remove_settlement(batch.zone_height, certificate.digest);
+                    return Err(err.into());
+                }
+            }
+            let current_l1_block = self.validate_prepared_anchor(prepared).await?;
+            (Some(certificate), current_l1_block)
+        } else {
+            let current_l1_block = self.validate_prepared_anchor(prepared).await?;
+            (None, current_l1_block)
+        };
+        let recent_tempo_block_number = prepared.anchor.recent_block_number();
         // EIP-2935 exposes hash(N) starting in N+1. A transaction built after observing head N
         // cannot land before N+1, so anchoring to the current tip is valid at execution time.
-        let anchors_to_current_tip =
-            anchor_mode.anchor_block_number(batch.tempo_block_number) == current_l1_block;
+        let anchor_block_number = prepared.anchor.block_number(batch.tempo_block_number);
+        let anchor_block_hash = prepared.anchor.block_hash();
+        let anchors_to_current_tip = anchor_block_number == current_l1_block;
 
         let signatures = if let Some(certificate) = &certificate {
             certificate.signatures.clone()
         } else {
             // Legacy mode, where the 1-of-1 sequencer will self-sign the attestation
-            let anchor_block_number = anchor_mode.anchor_block_number(batch.tempo_block_number);
-            let anchor_block_hash = self
-                .l1_provider
-                .get_block_by_number(anchor_block_number.into())
-                .await
-                .map_err(|error| BatchSubmitError::Other(error.into()))?
-                .ok_or_eyre(format!("L1 anchor block {anchor_block_number} not found"))?
-                .header
-                .hash;
             let signer = signer
                 .ok_or_eyre("TIP-1091 batch submission requires the local sequencer signer")?;
             if !metadata.signer_is_sequencer {
@@ -465,7 +459,9 @@ impl BatchSubmitter {
             .map_err(|error| BatchSubmitError::Other(error.into()))?;
 
         info!(
-            anchor_mode = %anchor_mode,
+            anchor_mode = prepared.anchor.mode_name(),
+            anchor_block_number,
+            anchor_block_hash = %anchor_block_hash,
             recent_tempo_block_number,
             current_l1_block,
             anchors_to_current_tip,
@@ -559,6 +555,7 @@ impl BatchSubmitter {
         height: u64,
         threshold: usize,
         expected_portal_hash: B256,
+        prepared: &PreparedBatch,
         shutdown: &sync::CancellationToken,
     ) -> std::result::Result<SettlementCertificate, BatchSubmitError> {
         loop {
@@ -583,6 +580,7 @@ impl BatchSubmitter {
             if portal_hash != expected_portal_hash {
                 return Err(BatchSubmitError::PortalAdvanced);
             }
+            self.validate_prepared_anchor(prepared).await?;
         }
     }
 
@@ -762,14 +760,15 @@ impl BatchSubmitter {
 
     /// Validate that a collected certificate commits to the exact calldata this submitter will
     /// send, and derive the anchor mode from the signed statement instead of recomputing it.
-    async fn validate_certificate(
+    fn validate_certificate(
         &self,
-        batch: &BatchData,
+        prepared: &PreparedBatch,
         settlement_abi: SettlementAbi,
         zone_height: u64,
         metadata: PortalSubmissionMetadata,
         certificate: &SettlementCertificate,
-    ) -> Result<AnchorMode> {
+    ) -> Result<()> {
+        let batch = &prepared.batch;
         if certificate.height != zone_height {
             return Err(eyre::eyre!(
                 "settlement certificate height {} does not match batch height {zone_height}",
@@ -841,42 +840,16 @@ impl BatchSubmitter {
             attestation.verifierConfigHash == alloy_primitives::keccak256(Bytes::new()),
             "certificate verifier config changed"
         );
-
-        let current_l1_block = self.l1_provider.get_block_number().await?;
-        validate_certificate_anchor(
-            attestation.anchorBlockNumber,
-            current_l1_block,
-            self.anchor_config.history_window(),
-        )?;
-
-        let anchor = self
-            .l1_provider
-            .get_block_by_number(attestation.anchorBlockNumber.into())
-            .await?
-            .ok_or_eyre(format!(
-                "missing certified L1 anchor block {}",
-                attestation.anchorBlockNumber
-            ))?;
         eyre::ensure!(
-            anchor.header.hash == attestation.anchorBlockHash,
+            attestation.anchorBlockNumber == prepared.anchor.block_number(batch.tempo_block_number),
+            "certificate anchor block changed"
+        );
+        eyre::ensure!(
+            attestation.anchorBlockHash == prepared.anchor.block_hash(),
             "certificate anchor hash changed"
         );
 
-        if attestation.anchorBlockNumber == batch.tempo_block_number {
-            Ok(AnchorMode::Direct)
-        } else {
-            eyre::ensure!(
-                attestation.anchorBlockNumber > batch.tempo_block_number,
-                "certificate ancestry anchor does not follow its Tempo block"
-            );
-            let ancestry_headers = self
-                .fetch_ancestry_headers(batch.tempo_block_number, attestation.anchorBlockNumber)
-                .await?;
-            Ok(AnchorMode::Ancestry {
-                anchor_block: attestation.anchorBlockNumber,
-                ancestry_headers,
-            })
-        }
+        Ok(())
     }
 
     /// Resolve the anchor mode for the given `tempo_block_number`.
@@ -886,7 +859,7 @@ impl BatchSubmitter {
     /// - **Ancestry** (gap ≥ configured effective window): a recent L1 block
     ///   behind the configured safety margin is used as anchor. Ancestry headers
     ///   are collected and validated for future prover integration.
-    async fn resolve_anchor_mode(&self, tempo_block_number: u64) -> Result<(AnchorMode, u64)> {
+    async fn resolve_batch_anchor(&self, tempo_block_number: u64) -> Result<BatchAnchor> {
         let current_l1_block = self.l1_provider.get_block_number().await?;
 
         if tempo_block_number > current_l1_block {
@@ -906,7 +879,14 @@ impl BatchSubmitter {
                 *self.ancestry_header_cache.write() =
                     LruMap::new(ByLength::new(DEFAULT_ANCESTRY_HEADER_CACHE_CAPACITY));
             }
-            return Ok((AnchorMode::Direct, current_l1_block));
+            let block_hash = self
+                .l1_provider
+                .get_header_by_number(tempo_block_number.into())
+                .await?
+                .ok_or_eyre(format!("L1 anchor block {tempo_block_number} not found"))?
+                .inner
+                .hash;
+            return Ok(BatchAnchor::Direct { block_hash });
         }
 
         let anchor_block = current_l1_block.saturating_sub(self.anchor_config.safety_margin());
@@ -924,13 +904,67 @@ impl BatchSubmitter {
             "tempo_block_number outside EIP-2935 effective window, using ancestry mode"
         );
 
-        Ok((
-            AnchorMode::Ancestry {
-                anchor_block,
-                ancestry_headers,
-            },
-            current_l1_block,
-        ))
+        let block_hash = self
+            .l1_provider
+            .get_header_by_number(anchor_block.into())
+            .await?
+            .ok_or_eyre(format!("L1 anchor block {anchor_block} not found"))?
+            .inner
+            .hash;
+        Ok(BatchAnchor::Ancestry {
+            block_number: anchor_block,
+            block_hash,
+            ancestry_headers,
+        })
+    }
+
+    async fn validate_prepared_anchor(
+        &self,
+        prepared: &PreparedBatch,
+    ) -> std::result::Result<u64, BatchSubmitError> {
+        let anchor = &prepared.anchor;
+        let anchor_block_number = anchor.block_number(prepared.batch.tempo_block_number);
+        if anchor_block_number < prepared.batch.tempo_block_number {
+            return Err(BatchSubmitError::PreparedAnchorInvalid(eyre::eyre!(
+                "prepared L1 anchor predates the batch Tempo block"
+            )));
+        }
+
+        let current_l1_block = self
+            .l1_provider
+            .get_block_number()
+            .await
+            .map_err(|error| BatchSubmitError::Other(error.into()))?;
+        if anchor_block_number > current_l1_block {
+            return Err(BatchSubmitError::Other(eyre::eyre!(
+                "prepared L1 anchor block is ahead of the current L1 tip"
+            )));
+        }
+        if current_l1_block.saturating_sub(anchor_block_number)
+            >= self.anchor_config.history_window()
+        {
+            return Err(BatchSubmitError::PreparedAnchorInvalid(eyre::eyre!(
+                "prepared L1 anchor block fell outside the EIP-2935 history window"
+            )));
+        }
+
+        let canonical = self
+            .l1_provider
+            .get_header_by_number(anchor_block_number.into())
+            .await
+            .map_err(|error| BatchSubmitError::Other(error.into()))?
+            .ok_or_else(|| {
+                BatchSubmitError::Other(eyre::eyre!(
+                    "prepared L1 anchor block {} not found",
+                    anchor_block_number
+                ))
+            })?;
+        if canonical.inner.hash != anchor.block_hash() {
+            return Err(BatchSubmitError::PreparedAnchorInvalid(eyre::eyre!(
+                "prepared L1 anchor hash is no longer canonical"
+            )));
+        }
+        Ok(current_l1_block)
     }
 
     /// Fetch and RLP-encode L1 block headers from `from + 1` to `to` (inclusive),
@@ -1275,7 +1309,7 @@ impl SettlementAbi {
 
 /// Data required to submit a single batch to the ZonePortal on L1.
 ///
-/// Produced by the zone block builder and sent to [`BatchSubmitter`] via channel.
+/// Produced by the zone monitor and combined with one [`BatchAnchor`] in [`PreparedBatch`].
 #[derive(Debug, Clone)]
 pub struct BatchData {
     /// Zone L2 height committed by this batch.
@@ -1302,6 +1336,74 @@ pub struct BatchData {
     pub withdrawal_queue_hash: B256,
     /// L2 withdrawal batch index validated against the portal before submission.
     pub withdrawal_batch_index: u64,
+}
+
+/// Immutable Tempo anchor selected for one settlement attempt.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum BatchAnchor {
+    /// The batch's Tempo block remains directly available through EIP-2935.
+    Direct {
+        /// Canonical hash of `BatchData::tempo_block_number` at preparation time.
+        block_hash: B256,
+    },
+    /// A recent L1 block anchors a parent-linked header chain from the batch's Tempo block.
+    Ancestry {
+        /// Recent L1 block number whose hash the portal passes to the verifier.
+        block_number: u64,
+        /// Canonical hash of `block_number` at preparation time.
+        block_hash: B256,
+        /// Headers from `BatchData::tempo_block_number + 1` through `block_number`.
+        ancestry_headers: Vec<Bytes>,
+    },
+}
+
+impl BatchAnchor {
+    /// Returns the L1 block whose hash the portal passes to the verifier.
+    pub const fn block_number(&self, tempo_block_number: u64) -> u64 {
+        match self {
+            Self::Direct { .. } => tempo_block_number,
+            Self::Ancestry { block_number, .. } => *block_number,
+        }
+    }
+
+    /// Returns the canonical hash of the selected anchor block.
+    pub const fn block_hash(&self) -> B256 {
+        match self {
+            Self::Direct { block_hash } | Self::Ancestry { block_hash, .. } => *block_hash,
+        }
+    }
+
+    /// Returns the prepared ancestry headers, empty in direct mode.
+    pub fn ancestry_headers(&self) -> &[Bytes] {
+        match self {
+            Self::Direct { .. } => &[],
+            Self::Ancestry {
+                ancestry_headers, ..
+            } => ancestry_headers,
+        }
+    }
+
+    /// Returns the `recentTempoBlockNumber` argument for `submitBatch`.
+    pub const fn recent_block_number(&self) -> u64 {
+        match self {
+            Self::Direct { .. } => 0,
+            Self::Ancestry { block_number, .. } => *block_number,
+        }
+    }
+
+    const fn mode_name(&self) -> &'static str {
+        match self {
+            Self::Direct { .. } => "direct",
+            Self::Ancestry { .. } => "ancestry",
+        }
+    }
+}
+
+/// Batch commitments and their single authoritative Tempo anchor.
+#[derive(Debug, Clone)]
+pub struct PreparedBatch {
+    pub batch: BatchData,
+    pub anchor: BatchAnchor,
 }
 
 /// One L2 withdrawal batch finalized by `ZoneOutbox`.
@@ -1388,73 +1490,6 @@ struct CachedAncestryHeader {
 struct ResolvedAncestry {
     headers: Vec<Bytes>,
     fetched_headers: Vec<(u64, CachedAncestryHeader)>,
-}
-
-/// How the batch submitter anchors `tempoBlockNumber` for EIP-2935 verification.
-///
-/// Resolved by [`BatchSubmitter::resolve_anchor_mode`] inside `submit_batch`.
-/// `submit_batch` can use ancestry mode when the batch-final block's
-/// `tempoBlockNumber` has fallen outside the configured direct-submission
-/// window.
-#[allow(dead_code)] // Ancestry::ancestry_headers is collected but not yet consumed — available for prover integration
-enum AnchorMode {
-    /// `tempoBlockNumber` is within the effective EIP-2935 window — the portal
-    /// reads its hash directly. No extra proof data required.
-    Direct,
-    /// `tempoBlockNumber` is outside the effective window. A recent L1 block is
-    /// used as anchor, and the collected headers prove the parent-hash chain.
-    Ancestry {
-        /// Recent L1 block number within the EIP-2935 window, used as the
-        /// on-chain anchor for hash verification.
-        anchor_block: u64,
-        /// RLP-encoded L1 block headers from `tempo_block_number + 1` to
-        /// `anchor_block`, in ascending order. Available for the prover to
-        /// consume when integrated.
-        ancestry_headers: Vec<Bytes>,
-    },
-}
-
-impl AnchorMode {
-    /// Returns the `recentTempoBlockNumber` argument for `submitBatch`:
-    /// `0` for direct mode, or the anchor block number for ancestry mode.
-    const fn recent_block_number(&self) -> u64 {
-        match self {
-            Self::Direct => 0,
-            Self::Ancestry { anchor_block, .. } => *anchor_block,
-        }
-    }
-
-    const fn anchor_block_number(&self, tempo_block_number: u64) -> u64 {
-        match self {
-            Self::Direct => tempo_block_number,
-            Self::Ancestry { anchor_block, .. } => *anchor_block,
-        }
-    }
-}
-
-fn validate_certificate_anchor(
-    anchor_block_number: u64,
-    current_l1_block: u64,
-    history_window: u64,
-) -> Result<()> {
-    eyre::ensure!(
-        anchor_block_number <= current_l1_block,
-        "certificate anchor block is ahead of the current L1 tip"
-    );
-    eyre::ensure!(
-        current_l1_block.saturating_sub(anchor_block_number) < history_window,
-        "certificate anchor block fell outside the EIP-2935 history window"
-    );
-    Ok(())
-}
-
-impl fmt::Display for AnchorMode {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        match self {
-            Self::Direct => f.write_str("direct"),
-            Self::Ancestry { .. } => f.write_str("ancestry"),
-        }
-    }
 }
 
 /// Merge cached and fetched headers into one validated ancestry range.
@@ -1950,6 +1985,28 @@ mod tests {
         assert_ne!(SettlementAbi::T12.token_transition_hash(0, 0), B256::ZERO);
     }
 
+    fn test_prepared_batch(zone_height: u64, tempo_block_number: u64) -> PreparedBatch {
+        PreparedBatch {
+            batch: BatchData {
+                zone_height,
+                tempo_block_number,
+                prev_block_hash: B256::repeat_byte(0x24),
+                next_block_hash: B256::repeat_byte(0x25),
+                prev_processed_deposit_hash: B256::ZERO,
+                next_processed_deposit_hash: B256::ZERO,
+                prev_deposit_number: 0,
+                next_deposit_number: 0,
+                prev_processed_token_count: 0,
+                next_processed_token_count: 0,
+                withdrawal_queue_hash: B256::ZERO,
+                withdrawal_batch_index: 1,
+            },
+            anchor: BatchAnchor::Direct {
+                block_hash: B256::repeat_byte(0x26),
+            },
+        }
+    }
+
     #[tokio::test]
     async fn resolves_portal_hash_to_local_zone_height() {
         let portal_hash = B256::repeat_byte(0x42);
@@ -2009,6 +2066,7 @@ mod tests {
                 120,
                 2,
                 B256::repeat_byte(0x24),
+                &test_prepared_batch(120, 100),
                 &sync::CancellationToken::new(),
             )
             .await
@@ -2354,11 +2412,14 @@ mod tests {
             .erased();
         let submitter = BatchSubmitter::new(Address::ZERO, provider);
 
+        let (header, hash) = mock_l1_header(100, B256::ZERO);
         asserter.push_success(&100_u64);
-        let (mode, current_l1_block) = submitter.resolve_anchor_mode(100).await.unwrap();
+        asserter.push_success(&header);
+        let anchor = submitter.resolve_batch_anchor(100).await.unwrap();
 
-        assert!(matches!(mode, AnchorMode::Direct));
-        assert_eq!(current_l1_block, 100);
+        assert_eq!(anchor.block_number(100), 100);
+        assert_eq!(anchor.block_hash(), hash);
+        assert!(anchor.ancestry_headers().is_empty());
         assert!(asserter.read_q().is_empty());
     }
 
@@ -2371,7 +2432,7 @@ mod tests {
         let submitter = BatchSubmitter::new(Address::ZERO, provider);
 
         asserter.push_success(&100_u64);
-        let err = match submitter.resolve_anchor_mode(101).await {
+        let err = match submitter.resolve_batch_anchor(101).await {
             Ok(_) => panic!("future L1 anchor was accepted"),
             Err(err) => err,
         };
@@ -2382,14 +2443,113 @@ mod tests {
         assert!(asserter.read_q().is_empty());
     }
 
-    #[test]
-    fn certificate_anchor_validation_accepts_tip_and_rejects_future() {
-        validate_certificate_anchor(100, 100, 10).unwrap();
+    #[tokio::test]
+    async fn prepared_anchor_survives_forward_head_drift() {
+        let asserter = Asserter::new();
+        let provider = mock_l1(asserter.clone());
+        let submitter = BatchSubmitter::new(Address::ZERO, provider);
+        let (header, hash) = mock_l1_header(162_196, B256::ZERO);
+        let mut prepared = test_prepared_batch(120, 160_000);
+        prepared.anchor = BatchAnchor::Ancestry {
+            block_number: 162_196,
+            block_hash: hash,
+            ancestry_headers: vec![Bytes::from_static(&[1])],
+        };
 
-        let err = validate_certificate_anchor(101, 100, 10).unwrap_err();
+        asserter.push_success(&162_208_u64);
+        asserter.push_success(&header);
+        let observed_head = submitter.validate_prepared_anchor(&prepared).await.unwrap();
+
+        assert_eq!(observed_head, 162_208);
+        assert_eq!(prepared.anchor.block_number(160_000), 162_196);
+        assert!(asserter.read_q().is_empty());
+    }
+
+    #[tokio::test]
+    async fn prepared_anchor_hard_expiry_requires_a_new_attempt() {
+        let asserter = Asserter::new();
+        let provider = mock_l1(asserter.clone());
+        let submitter = BatchSubmitter::with_anchor_config(
+            Address::ZERO,
+            provider,
+            BatchAnchorConfig::new(10, 4).unwrap(),
+        );
+        let mut prepared = test_prepared_batch(120, 90);
+        prepared.anchor = BatchAnchor::Ancestry {
+            block_number: 100,
+            block_hash: B256::repeat_byte(0x26),
+            ancestry_headers: vec![Bytes::from_static(&[1])],
+        };
+
+        asserter.push_success(&110_u64);
+        let error = submitter
+            .validate_prepared_anchor(&prepared)
+            .await
+            .unwrap_err();
+
+        assert!(matches!(error, BatchSubmitError::PreparedAnchorInvalid(_)));
         assert!(
-            err.to_string()
-                .contains("certificate anchor block is ahead of the current L1 tip")
+            error
+                .to_string()
+                .contains("outside the EIP-2935 history window")
+        );
+        assert!(asserter.read_q().is_empty());
+    }
+
+    #[test]
+    fn certificate_must_commit_the_prepared_anchor_exactly() {
+        let submitter = BatchSubmitter::new(Address::ZERO, mock_l1(Asserter::new()));
+        let prepared = test_prepared_batch(120, 100);
+        let batch = &prepared.batch;
+        let metadata = PortalSubmissionMetadata {
+            withdrawal_batch_index: 0,
+            stable: StablePortalMetadata {
+                zone_id: 7,
+                chain_id: 1,
+            },
+            sequencer_set_version: 3,
+            sequencer_threshold: 1,
+            signer_is_sequencer: true,
+            verifier: Address::repeat_byte(2),
+        };
+        let attestation = SettlementAttestation {
+            zoneId: 7,
+            sequencerSetVersion: 3,
+            zoneHeight: U256::from(batch.zone_height),
+            withdrawalBatchIndex: U256::from(batch.withdrawal_batch_index),
+            verifier: metadata.verifier,
+            tempoBlockNumber: batch.tempo_block_number,
+            anchorBlockNumber: prepared.anchor.block_number(batch.tempo_block_number) + 12,
+            anchorBlockHash: B256::repeat_byte(0x99),
+            blockTransitionHash: keccak256(
+                (batch.prev_block_hash, batch.next_block_hash).abi_encode(),
+            ),
+            depositQueueTransitionHash: keccak256(
+                (
+                    batch.prev_processed_deposit_hash,
+                    batch.next_processed_deposit_hash,
+                    batch.prev_deposit_number,
+                    batch.next_deposit_number,
+                )
+                    .abi_encode(),
+            ),
+            withdrawalQueueHash: batch.withdrawal_queue_hash,
+            verifierConfigHash: keccak256(Bytes::new()),
+        };
+        let certificate = SettlementCertificate {
+            height: batch.zone_height,
+            digest: B256::ZERO,
+            attestation,
+            signatures: Vec::new(),
+        };
+
+        let error = submitter
+            .validate_certificate(&prepared, batch.zone_height, metadata, &certificate)
+            .unwrap_err();
+        assert!(
+            error
+                .to_string()
+                .contains("certificate anchor block changed")
         );
     }
 
@@ -2505,10 +2665,12 @@ mod tests {
                 .insert(98, cached_header)
         );
 
+        let (header, hash) = mock_l1_header(99, B256::ZERO);
         asserter.push_success(&100_u64);
-        let (mode, _) = submitter.resolve_anchor_mode(99).await.unwrap();
+        asserter.push_success(&header);
+        let anchor = submitter.resolve_batch_anchor(99).await.unwrap();
 
-        assert!(matches!(mode, AnchorMode::Direct));
+        assert_eq!(anchor.block_hash(), hash);
         assert!(submitter.ancestry_header_cache.read().is_empty());
         assert!(asserter.read_q().is_empty());
     }

--- a/crates/sequencer/src/settlement.rs
+++ b/crates/sequencer/src/settlement.rs
@@ -376,7 +376,7 @@ impl BatchSubmitter {
             .read_submission_metadata(signer.map_or(Address::ZERO, PrivateKeySigner::address))
             .await?;
         self.validate_submission_metadata(batch, metadata)?;
-        let (certificate, current_l1_block) = if let Some(store) = &self.attestation_store {
+        let certificate = if let Some(store) = &self.attestation_store {
             let threshold = metadata.sequencer_threshold as usize;
             info!(
                 zone_height = batch.zone_height,
@@ -405,12 +405,11 @@ impl BatchSubmitter {
                     return Err(err.into());
                 }
             }
-            let current_l1_block = self.validate_prepared_anchor(prepared).await?;
-            (Some(certificate), current_l1_block)
+            Some(certificate)
         } else {
-            let current_l1_block = self.validate_prepared_anchor(prepared).await?;
-            (None, current_l1_block)
+            None
         };
+        let current_l1_block = self.validate_prepared_anchor(prepared).await?;
         let recent_tempo_block_number = prepared.anchor.recent_block_number();
         // EIP-2935 exposes hash(N) starting in N+1. A transaction built after observing head N
         // cannot land before N+1, so anchoring to the current tip is valid at execution time.

--- a/crates/sequencer/src/settlement.rs
+++ b/crates/sequencer/src/settlement.rs
@@ -2539,6 +2539,7 @@ mod tests {
                 )
                     .abi_encode(),
             ),
+            tokenEnablementTransitionHash: B256::ZERO,
             withdrawalQueueHash: batch.withdrawal_queue_hash,
             verifierConfigHash: keccak256(Bytes::new()),
         };
@@ -2550,7 +2551,13 @@ mod tests {
         };
 
         let error = submitter
-            .validate_certificate(&prepared, batch.zone_height, metadata, &certificate)
+            .validate_certificate(
+                &prepared,
+                SettlementAbi::Legacy,
+                batch.zone_height,
+                metadata,
+                &certificate,
+            )
             .unwrap_err();
         assert!(
             error

--- a/crates/sequencer/src/settlement.rs
+++ b/crates/sequencer/src/settlement.rs
@@ -341,7 +341,7 @@ impl BatchSubmitter {
     #[instrument(skip_all, fields(
         portal = %self.portal_address,
         tempo_block = prepared.batch.tempo_block_number,
-        anchor_block = prepared.anchor.block_number(prepared.batch.tempo_block_number),
+        anchor_block = prepared.anchor_block_number(),
         prev_block_hash = %prepared.batch.prev_block_hash,
         next_block_hash = %prepared.batch.next_block_hash,
         withdrawal_queue_hash = %prepared.batch.withdrawal_queue_hash,
@@ -413,7 +413,7 @@ impl BatchSubmitter {
         let recent_tempo_block_number = prepared.anchor.recent_block_number();
         // EIP-2935 exposes hash(N) starting in N+1. A transaction built after observing head N
         // cannot land before N+1, so anchoring to the current tip is valid at execution time.
-        let anchor_block_number = prepared.anchor.block_number(batch.tempo_block_number);
+        let anchor_block_number = prepared.anchor_block_number();
         let anchor_block_hash = prepared.anchor.block_hash();
         let anchors_to_current_tip = anchor_block_number == current_l1_block;
 
@@ -840,7 +840,7 @@ impl BatchSubmitter {
             "certificate verifier config changed"
         );
         eyre::ensure!(
-            attestation.anchorBlockNumber == prepared.anchor.block_number(batch.tempo_block_number),
+            attestation.anchorBlockNumber == prepared.anchor_block_number(),
             "certificate anchor block changed"
         );
         eyre::ensure!(
@@ -922,7 +922,7 @@ impl BatchSubmitter {
         prepared: &PreparedBatch,
     ) -> std::result::Result<u64, BatchSubmitError> {
         let anchor = &prepared.anchor;
-        let anchor_block_number = anchor.block_number(prepared.batch.tempo_block_number);
+        let anchor_block_number = prepared.anchor_block_number();
         if anchor_block_number < prepared.batch.tempo_block_number {
             return Err(BatchSubmitError::PreparedAnchorInvalid(eyre::eyre!(
                 "prepared L1 anchor predates the batch Tempo block"
@@ -1403,6 +1403,13 @@ impl BatchAnchor {
 pub struct PreparedBatch {
     pub batch: BatchData,
     pub anchor: BatchAnchor,
+}
+
+impl PreparedBatch {
+    /// Returns the L1 block whose hash the portal passes to the verifier.
+    pub const fn anchor_block_number(&self) -> u64 {
+        self.anchor.block_number(self.batch.tempo_block_number)
+    }
 }
 
 /// One L2 withdrawal batch finalized by `ZoneOutbox`.
@@ -2460,7 +2467,7 @@ mod tests {
         let observed_head = submitter.validate_prepared_anchor(&prepared).await.unwrap();
 
         assert_eq!(observed_head, 162_208);
-        assert_eq!(prepared.anchor.block_number(160_000), 162_196);
+        assert_eq!(prepared.anchor_block_number(), 162_196);
         assert!(asserter.read_q().is_empty());
     }
 
@@ -2518,7 +2525,7 @@ mod tests {
             withdrawalBatchIndex: U256::from(batch.withdrawal_batch_index),
             verifier: metadata.verifier,
             tempoBlockNumber: batch.tempo_block_number,
-            anchorBlockNumber: prepared.anchor.block_number(batch.tempo_block_number) + 12,
+            anchorBlockNumber: prepared.anchor_block_number() + 12,
             anchorBlockHash: B256::repeat_byte(0x99),
             blockTransitionHash: keccak256(
                 (batch.prev_block_hash, batch.next_block_hash).abi_encode(),


### PR DESCRIPTION
## Summary

Resolve each batch anchor once in the monitor and share it across quorum, prover, and submission paths. Reuse prepared anchors across retries and rebuild attempts when anchors expire or become non-canonical.

Moving the anchor is necessary for prover and attestation builder to use the same anchor resolved by the monitor instead of resolving one independently.