### PR TITLE
refactor(node): deprecate manifestless startup

### DIFF
--- a/Justfile
+++ b/Justfile
@@ -961,7 +961,8 @@ deploy-zone name token="" access_enforced="false" gateway_enforced="false":
     cargo build --bin tempo-zone --release
     DATADIR="/tmp/tempo-zone-{{name}}"
     rm -rf "$DATADIR" || true
-    exec cargo run --release --bin tempo-zone -- \
+    exec env -u SEQUENCER_MANIFEST -u P2P_KEY -u SECP256K1_KEY \
+        cargo run --release --bin tempo-zone -- \
                       node \
                       --chain "$OUTPUT/genesis.json" \
                       --l1.rpc-url "$L1_RPC" \

--- a/Justfile
+++ b/Justfile
@@ -231,7 +231,7 @@ demo-swap-and-deposit name amount="100000000" tick="0" rpc=zone_rpc:
         --tick "{{tick}}"
 
 [group('zone')]
-[doc('Starts a Tempo Zone L2 node, subscribing to L1 deposits. Pass the zone name used in create-zone. Use profile=release for production.')]
+[doc('Starts a manifest-backed Tempo Zone node. Requires SEQUENCER_MANIFEST, P2P_KEY, and SECP256K1_KEY. Use profile=release for production.')]
 zone-up name reset="false" profile="dev" args="":
     #!/bin/bash
     set -euo pipefail
@@ -249,6 +249,9 @@ zone-up name reset="false" profile="dev" args="":
     PORTAL=$(jq -r '.portal' "$ZONE_JSON")
     ANCHOR_BLOCK=$(jq -r '.tempoAnchorBlock' "$ZONE_JSON")
     ZONE_ID=$(jq -r '.zoneId' "$ZONE_JSON")
+    MANIFEST="${SEQUENCER_MANIFEST:?Set SEQUENCER_MANIFEST to the Zone topology manifest}"
+    P2P_KEY_FILE="${P2P_KEY:?Set P2P_KEY to this node's Ed25519 identity key}"
+    SECP256K1_KEY_FILE="${SECP256K1_KEY:?Set SECP256K1_KEY to this node's settlement key}"
     SEQ_KEY_FILE="${SEQUENCER_KEY_FILE:-}"
     if [[ -z "$SEQ_KEY_FILE" ]] && ! jq -e '.sequencerKey? | strings | select(length > 0)' "$ZONE_JSON" > /dev/null; then
         echo "Error: SEQUENCER_KEY_FILE env var not set and no sequencer key found in $ZONE_JSON" >&2
@@ -279,7 +282,10 @@ zone-up name reset="false" profile="dev" args="":
                       --http.api all \
                       --datadir "$DATADIR" \
                       --log.file.directory "$DATADIR/logs" \
-                      --sequencer \
+                      --sequencer.manifest "$MANIFEST" \
+                      --p2p.key "$P2P_KEY_FILE" \
+                      --secp256k1.key "$SECP256K1_KEY_FILE" \
+                      --sequencer.role leader \
                       --sequencer-key-file "$SEQ_KEY_FILE" \
                       {{args}}
 

--- a/contrib/bench/provision-topology.sh
+++ b/contrib/bench/provision-topology.sh
@@ -951,6 +951,7 @@ provision_up() {
     # default sparse-trie pruning can make a multi-transaction Zone payload
     # disagree with the root obtained during final validation.
     start_process zone "$ZONE_BIN" "${ZONES_BENCH_ZONE_CPUS:-8-13,24-29}" "$log_dir/zone.log" \
+        env -u SEQUENCER_MANIFEST -u P2P_KEY -u SECP256K1_KEY \
         "$ZONE_BIN" node \
         --chain "$zone_genesis" --datadir "$zone_db" \
         --l1.rpc-url ws://127.0.0.1:8545 \

--- a/crates/node/src/cli.rs
+++ b/crates/node/src/cli.rs
@@ -348,6 +348,16 @@ async fn configure_sequencing(
     }
 
     let rpc_only = p2p_config.as_ref().is_some_and(P2pConfig::is_rpc_only);
+    eyre::ensure!(
+        args.enable_sequencer || p2p_config.is_some(),
+        "--sequencer.manifest is required for node startup"
+    );
+    if args.enable_sequencer {
+        warn!(
+            target: "reth::cli",
+            "--sequencer is deprecated; configure --sequencer.manifest, --p2p.key, and --secp256k1.key"
+        );
+    }
     let should_sequence_blocks = args.enable_sequencer
         || p2p_config
             .as_ref()
@@ -633,12 +643,15 @@ pub struct ZoneArgs {
     )]
     pub redacted_rpc_max_auth_token_validity_secs: u64,
 
