### PR TITLE
refactor(dev): launch dev node directly

### DIFF
--- a/crates/node/src/cli.rs
+++ b/crates/node/src/cli.rs
@@ -190,6 +190,10 @@ pub(crate) fn run_dev_node(mut cli: Cli<ZoneChainSpecParser, ZoneArgs>) -> eyre:
             args.sequencer_manifest.is_none(),
             "--sequencer.manifest is not supported with `tempo-zone dev`"
         );
+        eyre::ensure!(
+            args.checker_mode == CheckerMode::Off,
+            "--checker.mode is not supported with `tempo-zone dev`"
+        );
 
         let zone_id = builder.config().chain.zone_id();
         validate_deprecated_zone_id(args.zone_id, zone_id)?;
@@ -215,34 +219,12 @@ pub(crate) fn run_dev_node(mut cli: Cli<ZoneChainSpecParser, ZoneArgs>) -> eyre:
             prover_address: args.prover_address.clone(),
         });
 
-        match args.checker_mode {
-            CheckerMode::Off => {
-                let handle = builder
-                    .node(node)
-                    .launch_with_debug_capabilities()
-                    .await?;
-                handle.wait_for_node_exit().await
-            }
-            CheckerMode::Observe => {
-                info!(target: "reth::cli", "Checker ExEx enabled (observe mode)");
-                let node = node.with_portal_evidence_retention();
-                let checker = CheckerExEx::new(CheckerConfig {
-                    l1_rpc_url: args.l1_rpc_url.clone(),
-                    portal_address: args.portal_address,
-                    zone_id,
-                    zone_chain_id: builder.config().chain.chain().id(),
-                    database_path: builder.config().datadir().data_dir().join("checker"),
-                    l1_block_tracker: node.l1_block_tracker(),
-                });
-                builder
-                    .node(node)
-                    .install_exex("zone-checker", async move |ctx| Ok(checker.run(ctx)))
-                    .launch_with_debug_capabilities()
-                    .await?
-                    .wait_for_node_exit()
-                    .await
-            }
-        }
+        builder
+            .node(node)
+            .launch_with_debug_capabilities()
+            .await?
+            .wait_for_node_exit()
+            .await
     })
 }
 

