### PR TITLE
refactor(node): deprecate manifestless startup

### DIFF
--- a/Justfile
+++ b/Justfile
@@ -231,7 +231,7 @@ demo-swap-and-deposit name amount="100000000" tick="0" rpc=zone_rpc:
         --tick "{{tick}}"
 
 [group('zone')]
-[doc('Starts a Tempo Zone L2 node, subscribing to L1 deposits. Pass the zone name used in create-zone. Use profile=release for production.')]
+[doc('Starts a manifest-backed Tempo Zone node. Requires SEQUENCER_MANIFEST, P2P_KEY, and SECP256K1_KEY. Use profile=release for production.')]
 zone-up name reset="false" profile="dev" args="":
     #!/bin/bash
     set -euo pipefail
@@ -249,6 +249,9 @@ zone-up name reset="false" profile="dev" args="":
     PORTAL=$(jq -r '.portal' "$ZONE_JSON")
     ANCHOR_BLOCK=$(jq -r '.tempoAnchorBlock' "$ZONE_JSON")
     ZONE_ID=$(jq -r '.zoneId' "$ZONE_JSON")
+    MANIFEST="${SEQUENCER_MANIFEST:?Set SEQUENCER_MANIFEST to the Zone topology manifest}"
+    P2P_KEY_FILE="${P2P_KEY:?Set P2P_KEY to this node's Ed25519 identity key}"
+    SECP256K1_KEY_FILE="${SECP256K1_KEY:?Set SECP256K1_KEY to this node's settlement key}"
     SEQ_KEY_FILE="${SEQUENCER_KEY_FILE:-}"
     if [[ -z "$SEQ_KEY_FILE" ]] && ! jq -e '.sequencerKey? | strings | select(length > 0)' "$ZONE_JSON" > /dev/null; then
         echo "Error: SEQUENCER_KEY_FILE env var not set and no sequencer key found in $ZONE_JSON" >&2
@@ -279,7 +282,10 @@ zone-up name reset="false" profile="dev" args="":
                       --http.api all \
                       --datadir "$DATADIR" \
                       --log.file.directory "$DATADIR/logs" \
-                      --sequencer \
+                      --sequencer.manifest "$MANIFEST" \
+                      --p2p.key "$P2P_KEY_FILE" \
+                      --secp256k1.key "$SECP256K1_KEY_FILE" \
+                      --sequencer.role leader \
                       --sequencer-key-file "$SEQ_KEY_FILE" \
                       {{args}}
 

--- a/crates/node/src/cli.rs
+++ b/crates/node/src/cli.rs
@@ -348,6 +348,16 @@ async fn configure_sequencing(
     }
 
     let rpc_only = p2p_config.as_ref().is_some_and(P2pConfig::is_rpc_only);
+    eyre::ensure!(
+        args.enable_sequencer || p2p_config.is_some(),
+        "--sequencer.manifest is required for node startup"
+    );
+    if args.enable_sequencer {
+        warn!(
+            target: "reth::cli",
+            "--sequencer is deprecated; configure --sequencer.manifest, --p2p.key, and --secp256k1.key"
+        );
+    }
     let should_sequence_blocks = args.enable_sequencer
         || p2p_config
             .as_ref()
@@ -633,12 +643,15 @@ pub struct ZoneArgs {
     )]
     pub redacted_rpc_max_auth_token_validity_secs: u64,
 
-    /// Enable the Zone node in sequencer mode. This advances block production and submits
-    /// withdrawal batches.
+    /// Deprecated manifestless node startup.
+    ///
+    /// Use `--sequencer.manifest` with the node's P2P and settlement identity keys. Local
+    /// development should use `tempo-zone dev` instead.
     #[arg(
         long = "sequencer",
         env = "SEQUENCER",
-        conflicts_with = "sequencer_manifest"
+        conflicts_with = "sequencer_manifest",
+        help = "Deprecated: start a node without a sequencer manifest"
     )]
     pub enable_sequencer: bool,
 

--- a/crates/p2p/README.md
+++ b/crates/p2p/README.md
@@ -32,8 +32,8 @@ unavailable, or skipped Portal epochs make the recovery boundary ambiguous.
 After a normal Portal transition ends recovery, a restart skips the completed stale directive and
 logs a removal warning. Operators should still remove the directive from every manifest promptly.
 
-If a manifest is not specified, `tempo-zone` retains its existing single-sequencer startup
-behavior.
+The manifestless `--sequencer` startup path is deprecated. Use `tempo-zone dev` for local
+development.
 
 ## Roles
 
@@ -208,8 +208,8 @@ the internet-facing standby would put deposit recipients and memos within reach 
 compromise. Startup rejects that key-file flag on an `rpc_only` node rather than ignoring it.
 This key is independent from the shared `--sequencer-key-file`; reusing that shared key
 would collapse several nodes into one recoverable quorum identity.
-The `--sequencer` flag conflicts with `--sequencer.manifest` because the
-manifest determines whether the node starts the sequencer tasks.
+The deprecated `--sequencer` flag conflicts with `--sequencer.manifest` because the manifest
+determines whether the node starts the sequencer tasks.
 
 DNS peer addresses do not provide a stable egress IP for Commonware's inbound
 source-IP filter. A manifest containing any DNS peer therefore requires the

--- a/docs/ZONES.md
+++ b/docs/ZONES.md
@@ -684,7 +684,8 @@ cast code 0x5A4d000000000000000000000000000000000000 --rpc-url "$ETH_RPC_URL"
 | `--l1.rpc-url` | (required) | Certified Tempo follower WebSocket RPC URL |
 | `--l1.portal-address` | (from zone.json) | ZonePortal contract on L1 |
 | `--zone.id` | (deprecated) | Optional compatibility check against the zone ID encoded in the genesis chain ID. |
-| `--sequencer` | false | Enable sequencer mode for block production and withdrawal batch submission |
+| `--sequencer` | false | Deprecated manifestless node startup. Use `tempo-zone dev` locally or `--sequencer.manifest` for a node. |
+| `--sequencer.manifest` | (required for networked nodes) | Static Zone P2P topology and settlement membership |
 | `--sequencer-key-file` | (required for sequencing) | Owner-readable file or FIFO containing the sequencer private key |
 | `--deposit-decryption-keys-file` | (optional) | File containing additional historical or pre-provisioned deposit decryption keys, one hex key per line |
 | `--zone.batch-interval-blocks` | 120 | Zone blocks between empty withdrawal batch boundaries / L1 submissions (~1 minute at Tempo's 500 ms block time) |


### PR DESCRIPTION
This PR deprecates manifestless `tempo-zone node --sequencer` startup and migrates `just zone-up` to a sequencer manifest. The legacy flag remains supported for compatibility.