-    /// Enable the Zone node in sequencer mode. This advances block production and submits
-    /// withdrawal batches.
+    /// Deprecated manifestless node startup.
+    ///
+    /// Use `--sequencer.manifest` with the node's P2P and settlement identity keys. Local
+    /// development should use `tempo-zone dev` instead.
     #[arg(
         long = "sequencer",
         env = "SEQUENCER",
-        conflicts_with = "sequencer_manifest"
+        conflicts_with = "sequencer_manifest",
+        help = "Deprecated: start a node without a sequencer manifest"
     )]
     pub enable_sequencer: bool,
 

--- a/crates/node/src/cli.rs
+++ b/crates/node/src/cli.rs
@@ -227,10 +227,9 @@ pub(crate) fn run_dev_node(mut cli: Cli<ZoneChainSpecParser, ZoneArgs>) -> eyre:
             warn!(target: "reth::cli", "--block.interval-ms is deprecated, has no effect, and will be removed in the next release");
         }
 
-        eyre::ensure!(
-            args.sequencer_manifest.is_none(),
-            "--sequencer.manifest is not supported with `tempo-zone dev`"
-        );
+        if args.sequencer_manifest.is_some() {
+            warn!(target: "reth::cli", "Ignoring sequencer manifest in Tempo Zone dev mode");
+        }
         eyre::ensure!(
             args.checker_mode == CheckerMode::Off,
             "--checker.mode is not supported with `tempo-zone dev`"

--- a/crates/node/src/node.rs
+++ b/crates/node/src/node.rs
@@ -4,7 +4,6 @@
 //! It reuses Tempo's EVM, primitives, and pool, but with noop consensus/network/payload.
 
 use crate::{
-    ZoneEngine,
     replication::{
         AttestationContext, BACKFILL_SERVE_QUEUE_CAPACITY, PeerTipRegistry, serve_backfill_requests,
     },
@@ -99,7 +98,7 @@ use zone_primitives::constants::{decode_l1_chain_id, zone_chain_id};
 use zone_rpc::ZoneDebugApiRpcServer;
 use zone_sequencer::{
     AttestationStore, BatchAnchorConfig, ShadowProverConfig, WithdrawalBatchLimits,
-    ZoneSequencerConfig, attestation::AttestationDomain, spawn_zone_sequencer,
+    ZoneSequencerConfig, attestation::AttestationDomain,
 };
 
 fn validate_zone_chain_id(parent_chain_id: u64, zone_id: u32, chain_id: u64) -> eyre::Result<()> {
@@ -237,8 +236,6 @@ pub struct ZoneNode {
     sequencer_config: Option<ZoneSequencerAddOnsConfig>,
     /// Optional static Zone P2P networking config.
     p2p_config: Option<P2pConfig>,
-    /// Whether a consumer outside this builder drains the deposit queue.
-    external_deposit_consumer: bool,
 }
 
 impl ZoneNode {
@@ -287,7 +284,6 @@ impl ZoneNode {
             redacted_rpc_config: ZoneRedactedRpcConfig::default(),
             sequencer_config: None,
             p2p_config: None,
-            external_deposit_consumer: false,
         }
     }
 
@@ -328,15 +324,6 @@ impl ZoneNode {
         for key in keys {
             ring.add_candidate(key);
         }
-        self
-    }
-
-    /// Declare that a consumer outside this builder drains [`Self::deposit_queue`].
-    ///
-    /// Callers that drive their own [`crate::ZoneEngine`] against the shared queue — such as test
-    /// harnesses — must opt in so node startup knows the Zone chain can advance.
-    pub fn with_external_deposit_consumer(mut self) -> Self {
-        self.external_deposit_consumer = true;
         self
     }
 
@@ -426,6 +413,8 @@ where
         BasicEngineValidatorBuilder<ZoneEngineValidatorBuilder>,
         Identity,
     >,
+
+    // TODO: KIT: also clean this up, use channels
     /// Queue of L1 deposit messages to be included in the next zone block.
     deposit_queue: DepositQueue,
     /// Configuration for the L1 event subscriber
@@ -437,9 +426,8 @@ where
     /// Sequencer configuration.
     sequencer_config: Option<ZoneSequencerAddOnsConfig>,
     /// Static Zone P2P networking configuration.
-    p2p_config: Option<P2pConfig>,
-    /// Whether a consumer outside this builder drains the deposit queue.
-    external_deposit_consumer: bool,
+    // NOTE: we always need this? why is this option?
+    p2p_config: P2pConfig,
 }
 
 impl<N> std::fmt::Debug for ZoneAddOns<N>
@@ -463,8 +451,7 @@ where
         portal_address: Address,
         redacted_rpc_config: ZoneRedactedRpcConfig,
         sequencer_config: Option<ZoneSequencerAddOnsConfig>,
-        p2p_config: Option<P2pConfig>,
-        external_deposit_consumer: bool,
+        p2p_config: P2pConfig,
     ) -> Self {
         Self {
             inner: RpcAddOns::new(
@@ -481,7 +468,6 @@ where
             redacted_rpc_config,
             sequencer_config,
             p2p_config,
-            external_deposit_consumer,
         }
     }
 }
@@ -524,13 +510,7 @@ where
     > as NodeAddOns<N>>::Handle;
 
     async fn launch_add_ons(mut self, ctx: AddOnsContext<'_, N>) -> eyre::Result<Self::Handle> {
-        eyre::ensure!(
-            self.sequencer_config.is_some()
-                || self.p2p_config.is_some()
-                || self.external_deposit_consumer,
-            "no Zone chain advancement mechanism configured: enable a sequencer, configure P2P, or register an external deposit consumer"
-        );
-
+        // TODO: KIT: this all seems so windy why do we need all this?
         let tempo_block_number = ctx.node.provider().latest()?.tempo_block_number()?;
         let l1_provider = alloy_provider::ProviderBuilder::new_with_network::<TempoNetwork>()
             .connect_with_config(
@@ -575,9 +555,11 @@ where
                     portal_zone_id,
                 )?;
             }
-            if let Some(config) = self.p2p_config.as_ref() {
-                validate_configured_zone_id("P2P configuration", config.zone_id(), portal_zone_id)?;
-            }
+            validate_configured_zone_id(
+                "P2P configuration",
+                self.p2p_config.zone_id(),
+                portal_zone_id,
+            )?;
             validate_zone_chain_id(l1_chain_id, portal_zone_id, chain_id)?;
         }
 