--- a/crates/node/src/cli.rs
+++ b/crates/node/src/cli.rs
@@ -132,7 +132,7 @@ fn run_node(mut cli: Cli<ZoneChainSpecParser, ZoneArgs>) -> eyre::Result<()> {
         builder.config_mut().rpc.rpc_max_logs_per_response = MAX_LOGS_PER_RESPONSE.into();
         builder.config_mut().rpc.rpc_max_blocks_per_filter = MAX_BLOCKS_PER_FILTER.into();
 
-        let mut node = base_zone_node(&args, zone_id).await?;
+        let mut node = create_zone_node(&args, zone_id).await?;
         node = configure_sequencing(&args, zone_id, node).await?;
 
         // Install or skip the checker ExEx based on the configured mode.
@@ -198,7 +198,7 @@ pub(crate) fn run_dev_node(mut cli: Cli<ZoneChainSpecParser, ZoneArgs>) -> eyre:
         builder.config_mut().rpc.rpc_max_logs_per_response = MAX_LOGS_PER_RESPONSE.into();
         builder.config_mut().rpc.rpc_max_blocks_per_filter = MAX_BLOCKS_PER_FILTER.into();
 
-        let mut node = base_zone_node(&args, zone_id).await?;
+        let mut node = create_zone_node(&args, zone_id).await?;
         let sequencer_signer = load_sequencer_signer(args.sequencer_key_file.as_deref()).await?;
         node = node.with_sequencer(ZoneSequencerAddOnsConfig {
             sequencer_signer,
@@ -271,7 +271,7 @@ fn l1_evm_config_from_env() -> eyre::Result<Option<(url::Url, Address)>> {
     }
 }
 
-async fn base_zone_node(args: &ZoneArgs, zone_id: u32) -> eyre::Result<ZoneNode> {
+async fn create_zone_node(args: &ZoneArgs, zone_id: u32) -> eyre::Result<ZoneNode> {
     let additional_decryption_keys =
         load_decryption_keys(args.deposit_decryption_keys_file.as_deref()).await?;
     let mut node = ZoneNode::new(

--- a/crates/node/src/cli.rs
+++ b/crates/node/src/cli.rs
@@ -99,7 +99,28 @@ fn run_node(mut cli: Cli<ZoneChainSpecParser, ZoneArgs>) -> eyre::Result<()> {
     prepend_log_filter(&mut cli.logs.log_stdout_filter, ZONE_LOG_FILTER_DIRECTIVES);
     prepend_log_filter(&mut cli.logs.log_file_filter, ZONE_LOG_FILTER_DIRECTIVES);
 
-    let l1_config = l1_evm_config_from_env()?;
+    let l1_config = match std::env::var("L1_HTTP_RPC_URL") {
+        Ok(url) if !url.is_empty() => {
+            let url = url
+                .parse()
+                .map_err(|error| eyre::eyre!("invalid L1_HTTP_RPC_URL: {error}"))?;
+            let portal_address: Address = std::env::var("L1_PORTAL_ADDRESS")
+                .map_err(|error| {
+                    eyre::eyre!(
+                        "L1_PORTAL_ADDRESS must be set when L1_HTTP_RPC_URL is set: {error}"
+                    )
+                })?
+                .parse()
+                .map_err(|error| eyre::eyre!("invalid L1_PORTAL_ADDRESS: {error}"))?;
+            eyre::ensure!(
+                !portal_address.is_zero(),
+                "L1_PORTAL_ADDRESS must be nonzero"
+            );
+            Some((url, portal_address))
+        }
+        Ok(_) | Err(std::env::VarError::NotPresent) => None,
+        Err(error) => return Err(eyre::eyre!("invalid L1_HTTP_RPC_URL: {error}")),
+    };
 
     let components = move |spec: Arc<ZoneChainSpec>| {
         let evm_config = cli_evm_config(spec.clone(), l1_config.clone());
@@ -127,12 +148,32 @@ fn run_node(mut cli: Cli<ZoneChainSpecParser, ZoneArgs>) -> eyre::Result<()> {
             builder.config_mut().engine.persistence_threshold = 0;
             builder.config_mut().engine.memory_block_buffer_target = Some(0);
         }
+        let additional_decryption_keys =
+            load_decryption_keys(args.deposit_decryption_keys_file.as_deref()).await?;
+
         builder.config_mut().network.discovery.disable_discovery = true;
         builder.config_mut().rpc.disable_auth_server = true;
         builder.config_mut().rpc.rpc_max_logs_per_response = MAX_LOGS_PER_RESPONSE.into();
         builder.config_mut().rpc.rpc_max_blocks_per_filter = MAX_BLOCKS_PER_FILTER.into();
 
-        let mut node = create_zone_node(&args, zone_id).await?;
+        let mut node = ZoneNode::new(
+            args.l1_rpc_url.clone(),
+            args.portal_address,
+            args.l1_fetch_concurrency,
+            Duration::from_millis(args.l1_retry_connection_interval_ms),
+        )
+        .with_withdrawal_batch_interval_blocks(args.zone_batch_interval_blocks)
+        .with_redacted_rpc(ZoneRedactedRpcConfig {
+            redacted_rpc_port: args.redacted_rpc_port,
+            zone_id,
+            max_auth_token_validity: Duration::from_secs(
+                args.redacted_rpc_max_auth_token_validity_secs,
+            ),
+        });
+        if !additional_decryption_keys.is_empty() {
+            node = node.with_deposit_decryption_keys(additional_decryption_keys);
+        }
+
         node = configure_sequencing(&args, zone_id, node).await?;
 
         // Install or skip the checker ExEx based on the configured mode.

--- a/crates/node/src/cli.rs
+++ b/crates/node/src/cli.rs
@@ -99,28 +99,7 @@ fn run_node(mut cli: Cli<ZoneChainSpecParser, ZoneArgs>) -> eyre::Result<()> {
     prepend_log_filter(&mut cli.logs.log_stdout_filter, ZONE_LOG_FILTER_DIRECTIVES);
     prepend_log_filter(&mut cli.logs.log_file_filter, ZONE_LOG_FILTER_DIRECTIVES);
 
-    let l1_config = match std::env::var("L1_HTTP_RPC_URL") {
-        Ok(url) if !url.is_empty() => {
-            let url = url
-                .parse()
-                .map_err(|error| eyre::eyre!("invalid L1_HTTP_RPC_URL: {error}"))?;
-            let portal_address: Address = std::env::var("L1_PORTAL_ADDRESS")
-                .map_err(|error| {
-                    eyre::eyre!(
-                        "L1_PORTAL_ADDRESS must be set when L1_HTTP_RPC_URL is set: {error}"
-                    )
-                })?
-                .parse()
-                .map_err(|error| eyre::eyre!("invalid L1_PORTAL_ADDRESS: {error}"))?;
-            eyre::ensure!(
-                !portal_address.is_zero(),
-                "L1_PORTAL_ADDRESS must be nonzero"
-            );
-            Some((url, portal_address))
-        }
-        Ok(_) | Err(std::env::VarError::NotPresent) => None,
-        Err(error) => return Err(eyre::eyre!("invalid L1_HTTP_RPC_URL: {error}")),
-    };
+    let l1_config = l1_evm_config_from_env()?;
 
     let components = move |spec: Arc<ZoneChainSpec>| {
         let evm_config = cli_evm_config(spec.clone(), l1_config.clone());
@@ -148,32 +127,12 @@ fn run_node(mut cli: Cli<ZoneChainSpecParser, ZoneArgs>) -> eyre::Result<()> {
             builder.config_mut().engine.persistence_threshold = 0;
             builder.config_mut().engine.memory_block_buffer_target = Some(0);
         }
-        let additional_decryption_keys =
-            load_decryption_keys(args.deposit_decryption_keys_file.as_deref()).await?;
-
         builder.config_mut().network.discovery.disable_discovery = true;
         builder.config_mut().rpc.disable_auth_server = true;
         builder.config_mut().rpc.rpc_max_logs_per_response = MAX_LOGS_PER_RESPONSE.into();
         builder.config_mut().rpc.rpc_max_blocks_per_filter = MAX_BLOCKS_PER_FILTER.into();
 
-        let mut node = ZoneNode::new(
-            args.l1_rpc_url.clone(),
-            args.portal_address,
-            args.l1_fetch_concurrency,
-            Duration::from_millis(args.l1_retry_connection_interval_ms),
-        )
-        .with_withdrawal_batch_interval_blocks(args.zone_batch_interval_blocks)
-        .with_redacted_rpc(ZoneRedactedRpcConfig {
-            redacted_rpc_port: args.redacted_rpc_port,
-            zone_id,
-            max_auth_token_validity: Duration::from_secs(
-                args.redacted_rpc_max_auth_token_validity_secs,
-            ),
-        });
-        if !additional_decryption_keys.is_empty() {
-            node = node.with_deposit_decryption_keys(additional_decryption_keys);
-        }
-
+        let mut node = base_zone_node(&args, zone_id).await?;
         node = configure_sequencing(&args, zone_id, node).await?;
 
         // Install or skip the checker ExEx based on the configured mode.
@@ -206,6 +165,133 @@ fn run_node(mut cli: Cli<ZoneChainSpecParser, ZoneArgs>) -> eyre::Result<()> {
             }
         }
     })
+}
+
+/// Launches the node provisioned by the Zone dev harness.
+pub(crate) fn run_dev_node(mut cli: Cli<ZoneChainSpecParser, ZoneArgs>) -> eyre::Result<()> {
+    prepend_log_filter(&mut cli.logs.log_stdout_filter, ZONE_LOG_FILTER_DIRECTIVES);
+    prepend_log_filter(&mut cli.logs.log_file_filter, ZONE_LOG_FILTER_DIRECTIVES);
+
+    let l1_config = l1_evm_config_from_env()?;
+
+    let components = move |spec: Arc<ZoneChainSpec>| {
+        let evm_config = cli_evm_config(spec.clone(), l1_config.clone());
+        (evm_config, TempoConsensus::new(spec))
+    };
+
+    cli.run_with_components::<ZoneNode>(components, async move |mut builder, args| {
+        info!(target: "reth::cli", "Launching Tempo Zone dev node");
+
+        if args.block_interval_ms.is_some() {
+            warn!(target: "reth::cli", "--block.interval-ms is deprecated, has no effect, and will be removed in the next release");
+        }
+
+        eyre::ensure!(
+            args.sequencer_manifest.is_none(),
+            "--sequencer.manifest is not supported with `tempo-zone dev`"
+        );
+
+        let zone_id = builder.config().chain.zone_id();
+        validate_deprecated_zone_id(args.zone_id, zone_id)?;
+        builder.config_mut().network.discovery.disable_discovery = true;
+        builder.config_mut().rpc.disable_auth_server = true;
+        builder.config_mut().rpc.rpc_max_logs_per_response = MAX_LOGS_PER_RESPONSE.into();
+        builder.config_mut().rpc.rpc_max_blocks_per_filter = MAX_BLOCKS_PER_FILTER.into();
+
+        let mut node = base_zone_node(&args, zone_id).await?;
+        let sequencer_signer = load_sequencer_signer(args.sequencer_key_file.as_deref()).await?;
+        node = node.with_sequencer(ZoneSequencerAddOnsConfig {
+            sequencer_signer,
+            l1_transaction_signer: None,
+            zone_id,
+            zone_poll_interval: Duration::from_secs(args.zone_poll_interval_secs),
+            batch_anchor_config: BatchAnchorConfig::default(),
+            withdrawal_poll_interval: Duration::from_secs(args.withdrawal_poll_interval_secs),
+            withdrawal_batch_limits: WithdrawalBatchLimits {
+                max_batch_gas: args.withdrawal_max_batch_gas,
+                max_in_flight_batches: args.withdrawal_max_in_flight_batches,
+            },
+            enable_prover: args.enable_prover,
+            prover_address: args.prover_address.clone(),
+        });
+
+        match args.checker_mode {
+            CheckerMode::Off => {
+                let handle = builder
+                    .node(node)
+                    .launch_with_debug_capabilities()
+                    .await?;
+                handle.wait_for_node_exit().await
+            }
+            CheckerMode::Observe => {
+                info!(target: "reth::cli", "Checker ExEx enabled (observe mode)");
+                let node = node.with_portal_evidence_retention();
+                let checker = CheckerExEx::new(CheckerConfig {
+                    l1_rpc_url: args.l1_rpc_url.clone(),
+                    portal_address: args.portal_address,
+                    zone_id,
+                    zone_chain_id: builder.config().chain.chain().id(),
+                    database_path: builder.config().datadir().data_dir().join("checker"),
+                    l1_block_tracker: node.l1_block_tracker(),
+                });
+                builder
+                    .node(node)
+                    .install_exex("zone-checker", async move |ctx| Ok(checker.run(ctx)))
+                    .launch_with_debug_capabilities()
+                    .await?
+                    .wait_for_node_exit()
+                    .await
+            }
+        }
+    })
+}
+
+fn l1_evm_config_from_env() -> eyre::Result<Option<(url::Url, Address)>> {
+    match std::env::var("L1_HTTP_RPC_URL") {
+        Ok(url) if !url.is_empty() => {
+            let url = url
+                .parse()
+                .map_err(|error| eyre::eyre!("invalid L1_HTTP_RPC_URL: {error}"))?;
+            let portal_address: Address = std::env::var("L1_PORTAL_ADDRESS")
+                .map_err(|error| {
+                    eyre::eyre!(
+                        "L1_PORTAL_ADDRESS must be set when L1_HTTP_RPC_URL is set: {error}"
+                    )
+                })?
+                .parse()
+                .map_err(|error| eyre::eyre!("invalid L1_PORTAL_ADDRESS: {error}"))?;
+            eyre::ensure!(
+                !portal_address.is_zero(),
+                "L1_PORTAL_ADDRESS must be nonzero"
+            );
+            Ok(Some((url, portal_address)))
+        }
+        Ok(_) | Err(std::env::VarError::NotPresent) => Ok(None),
+        Err(error) => Err(eyre::eyre!("invalid L1_HTTP_RPC_URL: {error}")),
+    }
+}
+
+async fn base_zone_node(args: &ZoneArgs, zone_id: u32) -> eyre::Result<ZoneNode> {
+    let additional_decryption_keys =
+        load_decryption_keys(args.deposit_decryption_keys_file.as_deref()).await?;
+    let mut node = ZoneNode::new(
+        args.l1_rpc_url.clone(),
+        args.portal_address,
+        args.l1_fetch_concurrency,
+        Duration::from_millis(args.l1_retry_connection_interval_ms),
+    )
+    .with_withdrawal_batch_interval_blocks(args.zone_batch_interval_blocks)
+    .with_redacted_rpc(ZoneRedactedRpcConfig {
+        redacted_rpc_port: args.redacted_rpc_port,
+        zone_id,
+        max_auth_token_validity: Duration::from_secs(
+            args.redacted_rpc_max_auth_token_validity_secs,
+        ),
+    });
+    if !additional_decryption_keys.is_empty() {
+        node = node.with_deposit_decryption_keys(additional_decryption_keys);
+    }
+    Ok(node)
 }
 
 /// Creates the EVM config used by CLI subcommands.

--- a/crates/node/src/cli.rs
+++ b/crates/node/src/cli.rs
@@ -231,10 +231,6 @@ pub(crate) fn run_dev_node(mut cli: Cli<ZoneChainSpecParser, ZoneArgs>) -> eyre:
             args.sequencer_manifest.is_none(),
             "--sequencer.manifest is not supported with `tempo-zone dev`"
         );
-        eyre::ensure!(
-            args.checker_mode == CheckerMode::Off,
-            "--checker.mode is not supported with `tempo-zone dev`"
-        );
 
         let zone_id = builder.config().chain.zone_id();
         validate_deprecated_zone_id(args.zone_id, zone_id)?;
@@ -260,12 +256,35 @@ pub(crate) fn run_dev_node(mut cli: Cli<ZoneChainSpecParser, ZoneArgs>) -> eyre:
             prover_address: args.prover_address.clone(),
         });
 
-        builder
-            .node(node)
-            .launch_with_debug_capabilities()
-            .await?
-            .wait_for_node_exit()
-            .await
+        match args.checker_mode {
+            CheckerMode::Off => {
+                builder
+                    .node(node)
+                    .launch_with_debug_capabilities()
+                    .await?
+                    .wait_for_node_exit()
+                    .await
+            }
+            CheckerMode::Observe => {
+                info!(target: "reth::cli", "Checker ExEx enabled (observe mode)");
+                let node = node.with_portal_evidence_retention();
+                let checker = CheckerExEx::new(CheckerConfig {
+                    l1_rpc_url: args.l1_rpc_url.clone(),
+                    portal_address: args.portal_address,
+                    zone_id,
+                    zone_chain_id: builder.config().chain.chain().id(),
+                    database_path: builder.config().datadir().data_dir().join("checker"),
+                    l1_block_tracker: node.l1_block_tracker(),
+                });
+                builder
+                    .node(node)
+                    .install_exex("zone-checker", async move |ctx| Ok(checker.run(ctx)))
+                    .launch_with_debug_capabilities()
+                    .await?
+                    .wait_for_node_exit()
+                    .await
+            }
+        }
     })
 }
 

