### PR TITLE
fix(spf): use zero parent hash for first batch

### DIFF
--- a/crates/node/tests/it/spf.rs
+++ b/crates/node/tests/it/spf.rs
@@ -160,7 +160,7 @@ async fn spf_batch_execute() -> eyre::Result<()> {
 
     let output = prove_zone_batch(&config, witness)?;
 
-    assert_eq!(output.block_transition.prevBlockHash, parent_hash);
+    assert_eq!(output.block_transition.prevBlockHash, B256::ZERO);
     assert_eq!(output.block_transition.nextBlockHash, expected_hash);
     assert_eq!(
         output.deposit_queue_transition.prevProcessedHash,

--- a/crates/sequencer/src/prover.rs
+++ b/crates/sequencer/src/prover.rs
@@ -407,7 +407,7 @@ async fn validate_candidate<P: ZoneSequencerProvider>(
         .record(started.elapsed().as_secs_f64());
 
     let started = Instant::now();
-    compare_output(&output, &job.batch, witness.parent_header.hash_slow())?;
+    compare_output(&output, &job.batch, job.batch.prev_block_hash)?;
     metrics
         .output_validation_duration_seconds
         .record(started.elapsed().as_secs_f64());

--- a/crates/spf/src/lib.rs
+++ b/crates/spf/src/lib.rs
@@ -118,6 +118,14 @@ pub fn prove_zone_batch(config: &SpfConfig, witness: BatchWitness) -> Result<Bat
     // predecessor. Replay feeds the execution result through Tempo's block
     // assembler, which derives the aggregate logs bloom from the receipts.
     let initial_parent_hash = witness.parent_header.hash_slow();
+    // ZonePortal represents the parent of the first submitted batch with the
+    // zero pre-genesis sentinel, even though block 1 executes on top of the
+    // canonical (non-zero) genesis block hash.
+    let output_parent_hash = if witness.zone_blocks[0].number == 1 {
+        B256::ZERO
+    } else {
+        initial_parent_hash
+    };
     let mut previous_header = witness.parent_header.clone();
     for (block_index, block) in witness.zone_blocks.iter().enumerate() {
         let expected_parent_hash = previous_header.hash_slow();
@@ -290,7 +298,7 @@ pub fn prove_zone_batch(config: &SpfConfig, witness: BatchWitness) -> Result<Bat
     }
     Ok(BatchOutput {
         block_transition: BlockTransition {
-            prevBlockHash: initial_parent_hash,
+            prevBlockHash: output_parent_hash,
             nextBlockHash: previous_header.hash_slow(),
         },
         deposit_queue_transition: DepositQueueTransition {


### PR DESCRIPTION
## Summary

Emit a zero `prevBlockHash` in `BatchOutput` for the first Zone batch. 