@@ -592,50 +574,70 @@ where
         // snapshot at the local Tempo anchor, and install the transition sink before
         // the subscriber starts so no block is ever consumed ahead of its
         // leadership transition.
-        if let Some(p2p) = self.p2p_config.as_ref() {
-            let schedule = p2p.leadership();
-            let snapshot_anchor = tempo_block_number;
-            // Freeze the replay/live boundary before the subscriber starts. Historical identities
-            // may authenticate transitions that were already finalized when this process began,
-            // but must never authorize a leader selected later.
-            let finalized_replay_boundary = async {
-                l1_provider
-                    .get_header_by_number(BlockNumberOrTag::Finalized)
-                    .await
-                    .map_err(|err| {
-                        eyre::eyre!("failed reading finalized L1 replay boundary: {err}")
-                    })?
-                    .map(|header| header.number())
-                    .ok_or_else(|| eyre::eyre!("L1 finalized block is not available"))
-            };
-            let (historical_replay_through, ()) = tokio::try_join!(
-                finalized_replay_boundary,
-                seed_leadership_schedule(
-                    &l1_provider,
-                    self.portal_address,
-                    snapshot_anchor,
-                    p2p.manifest(),
-                    &schedule,
-                ),
-            )?;
-            // Seed the applied anchor from the persisted checkpoint so it targets the leader
-            // of the next anchor from the very start (and not after the first post-restart block)
-            schedule.record_applied_anchor(snapshot_anchor);
-            install_manifest_forced_recovery(
-                ctx.node.provider(),
+        let schedule = self.p2p_config.leadership();
+        let snapshot_anchor = tempo_block_number;
+        // Freeze the replay/live boundary before the subscriber starts. Historical identities
+        // may authenticate transitions that were already finalized when this process began,
+        // but must never authorize a leader selected later.
+        let finalized_replay_boundary = async {
+            l1_provider
+                .get_header_by_number(BlockNumberOrTag::Finalized)
+                .await
+                .map_err(|err| eyre::eyre!("failed reading finalized L1 replay boundary: {err}"))?
+                .map(|header| header.number())
+                .ok_or_else(|| eyre::eyre!("L1 finalized block is not available"))
+        };
+        let (historical_replay_through, ()) = tokio::try_join!(
+            finalized_replay_boundary,
+            seed_leadership_schedule(
                 &l1_provider,
                 self.portal_address,
                 snapshot_anchor,
-                p2p.manifest(),
+                self.p2p_config.manifest(),
                 &schedule,
-            )
-            .await?;
-            self.l1_config.leadership_sink = Some(Arc::new(ScheduleLeadershipSink {
-                schedule,
-                manifest: p2p.manifest().clone(),
-                historical_replay_through,
-            }));
-        }
+            ),
+        )?;
+        // Seed the applied anchor from the persisted checkpoint so it targets the leader
+        // of the next anchor from the very start (and not after the first post-restart block)
+        schedule.record_applied_anchor(snapshot_anchor);
+        install_manifest_forced_recovery(
+            ctx.node.provider(),
+            &l1_provider,
+            self.portal_address,
+            snapshot_anchor,
+            self.p2p_config.manifest(),
+            &schedule,
+        )
+        .await?;
+        self.l1_config.leadership_sink = Some(Arc::new(ScheduleLeadershipSink {
+            schedule,
+            manifest: self.p2p_config.manifest().clone(),
+            historical_replay_through,
+        }));
+
+        // TODO: clean this up, basically want to start P2P better here, muuuuuch more contained.
+        // not sure why this is separate from the above
+
+        let task_executor = ctx.node.task_executor().clone();
+        // Start the Commonware network and the long-lived event router
+        let sequencer_rpc_slot = Arc::new(std::sync::OnceLock::new());
+        let p2p_runtime = Self::start_p2p(
+            self.p2p_config,
+            &l1_provider,
+            l1_chain_id,
+            genesis_zone_id,
+            self.portal_address,
+            self.sequencer_config
+                .as_ref()
+                .map(|config| config.batch_anchor_config)
+                .unwrap_or_default(),
+            self.l1_config.l1_rpc_url.clone(),
+            self.l1_config.retry_connection_interval,
+            self.l1_config.encryption_keys.clone().unwrap_or_default(),
+            &task_executor,
+            &sequencer_rpc_slot,
+        )
+        .await?;
 
         L1Subscriber::spawn(
             self.l1_config.clone(),
@@ -645,38 +647,6 @@ where
         );
         info!(target: "reth::cli", "L1 subscriber started with deposit enqueueing");
 
