### PR TITLE
fix(prover): harden Nitro enclave bootstrap

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -195,6 +195,14 @@ jobs:
 
           docker run --rm \
             --platform linux/amd64 \
+            --entrypoint /bin/cp \
+            --volume "$PWD/$EIF_OUTPUT_DIR:/output" \
+            "$EIF_BUILDER_IMAGE" \
+            /usr/share/nitro_enclaves/components.sha384 \
+            /output/components.sha384
+
+          docker run --rm \
+            --platform linux/amd64 \
             --volume /var/run/docker.sock:/var/run/docker.sock \
             --volume "$PWD/$EIF_OUTPUT_DIR:/output" \
             "$EIF_BUILDER_IMAGE" \
@@ -222,7 +230,9 @@ jobs:
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: tempo-zone-prover-measurements-${{ steps.shortsha.outputs.shortsha }}
-          path: target/tempo-zone-prover-eif/measurements.json
+          path: |
+            target/tempo-zone-prover-eif/measurements.json
+            target/tempo-zone-prover-eif/components.sha384
           if-no-files-found: error
 
       - name: Publish Zones CI event

--- a/bin/prover/enclave/README.md
+++ b/bin/prover/enclave/README.md
@@ -79,11 +79,22 @@ docker buildx bake \
 ```
 
 The EIF and PCR measurements are written under `target/tempo-zone-prover-eif/`. CI embeds the EIF
-in the published image and uploads the measurements as a commit-specific workflow artifact.
+in the published image and uploads the measurements and `components.sha384` as commit-specific
+workflow artifacts.
 
-The EIF uses Linux 6.6.79 and its matching NSM driver, built from a pinned AWS Nitro bootstrap
-commit. Changing either one changes the EIF PCR measurements, so the expected measurements must
-also be updated.
+The EIF uses Linux 6.6.79 and a complete matched bootstrap set built from a pinned AWS Nitro
+bootstrap commit: kernel, resolved config, command line, NSM driver, init, and linuxkit. The Nix
+builder image is pinned by digest, and `components.sha384` records the SHA-384 digest of each
+bootstrap artifact. Changing any of these inputs changes the EIF PCR measurements, so the expected
+measurements must also be reviewed and updated.
+
+The x86_64 kernel build applies `docker/nitro/zones-hardening-x86_64.config` over AWS's baseline.
+CI asserts the resolved configuration after `olddefconfig`. The enforced delta enables kernel and
+kernel-memory ASLR, hardened user copies, slab-freelist randomization, and unprivileged `dmesg`
+restriction. It disables debugfs, Magic SysRq, kexec, io_uring, the BPF syscall/JIT, userfaultfd,
+user and network namespaces, 32-bit compatibility, `modify_ldt`, `/dev/mem`, and `/proc/kcore`.
+The stateless prover does not use these kernel interfaces; removing them reduces unnecessary attack
+surface.
 
 Verifying a batch does not use local randomness or wall-clock time. If we add key or nonce
 generation or KMS/HTTPS calls, configure `random.trust_bootloader=off random.trust_cpu=off` and

--- a/docker/Dockerfile.nitro-enclaves-bootstrap
+++ b/docker/Dockerfile.nitro-enclaves-bootstrap
@@ -1,0 +1,22 @@
+# syntax=docker/dockerfile:1.7
+
+# Keep the Nix implementation as a content-addressed build input. The AWS bootstrap source is
+# supplied separately as the pinned `nitro-bootstrap-source` named context in docker-bake.hcl.
+ARG NIX_IMAGE=nixos/nix:2.21.4@sha256:91b689f94a101aa67f95034dffd9a4858e85d0946f67c64dd65ed241644454b9
+FROM ${NIX_IMAGE} AS build
+
+ARG TARGET=all
+
+COPY --from=nitro-bootstrap-source / /build/
+# Keep AWS's pinned kernel expression as the source of truth and apply only the reviewed Zones
+# hardening delta. git apply fails if the pinned source no longer matches the patch.
+COPY docker/nitro/kernel.patch /tmp/kernel.patch
+COPY docker/nitro/zones-hardening-x86_64.config /build/kernel/zones-hardening-x86_64.config
+
+WORKDIR /build
+RUN git apply /tmp/kernel.patch
+RUN nix-build -A "${TARGET}"
+
+FROM scratch AS artifacts
+COPY --from=build /build/result/* /blobs/
+CMD ["dummy"]

--- a/docker/Dockerfile.nitro-enclaves-bootstrap
+++ b/docker/Dockerfile.nitro-enclaves-bootstrap
@@ -18,5 +18,5 @@ RUN git apply /tmp/kernel.patch
 RUN nix-build -A "${TARGET}"
 
 FROM scratch AS artifacts
-COPY --from=build /build/result/* /blobs/
+COPY --from=build /build/result/ /blobs/
 CMD ["dummy"]

--- a/docker/Dockerfile.prover-eif-builder
+++ b/docker/Dockerfile.prover-eif-builder
@@ -1,4 +1,4 @@
-FROM nitro-kernel AS nitro-kernel
+FROM nitro-bootstrap AS nitro-bootstrap
 
 FROM public.ecr.aws/amazonlinux/amazonlinux:2023@sha256:6d8e068b91f351df5bf6acd4bd261316e42747ad4bae76689ff6f4939e2180a2
 
@@ -11,14 +11,21 @@ RUN dnf install -y \
     && dnf clean all \
     && rm -rf /var/cache/dnf
 
-# Nitro CLI 1.4.5 ships a Linux 4.14 kernel and a module built specifically for it. Replace the
-# kernel, config, and NSM module as one matched set from the pinned AWS bootstrap build. Its Linux
-# 6.6.79 kernel includes the modern RNG and the Nitro-specific VSOCK deadlock fix.
-COPY --from=nitro-kernel /blobs/bzImage /usr/share/nitro_enclaves/blobs/bzImage
-COPY --from=nitro-kernel /blobs/bzImage.config /usr/share/nitro_enclaves/blobs/bzImage.config
-COPY --from=nitro-kernel /blobs/nsm.ko /usr/share/nitro_enclaves/blobs/nsm.ko
+# Nitro CLI 1.4.5 ships precompiled bootstrap blobs. Replace all of them as one matched set from the
+# pinned AWS bootstrap build: hardened Linux 6.6.79, its config and command line, the matching NSM
+# driver and init, and AWS's patched linuxkit.
+COPY --from=nitro-bootstrap /blobs/x86_64/ /usr/share/nitro_enclaves/blobs/
 
-RUN file /usr/share/nitro_enclaves/blobs/bzImage | grep -Fq 'version 6.6.79' \
-    && grep -aFq 'vermagic=6.6.79' /usr/share/nitro_enclaves/blobs/nsm.ko
+RUN set -eu; \
+    blob_dir=/usr/share/nitro_enclaves/blobs; \
+    file "$blob_dir/bzImage" | grep -Fq 'version 6.6.79'; \
+    grep -aFq 'vermagic=6.6.79' "$blob_dir/nsm.ko"; \
+    if grep -qw nokaslr "$blob_dir/cmdline"; then \
+        echo 'kernel cmdline must not disable KASLR' >&2; \
+        exit 1; \
+    fi; \
+    cd "$blob_dir"; \
+    sha384sum bzImage bzImage.config cmdline nsm.ko init linuxkit \
+        > /usr/share/nitro_enclaves/components.sha384
 
 ENTRYPOINT ["nitro-cli"]

--- a/docker/Dockerfile.prover-eif-builder
+++ b/docker/Dockerfile.prover-eif-builder
@@ -20,10 +20,6 @@ RUN set -eu; \
     blob_dir=/usr/share/nitro_enclaves/blobs; \
     file "$blob_dir/bzImage" | grep -Fq 'version 6.6.79'; \
     grep -aFq 'vermagic=6.6.79' "$blob_dir/nsm.ko"; \
-    if grep -qw nokaslr "$blob_dir/cmdline"; then \
-        echo 'kernel cmdline must not disable KASLR' >&2; \
-        exit 1; \
-    fi; \
     cd "$blob_dir"; \
     sha384sum bzImage bzImage.config cmdline nsm.ko init linuxkit \
         > /usr/share/nitro_enclaves/components.sha384

--- a/docker/docker-bake.hcl
+++ b/docker/docker-bake.hcl
@@ -70,13 +70,17 @@ target "tempo-zone-prover-enclave" {
   platforms = ["linux/amd64"]
 }
 
-# Build a matched Nitro guest kernel and NSM module from AWS's bootstrap sources. Keep this
-# source pinned: changing it changes the EIF kernel and its PCR measurements.
-target "nitro-enclaves-kernel" {
-  context = "https://github.com/aws/aws-nitro-enclaves-sdk-bootstrap.git#f718dea60a9d9bb8b8682fd852ad793912f3c5db"
+# Build a hardened, matched set of Nitro bootstrap artifacts from pinned AWS sources. The local
+# wrapper pins the Nix builder and applies the reviewed Zones kernel-config delta.
+target "nitro-enclaves-bootstrap" {
+  dockerfile = "docker/Dockerfile.nitro-enclaves-bootstrap"
+  context = "."
+  contexts = {
+    nitro-bootstrap-source = "https://github.com/aws/aws-nitro-enclaves-sdk-bootstrap.git#f718dea60a9d9bb8b8682fd852ad793912f3c5db"
+  }
   target = "artifacts"
   args = {
-    TARGET = "kernel"
+    TARGET = "all"
   }
   platforms = ["linux/amd64"]
 }
@@ -85,7 +89,7 @@ target "tempo-zone-prover-eif-builder" {
   dockerfile = "docker/Dockerfile.prover-eif-builder"
   context = "."
   contexts = {
-    nitro-kernel = "target:nitro-enclaves-kernel"
+    nitro-bootstrap = "target:nitro-enclaves-bootstrap"
   }
   platforms = ["linux/amd64"]
 }

--- a/docker/nitro/kernel.patch
+++ b/docker/nitro/kernel.patch
@@ -1,0 +1,36 @@
+diff --git a/kernel/kernel.nix b/kernel/kernel.nix
+index b655be2..7125d52 100644
+--- a/kernel/kernel.nix
++++ b/kernel/kernel.nix
+@@ -82,2 +82,7 @@ pkgs.stdenv.mkDerivation rec {
+     ( cat $files; echo CONFIG_NSM=m ) > .config
++    ${if arch == "x86_64" then
++      "sh ./scripts/kconfig/merge_config.sh -m .config ${./zones-hardening-x86_64.config}"
++    else
++      "true"
++    }
+   '';
+@@ -92,2 +97,23 @@ pkgs.stdenv.mkDerivation rec {
+       CC="$CC" LD="$LD" OBJCOPY="$OBJCOPY" OBJDUMP="$OBJDUMP" READELF="$READELF" STRIP="$STRIP"
++
++    ${if arch == "x86_64" then ''
++    # Check only the Zones delta. Existing AWS defaults are not duplicated as Zones policy.
++    for option in EXPERT RANDOMIZE_BASE RANDOMIZE_MEMORY HARDENED_USERCOPY \
++      SLAB_FREELIST_RANDOM SECURITY_DMESG_RESTRICT; do
++      grep -Fqx "CONFIG_$option=y" .config || {
++        echo "expected CONFIG_$option=y after olddefconfig" >&2
++        exit 1
++      }
++    done
++    grep -Fqx 'CONFIG_NSM=m' .config
++
++    for option in DEBUG_FS MAGIC_SYSRQ KEXEC KEXEC_FILE IO_URING BPF_SYSCALL BPF_JIT \
++      USERFAULTFD USER_NS NET_NS IA32_EMULATION X86_X32_ABI COMPAT \
++      MODIFY_LDT_SYSCALL DEVMEM PROC_KCORE; do
++      if grep -Eq "^CONFIG_$option=[ym]$" .config; then
++        echo "expected CONFIG_$option to be disabled after olddefconfig" >&2
++        exit 1
++      fi
++    done
++    '' else ""}
+   '';

--- a/docker/nitro/zones-hardening-x86_64.config
+++ b/docker/nitro/zones-hardening-x86_64.config
@@ -1,0 +1,33 @@
+# Zones' production hardening delta over the pinned AWS Nitro x86_64 config.
+# The final resolved values are asserted by kernel.nix after olddefconfig.
+
+# Several removable facilities are hidden behind EXPERT and otherwise forced to their defaults.
+CONFIG_EXPERT=y
+
+# Runtime layout randomization does not affect the reproducibility of the kernel image or PCRs.
+CONFIG_RANDOMIZE_BASE=y
+CONFIG_RANDOMIZE_MEMORY=y
+
+# The production enclave has no interactive kernel administration or in-place kernel replacement.
+# CONFIG_DEBUG_FS is not set
+# CONFIG_MAGIC_SYSRQ is not set
+# CONFIG_KEXEC is not set
+# CONFIG_KEXEC_FILE is not set
+
+# Remove kernel interfaces that the stateless prover does not use.
+# CONFIG_IO_URING is not set
+# CONFIG_BPF_SYSCALL is not set
+# CONFIG_BPF_JIT is not set
+# CONFIG_USERFAULTFD is not set
+# CONFIG_USER_NS is not set
+# CONFIG_NET_NS is not set
+# CONFIG_IA32_EMULATION is not set
+# CONFIG_X86_X32_ABI is not set
+# CONFIG_MODIFY_LDT_SYSCALL is not set
+# CONFIG_DEVMEM is not set
+# CONFIG_PROC_KCORE is not set
+
+# Low-overhead kernel memory-corruption and information-disclosure defenses.
+CONFIG_HARDENED_USERCOPY=y
+CONFIG_SLAB_FREELIST_RANDOM=y
+CONFIG_SECURITY_DMESG_RESTRICT=y


### PR DESCRIPTION
## Summary

Stacked on #1301.

- build the kernel, resolved config, cmdline, NSM driver, init, and linuxkit from the same pinned AWS Nitro bootstrap source
- pin the Nix builder image by digest and publish SHA-384 hashes for the matched bootstrap artifacts
- apply a focused patch to AWS's pinned kernel expression rather than vendoring it
- apply a small Zones Kconfig fragment over AWS's x86_64 baseline and assert the resolved values after olddefconfig
- enable KASLR, kernel-memory ASLR, hardened usercopy, slab-freelist randomization, and dmesg restrictions
- remove unused enclave interfaces: debugfs, Magic SysRq, kexec, io_uring, BPF/JIT, userfaultfd, user/network namespaces, 32-bit compatibility, modify_ldt, /dev/mem, and /proc/kcore

These are actual changes from AWS's baseline rather than restatements of its defaults. CONFIG_EXPERT is enabled only so hidden default-on facilities can be disabled; it does not add a runtime interface.

## Validation

- [x] resolved Kconfig assertions pass
- [x] native CI compiles the patched Linux 6.6.79 kernel and matching NSM module with Nix's syscall filter enabled
- [x] pinned init and linuxkit builds/tests exercised
- [x] Docker Bake graph parses
- [x] git diff --check
- [x] existing Docker Build workflow completes the full EIF build
- [ ] boot on real Nitro hardware
- [ ] successful prover request on real Nitro hardware

Because this is a compatibility-sensitive reduction of AWS's baseline, the PR must pass a full EIF build, real-Nitro boot, and prover request before merge.

## Deferred follow-ups

- PERF_EVENTS and kprobes remain selected by other AWS baseline functionality. Disabling them should be a focused dependency review rather than expanding this PR's scope.
- INIT_ON_ALLOC_DEFAULT_ON and PAGE_TABLE_CHECK_ENFORCED should be reconsidered only with same-hardware prover memory and throughput benchmarks. INIT_ON_FREE_DEFAULT_ON is excluded because its runtime cost is disproportionate for this memory-heavy prover.
- AWS's cmdline uses nomodules, while Linux documents nomodule. Changing it directly would prevent the pinned init from loading nsm.ko; NSM should first be built in or init should disable further module loading after startup.
