### PR TITLE
chore: bump workspace version to 0.2.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -11740,7 +11740,7 @@ dependencies = [
 
 [[package]]
 name = "tempo-vsock-proxy"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "clap",
  "libc",
@@ -11753,7 +11753,7 @@ dependencies = [
 
 [[package]]
 name = "tempo-xtask"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "alloy",
  "alloy-eips",
@@ -11793,7 +11793,7 @@ dependencies = [
 
 [[package]]
 name = "tempo-zone"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "reth-cli-util",
  "rustls",
@@ -11802,7 +11802,7 @@ dependencies = [
 
 [[package]]
 name = "tempo-zone-contracts"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "alloy-contract",
  "alloy-network",
@@ -11821,7 +11821,7 @@ dependencies = [
 
 [[package]]
 name = "tempo-zone-prover-enclave"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "alloy-consensus",
  "alloy-genesis",
@@ -11844,7 +11844,7 @@ dependencies = [
 
 [[package]]
 name = "tempo-zone-prover-utils"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -13697,7 +13697,7 @@ checksum = "29666d0abbfad1e3dc4dcf6144730dd3a3ab225bbbdac83319345b1b44ccfc1b"
 
 [[package]]
 name = "zone-chainspec"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "alloy-eips",
  "alloy-evm",
@@ -13717,7 +13717,7 @@ dependencies = [
 
 [[package]]
 name = "zone-checker"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "alloy-consensus",
  "alloy-contract",
@@ -13764,7 +13764,7 @@ dependencies = [
 
 [[package]]
 name = "zone-evm"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "alloy-consensus",
  "alloy-evm",
@@ -13799,7 +13799,7 @@ dependencies = [
 
 [[package]]
 name = "zone-hardfork"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "alloy-hardforks",
  "paste",
@@ -13807,7 +13807,7 @@ dependencies = [
 
 [[package]]
 name = "zone-l1"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -13847,7 +13847,7 @@ dependencies = [
 
 [[package]]
 name = "zone-node"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "alloy",
  "alloy-chains",
@@ -13942,7 +13942,7 @@ dependencies = [
 
 [[package]]
 name = "zone-p2p"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "alloy-primitives",
  "alloy-signer-local",
@@ -13966,7 +13966,7 @@ dependencies = [
 
 [[package]]
 name = "zone-payload"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -14007,7 +14007,7 @@ dependencies = [
 
 [[package]]
 name = "zone-precompiles"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "aes-gcm",
  "alloy",
@@ -14038,7 +14038,7 @@ dependencies = [
 
 [[package]]
 name = "zone-primitives"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "alloy-primitives",
  "tempo-hardfork",
@@ -14047,7 +14047,7 @@ dependencies = [
 
 [[package]]
 name = "zone-prover"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -14066,7 +14066,7 @@ dependencies = [
 
 [[package]]
 name = "zone-rpc"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -14105,7 +14105,7 @@ dependencies = [
 
 [[package]]
 name = "zone-sequencer"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "alloy-chains",
  "alloy-consensus",
@@ -14151,7 +14151,7 @@ dependencies = [
 
 [[package]]
 name = "zone-spf"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,5 @@
 [workspace.package]
-version = "0.2.0"
+version = "0.2.1"
 edition = "2024"
 rust-version = "1.95.0"
 license = "MIT OR Apache-2.0"


### PR DESCRIPTION
Bumps the workspace package version from 0.2.0 to 0.2.1 and refreshes workspace package versions in Cargo.lock.

Prompted by: @grandizzy