-        let task_executor = ctx.node.task_executor().clone();
-        // Start the Commonware network and the long-lived event router
-        let sequencer_rpc_slot = Arc::new(std::sync::OnceLock::new());
-        let p2p_runtime = if let Some(config) = self.p2p_config.take() {
-            Some(
-                Self::start_p2p(
-                    config,
-                    &l1_provider,
-                    l1_chain_id,
-                    genesis_zone_id,
-                    self.portal_address,
-                    self.sequencer_config
-                        .as_ref()
-                        .map(|config| config.batch_anchor_config)
-                        .unwrap_or_default(),
-                    self.l1_config.l1_rpc_url.clone(),
-                    self.l1_config.retry_connection_interval,
-                    self.l1_config.encryption_keys.clone().unwrap_or_default(),
-                    &task_executor,
-                    &sequencer_rpc_slot,
-                )
-                .await?,
-            )
-        } else {
-            if let Some(ref config) = self.sequencer_config {
-                // Legacy single-sequencer mode keeps the static engine.
-                let sequencer_addr = config.sequencer_signer.address();
-                self.spawn_zone_engine(&ctx, sequencer_addr)?;
-            }
-            None
-        };
-
         let chain_id = ctx.node.provider().chain_spec().genesis().config.chain_id;
         let max_response_size = ctx
             .config
@@ -685,7 +655,6 @@ where
             .get()
             .saturating_mul(1024 * 1024) as usize;
         let provider = ctx.node.provider().clone();
-        let zone_provider = provider.clone();
         let pool = ctx.node.pool().clone();
         let engine_handle = ctx.beacon_engine_handle.clone();
         let payload_builder = ctx.node.payload_builder_handle().clone();
@@ -746,7 +715,7 @@ where
         )
         .await?;
 
