### PR TITLE
test(node): Add 503, asymmetric L1 outage and silent broadcast stalls to chaos tests

### DIFF
--- a/crates/node/tests/it/network_chaos_e2e.rs
+++ b/crates/node/tests/it/network_chaos_e2e.rs
@@ -26,6 +26,212 @@ const INITIAL_DEPOSIT: u128 = 10_000_000;
 const OUTAGE_DEPOSIT: u128 = 1_000_000;
 const OUTAGE_WITHDRAWAL: u128 = 250_000;
 
+// This seeded 95% schedule starts with 64 rejected attempts. That gives the short E2E outage a
+// deterministic failure window while retaining probability-based behavior in the proxy itself.
+const WEBSOCKET_503_SEED: u64 = 385;
+const WEBSOCKET_503_PROBABILITY_PERCENT: u8 = 95;
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+enum AffectedNodes {
+    Leader,
+    BothFollowers,
+    OneFollower,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+enum L1Fault {
+    Disconnect,
+    RandomWebSocket503,
+    SilentBidirectionalStall,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+enum ProgressExpectation {
+    Stalls,
+    Continues,
+}
+
+#[derive(Clone, Copy, Debug)]
+struct L1OutageCase {
+    phase: &'static str,
+    affected_nodes: AffectedNodes,
+    fault: L1Fault,
+    production: ProgressExpectation,
+    settlement: ProgressExpectation,
+}
+
+const L1_OUTAGE_CASES: &[L1OutageCase] = &[
+    L1OutageCase {
+        phase: "both followers disconnected",
+        affected_nodes: AffectedNodes::BothFollowers,
+        fault: L1Fault::Disconnect,
+        production: ProgressExpectation::Continues,
+        settlement: ProgressExpectation::Stalls,
+    },
+    L1OutageCase {
+        phase: "leader disconnected",
+        affected_nodes: AffectedNodes::Leader,
+        fault: L1Fault::Disconnect,
+        production: ProgressExpectation::Stalls,
+        settlement: ProgressExpectation::Stalls,
+    },
+    L1OutageCase {
+        phase: "one follower disconnected",
+        affected_nodes: AffectedNodes::OneFollower,
+        fault: L1Fault::Disconnect,
+        production: ProgressExpectation::Continues,
+        settlement: ProgressExpectation::Continues,
+    },
+    L1OutageCase {
+        phase: "both followers receiving WebSocket 503s",
+        affected_nodes: AffectedNodes::BothFollowers,
+        fault: L1Fault::RandomWebSocket503,
+        production: ProgressExpectation::Continues,
+        settlement: ProgressExpectation::Stalls,
+    },
+    L1OutageCase {
+        phase: "leader receiving WebSocket 503s",
+        affected_nodes: AffectedNodes::Leader,
+        fault: L1Fault::RandomWebSocket503,
+        production: ProgressExpectation::Stalls,
+        settlement: ProgressExpectation::Stalls,
+    },
+    L1OutageCase {
+        phase: "one follower receiving WebSocket 503s",
+        affected_nodes: AffectedNodes::OneFollower,
+        fault: L1Fault::RandomWebSocket503,
+        production: ProgressExpectation::Continues,
+        settlement: ProgressExpectation::Continues,
+    },
+    L1OutageCase {
+        phase: "both followers silently stalled",
+        affected_nodes: AffectedNodes::BothFollowers,
+        fault: L1Fault::SilentBidirectionalStall,
+        production: ProgressExpectation::Continues,
+        settlement: ProgressExpectation::Stalls,
+    },
+    L1OutageCase {
+        phase: "leader silently stalled",
+        affected_nodes: AffectedNodes::Leader,
+        fault: L1Fault::SilentBidirectionalStall,
+        production: ProgressExpectation::Stalls,
+        settlement: ProgressExpectation::Stalls,
+    },
+    L1OutageCase {
+        phase: "one follower silently stalled",
+        affected_nodes: AffectedNodes::OneFollower,
+        fault: L1Fault::SilentBidirectionalStall,
+        production: ProgressExpectation::Continues,
+        settlement: ProgressExpectation::Continues,
+    },
+];
+
+struct ActiveFault {
+    accepted_before: Vec<u64>,
+    active_before: Vec<u64>,
+}
+
+async fn start_fault(fault: L1Fault, proxies: &[&TcpChaosProxy]) -> eyre::Result<ActiveFault> {
+    let accepted_before = proxies
+        .iter()
+        .map(|proxy| proxy.accepted_connections())
+        .collect();
+    let active_before: Vec<_> = proxies
+        .iter()
+        .map(|proxy| proxy.active_connections())
+        .collect();
+    let injected_before: Vec<_> = proxies
+        .iter()
+        .map(|proxy| proxy.injected_websocket_503s())
+        .collect();
+
+    match fault {
+        L1Fault::Disconnect => {
+            for proxy in proxies {
+                proxy.disconnect();
+            }
+        }
+        L1Fault::RandomWebSocket503 => {
+            for proxy in proxies {
+                proxy
+                    .set_websocket_503_fault(WEBSOCKET_503_SEED, WEBSOCKET_503_PROBABILITY_PERCENT);
+                proxy.drop_active_connections();
+            }
+        }
+        L1Fault::SilentBidirectionalStall => {
+            for (proxy, active) in proxies.iter().zip(&active_before) {
+                eyre::ensure!(
+                    *active > 0,
+                    "cannot silently stall proxy {} without an established connection",
+                    proxy.listen_addr()
+                );
+                proxy.pause_client_to_upstream(true);
+                proxy.pause_upstream_to_client(true);
+            }
+        }
+    }
+    if fault != L1Fault::SilentBidirectionalStall {
+        for proxy in proxies {
+            proxy.wait_for_no_connections(NETWORK_TIMEOUT).await?;
+        }
+    }
+    if fault == L1Fault::RandomWebSocket503 {
+        for (proxy, previous) in proxies.iter().zip(injected_before) {
+            proxy
+                .wait_for_injected_websocket_503s_after(previous, 1, NETWORK_TIMEOUT)
+                .await?;
+        }
+    }
+    Ok(ActiveFault {
+        accepted_before,
+        active_before,
+    })
+}
+
+async fn clear_fault(
+    fault: L1Fault,
+    proxies: &[&TcpChaosProxy],
+    active: ActiveFault,
+) -> eyre::Result<()> {
+    match fault {
+        L1Fault::Disconnect | L1Fault::RandomWebSocket503 => {
+            for proxy in proxies {
+                match fault {
+                    L1Fault::Disconnect => proxy.resume(),
+                    L1Fault::RandomWebSocket503 => proxy.clear_websocket_503_fault(),
+                    L1Fault::SilentBidirectionalStall => unreachable!(),
+                }
+            }
+            for (proxy, accepted) in proxies.iter().zip(active.accepted_before) {
+                proxy
+                    .wait_for_connections_after(accepted, 1, NETWORK_TIMEOUT)
+                    .await?;
+            }
+        }
+        L1Fault::SilentBidirectionalStall => {
+            for ((proxy, accepted_before), active_before) in proxies
+                .iter()
+                .zip(active.accepted_before)
+                .zip(active.active_before)
+            {
+                eyre::ensure!(
+                    proxy.accepted_connections() == accepted_before,
+                    "silently stalled proxy {} accepted a replacement connection",
+                    proxy.listen_addr()
+                );
+                eyre::ensure!(
+                    proxy.active_connections() == active_before,
+                    "silently stalled proxy {} did not preserve its established connections",
+                    proxy.listen_addr()
+                );
+                proxy.pause_client_to_upstream(false);
+                proxy.pause_upstream_to_client(false);
+            }
+        }
+    }
+    Ok(())
+}
+
 struct OutageAssetFlow {
     phase: &'static str,
     l2_balance_before: U256,
@@ -181,21 +387,13 @@ async fn recover_both_followers(
     follower_one_proxy: &TcpChaosProxy,
     follower_two_proxy: &TcpChaosProxy,
     baseline_height: u64,
+    case: L1OutageCase,
 ) -> eyre::Result<()> {
-    let accepted_before_outage = [
-        follower_one_proxy.accepted_connections(),
-        follower_two_proxy.accepted_connections(),
-    ];
-    for proxy in [follower_one_proxy, follower_two_proxy] {
-        proxy.disconnect();
-    }
-    for proxy in [follower_one_proxy, follower_two_proxy] {
-        proxy.wait_for_no_connections(NETWORK_TIMEOUT).await?;
-    }
+    let affected_proxies = [follower_one_proxy, follower_two_proxy];
+    let active_fault = start_fault(case.fault, &affected_proxies).await?;
 
     let outage_start = cluster.l1.provider().get_block_number().await?;
-    let assets =
-        submit_outage_asset_flow(cluster, account, "both-follower outage", outage_start).await?;
+    let assets = submit_outage_asset_flow(cluster, account, case.phase, outage_start).await?;
     let target = (outage_start + OUTAGE_BLOCK_GAP).max(assets.deposit_block + 1);
     cluster.nodes[0]
         .wait_for_tempo_block_number(target, NETWORK_TIMEOUT)
@@ -207,17 +405,14 @@ async fn recover_both_followers(
             index + 1
         );
     }
-    for proxy in [follower_one_proxy, follower_two_proxy] {
-        proxy.resume();
-    }
-    for (proxy, accepted) in [follower_one_proxy, follower_two_proxy]
-        .into_iter()
-        .zip(accepted_before_outage)
-    {
-        proxy
-            .wait_for_connections_after(accepted, 1, NETWORK_TIMEOUT)
-            .await?;
-    }
+    let portal = ZonePortal::new(cluster.portal_address, cluster.l1.provider());
+    let settled_during_outage = portal.zoneHeight().call().await?;
+    eyre::ensure!(
+        settled_during_outage < U256::from(target),
+        "{} unexpectedly settled through height {target} without follower quorum",
+        case.phase
+    );
+    clear_fault(case.fault, &affected_proxies, active_fault).await?;
     for follower in &cluster.nodes[1..] {
         follower
             .wait_for_tempo_block_number(target, NETWORK_TIMEOUT)
@@ -233,7 +428,6 @@ async fn recover_both_followers(
         .wait_all_at(recovered_height, NETWORK_TIMEOUT)
         .await?;
     cluster.assert_same_block(recovered_height).await?;
-    let portal = ZonePortal::new(cluster.portal_address, cluster.l1.provider());
     wait_for_settled_height(
         &portal,
         recovered_height,
@@ -249,6 +443,7 @@ async fn recover_leader(
     leader_proxy: &TcpChaosProxy,
     follower_one_proxy: &TcpChaosProxy,
     follower_two_proxy: &TcpChaosProxy,
+    case: L1OutageCase,
 ) -> eyre::Result<()> {
     let baseline_height = cluster.nodes[0].provider().get_block_number().await?;
     cluster
@@ -258,14 +453,11 @@ async fn recover_leader(
     leader_proxy
         .wait_for_connections_after(0, 1, NETWORK_TIMEOUT)
         .await?;
-    let accepted_before_outage = leader_proxy.accepted_connections();
-    leader_proxy.disconnect();
-    leader_proxy
-        .wait_for_no_connections(NETWORK_TIMEOUT)
-        .await?;
+    let affected_proxies = [leader_proxy];
+    let active_fault = start_fault(case.fault, &affected_proxies).await?;
 
     let outage_start = cluster.l1.provider().get_block_number().await?;
-    let assets = submit_outage_asset_flow(cluster, account, "leader outage", outage_start).await?;
+    let assets = submit_outage_asset_flow(cluster, account, case.phase, outage_start).await?;
     let target = (outage_start + OUTAGE_BLOCK_GAP).max(assets.deposit_block + 1);
     for (index, follower) in cluster.nodes[1..].iter().enumerate() {
         poll_until(
@@ -295,10 +487,14 @@ async fn recover_leader(
             "node {index} advanced zone state without a connected leader"
         );
     }
-    leader_proxy.resume();
-    leader_proxy
-        .wait_for_connections_after(accepted_before_outage, 1, NETWORK_TIMEOUT)
-        .await?;
+    let portal = ZonePortal::new(cluster.portal_address, cluster.l1.provider());
+    let settled_during_outage = portal.zoneHeight().call().await?;
+    eyre::ensure!(
+        settled_during_outage < U256::from(target),
+        "{} unexpectedly settled through height {target} without leader production",
+        case.phase
+    );
+    clear_fault(case.fault, &affected_proxies, active_fault).await?;
     for node in &cluster.nodes {
         node.wait_for_tempo_block_number(target, NETWORK_TIMEOUT)
             .await?;
@@ -313,7 +509,6 @@ async fn recover_leader(
         .wait_all_at(recovered_height, NETWORK_TIMEOUT)
         .await?;
     cluster.assert_same_block(recovered_height).await?;
-    let portal = ZonePortal::new(cluster.portal_address, cluster.l1.provider());
     wait_for_settled_height(
         &portal,
         recovered_height,
@@ -329,21 +524,18 @@ async fn recover_single_follower(
     leader_proxy: &TcpChaosProxy,
     follower_one_proxy: &TcpChaosProxy,
     follower_two_proxy: &TcpChaosProxy,
+    case: L1OutageCase,
 ) -> eyre::Result<()> {
     let baseline_height = cluster.nodes[0].provider().get_block_number().await?;
     cluster
         .wait_all_at(baseline_height, NETWORK_TIMEOUT)
         .await?;
     cluster.assert_same_block(baseline_height).await?;
-    let accepted_before_outage = follower_one_proxy.accepted_connections();
-    follower_one_proxy.disconnect();
-    follower_one_proxy
-        .wait_for_no_connections(NETWORK_TIMEOUT)
-        .await?;
+    let affected_proxies = [follower_one_proxy];
+    let active_fault = start_fault(case.fault, &affected_proxies).await?;
 
     let outage_start = cluster.l1.provider().get_block_number().await?;
-    let assets =
-        submit_outage_asset_flow(cluster, account, "single-follower outage", outage_start).await?;
+    let assets = submit_outage_asset_flow(cluster, account, case.phase, outage_start).await?;
     let target = (outage_start + OUTAGE_BLOCK_GAP).max(assets.deposit_block + 1);
     cluster.nodes[0]
         .wait_for_tempo_block_number(target, NETWORK_TIMEOUT)
@@ -371,10 +563,7 @@ async fn recover_single_follower(
     )
     .await?;
 
-    follower_one_proxy.resume();
-    follower_one_proxy
-        .wait_for_connections_after(accepted_before_outage, 1, NETWORK_TIMEOUT)
-        .await?;
+    clear_fault(case.fault, &affected_proxies, active_fault).await?;
     cluster.nodes[1]
         .wait_for_tempo_block_number(target, NETWORK_TIMEOUT)
         .await?;
@@ -389,6 +578,64 @@ async fn recover_single_follower(
         .await?;
     cluster.assert_same_block(recovered_height).await?;
     assert_outage_asset_flow(cluster, account, assets).await
+}
+
+async fn run_l1_outage_case(
+    cluster: &RealP2pCluster,
+    account: &mut ZoneAccount,
+    proxies: &[TcpChaosProxy; 3],
+    case: L1OutageCase,
+) -> eyre::Result<()> {
+    let [leader_proxy, follower_one_proxy, follower_two_proxy] = proxies;
+    match (case.affected_nodes, case.production, case.settlement) {
+        (
+            AffectedNodes::BothFollowers,
+            ProgressExpectation::Continues,
+            ProgressExpectation::Stalls,
+        ) => {
+            let baseline_height = cluster.nodes[0].provider().get_block_number().await?;
+            recover_both_followers(
+                cluster,
+                account,
+                follower_one_proxy,
+                follower_two_proxy,
+                baseline_height,
+                case,
+            )
+            .await
+        }
+        (AffectedNodes::Leader, ProgressExpectation::Stalls, ProgressExpectation::Stalls) => {
+            recover_leader(
+                cluster,
+                account,
+                leader_proxy,
+                follower_one_proxy,
+                follower_two_proxy,
+                case,
+            )
+            .await
+        }
+        (
+            AffectedNodes::OneFollower,
+            ProgressExpectation::Continues,
+            ProgressExpectation::Continues,
+        ) => {
+            recover_single_follower(
+                cluster,
+                account,
+                leader_proxy,
+                follower_one_proxy,
+                follower_two_proxy,
+                case,
+            )
+            .await
+        }
+        _ => eyre::bail!(
+            "unsupported L1 outage matrix row {}: {:?}",
+            case.phase,
+            case
+        ),
+    }
 }
 
 /// All three sequencers lose their established L1 connections, remain running while L1 advances,
@@ -504,12 +751,12 @@ async fn test_three_sequencers_reconnect_and_catch_up_after_l1_network_outage() 
     Ok(())
 }
 
-/// Exercise three asymmetric L1 outages: both followers, the leader, then one follower. Each
-/// restored side must backfill its missed anchors, process a deposit and withdrawal submitted
-/// during the outage, and converge before the next phase. The final phase also proves that one
-/// healthy follower preserves 2-of-3 settlement.
+/// Exercise the asymmetric L1 fault matrix. Each restored side must backfill its missed anchors,
+/// process a deposit and withdrawal submitted during the fault, and converge before the next row.
+/// HTTP 503 faults happen during the WebSocket upgrade because established WebSockets do not have
+/// per-request HTTP status codes.
 #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
-async fn test_asymmetric_l1_outages_recover_followers_then_leader() -> eyre::Result<()> {
+async fn test_asymmetric_l1_fault_matrix() -> eyre::Result<()> {
     reth_tracing::init_test_tracing();
 
     let (cluster, [leader_proxy, follower_one_proxy, follower_two_proxy]) =
@@ -548,7 +795,7 @@ async fn test_asymmetric_l1_outages_recover_followers_then_leader() -> eyre::Res
         .l1
         .fund_user(
             account.address(),
-            INITIAL_DEPOSIT + 3 * OUTAGE_DEPOSIT + 10_000_000,
+            INITIAL_DEPOSIT + L1_OUTAGE_CASES.len() as u128 * OUTAGE_DEPOSIT + 10_000_000,
         )
         .await?;
     let initial_balance = account
@@ -566,41 +813,10 @@ async fn test_asymmetric_l1_outages_recover_followers_then_leader() -> eyre::Res
     }
     account.approve_outbox(ZONE_TOKEN_ADDRESS).await?;
 
-    let baseline_height = cluster.nodes[0].provider().get_block_number().await?;
-    cluster
-        .wait_all_at(baseline_height, NETWORK_TIMEOUT)
-        .await?;
-    cluster.assert_same_block(baseline_height).await?;
-
-    recover_both_followers(
-        &cluster,
-        &mut account,
-        &follower_one_proxy,
-        &follower_two_proxy,
-        baseline_height,
-    )
-    .await?;
-
-    // Phase 2 reverses the fault: followers observe L1, but zone state cannot move without the
-    // disconnected leader.
-    recover_leader(
-        &cluster,
-        &mut account,
-        &leader_proxy,
-        &follower_one_proxy,
-        &follower_two_proxy,
-    )
-    .await?;
-
-    // Phase 3 leaves a healthy 2-of-3 quorum while one follower catches up after reconnection.
-    recover_single_follower(
-        &cluster,
-        &mut account,
-        &leader_proxy,
-        &follower_one_proxy,
-        &follower_two_proxy,
-    )
-    .await?;
+    let proxies = [leader_proxy, follower_one_proxy, follower_two_proxy];
+    for &case in L1_OUTAGE_CASES {
+        run_l1_outage_case(&cluster, &mut account, &proxies, case).await?;
+    }
 
     Ok(())
 }

--- a/crates/node/tests/it/network_chaos_e2e.rs
+++ b/crates/node/tests/it/network_chaos_e2e.rs
@@ -25,6 +25,10 @@ const OUTAGE_BLOCK_GAP: u64 = 8;
 const INITIAL_DEPOSIT: u128 = 10_000_000;
 const OUTAGE_DEPOSIT: u128 = 1_000_000;
 const OUTAGE_WITHDRAWAL: u128 = 250_000;
+const ACTIVE_CONNECTION_RESET_SEED: u64 = 0x503;
+const ACTIVE_CONNECTION_RESET_COUNT: u64 = 4;
+const MIN_ACTIVE_CONNECTION_RESET_DELAY: Duration = Duration::from_millis(100);
+const ACTIVE_CONNECTION_RESET_JITTER: Duration = Duration::from_millis(400);
 
 // This seeded 95% schedule starts with 64 rejected attempts. That gives the short E2E outage a
 // deterministic failure window while retaining probability-based behavior in the proxy itself.
@@ -636,6 +640,96 @@ async fn run_l1_outage_case(
             case
         ),
     }
+}
+
+fn active_connection_reset_delay(attempt: u64) -> Duration {
+    let mut sample = ACTIVE_CONNECTION_RESET_SEED.wrapping_add(attempt);
+    sample = sample.wrapping_add(0x9e37_79b9_7f4a_7c15);
+    sample = (sample ^ (sample >> 30)).wrapping_mul(0xbf58_476d_1ce4_e5b9);
+    sample = (sample ^ (sample >> 27)).wrapping_mul(0x94d0_49bb_1331_11eb);
+    sample ^= sample >> 31;
+    let jitter_bound = ACTIVE_CONNECTION_RESET_JITTER.as_millis() as u64;
+    MIN_ACTIVE_CONNECTION_RESET_DELAY + Duration::from_millis(sample % (jitter_bound + 1))
+}
+
+async fn randomly_reset_active_connections(proxy: &TcpChaosProxy) -> eyre::Result<()> {
+    for attempt in 0..ACTIVE_CONNECTION_RESET_COUNT {
+        tokio::time::sleep(active_connection_reset_delay(attempt)).await;
+        eyre::ensure!(
+            proxy.active_connections() >= 3,
+            "shared L1 proxy had fewer than three active connections before reset {attempt}"
+        );
+        let accepted_before_reset = proxy.accepted_connections();
+        proxy.drop_active_connections();
+        proxy
+            .wait_for_connections_after(accepted_before_reset, 3, NETWORK_TIMEOUT)
+            .await?;
+    }
+    Ok(())
+}
+
+/// Repeatedly reset established L1 WebSockets at seeded random times while the cluster remains in
+/// normal operation. Every reset must drive fresh connections, without preventing zone progress,
+/// node convergence, or quorum settlement.
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn test_three_sequencers_tolerate_random_active_l1_connection_resets() -> eyre::Result<()> {
+    reth_tracing::init_test_tracing();
+
+    let (cluster, proxy) = start_real_p2p_cluster_with_l1_proxy(4, L1_BLOCK_TIME).await?;
+    eyre::ensure!(
+        cluster.nodes.len() == 3,
+        "network-chaos fixture must start three nodes"
+    );
+    proxy
+        .wait_for_connections_after(0, 3, NETWORK_TIMEOUT)
+        .await?;
+
+    let portal = ZonePortal::new(cluster.portal_address, cluster.l1.provider());
+    poll_until(
+        NETWORK_TIMEOUT,
+        POLL_INTERVAL,
+        "an initial settled batch before active L1 connection resets",
+        || {
+            let portal = &portal;
+            async move {
+                let count = batch_count(portal).await?;
+                Ok((count > 0).then_some(count))
+            }
+        },
+    )
+    .await?;
+    let baseline_height = cluster.nodes[0].provider().get_block_number().await?;
+    cluster
+        .wait_all_at(baseline_height, NETWORK_TIMEOUT)
+        .await?;
+    cluster.assert_same_block(baseline_height).await?;
+
+    let target = baseline_height + OUTAGE_BLOCK_GAP;
+    let reset_connections = randomly_reset_active_connections(&proxy);
+    let maintain_progress = cluster.nodes[0].wait_for_tempo_block_number(target, NETWORK_TIMEOUT);
+    tokio::try_join!(reset_connections, maintain_progress)?;
+    cluster.wait_all_at(target, NETWORK_TIMEOUT).await?;
+
+    let mut recovered_height = u64::MAX;
+    for node in &cluster.nodes {
+        recovered_height = recovered_height.min(node.provider().get_block_number().await?);
+    }
+    eyre::ensure!(
+        recovered_height >= target,
+        "zone did not reach target {target} during random active connection resets"
+    );
+    cluster
+        .wait_all_at(recovered_height, NETWORK_TIMEOUT)
+        .await?;
+    cluster.assert_same_block(recovered_height).await?;
+    wait_for_settled_height(
+        &portal,
+        recovered_height,
+        "quorum settlement after random active L1 connection resets",
+    )
+    .await?;
+
+    Ok(())
 }
 
 /// All three sequencers lose their established L1 connections, remain running while L1 advances,

--- a/crates/node/tests/it/utils/network.rs
+++ b/crates/node/tests/it/utils/network.rs
@@ -2,7 +2,6 @@
 
 use std::{
     net::{SocketAddr, ToSocketAddrs as _},
-    num::NonZeroU64,
     sync::{
         Arc, Mutex,
         atomic::{AtomicBool, AtomicU64, Ordering},
@@ -21,17 +20,20 @@ use tokio_util::sync::CancellationToken;
 struct DirectionCondition {
     paused: bool,
     latency: Duration,
-    bytes_per_second: Option<NonZeroU64>,
 }
 
 #[derive(Debug, Default)]
 struct ProxyStats {
     accepted: AtomicU64,
     active: AtomicU64,
-    closed: AtomicU64,
-    rejected_while_disconnected: AtomicU64,
-    client_to_upstream_bytes: AtomicU64,
-    upstream_to_client_bytes: AtomicU64,
+    injected_websocket_503s: AtomicU64,
+}
+
+#[derive(Clone, Copy, Debug)]
+struct WebSocket503Fault {
+    seed: u64,
+    probability_percent: u8,
+    attempts: u64,
 }
 
 #[derive(Debug)]
@@ -41,6 +43,7 @@ struct ProxyInner {
     shutdown: CancellationToken,
     stats: ProxyStats,
     changed: Notify,
+    websocket_503_fault: Mutex<Option<WebSocket503Fault>>,
     client_to_upstream: watch::Sender<DirectionCondition>,
     upstream_to_client: watch::Sender<DirectionCondition>,
 }
@@ -149,6 +152,7 @@ impl TcpChaosProxy {
             shutdown: CancellationToken::new(),
             stats: ProxyStats::default(),
             changed: Notify::new(),
+            websocket_503_fault: Mutex::new(None),
             client_to_upstream,
             upstream_to_client,
         });
@@ -199,8 +203,55 @@ impl TcpChaosProxy {
         self.inner.stats.active.load(Ordering::Acquire)
     }
 
+    pub(crate) fn injected_websocket_503s(&self) -> u64 {
+        self.inner
+            .stats
+            .injected_websocket_503s
+            .load(Ordering::Acquire)
+    }
+
+    /// Randomly reject WebSocket upgrade handshakes with HTTP 503 responses.
+    ///
+    /// Randomness is seeded so integration tests can reproduce the exact failure sequence. This
+    /// only affects newly accepted connections; use `drop_active_connections` to make an already
+    /// connected WebSocket client exercise its reconnect path.
+    pub(crate) fn set_websocket_503_fault(&self, seed: u64, probability_percent: u8) {
+        assert!(
+            (1..=100).contains(&probability_percent),
+            "503 probability must be between 1 and 100 percent"
+        );
+        *self
+            .inner
+            .websocket_503_fault
+            .lock()
+            .expect("proxy lock poisoned") = Some(WebSocket503Fault {
+            seed,
+            probability_percent,
+            attempts: 0,
+        });
+        self.inner.changed.notify_waiters();
+    }
+
+    pub(crate) fn clear_websocket_503_fault(&self) {
+        *self
+            .inner
+            .websocket_503_fault
+            .lock()
+            .expect("proxy lock poisoned") = None;
+        self.inner.changed.notify_waiters();
+    }
+
+    /// Close established streams without disabling the listener or rejecting new connections.
+    pub(crate) fn drop_active_connections(&self) {
+        self.rotate_generation();
+    }
+
     pub(crate) fn disconnect(&self) {
         self.inner.enabled.store(false, Ordering::Release);
+        self.rotate_generation();
+    }
+
+    fn rotate_generation(&self) {
         let mut generation = self.inner.generation.lock().expect("proxy lock poisoned");
         generation.cancel();
         *generation = CancellationToken::new();
@@ -237,18 +288,6 @@ impl TcpChaosProxy {
             .send_modify(|condition| condition.latency = latency);
     }
 
-    pub(crate) fn set_client_to_upstream_bandwidth(&self, bytes_per_second: Option<NonZeroU64>) {
-        self.inner
-            .client_to_upstream
-            .send_modify(|condition| condition.bytes_per_second = bytes_per_second);
-    }
-
-    pub(crate) fn set_upstream_to_client_bandwidth(&self, bytes_per_second: Option<NonZeroU64>) {
-        self.inner
-            .upstream_to_client
-            .send_modify(|condition| condition.bytes_per_second = bytes_per_second);
-    }
-
     pub(crate) async fn wait_for_no_connections(&self, timeout: Duration) -> eyre::Result<()> {
         self.wait_for(timeout, "all proxied connections to close", || {
             self.active_connections() == 0
@@ -261,14 +300,29 @@ impl TcpChaosProxy {
         previous_accepted: u64,
         minimum_new_connections: u64,
         timeout: Duration,
-    ) -> eyre::Result<u64> {
+    ) -> eyre::Result<()> {
         assert!(minimum_new_connections > 0);
         let target = previous_accepted.saturating_add(minimum_new_connections);
         self.wait_for(timeout, "fresh proxied connections", || {
             self.accepted_connections() >= target
         })
         .await?;
-        Ok(self.accepted_connections())
+        Ok(())
+    }
+
+    pub(crate) async fn wait_for_injected_websocket_503s_after(
+        &self,
+        previous_injected: u64,
+        minimum_new_responses: u64,
+        timeout: Duration,
+    ) -> eyre::Result<()> {
+        assert!(minimum_new_responses > 0);
+        let target = previous_injected.saturating_add(minimum_new_responses);
+        self.wait_for(timeout, "injected WebSocket HTTP 503 responses", || {
+            self.injected_websocket_503s() >= target
+        })
+        .await?;
+        Ok(())
     }
 
     async fn wait_for(
@@ -313,12 +367,7 @@ async fn run_accept_loop(listener: TcpListener, upstream: SocketAddr, inner: Arc
             return;
         };
         if !inner.enabled.load(Ordering::Acquire) {
-            inner
-                .stats
-                .rejected_while_disconnected
-                .fetch_add(1, Ordering::AcqRel);
             drop(client);
-            inner.changed.notify_waiters();
             continue;
         }
 
@@ -335,11 +384,25 @@ async fn run_accept_loop(listener: TcpListener, upstream: SocketAddr, inner: Arc
 }
 
 async fn run_connection(
-    client: TcpStream,
+    mut client: TcpStream,
     upstream: SocketAddr,
     generation: CancellationToken,
     inner: Arc<ProxyInner>,
 ) {
+    if should_inject_websocket_503(&inner) {
+        if matches!(
+            write_websocket_503(&mut client, &generation).await,
+            Ok(true)
+        ) {
+            inner
+                .stats
+                .injected_websocket_503s
+                .fetch_add(1, Ordering::AcqRel);
+            inner.changed.notify_waiters();
+        }
+        return;
+    }
+
     let upstream_stream = tokio::select! {
         _ = generation.cancelled() => return,
         result = TcpStream::connect(upstream) => match result {
@@ -363,14 +426,12 @@ async fn run_connection(
         upstream_write,
         inner.client_to_upstream.subscribe(),
         connection_cancel.clone(),
-        &inner.stats.client_to_upstream_bytes,
     );
     let upstream_to_client = pump(
         upstream_read,
         client_write,
         inner.upstream_to_client.subscribe(),
         connection_cancel.clone(),
-        &inner.stats.upstream_to_client_bytes,
     );
     tokio::pin!(client_to_upstream, upstream_to_client);
     tokio::select! {
@@ -380,8 +441,62 @@ async fn run_connection(
     }
     connection_cancel.cancel();
     inner.stats.active.fetch_sub(1, Ordering::AcqRel);
-    inner.stats.closed.fetch_add(1, Ordering::AcqRel);
     inner.changed.notify_waiters();
+}
+
+fn should_inject_websocket_503(inner: &ProxyInner) -> bool {
+    let mut fault = inner
+        .websocket_503_fault
+        .lock()
+        .expect("proxy lock poisoned");
+    let Some(fault) = fault.as_mut() else {
+        return false;
+    };
+    let sample = splitmix64(fault.seed.wrapping_add(fault.attempts)) % 100;
+    fault.attempts = fault.attempts.wrapping_add(1);
+    sample < u64::from(fault.probability_percent)
+}
+
+/// A small, stable mixer keeps seeded fault schedules reproducible across dependency upgrades.
+const fn splitmix64(mut value: u64) -> u64 {
+    value = value.wrapping_add(0x9e37_79b9_7f4a_7c15);
+    value = (value ^ (value >> 30)).wrapping_mul(0xbf58_476d_1ce4_e5b9);
+    value = (value ^ (value >> 27)).wrapping_mul(0x94d0_49bb_1331_11eb);
+    value ^ (value >> 31)
+}
+
+async fn write_websocket_503(
+    client: &mut TcpStream,
+    cancel: &CancellationToken,
+) -> std::io::Result<bool> {
+    // Wait for the HTTP upgrade request before responding. Besides modeling an actual server more
+    // faithfully, this avoids racing clients that have not started their handshake yet.
+    let mut request = Vec::with_capacity(1024);
+    let mut buffer = [0_u8; 1024];
+    while !request.windows(4).any(|window| window == b"\r\n\r\n") {
+        if request.len() >= 16 * 1024 {
+            return Err(std::io::Error::new(
+                std::io::ErrorKind::InvalidData,
+                "WebSocket upgrade request exceeded 16 KiB",
+            ));
+        }
+        let read = tokio::select! {
+            _ = cancel.cancelled() => return Ok(false),
+            result = client.read(&mut buffer) => result?,
+        };
+        if read == 0 {
+            return Ok(false);
+        }
+        request.extend_from_slice(&buffer[..read]);
+    }
+
+    client
+        .write_all(
+            b"HTTP/1.1 503 Service Unavailable\r\nContent-Length: 0\r\nConnection: close\r\nRetry-After: 0\r\n\r\n",
+        )
+        .await?;
+    client.shutdown().await?;
+    Ok(true)
 }
 
 async fn pump<R, W>(
@@ -389,7 +504,6 @@ async fn pump<R, W>(
     mut writer: W,
     mut conditions: watch::Receiver<DirectionCondition>,
     cancel: CancellationToken,
-    bytes: &AtomicU64,
 ) -> std::io::Result<()>
 where
     R: AsyncRead + Unpin,
@@ -414,11 +528,7 @@ where
             return Ok(());
         }
 
-        let condition = *conditions.borrow();
-        let throttle = condition.bytes_per_second.map_or(Duration::ZERO, |rate| {
-            Duration::from_secs_f64(read as f64 / rate.get() as f64)
-        });
-        let delay = condition.latency.saturating_add(throttle);
+        let delay = conditions.borrow().latency;
         if !delay.is_zero() {
             tokio::select! {
                 _ = cancel.cancelled() => return Ok(()),
@@ -426,7 +536,7 @@ where
             }
         }
 
-        // The pause can also be enabled while the latency or bandwidth delay is pending.
+        // The pause can also be enabled while the latency delay is pending.
         // Recheck immediately before forwarding so that delayed chunks cannot leak through.
         if !wait_until_resumed(&mut conditions, &cancel).await {
             return Ok(());
@@ -435,7 +545,6 @@ where
             _ = cancel.cancelled() => return Ok(()),
             result = writer.write_all(&buffer[..read]) => result?,
         }
-        bytes.fetch_add(read as u64, Ordering::Relaxed);
     }
 }
 
@@ -516,7 +625,84 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn directional_pause_latency_and_bandwidth_preserve_the_stream() -> eyre::Result<()> {
+    async fn websocket_503_fault_rejects_handshakes_and_then_recovers() -> eyre::Result<()> {
+        let (upstream, shutdown) = start_echo_server().await?;
+        let proxy = TcpChaosProxy::start(upstream).await?;
+        let injected_before = proxy.injected_websocket_503s();
+        proxy.set_websocket_503_fault(7, 100);
+
+        let mut rejected = TcpStream::connect(proxy.listen_addr()).await?;
+        rejected
+            .write_all(
+                b"GET / HTTP/1.1\r\nHost: localhost\r\nConnection: Upgrade\r\nUpgrade: websocket\r\n\r\n",
+            )
+            .await?;
+        let mut response = Vec::new();
+        rejected.read_to_end(&mut response).await?;
+        assert!(
+            response.starts_with(b"HTTP/1.1 503 Service Unavailable\r\n"),
+            "proxy returned an unexpected handshake response: {:?}",
+            String::from_utf8_lossy(&response)
+        );
+        proxy
+            .wait_for_injected_websocket_503s_after(injected_before, 1, Duration::from_secs(2))
+            .await?;
+        assert_eq!(proxy.accepted_connections(), 0);
+
+        proxy.clear_websocket_503_fault();
+        let mut recovered = TcpStream::connect(proxy.listen_addr()).await?;
+        recovered.write_all(b"healthy").await?;
+        let mut echoed = [0_u8; 7];
+        recovered.read_exact(&mut echoed).await?;
+        assert_eq!(&echoed, b"healthy");
+        shutdown.cancel();
+        Ok(())
+    }
+
+    #[test]
+    fn seeded_503_schedule_used_by_e2e_starts_with_a_stable_failure_window() {
+        assert!(
+            (0..64).all(|attempt| splitmix64(385_u64.wrapping_add(attempt)) % 100 < 95),
+            "the E2E seed must keep the L1 unavailable throughout its short outage window"
+        );
+    }
+
+    #[tokio::test]
+    async fn bidirectional_stall_preserves_and_resumes_the_same_connection() -> eyre::Result<()> {
+        let (upstream, shutdown) = start_echo_server().await?;
+        let proxy = TcpChaosProxy::start(upstream).await?;
+        let mut client = TcpStream::connect(proxy.listen_addr()).await?;
+        client.write_all(b"ready!").await?;
+        let mut response = [0_u8; 6];
+        client.read_exact(&mut response).await?;
+        assert_eq!(&response, b"ready!");
+
+        let accepted_before = proxy.accepted_connections();
+        let active_before = proxy.active_connections();
+        proxy.pause_client_to_upstream(true);
+        proxy.pause_upstream_to_client(true);
+        client.write_all(b"paused").await?;
+        assert!(
+            tokio::time::timeout(Duration::from_millis(100), client.read_exact(&mut response))
+                .await
+                .is_err(),
+            "bidirectionally stalled proxy unexpectedly forwarded traffic"
+        );
+        assert_eq!(proxy.accepted_connections(), accepted_before);
+        assert_eq!(proxy.active_connections(), active_before);
+
+        proxy.pause_client_to_upstream(false);
+        proxy.pause_upstream_to_client(false);
+        client.read_exact(&mut response).await?;
+        assert_eq!(&response, b"paused");
+        assert_eq!(proxy.accepted_connections(), accepted_before);
+        assert_eq!(proxy.active_connections(), active_before);
+        shutdown.cancel();
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn directional_pause_and_latency_preserve_the_stream() -> eyre::Result<()> {
         let (upstream, shutdown) = start_echo_server().await?;
         let proxy = TcpChaosProxy::start(upstream).await?;
         let mut client = TcpStream::connect(proxy.listen_addr()).await?;
@@ -530,8 +716,7 @@ mod tests {
         proxy.pause_client_to_upstream(true);
         proxy.pause_upstream_to_client(false);
         proxy.set_upstream_to_client_latency(Duration::from_millis(100));
-        proxy.set_client_to_upstream_bandwidth(NonZeroU64::new(8 * 1024));
-        proxy.set_upstream_to_client_bandwidth(None);
+        proxy.set_client_to_upstream_latency(Duration::from_millis(500));
 
         let payload = vec![0x5a; 4 * 1024];
         client.write_all(&payload).await?;
@@ -551,14 +736,14 @@ mod tests {
             tokio::time::timeout(Duration::from_millis(800), client.read_exact(&mut echoed))
                 .await
                 .is_err(),
-            "pause enabled during the bandwidth delay leaked the pending payload"
+            "pause enabled during the latency delay leaked the pending payload"
         );
         proxy.pause_client_to_upstream(false);
         client.read_exact(&mut echoed).await?;
         assert_eq!(echoed, payload);
         assert!(
             started.elapsed() >= Duration::from_millis(500),
-            "configured latency and bandwidth limit were not applied"
+            "configured latency was not applied"
         );
 
         proxy.set_client_to_upstream_latency(Duration::ZERO);


### PR DESCRIPTION
## Summary

- refactor asymmetric L1 outage coverage into a readable role/fault matrix
- add seeded WebSocket upgrade 503 injection with observable rejection counts
- cover silent bidirectional stalls while preserving established connections
- add seeded, randomly timed active WebSocket resets through the shared L1 proxy
- remove unused bandwidth throttling and write-only proxy statistics

## Test plan

- `cargo test -p zone-node --test it utils::network::tests::`
- `cargo test -p zone-node --test it test_asymmetric_l1_fault_matrix -- --nocapture`
- `cargo test -p zone-node --test it test_three_sequencers_tolerate_random_active_l1_connection_resets -- --nocapture`
- `cargo test -p zone-node --test it keeps_up_with_high -- --nocapture`
- `cargo fmt --all -- --check`
- `git diff --check`