--- a/crates/node/src/dev.rs
+++ b/crates/node/src/dev.rs
@@ -241,9 +241,12 @@ mod command {
 
     use alloy_primitives::Address;
     use alloy_signer_local::PrivateKeySigner;
+    use clap::Parser as _;
+    use reth_ethereum::cli::Cli;
+    use zone_chainspec::ZoneChainSpecParser;
 
     use super::{ProvisionConfig, provision_zone};
-    use crate::cli::ZoneCli;
+    use crate::cli::{ZoneArgs, run_dev_node};
     use tempo_contracts::precompiles::PATH_USD_ADDRESS;
 
     /// Default dev private key (account #0 of the standard `test test ... junk` mnemonic).
@@ -447,7 +450,6 @@ mod command {
                 &self.datadir.join("node").display().to_string(),
                 "--log.file.directory",
                 &self.datadir.join("logs").display().to_string(),
-                "--sequencer",
                 "--sequencer-key-file",
                 &sequencer_key_path.display().to_string(),
             ]
@@ -455,7 +457,8 @@ mod command {
             .to_vec();
             argv.extend(self.node_args);
 
-            ZoneCli::parse_from(argv).run()
+            let cli = Cli::<ZoneChainSpecParser, ZoneArgs>::parse_from(argv);
+            run_dev_node(cli)
         }
     }
 