-        if let Some(P2PRuntime {
+        let P2PRuntime {
             sinks,
             commands,
             backfill_commands,
@@ -756,82 +725,64 @@ where
             role_status,
             peer_tips,
             backfill_requests_rx,
-        }) = p2p_runtime
-        {
-            // Backfill serving is role-neutral: every role serves the same canonical
-            // provider, so the server outlives role generations and a leadership handoff
-            // can never drop an accepted request.
-            task_executor.spawn_critical_task(
-                "zone-backfill-server",
-                serve_backfill_requests(
-                    provider.clone(),
-                    backfill_commands.clone(),
-                    backfill_requests_rx,
-                ),
-            );
-            let sequencer = match self.sequencer_config.take() {
-                Some(config) => Some(Self::build_leader_sequencer_deps(
-                    config,
-                    self.l1_config.l1_rpc_url.clone(),
-                    self.l1_config.portal_address,
-                    self.l1_config.retry_connection_interval,
-                    attestation.store.clone(),
-                    prover_config.clone(),
-                )?),
-                None => None,
-            };
-            let context = RoleControllerContext {
-                local_ed25519_public_key,
-                schedule,
-                provider: provider.clone(),
-                pool,
-                engine_handle,
-                payload_builder,
-                chain_spec: provider.chain_spec(),
-                deposit_queue: self.deposit_queue.clone(),
-                l1_block_tracker: self.l1_config.block_tracker.clone(),
-                // Follower-only nodes have no private keys and never construct an engine.
-                encryption_keys: self.l1_config.encryption_keys.clone().unwrap_or_default(),
-                commands,
-                backfill_commands,
-                attestation,
-                portal_address: self.portal_address,
-                sequencer,
-                peer_tips,
-                status: role_status,
-            };
-            task_executor
-                .spawn_critical_task("zone-role-controller", run_role_controller(context, sinks));
-
-            // Flush unpersisted blocks on shutdown.
-            let engine_shutdown = handle.engine_shutdown.clone();
-            task_executor.spawn_critical_with_graceful_shutdown_signal(
-                "zone-engine-shutdown",
-                |shutdown| async move {
-                    let _guard = shutdown.await;
-                    info!(target: "reth::cli", "Shutdown signal received — flushing engine state");
-                    if let Some(done) = engine_shutdown.shutdown() {
-                        let _ = done.await;
-                    }
-                },
-            );
-        } else if let Some(config) = self.sequencer_config.take() {
-            let sequencer_addr = config.sequencer_signer.address();
-
-            Self::launch_sequencer_tasks(
+        } = p2p_runtime;
+        // Backfill serving is role-neutral: every role serves the same canonical
+        // provider, so the server outlives role generations and a leadership handoff
+        // can never drop an accepted request.
+        task_executor.spawn_critical_task(
+            "zone-backfill-server",
+            serve_backfill_requests(
+                provider.clone(),
+                backfill_commands.clone(),
+                backfill_requests_rx,
+            ),
+        );
+        let sequencer = match self.sequencer_config.take() {
+            Some(config) => Some(Self::build_leader_sequencer_deps(
                 config,
-                &handle,
-                zone_provider,
-                &task_executor,
-                self.l1_config.l1_rpc_url,
+                self.l1_config.l1_rpc_url.clone(),
                 self.l1_config.portal_address,
                 self.l1_config.retry_connection_interval,
-                sequencer_addr,
-                None,
-                prover_config,
-            )
-            .await?;
-        }
+                attestation.store.clone(),
+                prover_config.clone(),
+            )?),
+            None => None,
+        };
+        let context = RoleControllerContext {
+            local_ed25519_public_key,
+            schedule,
+            provider: provider.clone(),
+            pool,
+            engine_handle,
+            payload_builder,
+            chain_spec: provider.chain_spec(),
+            deposit_queue: self.deposit_queue.clone(),
+            l1_block_tracker: self.l1_config.block_tracker.clone(),
+            // Follower-only nodes have no private keys and never construct an engine.
+            encryption_keys: self.l1_config.encryption_keys.clone().unwrap_or_default(),
+            commands,
+            backfill_commands,
+            attestation,
+            portal_address: self.portal_address,
+            sequencer,
+            peer_tips,
+            status: role_status,
+        };
+        task_executor
+            .spawn_critical_task("zone-role-controller", run_role_controller(context, sinks));
+
+        // Flush unpersisted blocks on shutdown.
+        let engine_shutdown = handle.engine_shutdown.clone();
+        task_executor.spawn_critical_with_graceful_shutdown_signal(
+            "zone-engine-shutdown",
+            |shutdown| async move {
+                let _guard = shutdown.await;
+                info!(target: "reth::cli", "Shutdown signal received — flushing engine state");
+                if let Some(done) = engine_shutdown.shutdown() {
+                    let _ = done.await;
+                }
+            },
+        );
 
         Ok(handle)
     }
@@ -1377,37 +1328,6 @@ where
         Ok(())
     }
 
-    /// Spawn the [`ZoneEngine`] for L1-event-driven block production.
-    fn spawn_zone_engine(
-        &self,
-        ctx: &AddOnsContext<'_, N>,
-        fee_recipient: Address,
-    ) -> eyre::Result<()> {
-        let provider = ctx.node.provider();
-        let last_header = provider
-            .sealed_header(provider.best_block_number()?)?
-            .ok_or_else(|| eyre::eyre!("no latest block header"))?;
-        let engine = ZoneEngine::new(
-            provider.chain_spec(),
-            ctx.beacon_engine_handle.clone(),
-            ctx.node.payload_builder_handle().clone(),
-            self.deposit_queue.clone(),
-            self.l1_config.block_tracker.clone(),
-            last_header,
-            fee_recipient,
-            self.l1_config
-                .encryption_keys
-                .clone()
-                .expect("sequencer mode configures deposit decryption keys"),
-            self.portal_address,
-        );
-        ctx.node
-            .task_executor()
-            .spawn_critical_task("zone-engine", engine.run());
-        info!(target: "reth::cli", "ZoneEngine spawned");
-        Ok(())
-    }
-
     /// Launch the redacted RPC server.
     async fn launch_redacted_rpc(
         config: ZoneRedactedRpcConfig,
@@ -1443,75 +1363,6 @@ where
         ));
         let local_addr = start_redacted_rpc(redacted_rpc_config, api).await?;
         info!(target: "reth::cli", %local_addr, "Redacted zone RPC server started");
