### PR TITLE
fix(prover): update Nitro guest kernel to 6.6.79

### DIFF
--- a/bin/prover/enclave/README.md
+++ b/bin/prover/enclave/README.md
@@ -81,6 +81,16 @@ docker buildx bake \
 The EIF and PCR measurements are written under `target/tempo-zone-prover-eif/`. CI embeds the EIF
 in the published image and uploads the measurements as a commit-specific workflow artifact.
 
+The EIF uses Linux 6.6.79 and its matching NSM driver, built from a pinned AWS Nitro bootstrap
+commit. Changing either one changes the EIF PCR measurements, so the expected measurements must
+also be updated.
+
+Verifying a batch does not use local randomness or wall-clock time. If we add key or nonce
+generation or KMS/HTTPS calls, configure `random.trust_bootloader=off random.trust_cpu=off` and
+require `rng_current` to be `nsm-hwrng`. If we add KMS/HTTPS calls, expiring credentials, protocol
+timestamps, or time-based replay checks, use `kvm-clock`. Operational timeouts affect only liveness
+and can use a monotonic clock.
+
 The host image launches the enclave in non-debug mode and exposes TCP port `5000`. It accepts
 `PROVER_EIF_PATH`, `ENCLAVE_NAME`, `ENCLAVE_CPU_COUNT`, `ENCLAVE_MEMORY_MIB`, `ENCLAVE_CID`,
 `PROVER_TCP_PORT`, `PROVER_VSOCK_PORT`, and `MONITOR_INTERVAL_SECONDS` as runtime configuration.

--- a/docker/Dockerfile.prover-eif-builder
+++ b/docker/Dockerfile.prover-eif-builder
@@ -1,12 +1,24 @@
+FROM nitro-kernel AS nitro-kernel
+
 FROM public.ecr.aws/amazonlinux/amazonlinux:2023@sha256:6d8e068b91f351df5bf6acd4bd261316e42747ad4bae76689ff6f4939e2180a2
 
 ARG NITRO_CLI_VERSION=1.4.5-0.amzn2023
 
 RUN dnf install -y \
+        file \
         "aws-nitro-enclaves-cli-${NITRO_CLI_VERSION}" \
         "aws-nitro-enclaves-cli-devel-${NITRO_CLI_VERSION}" \
     && dnf clean all \
     && rm -rf /var/cache/dnf
 
-ENTRYPOINT ["nitro-cli"]
+# Nitro CLI 1.4.5 ships a Linux 4.14 kernel and a module built specifically for it. Replace the
+# kernel, config, and NSM module as one matched set from the pinned AWS bootstrap build. Its Linux
+# 6.6.79 kernel includes the modern RNG and the Nitro-specific VSOCK deadlock fix.
+COPY --from=nitro-kernel /blobs/bzImage /usr/share/nitro_enclaves/blobs/bzImage
+COPY --from=nitro-kernel /blobs/bzImage.config /usr/share/nitro_enclaves/blobs/bzImage.config
+COPY --from=nitro-kernel /blobs/nsm.ko /usr/share/nitro_enclaves/blobs/nsm.ko
 
+RUN file /usr/share/nitro_enclaves/blobs/bzImage | grep -Fq 'version 6.6.79' \
+    && grep -aFq 'vermagic=6.6.79' /usr/share/nitro_enclaves/blobs/nsm.ko
+
+ENTRYPOINT ["nitro-cli"]

--- a/docker/docker-bake.hcl
+++ b/docker/docker-bake.hcl
@@ -70,9 +70,23 @@ target "tempo-zone-prover-enclave" {
   platforms = ["linux/amd64"]
 }
 
+# Build a matched Nitro guest kernel and NSM module from AWS's bootstrap sources. Keep this
+# source pinned: changing it changes the EIF kernel and its PCR measurements.
+target "nitro-enclaves-kernel" {
+  context = "https://github.com/aws/aws-nitro-enclaves-sdk-bootstrap.git#f718dea60a9d9bb8b8682fd852ad793912f3c5db"
+  target = "artifacts"
+  args = {
+    TARGET = "kernel"
+  }
+  platforms = ["linux/amd64"]
+}
+
 target "tempo-zone-prover-eif-builder" {
   dockerfile = "docker/Dockerfile.prover-eif-builder"
   context = "."
+  contexts = {
+    nitro-kernel = "target:nitro-enclaves-kernel"
+  }
   platforms = ["linux/amd64"]
 }
 


### PR DESCRIPTION
## Summary

- replace the Nitro CLI bundled Linux 4.14 kernel with Linux 6.6.79
- build the kernel and matching NSM driver from a pinned AWS Nitro bootstrap commit
- verify the kernel version and module vermagic during the EIF builder build
- document PCR measurement impact and when future RNG or clock hardening is needed

## Testing

- `cargo test -p tempo-zone-prover-enclave`
- `docker buildx bake -f docker/docker-bake.hcl --print tempo-zone-prover-eif-builder`
- `git diff --check`

The full EIF builder image was not built because the local Docker daemon was unavailable.