--- a/crates/node/src/dev.rs
+++ b/crates/node/src/dev.rs
@@ -241,7 +241,7 @@ mod command {
 
     use alloy_primitives::Address;
     use alloy_signer_local::PrivateKeySigner;
-    use clap::{CommandFactory as _, FromArgMatches as _};
+    use clap::Parser as _;
     use reth_ethereum::cli::Cli;
     use zone_chainspec::ZoneChainSpecParser;
 
@@ -252,16 +252,6 @@ mod command {
     /// Default dev private key (account #0 of the standard `test test ... junk` mnemonic).
     const DEFAULT_DEV_KEY: &str =
         "0xac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80";
-
-    const DEV_IGNORED_TOPOLOGY_ENV: [&str; 7] = [
-        "SEQUENCER_MANIFEST",
-        "P2P_KEY",
-        "SECP256K1_KEY",
-        "P2P_LISTEN",
-        "P2P_BYPASS_IP_CHECK",
-        "SEQUENCER_ROLE",
-        "SEQUENCER",
-    ];
 
     /// Provisions a fresh zone against a Tempo dev L1 and runs the zone node.
     #[derive(Debug, clap::Parser)]
@@ -467,30 +457,9 @@ mod command {
             .to_vec();
             argv.extend(self.node_args);
 
-            let cli = parse_dev_node_cli(argv)?;
+            let cli = Cli::<ZoneChainSpecParser, ZoneArgs>::parse_from(argv);
             run_dev_node(cli)
         }
-    }
-
-    fn parse_dev_node_cli(argv: Vec<String>) -> eyre::Result<Cli<ZoneChainSpecParser, ZoneArgs>> {
-        let matches = dev_node_command().try_get_matches_from(argv)?;
-        Ok(Cli::from_arg_matches(&matches)?)
-    }
-
-    fn dev_node_command() -> clap::Command {
-        Cli::<ZoneChainSpecParser, ZoneArgs>::command().mut_subcommand("node", |command| {
-            command.mut_args(|arg| {
-                if arg.get_env().is_some_and(|env| {
-                    DEV_IGNORED_TOPOLOGY_ENV
-                        .iter()
-                        .any(|ignored| env == std::ffi::OsStr::new(ignored))
-                }) {
-                    arg.env(None::<&'static str>)
-                } else {
-                    arg
-                }
-            })
-        })
     }
 
     fn default_datadir() -> PathBuf {
@@ -535,7 +504,7 @@ mod command {
     mod tests {
         use clap::Parser as _;
 
-        use super::{DEV_IGNORED_TOPOLOGY_ENV, DevCommand, dev_node_command, ensure_ws_url};
+        use super::{DevCommand, ensure_ws_url};
 
         #[test]
         fn private_rpc_port_alias_is_accepted() {
@@ -546,29 +515,6 @@ mod command {
 
             assert_eq!(redacted.redacted_rpc_port, 9544);
             assert_eq!(private.redacted_rpc_port, 9544);
-        }
-
-        #[test]
-        fn dev_node_parser_ignores_topology_environment() {
-            let command = dev_node_command();
-            let node = command.find_subcommand("node").unwrap();
-
-            for env in DEV_IGNORED_TOPOLOGY_ENV {
-                assert!(
-                    node.get_arguments()
-                        .all(|arg| arg.get_env() != Some(std::ffi::OsStr::new(env))),
-                    "dev node still reads {env}"
-                );
-            }
-
-            let checker = node
-                .get_arguments()
-                .find(|arg| arg.get_id().as_str() == "checker_mode")
-                .unwrap();
-            assert_eq!(
-                checker.get_env(),
-                Some(std::ffi::OsStr::new("CHECKER_MODE"))
-            );
         }
 
         #[test]

--- a/crates/node/src/dev.rs
+++ b/crates/node/src/dev.rs
@@ -241,7 +241,7 @@ mod command {
 
     use alloy_primitives::Address;
     use alloy_signer_local::PrivateKeySigner;
-    use clap::Parser as _;
+    use clap::{CommandFactory as _, FromArgMatches as _};
     use reth_ethereum::cli::Cli;
     use zone_chainspec::ZoneChainSpecParser;
 
@@ -252,6 +252,16 @@ mod command {
     /// Default dev private key (account #0 of the standard `test test ... junk` mnemonic).
     const DEFAULT_DEV_KEY: &str =
         "0xac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80";
+
+    const DEV_IGNORED_TOPOLOGY_ENV: [&str; 7] = [
+        "SEQUENCER_MANIFEST",
+        "P2P_KEY",
+        "SECP256K1_KEY",
+        "P2P_LISTEN",
+        "P2P_BYPASS_IP_CHECK",
+        "SEQUENCER_ROLE",
+        "SEQUENCER",
+    ];
 
     /// Provisions a fresh zone against a Tempo dev L1 and runs the zone node.
     #[derive(Debug, clap::Parser)]
@@ -457,9 +467,30 @@ mod command {
             .to_vec();
             argv.extend(self.node_args);
 
-            let cli = Cli::<ZoneChainSpecParser, ZoneArgs>::parse_from(argv);
+            let cli = parse_dev_node_cli(argv)?;
             run_dev_node(cli)
         }
+    }
+
+    fn parse_dev_node_cli(argv: Vec<String>) -> eyre::Result<Cli<ZoneChainSpecParser, ZoneArgs>> {
+        let matches = dev_node_command().try_get_matches_from(argv)?;
+        Ok(Cli::from_arg_matches(&matches)?)
+    }
+
+    fn dev_node_command() -> clap::Command {
+        Cli::<ZoneChainSpecParser, ZoneArgs>::command().mut_subcommand("node", |command| {
+            command.mut_args(|arg| {
+                if arg.get_env().is_some_and(|env| {
+                    DEV_IGNORED_TOPOLOGY_ENV
+                        .iter()
+                        .any(|ignored| env == std::ffi::OsStr::new(ignored))
+                }) {
+                    arg.env(None::<&'static str>)
+                } else {
+                    arg
+                }
+            })
+        })
     }
 
     fn default_datadir() -> PathBuf {
@@ -504,7 +535,7 @@ mod command {
     mod tests {
         use clap::Parser as _;
 
-        use super::{DevCommand, ensure_ws_url};
+        use super::{DEV_IGNORED_TOPOLOGY_ENV, DevCommand, dev_node_command, ensure_ws_url};
 
         #[test]
         fn private_rpc_port_alias_is_accepted() {
@@ -515,6 +546,29 @@ mod command {
 
             assert_eq!(redacted.redacted_rpc_port, 9544);
             assert_eq!(private.redacted_rpc_port, 9544);
+        }
+
+        #[test]
+        fn dev_node_parser_ignores_topology_environment() {
+            let command = dev_node_command();
+            let node = command.find_subcommand("node").unwrap();
+
+            for env in DEV_IGNORED_TOPOLOGY_ENV {
+                assert!(
+                    node.get_arguments()
+                        .all(|arg| arg.get_env() != Some(std::ffi::OsStr::new(env))),
+                    "dev node still reads {env}"
+                );
+            }
+
+            let checker = node
+                .get_arguments()
+                .find(|arg| arg.get_id().as_str() == "checker_mode")
+                .unwrap();
+            assert_eq!(
+                checker.get_env(),
+                Some(std::ffi::OsStr::new("CHECKER_MODE"))
+            );
         }
 
         #[test]


### PR DESCRIPTION
This PR gives `tempo-zone dev` its own Zone launch path instead of re-entering normal node startup through `--sequencer`. Normal `tempo-zone node` behavior is unchanged.