-
-        Ok(())
-    }
-
-    /// Launch sequencer background tasks: batch submission, withdrawal processing,
-    /// and engine shutdown hook.
-    async fn launch_sequencer_tasks(
-        config: ZoneSequencerAddOnsConfig,
-        handle: &<Self as NodeAddOns<N>>::Handle,
-        zone_provider: N::Provider,
-        task_executor: &reth_tasks::TaskExecutor,
-        l1_rpc_url: String,
-        portal_address: Address,
-        retry_connection_interval: Duration,
-        sequencer_addr: Address,
-        attestation_store: Option<AttestationStore>,
-        prover_config: Option<ShadowProverConfig>,
-    ) -> eyre::Result<()> {
-        info!(target: "reth::cli", %sequencer_addr, "Starting sequencer background tasks");
-        let sequencer_config = ZoneSequencerConfig {
-            portal_address,
-            l1_rpc_url,
-            retry_connection_interval,
-            zone_poll_interval: config.zone_poll_interval,
-            withdrawal_poll_interval: config.withdrawal_poll_interval,
-            withdrawal_batch_limits: config.withdrawal_batch_limits,
-            outbox_address: ZONE_OUTBOX_ADDRESS,
-            inbox_address: ZONE_INBOX_ADDRESS,
-            batch_anchor_config: config.batch_anchor_config,
-            attestation_store,
-        };
-        let l1_transaction_signer = config
-            .l1_transaction_signer
-            .unwrap_or(config.sequencer_signer);
-        // Legacy single-sequencer mode: the tasks run for the process lifetime.
-        let seq_handle = spawn_zone_sequencer(
-            sequencer_config,
-            l1_transaction_signer,
-            zone_provider,
-            prover_config,
-            tokio_util::sync::CancellationToken::new(),
-        )
-        .await;
-        info!(target: "reth::cli", "Sequencer tasks spawned");
-
-        // Critical task — node shuts down if either exits.
-        task_executor.spawn_critical_task("zone-monitor", async move {
-            tokio::select! {
-                res = seq_handle.withdrawal_handle => {
-                    tracing::error!(target: "reth::cli", ?res, "Withdrawal processor task exited");
-                }
-                res = seq_handle.monitor_handle => {
-                    tracing::error!(target: "reth::cli", ?res, "Zone monitor task exited");
-                }
-            }
-        });
-
-        // Flush unpersisted blocks on shutdown.
-        let engine_shutdown = handle.engine_shutdown.clone();
-        task_executor.spawn_critical_with_graceful_shutdown_signal(
-            "zone-engine-shutdown",
-            |shutdown| async move {
-                let _guard = shutdown.await;
-                info!(target: "reth::cli", "Shutdown signal received — flushing engine state");
-                if let Some(done) = engine_shutdown.shutdown() {
-                    let _ = done.await;
-                }
-            },
-        );
 
         Ok(())
     }
@@ -1596,8 +1447,9 @@ where
             self.portal_address,
             self.redacted_rpc_config.clone(),
             self.sequencer_config.clone(),
-            self.p2p_config.clone(),
-            self.external_deposit_consumer,
+            self.p2p_config
+                .clone()
+                .expect("P2P configuration is required"),
         )
     }
 }

--- a/crates/node/src/node.rs
+++ b/crates/node/src/node.rs
@@ -414,7 +414,6 @@ where
         Identity,
     >,
 
-    // TODO: KIT: also clean this up, use channels
     /// Queue of L1 deposit messages to be included in the next zone block.
     deposit_queue: DepositQueue,
     /// Configuration for the L1 event subscriber
@@ -426,7 +425,6 @@ where
     /// Sequencer configuration.
     sequencer_config: Option<ZoneSequencerAddOnsConfig>,
     /// Static Zone P2P networking configuration.
-    // NOTE: we always need this? why is this option?
     p2p_config: P2pConfig,
 }
 
@@ -510,7 +508,6 @@ where
     > as NodeAddOns<N>>::Handle;
 
     async fn launch_add_ons(mut self, ctx: AddOnsContext<'_, N>) -> eyre::Result<Self::Handle> {
-        // TODO: KIT: this all seems so windy why do we need all this?
         let tempo_block_number = ctx.node.provider().latest()?.tempo_block_number()?;
         let l1_provider = alloy_provider::ProviderBuilder::new_with_network::<TempoNetwork>()
             .connect_with_config(
@@ -614,9 +611,6 @@ where
             manifest: self.p2p_config.manifest().clone(),
             historical_replay_through,
         }));
-
-        // TODO: clean this up, basically want to start P2P better here, muuuuuch more contained.
-        // not sure why this is separate from the above
 
         let task_executor = ctx.node.task_executor().clone();
         // Start the Commonware network and the long-lived event router

--- a/crates/node/tests/it/utils.rs
+++ b/crates/node/tests/it/utils.rs
@@ -1369,11 +1369,6 @@ impl ZoneTestNode {
         // Multi-sequencer nodes run the real role controller, which owns the engine; the
         // harness must not drive a second head writer against the same queue.
         let spawn_engine = spawn_engine && !p2p_enabled;
-        if spawn_engine {
-            // The harness drives its own ZoneEngine against the shared queue below, so the
-            // node must keep enqueueing deposits even without a sequencer or P2P config.
-            zone_node = zone_node.with_external_deposit_consumer();
-        }
 
         // Don't use .dev() — it spawns a LocalMiner that conflicts with ZoneEngine.
         // The ZoneEngine is the sole block producer; it advances the chain when L1

--- a/crates/p2p/README.md
+++ b/crates/p2p/README.md
@@ -32,8 +32,8 @@ unavailable, or skipped Portal epochs make the recovery boundary ambiguous.
 After a normal Portal transition ends recovery, a restart skips the completed stale directive and
 logs a removal warning. Operators should still remove the directive from every manifest promptly.
 
-If a manifest is not specified, `tempo-zone` retains its existing single-sequencer startup
-behavior.
+The manifestless `--sequencer` startup path is deprecated. Use `tempo-zone dev` for local
+development.
 
 ## Roles
 
@@ -208,8 +208,8 @@ the internet-facing standby would put deposit recipients and memos within reach 
 compromise. Startup rejects that key-file flag on an `rpc_only` node rather than ignoring it.
 This key is independent from the shared `--sequencer-key-file`; reusing that shared key
 would collapse several nodes into one recoverable quorum identity.
-The `--sequencer` flag conflicts with `--sequencer.manifest` because the
-manifest determines whether the node starts the sequencer tasks.
+The deprecated `--sequencer` flag conflicts with `--sequencer.manifest` because the manifest
+determines whether the node starts the sequencer tasks.
 
 DNS peer addresses do not provide a stable egress IP for Commonware's inbound
 source-IP filter. A manifest containing any DNS peer therefore requires the

--- a/crates/precompiles/src/fee_manager.rs
+++ b/crates/precompiles/src/fee_manager.rs
@@ -1,0 +1,157 @@
+//! Zone fee manager.
+//!
+//! Zones keep the public Tempo FeeManager address and storage layout, but their
+//! protocol fee path differs from Tempo L1: the sequencer accepts the user's fee
+//! token directly, so fees never route through the Fee AMM or validator token
+//! preference.
+
+use alloy_primitives::{Address, U256};
+use tempo_precompiles::{
+    PrecompileEnv, TIP_FEE_MANAGER_ADDRESS,
+    error::{Result, TempoPrecompileError},
+    storage::Handler,
+    tip20::TIP20Token,
+};
+
+/// Zone protocol fee manager.
+///
+/// This intentionally shares the canonical FeeManager precompile address and
+/// storage with Tempo's [`TipFeeManager`](tempo_precompiles::tip_fee_manager::TipFeeManager),
+/// but its protocol hooks credit the sequencer in the transaction fee token.
+#[derive(Debug, Clone, Copy, Default)]
+pub struct ZoneFeeManager;
+
+impl ZoneFeeManager {
+    /// Creates a new zone fee manager handle.
+    pub const fn new() -> Self {
+        Self
+    }
+
+    /// Wraps the public FeeManager-compatible precompile for zone EVM registration.
+    ///
+    /// Contract-facing calls keep Tempo's FeeManager ABI and storage layout. The
+    /// protocol fee lifecycle uses [`Self::collect_fee_pre_tx`] and
+    /// [`Self::collect_fee_post_tx`] via the EVM fee-manager hook.
+    pub fn create_precompile(env: &PrecompileEnv) -> alloy_evm::precompiles::DynPrecompile {
+        tempo_precompiles::tip_fee_manager::TipFeeManager::create_precompile(env)
+    }
+
+    /// Collects the maximum possible fee before transaction execution.
+    ///
+    /// Unlike Tempo L1, zones do not inspect `validatorTokens` and do not reserve
+    /// AMM liquidity. The user's fee token is escrowed directly in the FeeManager
+    /// account and returned as the fee token for post-transaction settlement.
+    pub fn collect_fee_pre_tx(
+        &self,
+        fee_payer: Address,
+        fee_token: Address,
+        max_amount: U256,
+        _beneficiary: Address,
+        _skip_liquidity_check: bool,
+    ) -> Result<Address> {
+        let mut token = TIP20Token::from_address(fee_token)?;
+        token.ensure_transfer_authorized(fee_payer, TIP_FEE_MANAGER_ADDRESS)?;
+        token.transfer_fee_pre_tx(fee_payer, max_amount)?;
+
+        Ok(fee_token)
+    }
+
+    /// Settles the final fee after transaction execution.
+    ///
+    /// Refunds unused gas in the same token and credits the sequencer in that
+    /// token. No Fee AMM swap is attempted.
+    pub fn collect_fee_post_tx(
+        &self,
+        fee_payer: Address,
+        actual_spending: U256,
+        refund_amount: U256,
+        fee_token: Address,
+        beneficiary: Address,
+    ) -> Result<U256> {
+        let mut token = TIP20Token::from_address(fee_token)?;
+        token.transfer_fee_post_tx(fee_payer, refund_amount, actual_spending)?;
+
+        if !actual_spending.is_zero() {
+            let mut fee_manager = tempo_precompiles::tip_fee_manager::TipFeeManager::new();
+            let collected = fee_manager.collected_fees[beneficiary][fee_token].read()?;
+            let collected = collected
+                .checked_add(actual_spending)
+                .ok_or_else(TempoPrecompileError::under_overflow)?;
+            fee_manager.collected_fees[beneficiary][fee_token].write(collected)?;
+        }
+
+        Ok(actual_spending)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tempo_precompiles::{
+        TIP_FEE_MANAGER_ADDRESS,
+        storage::{ContractStorage, StorageCtx, hashmap::HashMapStorageProvider},
+        test_util::TIP20Setup,
+        tip_fee_manager::{TipFeeManager, amm::PoolKey},
+    };
+
+    #[test]
+    fn zone_fees_credit_user_token_without_amm_or_validator_override() -> Result<()> {
+        let mut storage = HashMapStorageProvider::new(1);
+        let admin = Address::random();
+        let user = Address::random();
+        let sequencer = Address::random();
+
+        StorageCtx::enter(&mut storage, || {
+            let user_token = TIP20Setup::create("User USD", "uUSD", admin)
+                .with_issuer(admin)
+                .with_mint(user, U256::from(10_000u64))
+                .with_approval(user, TIP_FEE_MANAGER_ADDRESS, U256::MAX)
+                .apply()?;
+            let validator_token = TIP20Setup::create("Validator USD", "vUSD", admin)
+                .with_issuer(admin)
+                .apply()?;
+
+            let mut tempo_fee_manager = TipFeeManager::new();
+            tempo_fee_manager.validator_tokens[sequencer].write(validator_token.address())?;
+
+            let max_fee = U256::from(5_000u64);
+            let actual_fee = U256::from(3_000u64);
+            ZoneFeeManager::new().collect_fee_pre_tx(
+                user,
+                user_token.address(),
+                max_fee,
+                sequencer,
+                false,
+            )?;
+            ZoneFeeManager::new().collect_fee_post_tx(
+                user,
+                actual_fee,
+                max_fee - actual_fee,
+                user_token.address(),
+                sequencer,
+            )?;
+
+            let fee_manager = TipFeeManager::new();
+            assert_eq!(
+                fee_manager.collected_fees[sequencer][user_token.address()].read()?,
+                actual_fee
+            );
+            assert_eq!(
+                fee_manager.collected_fees[sequencer][validator_token.address()].read()?,
+                U256::ZERO
+            );
+            assert_eq!(
+                fee_manager.get_validator_token(sequencer)?,
+                validator_token.address()
+            );
+
+            let pool = fee_manager.pools
+                [PoolKey::new(user_token.address(), validator_token.address()).get_id()]
+            .read()?;
+            assert_eq!(pool.reserve_user_token, 0);
+            assert_eq!(pool.reserve_validator_token, 0);
+
+            Ok(())
+        })
+    }
+}

--- a/docs/ZONES.md
+++ b/docs/ZONES.md
@@ -684,7 +684,8 @@ cast code 0x5A4d000000000000000000000000000000000000 --rpc-url "$ETH_RPC_URL"
 | `--l1.rpc-url` | (required) | Certified Tempo follower WebSocket RPC URL |
 | `--l1.portal-address` | (from zone.json) | ZonePortal contract on L1 |
 | `--zone.id` | (deprecated) | Optional compatibility check against the zone ID encoded in the genesis chain ID. |
-| `--sequencer` | false | Enable sequencer mode for block production and withdrawal batch submission |
+| `--sequencer` | false | Deprecated manifestless node startup. Use `tempo-zone dev` locally or `--sequencer.manifest` for a node. |
+| `--sequencer.manifest` | (required for networked nodes) | Static Zone P2P topology and settlement membership |
 | `--sequencer-key-file` | (required for sequencing) | Owner-readable file or FIFO containing the sequencer private key |
 | `--deposit-decryption-keys-file` | (optional) | File containing additional historical or pre-provisioned deposit decryption keys, one hex key per line |
 | `--zone.batch-interval-blocks` | 120 | Zone blocks between empty withdrawal batch boundaries / L1 submissions (~1 minute at Tempo's 500 ms block time) |


### PR DESCRIPTION
This PR deprecates manifestless `tempo-zone node --sequencer` startup and migrates `just zone-up` to a sequencer manifest. The legacy flag remains supported for compatibility.