### PR TITLE
feat(node): build checkpoint-only blocks and coordinate deferred Tempo imports

### DIFF
--- a/crates/l1/src/event.rs
+++ b/crates/l1/src/event.rs
@@ -98,6 +98,29 @@ impl L1PortalEvents {
         }
     }
 
+    /// Ensure the portal work used by `advanceTempo` remains within its protocol bounds.
+    pub(crate) fn ensure_operational_capacity(&self) -> eyre::Result<()> {
+        eyre::ensure!(
+            self.deposits.len() <= zone_primitives::constants::MAX_UNPROCESSED_DEPOSITS,
+            "outstanding deposit suffix exceeds protocol capacity"
+        );
+        eyre::ensure!(
+            self.enabled_tokens.len()
+                <= zone_primitives::constants::MAX_UNPROCESSED_TOKEN_ENABLEMENTS,
+            "outstanding token-enablement suffix exceeds protocol capacity"
+        );
+        Ok(())
+    }
+
+    /// Append only events consumed by `advanceTempo`.
+    ///
+    /// Key rotations and leadership transitions are applied during L1 ingestion and must not be
+    /// retained for a later operational import.
+    pub(crate) fn extend_operational(&mut self, mut other: Self) {
+        self.deposits.append(&mut other.deposits);
+        self.enabled_tokens.append(&mut other.enabled_tokens);
+    }
+
     /// Validate that `advanceTempo` processes every deposit and token enable observed in this
     /// block's verified L1 receipts, in canonical log order.
     ///

--- a/crates/l1/src/event.rs
+++ b/crates/l1/src/event.rs
@@ -98,20 +98,6 @@ impl L1PortalEvents {
         }
     }
 
-    /// Ensure the portal work used by `advanceTempo` remains within its protocol bounds.
-    pub(crate) fn ensure_operational_capacity(&self) -> eyre::Result<()> {
-        eyre::ensure!(
-            self.deposits.len() <= zone_primitives::constants::MAX_UNPROCESSED_DEPOSITS,
-            "outstanding deposit suffix exceeds protocol capacity"
-        );
-        eyre::ensure!(
-            self.enabled_tokens.len()
-                <= zone_primitives::constants::MAX_UNPROCESSED_TOKEN_ENABLEMENTS,
-            "outstanding token-enablement suffix exceeds protocol capacity"
-        );
-        Ok(())
-    }
-
     /// Append only events consumed by `advanceTempo`.
     ///
     /// Key rotations and leadership transitions are applied during L1 ingestion and must not be

--- a/crates/l1/src/lib.rs
+++ b/crates/l1/src/lib.rs
@@ -96,8 +96,8 @@ pub use ext::{ChainTempoStateExt, TempoStateExt};
 pub use queue::DepositQueue;
 pub use state::L1StateCache;
 pub use subscriber::{
-    AuthenticatedPortalLogs, L1BlockTracker, L1Subscriber, L1SubscriberConfig, LeadershipSink,
-    MAX_L1_LOOKAHEAD_BLOCKS, verify_receipts_against_header,
+    AuthenticatedPortalLogs, FinalizedTarget, L1BlockTracker, L1Subscriber, L1SubscriberConfig,
+    LeadershipSink, MAX_L1_LOOKAHEAD_BLOCKS, verify_receipts_against_header,
 };
 
 #[cfg(test)]

--- a/crates/l1/src/queue.rs
+++ b/crates/l1/src/queue.rs
@@ -10,6 +10,8 @@ use std::collections::VecDeque;
 pub(crate) struct PendingDeposits {
     /// Pending L1 blocks with their portal events, not yet processed by the Zone.
     pending: VecDeque<L1BlockDeposits>,
+    /// Portal work crossed by checkpoint-only Zone blocks and owed by the next full block.
+    deferred: Vec<L1BlockDeposits>,
     /// Highest L1 block ever enqueued (number + hash). Survives `confirm` /
     /// `drain` so that reconnecting subscribers know where the queue left off,
     /// even if the engine has already consumed the blocks.
@@ -83,6 +85,14 @@ impl PendingDeposits {
         self.pending.front()
     }
 
+    pub(crate) fn peek_headers(&self, maximum: usize) -> Vec<SealedHeader<TempoHeader>> {
+        self.pending
+            .iter()
+            .take(maximum)
+            .map(|block| block.header.clone())
+            .collect()
+    }
+
     /// Confirm the next pending L1 block was successfully processed and remove it.
     ///
     /// The caller must pass the [`NumHash`] returned by [`Self::peek`]. A
@@ -102,6 +112,81 @@ impl PendingDeposits {
             .pending
             .pop_front()
             .expect("front was checked immediately before pop"))
+    }
+
+    pub(crate) fn defer(&mut self, expected: NumHash) -> eyre::Result<()> {
+        let block = self.confirm(expected)?;
+        self.deferred.push(block);
+        Ok(())
+    }
+
+    /// Defer every pending block through a canonical checkpoint anchor.
+    ///
+    /// This is idempotent so follower imports can replay their post-forkchoice bookkeeping after
+    /// an interruption. Entries older than `expected` are also deferred because they belong to
+    /// the same checkpoint-only range.
+    pub(crate) fn defer_through(&mut self, expected: NumHash) -> eyre::Result<()> {
+        while let Some(front) = self.pending.front().map(|entry| entry.header.num_hash()) {
+            if front.number > expected.number {
+                break;
+            }
+            eyre::ensure!(
+                front.number < expected.number || front.hash == expected.hash,
+                "deposit queue holds L1 block {} with hash {}, but the checkpoint consumed {}",
+                front.number,
+                front.hash,
+                expected.hash,
+            );
+            self.defer(front)?;
+        }
+        if let Some(found) = self
+            .deferred
+            .iter()
+            .find(|entry| entry.header.number() == expected.number)
+        {
+            eyre::ensure!(
+                found.header.hash() == expected.hash,
+                "deferred L1 block {} has hash {}, but the checkpoint consumed {}",
+                expected.number,
+                found.header.hash(),
+                expected.hash,
+            );
+        }
+        Ok(())
+    }
+
+    pub(crate) fn operational_work(
+        &self,
+        current: &L1BlockDeposits,
+    ) -> eyre::Result<Vec<L1BlockDeposits>> {
+        let front = self
+            .pending
+            .front()
+            .ok_or_else(|| eyre::eyre!("cannot prepare work from an empty finalized L1 queue"))?;
+        eyre::ensure!(
+            front.header.num_hash() == current.header.num_hash(),
+            "operational L1 work does not match the queue front"
+        );
+        let mut work = self.deferred.clone();
+        work.push(current.clone());
+        Ok(work)
+    }
+
+    pub(crate) fn confirm_operational(&mut self, expected: NumHash) -> eyre::Result<()> {
+        self.confirm(expected)?;
+        self.deferred.clear();
+        Ok(())
+    }
+
+    /// Reconcile an already-canonical full import, including after its exact-front bookkeeping
+    /// was interrupted.
+    pub(crate) fn confirm_operational_through(&mut self, expected: NumHash) -> eyre::Result<()> {
+        self.confirm_through(expected)?;
+        // A delayed duplicate of an older full block must not erase checkpoint work deferred by
+        // newer canonical blocks. Only release work at or before the full block's anchor.
+        self.deferred
+            .retain(|entry| entry.header.number() > expected.number);
+        Ok(())
     }
 
     /// Confirm every pending L1 block up to and including `expected`.
@@ -225,10 +310,67 @@ impl DepositQueue {
         self.inner.lock().peek().cloned()
     }
 
+    /// Return up to `maximum` consecutive queued headers without consuming portal work.
+    pub fn peek_headers(&self, maximum: usize) -> Vec<SealedHeader<TempoHeader>> {
+        self.inner.lock().peek_headers(maximum)
+    }
+
     /// Confirm the next L1 block was successfully processed and remove it.
     ///
     pub fn confirm(&self, expected: NumHash) -> eyre::Result<L1BlockDeposits> {
         self.inner.lock().confirm(expected)
+    }
+
+    /// Move checkpointed portal work out of the header queue while retaining it for the next full
+    /// operational import. This state is shared across leadership-engine instances.
+    pub fn defer(&self, expected: NumHash) -> eyre::Result<()> {
+        self.inner.lock().defer(expected)
+    }
+
+    /// Idempotently move every pending block through a canonical checkpoint anchor to deferred
+    /// portal work.
+    pub fn defer_through(&self, expected: NumHash) -> eyre::Result<()> {
+        self.inner.lock().defer_through(expected)
+    }
+
+    /// Return deferred portal work followed by the current operational L1 block.
+    pub fn operational_work(
+        &self,
+        current: &L1BlockDeposits,
+    ) -> eyre::Result<Vec<L1BlockDeposits>> {
+        self.inner.lock().operational_work(current)
+    }
+
+    /// Restore portal work crossed by already-canonical checkpoint-only blocks after restart.
+    pub fn seed_deferred(&self, blocks: Vec<L1BlockDeposits>) -> eyre::Result<()> {
+        let mut recovered = PendingDeposits::default();
+        for block in blocks {
+            recovered.try_enqueue(block.header, block.events)?;
+        }
+        while let Some(front) = recovered
+            .pending
+            .front()
+            .map(|block| block.header.num_hash())
+        {
+            recovered.defer(front)?;
+        }
+        let mut queue = self.inner.lock();
+        eyre::ensure!(
+            queue.pending.is_empty() && queue.deferred.is_empty() && queue.last_enqueued.is_none(),
+            "cannot seed deferred portal work into a nonempty queue"
+        );
+        *queue = recovered;
+        Ok(())
+    }
+
+    /// Confirm a full operational import and release all deferred work it consumed.
+    pub fn confirm_operational(&self, expected: NumHash) -> eyre::Result<()> {
+        self.inner.lock().confirm_operational(expected)
+    }
+
+    /// Idempotently reconcile a canonical full import and release the deferred work it consumed.
+    pub fn confirm_operational_through(&self, expected: NumHash) -> eyre::Result<()> {
+        self.inner.lock().confirm_operational_through(expected)
     }
 
     /// Advance the queue past a canonical follower anchor.

--- a/crates/l1/src/queue.rs
+++ b/crates/l1/src/queue.rs
@@ -3,36 +3,22 @@ use std::collections::VecDeque;
 
 /// Bounded portal work crossed by canonical checkpoint-only Zone blocks.
 ///
-/// Empty L1 blocks and events already applied during ingestion are represented only by the range
-/// endpoints. Blocks containing deposits or token enablements retain one compact event group so a
-/// delayed full-import reconciliation can release just the prefix it consumed. The protocol caps
-/// bound the total number of retained groups.
+/// Empty L1 blocks and events already applied during ingestion are represented only by the final
+/// header. Blocks containing deposits or token enablements retain one compact event group. The
+/// protocol caps bound the total number of retained groups.
 #[derive(Debug, Clone)]
 pub(crate) struct DeferredPortalWork {
-    first_number: u64,
     last_header: SealedHeader<TempoHeader>,
-    event_blocks: Vec<DeferredPortalEventBlock>,
-    deposit_count: usize,
-    enabled_token_count: usize,
-}
-
-#[derive(Debug, Clone)]
-struct DeferredPortalEventBlock {
-    number: u64,
-    events: L1PortalEvents,
+    event_blocks: Vec<L1PortalEvents>,
 }
 
 impl DeferredPortalWork {
     pub(crate) fn new(block: L1BlockDeposits) -> Self {
-        let first_number = block.header.number();
         let mut work = Self {
-            first_number,
             last_header: block.header,
             event_blocks: Vec::new(),
-            deposit_count: 0,
-            enabled_token_count: 0,
         };
-        work.push_events(first_number, block.events);
+        work.push_events(block.events);
         work
     }
 
@@ -41,15 +27,14 @@ impl DeferredPortalWork {
     }
 
     pub(crate) fn push(&mut self, block: L1BlockDeposits) {
-        let number = block.header.number();
         self.last_header = block.header;
-        self.push_events(number, block.events);
+        self.push_events(block.events);
     }
 
     fn aggregated_block(&self) -> L1BlockDeposits {
         let mut events = L1PortalEvents::default();
         for block in &self.event_blocks {
-            events.extend_operational(block.events.clone());
+            events.extend_operational(block.clone());
         }
         L1BlockDeposits {
             header: self.last_header.clone(),
@@ -57,28 +42,10 @@ impl DeferredPortalWork {
         }
     }
 
-    fn push_events(&mut self, number: u64, events: L1PortalEvents) {
+    fn push_events(&mut self, events: L1PortalEvents) {
         if !events.deposits.is_empty() || !events.enabled_tokens.is_empty() {
-            self.deposit_count += events.deposits.len();
-            self.enabled_token_count += events.enabled_tokens.len();
-            self.event_blocks
-                .push(DeferredPortalEventBlock { number, events });
+            self.event_blocks.push(events);
         }
-    }
-
-    fn retain_after(&mut self, number: u64) {
-        self.first_number = number.saturating_add(1);
-        self.event_blocks.retain(|block| block.number > number);
-        self.deposit_count = self
-            .event_blocks
-            .iter()
-            .map(|block| block.events.deposits.len())
-            .sum();
-        self.enabled_token_count = self
-            .event_blocks
-            .iter()
-            .map(|block| block.events.enabled_tokens.len())
-            .sum();
     }
 
     #[cfg(test)]
@@ -301,8 +268,6 @@ impl PendingDeposits {
             // newer canonical blocks. Only release work at or before the full block's anchor.
             if deferred.last_header.number() <= expected.number {
                 self.deferred = None;
-            } else if deferred.first_number <= expected.number {
-                deferred.retain_after(expected.number);
             }
         }
         Ok(())
@@ -330,13 +295,6 @@ impl PendingDeposits {
         self.deferred
             .as_ref()
             .map_or(0, DeferredPortalWork::event_block_len)
-    }
-
-    #[cfg(test)]
-    pub(crate) fn deferred_range(&self) -> Option<(u64, u64)> {
-        self.deferred
-            .as_ref()
-            .map(|work| (work.first_number, work.last_header.number()))
     }
 }
 

--- a/crates/l1/src/queue.rs
+++ b/crates/l1/src/queue.rs
@@ -214,18 +214,16 @@ impl PendingDeposits {
         }
     }
 
-    /// Return deferred portal work followed by the provided current operational L1 block.
-    pub(crate) fn operational_work(
-        &self,
-        current: &L1BlockDeposits,
-    ) -> eyre::Result<Vec<L1BlockDeposits>> {
-        let front = self
+    /// Return deferred portal work followed by the current operational L1 block.
+    pub(crate) fn operational_work(&self, expected: NumHash) -> eyre::Result<Vec<L1BlockDeposits>> {
+        let current = self
             .pending
             .front()
             .ok_or_else(|| eyre::eyre!("cannot prepare work from an empty finalized L1 queue"))?;
         eyre::ensure!(
-            front.header.num_hash() == current.header.num_hash(),
-            "operational L1 work does not match the queue front"
+            current.header.num_hash() == expected,
+            "operational L1 work does not match the expected anchor: expected {expected:?}, front is {:?}",
+            current.header.num_hash()
         );
         let mut work = Vec::with_capacity(usize::from(self.deferred.is_some()) + 1);
         if let Some(deferred) = &self.deferred {
@@ -400,12 +398,9 @@ impl DepositQueue {
         self.inner.lock().defer_through(expected)
     }
 
-    /// Return deferred portal work followed by the provided current operational L1 block.
-    pub fn operational_work(
-        &self,
-        current: &L1BlockDeposits,
-    ) -> eyre::Result<Vec<L1BlockDeposits>> {
-        self.inner.lock().operational_work(current)
+    /// Return deferred portal work followed by the current operational L1 block.
+    pub fn operational_work(&self, expected: NumHash) -> eyre::Result<Vec<L1BlockDeposits>> {
+        self.inner.lock().operational_work(expected)
     }
 
     /// Restore portal work crossed by already-canonical checkpoint-only blocks after restart.

--- a/crates/l1/src/queue.rs
+++ b/crates/l1/src/queue.rs
@@ -23,32 +23,27 @@ struct DeferredPortalEventBlock {
 }
 
 impl DeferredPortalWork {
-    pub(crate) fn new(block: L1BlockDeposits) -> eyre::Result<Self> {
-        let number = block.header.number();
+    pub(crate) fn new(block: L1BlockDeposits) -> Self {
+        let first_number = block.header.number();
         let mut work = Self {
-            first_number: number,
+            first_number,
             last_header: block.header,
             event_blocks: Vec::new(),
             deposit_count: 0,
             enabled_token_count: 0,
         };
-        work.push_events(number, block.events);
-        Ok(work)
+        work.push_events(first_number, block.events);
+        work
+    }
+
+    pub(crate) fn last_num_hash(&self) -> NumHash {
+        self.last_header.num_hash()
     }
 
     pub(crate) fn push(&mut self, block: L1BlockDeposits) {
         let number = block.header.number();
         self.last_header = block.header;
         self.push_events(number, block.events);
-    }
-
-    fn push_events(&mut self, number: u64, events: L1PortalEvents) {
-        if !events.deposits.is_empty() || !events.enabled_tokens.is_empty() {
-            self.deposit_count += events.deposits.len();
-            self.enabled_token_count += events.enabled_tokens.len();
-            self.event_blocks
-                .push(DeferredPortalEventBlock { number, events });
-        }
     }
 
     fn aggregated_block(&self) -> L1BlockDeposits {
@@ -62,8 +57,13 @@ impl DeferredPortalWork {
         }
     }
 
-    pub(crate) fn last_num_hash(&self) -> NumHash {
-        self.last_header.num_hash()
+    fn push_events(&mut self, number: u64, events: L1PortalEvents) {
+        if !events.deposits.is_empty() || !events.enabled_tokens.is_empty() {
+            self.deposit_count += events.deposits.len();
+            self.enabled_token_count += events.enabled_tokens.len();
+            self.event_blocks
+                .push(DeferredPortalEventBlock { number, events });
+        }
     }
 
     fn retain_after(&mut self, number: u64) {
@@ -171,6 +171,7 @@ impl PendingDeposits {
         self.pending.front()
     }
 
+    /// Peek at the next `maximum` pending L1 block headers without removing them.
     pub(crate) fn peek_headers(&self, maximum: usize) -> Vec<SealedHeader<TempoHeader>> {
         self.pending
             .iter()
@@ -179,6 +180,7 @@ impl PendingDeposits {
             .collect()
     }
 
+    /// Return the latest queued L1 header, including headers beyond a bounded checkpoint batch.
     pub(crate) fn latest_header(&self) -> Option<&SealedHeader<TempoHeader>> {
         self.pending.back().map(|block| &block.header)
     }
@@ -204,42 +206,11 @@ impl PendingDeposits {
             .expect("front was checked immediately before pop"))
     }
 
-    pub(crate) fn defer(&mut self, expected: NumHash) -> eyre::Result<()> {
-        let front = self
-            .pending
-            .front()
-            .ok_or_else(|| eyre::eyre!("cannot defer an empty finalized L1 queue"))?;
-        eyre::ensure!(
-            front.header.num_hash() == expected,
-            "finalized L1 queue confirmation mismatch: expected {expected:?}, front is {:?}",
-            front.header.num_hash()
-        );
-
-        let block = self
-            .pending
-            .pop_front()
-            .expect("front was checked immediately before pop");
-        if let Some(deferred) = &mut self.deferred {
-            deferred.push(block);
-        } else {
-            self.deferred = Some(
-                DeferredPortalWork::new(block)
-                    .expect("deferred block capacity was checked before removal"),
-            );
-        }
-        Ok(())
-    }
-
     /// Defer every pending block through a canonical checkpoint anchor.
-    ///
-    /// This is idempotent so follower imports can replay their post-forkchoice bookkeeping after
-    /// an interruption. Entries older than `expected` are also deferred because they belong to
-    /// the same checkpoint-only range.
     pub(crate) fn defer_through(&mut self, expected: NumHash) -> eyre::Result<()> {
-        while let Some(front) = self.pending.front().map(|entry| entry.header.num_hash()) {
-            if front.number > expected.number {
-                break;
-            }
+        while let Some(front) = self.pending.front().map(|entry| entry.header.num_hash())
+            && front.number <= expected.number
+        {
             eyre::ensure!(
                 front.number < expected.number || front.hash == expected.hash,
                 "deposit queue holds L1 block {} with hash {}, but the checkpoint consumed {}",
@@ -247,7 +218,7 @@ impl PendingDeposits {
                 front.hash,
                 expected.hash,
             );
-            self.defer(front)?;
+            self.defer_front();
         }
         if let Some(deferred) = &self.deferred
             && deferred.last_header.number() == expected.number
@@ -263,6 +234,20 @@ impl PendingDeposits {
         Ok(())
     }
 
+    /// Move the front block from the pending queue to the deferred state.
+    fn defer_front(&mut self) {
+        let block = self
+            .pending
+            .pop_front()
+            .expect("defer_through checked the queue front");
+        if let Some(deferred) = &mut self.deferred {
+            deferred.push(block);
+        } else {
+            self.deferred = Some(DeferredPortalWork::new(block));
+        }
+    }
+
+    /// Return deferred portal work followed by the provided current operational L1 block.
     pub(crate) fn operational_work(
         &self,
         current: &L1BlockDeposits,
@@ -275,7 +260,6 @@ impl PendingDeposits {
             front.header.num_hash() == current.header.num_hash(),
             "operational L1 work does not match the queue front"
         );
-        current.events.ensure_operational_capacity()?;
         let mut work = Vec::with_capacity(usize::from(self.deferred.is_some()) + 1);
         if let Some(deferred) = &self.deferred {
             work.push(deferred.aggregated_block());
@@ -284,6 +268,7 @@ impl PendingDeposits {
         Ok(work)
     }
 
+    /// Confirm a full operational import and release all deferred work it consumed.
     pub(crate) fn confirm_operational(&mut self, expected: NumHash) -> eyre::Result<()> {
         self.confirm(expected)?;
         self.deferred = None;
@@ -329,6 +314,11 @@ impl PendingDeposits {
         Ok(())
     }
 
+    /// Returns the most recently enqueued L1 block (number + hash), if any.
+    pub(crate) fn last_enqueued(&self) -> Option<NumHash> {
+        self.last_enqueued
+    }
+
     /// Drain all pending L1 block deposits.
     #[cfg(test)]
     pub(crate) fn drain(&mut self) -> Vec<L1BlockDeposits> {
@@ -353,11 +343,6 @@ impl PendingDeposits {
         self.deferred
             .as_ref()
             .map(|work| (work.first_number, work.last_header.number()))
-    }
-
-    /// Returns the most recently enqueued L1 block (number + hash), if any.
-    pub(crate) fn last_enqueued(&self) -> Option<NumHash> {
-        self.last_enqueued
     }
 }
 
@@ -441,7 +426,7 @@ impl DepositQueue {
         self.inner.lock().peek().cloned()
     }
 
-    /// Return up to `maximum` consecutive queued headers without consuming portal work.
+    /// Peek at the next `maximum` pending L1 block headers without removing them.
     pub fn peek_headers(&self, maximum: usize) -> Vec<SealedHeader<TempoHeader>> {
         self.inner.lock().peek_headers(maximum)
     }
@@ -457,19 +442,13 @@ impl DepositQueue {
         self.inner.lock().confirm(expected)
     }
 
-    /// Move checkpointed portal work out of the header queue while retaining it for the next full
-    /// operational import. This state is shared across leadership-engine instances.
-    pub fn defer(&self, expected: NumHash) -> eyre::Result<()> {
-        self.inner.lock().defer(expected)
-    }
-
     /// Idempotently move every pending block through a canonical checkpoint anchor to deferred
     /// portal work.
     pub fn defer_through(&self, expected: NumHash) -> eyre::Result<()> {
         self.inner.lock().defer_through(expected)
     }
 
-    /// Return deferred portal work followed by the current operational L1 block.
+    /// Return deferred portal work followed by the provided current operational L1 block.
     pub fn operational_work(
         &self,
         current: &L1BlockDeposits,
@@ -478,7 +457,7 @@ impl DepositQueue {
     }
 
     /// Restore portal work crossed by already-canonical checkpoint-only blocks after restart.
-    pub(crate) fn seed_deferred(&self, deferred: DeferredPortalWork) -> eyre::Result<()> {
+    pub(crate) fn restore_deferred(&self, deferred: DeferredPortalWork) -> eyre::Result<()> {
         let mut queue = self.inner.lock();
         eyre::ensure!(
             queue.pending.is_empty() && queue.deferred.is_none() && queue.last_enqueued.is_none(),

--- a/crates/l1/src/queue.rs
+++ b/crates/l1/src/queue.rs
@@ -1,6 +1,92 @@
 use super::*;
 use std::collections::VecDeque;
 
+/// Bounded portal work crossed by canonical checkpoint-only Zone blocks.
+///
+/// Empty L1 blocks and events already applied during ingestion are represented only by the range
+/// endpoints. Blocks containing deposits or token enablements retain one compact event group so a
+/// delayed full-import reconciliation can release just the prefix it consumed. The protocol caps
+/// bound the total number of retained groups.
+#[derive(Debug, Clone)]
+pub(crate) struct DeferredPortalWork {
+    first_number: u64,
+    last_header: SealedHeader<TempoHeader>,
+    event_blocks: Vec<DeferredPortalEventBlock>,
+    deposit_count: usize,
+    enabled_token_count: usize,
+}
+
+#[derive(Debug, Clone)]
+struct DeferredPortalEventBlock {
+    number: u64,
+    events: L1PortalEvents,
+}
+
+impl DeferredPortalWork {
+    pub(crate) fn new(block: L1BlockDeposits) -> eyre::Result<Self> {
+        let number = block.header.number();
+        let mut work = Self {
+            first_number: number,
+            last_header: block.header,
+            event_blocks: Vec::new(),
+            deposit_count: 0,
+            enabled_token_count: 0,
+        };
+        work.push_events(number, block.events);
+        Ok(work)
+    }
+
+    pub(crate) fn push(&mut self, block: L1BlockDeposits) {
+        let number = block.header.number();
+        self.last_header = block.header;
+        self.push_events(number, block.events);
+    }
+
+    fn push_events(&mut self, number: u64, events: L1PortalEvents) {
+        if !events.deposits.is_empty() || !events.enabled_tokens.is_empty() {
+            self.deposit_count += events.deposits.len();
+            self.enabled_token_count += events.enabled_tokens.len();
+            self.event_blocks
+                .push(DeferredPortalEventBlock { number, events });
+        }
+    }
+
+    fn aggregated_block(&self) -> L1BlockDeposits {
+        let mut events = L1PortalEvents::default();
+        for block in &self.event_blocks {
+            events.extend_operational(block.events.clone());
+        }
+        L1BlockDeposits {
+            header: self.last_header.clone(),
+            events,
+        }
+    }
+
+    pub(crate) fn last_num_hash(&self) -> NumHash {
+        self.last_header.num_hash()
+    }
+
+    fn retain_after(&mut self, number: u64) {
+        self.first_number = number.saturating_add(1);
+        self.event_blocks.retain(|block| block.number > number);
+        self.deposit_count = self
+            .event_blocks
+            .iter()
+            .map(|block| block.events.deposits.len())
+            .sum();
+        self.enabled_token_count = self
+            .event_blocks
+            .iter()
+            .map(|block| block.events.enabled_tokens.len())
+            .sum();
+    }
+
+    #[cfg(test)]
+    fn event_block_len(&self) -> usize {
+        self.event_blocks.len()
+    }
+}
+
 /// Finalized L1 blocks waiting to be processed by the Zone engine.
 ///
 /// Tempo finality is deterministic, so this queue is append-only. Conflicting,
@@ -11,7 +97,7 @@ pub(crate) struct PendingDeposits {
     /// Pending L1 blocks with their portal events, not yet processed by the Zone.
     pending: VecDeque<L1BlockDeposits>,
     /// Portal work crossed by checkpoint-only Zone blocks and owed by the next full block.
-    deferred: Vec<L1BlockDeposits>,
+    deferred: Option<DeferredPortalWork>,
     /// Highest L1 block ever enqueued (number + hash). Survives `confirm` /
     /// `drain` so that reconnecting subscribers know where the queue left off,
     /// even if the engine has already consumed the blocks.
@@ -93,6 +179,10 @@ impl PendingDeposits {
             .collect()
     }
 
+    pub(crate) fn latest_header(&self) -> Option<&SealedHeader<TempoHeader>> {
+        self.pending.back().map(|block| &block.header)
+    }
+
     /// Confirm the next pending L1 block was successfully processed and remove it.
     ///
     /// The caller must pass the [`NumHash`] returned by [`Self::peek`]. A
@@ -115,8 +205,28 @@ impl PendingDeposits {
     }
 
     pub(crate) fn defer(&mut self, expected: NumHash) -> eyre::Result<()> {
-        let block = self.confirm(expected)?;
-        self.deferred.push(block);
+        let front = self
+            .pending
+            .front()
+            .ok_or_else(|| eyre::eyre!("cannot defer an empty finalized L1 queue"))?;
+        eyre::ensure!(
+            front.header.num_hash() == expected,
+            "finalized L1 queue confirmation mismatch: expected {expected:?}, front is {:?}",
+            front.header.num_hash()
+        );
+
+        let block = self
+            .pending
+            .pop_front()
+            .expect("front was checked immediately before pop");
+        if let Some(deferred) = &mut self.deferred {
+            deferred.push(block);
+        } else {
+            self.deferred = Some(
+                DeferredPortalWork::new(block)
+                    .expect("deferred block capacity was checked before removal"),
+            );
+        }
         Ok(())
     }
 
@@ -139,16 +249,14 @@ impl PendingDeposits {
             );
             self.defer(front)?;
         }
-        if let Some(found) = self
-            .deferred
-            .iter()
-            .find(|entry| entry.header.number() == expected.number)
+        if let Some(deferred) = &self.deferred
+            && deferred.last_header.number() == expected.number
         {
             eyre::ensure!(
-                found.header.hash() == expected.hash,
+                deferred.last_header.hash() == expected.hash,
                 "deferred L1 block {} has hash {}, but the checkpoint consumed {}",
                 expected.number,
-                found.header.hash(),
+                deferred.last_header.hash(),
                 expected.hash,
             );
         }
@@ -167,25 +275,34 @@ impl PendingDeposits {
             front.header.num_hash() == current.header.num_hash(),
             "operational L1 work does not match the queue front"
         );
-        let mut work = self.deferred.clone();
+        current.events.ensure_operational_capacity()?;
+        let mut work = Vec::with_capacity(usize::from(self.deferred.is_some()) + 1);
+        if let Some(deferred) = &self.deferred {
+            work.push(deferred.aggregated_block());
+        }
         work.push(current.clone());
         Ok(work)
     }
 
     pub(crate) fn confirm_operational(&mut self, expected: NumHash) -> eyre::Result<()> {
         self.confirm(expected)?;
-        self.deferred.clear();
+        self.deferred = None;
         Ok(())
     }
 
     /// Reconcile an already-canonical full import, including after its exact-front bookkeeping
     /// was interrupted.
     pub(crate) fn confirm_operational_through(&mut self, expected: NumHash) -> eyre::Result<()> {
-        self.confirm_through(expected)?;
         // A delayed duplicate of an older full block must not erase checkpoint work deferred by
         // newer canonical blocks. Only release work at or before the full block's anchor.
-        self.deferred
-            .retain(|entry| entry.header.number() > expected.number);
+        self.confirm_through(expected)?;
+        if let Some(deferred) = &mut self.deferred {
+            if deferred.last_header.number() <= expected.number {
+                self.deferred = None;
+            } else if deferred.first_number <= expected.number {
+                deferred.retain_after(expected.number);
+            }
+        }
         Ok(())
     }
 
@@ -222,6 +339,20 @@ impl PendingDeposits {
     #[cfg(test)]
     pub(crate) fn pending_len(&self) -> usize {
         self.pending.len()
+    }
+
+    #[cfg(test)]
+    pub(crate) fn deferred_event_block_len(&self) -> usize {
+        self.deferred
+            .as_ref()
+            .map_or(0, DeferredPortalWork::event_block_len)
+    }
+
+    #[cfg(test)]
+    pub(crate) fn deferred_range(&self) -> Option<(u64, u64)> {
+        self.deferred
+            .as_ref()
+            .map(|work| (work.first_number, work.last_header.number()))
     }
 
     /// Returns the most recently enqueued L1 block (number + hash), if any.
@@ -315,6 +446,11 @@ impl DepositQueue {
         self.inner.lock().peek_headers(maximum)
     }
 
+    /// Return the latest queued L1 header, including headers beyond a bounded checkpoint batch.
+    pub fn latest_header(&self) -> Option<SealedHeader<TempoHeader>> {
+        self.inner.lock().latest_header().cloned()
+    }
+
     /// Confirm the next L1 block was successfully processed and remove it.
     ///
     pub fn confirm(&self, expected: NumHash) -> eyre::Result<L1BlockDeposits> {
@@ -342,24 +478,14 @@ impl DepositQueue {
     }
 
     /// Restore portal work crossed by already-canonical checkpoint-only blocks after restart.
-    pub fn seed_deferred(&self, blocks: Vec<L1BlockDeposits>) -> eyre::Result<()> {
-        let mut recovered = PendingDeposits::default();
-        for block in blocks {
-            recovered.try_enqueue(block.header, block.events)?;
-        }
-        while let Some(front) = recovered
-            .pending
-            .front()
-            .map(|block| block.header.num_hash())
-        {
-            recovered.defer(front)?;
-        }
+    pub(crate) fn seed_deferred(&self, deferred: DeferredPortalWork) -> eyre::Result<()> {
         let mut queue = self.inner.lock();
         eyre::ensure!(
-            queue.pending.is_empty() && queue.deferred.is_empty() && queue.last_enqueued.is_none(),
+            queue.pending.is_empty() && queue.deferred.is_none() && queue.last_enqueued.is_none(),
             "cannot seed deferred portal work into a nonempty queue"
         );
-        *queue = recovered;
+        queue.last_enqueued = Some(deferred.last_num_hash());
+        queue.deferred = Some(deferred);
         Ok(())
     }
 

--- a/crates/l1/src/queue.rs
+++ b/crates/l1/src/queue.rs
@@ -275,28 +275,12 @@ impl PendingDeposits {
         Ok(())
     }
 
-    /// Reconcile an already-canonical full import, including after its exact-front bookkeeping
-    /// was interrupted.
-    pub(crate) fn confirm_operational_through(&mut self, expected: NumHash) -> eyre::Result<()> {
-        // A delayed duplicate of an older full block must not erase checkpoint work deferred by
-        // newer canonical blocks. Only release work at or before the full block's anchor.
-        self.confirm_through(expected)?;
-        if let Some(deferred) = &mut self.deferred {
-            if deferred.last_header.number() <= expected.number {
-                self.deferred = None;
-            } else if deferred.first_number <= expected.number {
-                deferred.retain_after(expected.number);
-            }
-        }
-        Ok(())
-    }
-
     /// Confirm every pending L1 block up to and including `expected`.
     ///
     /// Follower import calls this only after the corresponding zone block is
     /// canonical. It is therefore idempotent and tolerates stale entries before
     /// `expected`, but rejects a different hash at the expected height.
-    pub(crate) fn confirm_through(&mut self, expected: NumHash) -> eyre::Result<()> {
+    pub(crate) fn confirm_operational_through(&mut self, expected: NumHash) -> eyre::Result<()> {
         while let Some(front) = self.pending.front().map(|entry| entry.header.num_hash()) {
             if front.number > expected.number {
                 break;
@@ -310,6 +294,16 @@ impl PendingDeposits {
             );
             self.confirm(front)
                 .expect("front was just read and matches by construction");
+        }
+
+        if let Some(deferred) = &mut self.deferred {
+            // A delayed duplicate of an older full block must not erase checkpoint work deferred by
+            // newer canonical blocks. Only release work at or before the full block's anchor.
+            if deferred.last_header.number() <= expected.number {
+                self.deferred = None;
+            } else if deferred.first_number <= expected.number {
+                deferred.retain_after(expected.number);
+            }
         }
         Ok(())
     }
@@ -476,11 +470,6 @@ impl DepositQueue {
     /// Idempotently reconcile a canonical full import and release the deferred work it consumed.
     pub fn confirm_operational_through(&self, expected: NumHash) -> eyre::Result<()> {
         self.inner.lock().confirm_operational_through(expected)
-    }
-
-    /// Advance the queue past a canonical follower anchor.
-    pub fn confirm_through(&self, expected: NumHash) -> eyre::Result<()> {
-        self.inner.lock().confirm_through(expected)
     }
 
     /// Wait until an L1 block is available.

--- a/crates/l1/src/subscriber.rs
+++ b/crates/l1/src/subscriber.rs
@@ -1,3 +1,5 @@
+use crate::queue::DeferredPortalWork;
+
 use super::*;
 use eyre::WrapErr as _;
 use std::collections::HashSet;
@@ -16,7 +18,15 @@ struct L1BlockTrackerState {
     recent_portal_evidence: BTreeMap<u64, AuthenticatedPortalLogs>,
     latest: Option<NumHash>,
     pruned_through: Option<u64>,
-    finalized_target: Option<u64>,
+    finalized_target: Option<FinalizedTarget>,
+}
+
+/// Highest finalized L1 height announced by the subscriber and whether catch-up has verified that
+/// no newer finalized block remains.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct FinalizedTarget {
+    pub number: u64,
+    pub ready: bool,
 }
 
 #[derive(Debug, Clone)]
@@ -72,17 +82,46 @@ impl L1BlockTracker {
     /// Record the highest finalized L1 height the subscriber has been asked to ingest.
     ///
     /// This is published before backfill starts so the Zone engine does not mistake a partially
-    /// filled queue for the end of the finalized range. The watermark remains monotonic across
-    /// reconnects so a lagging RPC endpoint cannot move the target backwards.
+    /// filled queue for the end of the finalized range.
     pub fn record_finalized_target(&self, number: u64) {
         let mut state = self.state.write();
-        state.finalized_target = Some(state.finalized_target.map_or(number, |old| old.max(number)));
+        let advanced = state
+            .finalized_target
+            .is_none_or(|target| number > target.number);
+        if !advanced {
+            return;
+        }
+        state.finalized_target = Some(FinalizedTarget {
+            number,
+            ready: false,
+        });
         drop(state);
         self.changed.send_replace(());
     }
 
-    /// Return the highest finalized L1 height announced by the subscriber.
-    pub fn finalized_target(&self) -> Option<u64> {
+    /// Mark an announced target ready after a second finalized read observes no remaining delta.
+    pub fn mark_finalized_target_ready(&self, number: u64) -> eyre::Result<()> {
+        let mut state = self.state.write();
+        let target = state
+            .finalized_target
+            .as_mut()
+            .ok_or_else(|| eyre::eyre!("cannot mark an unannounced finalized target ready"))?;
+        eyre::ensure!(
+            target.number == number,
+            "cannot mark finalized target {number} ready; latest announced target is {}",
+            target.number
+        );
+        if target.ready {
+            return Ok(());
+        }
+        target.ready = true;
+        drop(state);
+        self.changed.send_replace(());
+        Ok(())
+    }
+
+    /// Return the highest finalized L1 height announced by the subscriber and its sync status.
+    pub fn finalized_target(&self) -> Option<FinalizedTarget> {
         self.state.read().finalized_target
     }
 
@@ -652,36 +691,54 @@ impl L1Subscriber {
 
     /// Synchronize all missing blocks through the current finalized L1 head.
     ///
+    /// The finalized L1 head is continuously updated on every iteration,
+    /// so the loop will terminate when `next_block` reaches or exceeds the finalized height.
+    ///
     /// Callers provide the next block number and receive the next cursor after
     /// a successful sync.
-    pub(crate) async fn sync_finalized_once(
+    pub(crate) async fn sync_to_finalized(
         &self,
         l1_provider: &impl Provider<TempoNetwork>,
-        next_block: u64,
+        mut next_block: u64,
     ) -> eyre::Result<u64> {
-        let finalized = self.finalized_block_number(l1_provider).await?;
-        self.config.block_tracker.record_finalized_target(finalized);
-        if next_block > finalized {
-            self.record_seen_block(finalized, 0);
-            return Ok(next_block);
+        let mut finalized = self.finalized_block_number(l1_provider).await?;
+        loop {
+            self.config.block_tracker.record_finalized_target(finalized);
+            if next_block <= finalized {
+                let blocks = finalized - next_block + 1;
+                self.record_seen_block(finalized, blocks);
+                info!(
+                    from = next_block,
+                    to = finalized,
+                    blocks,
+                    "Synchronizing finalized L1 blocks"
+                );
+
+                let start = std::time::Instant::now();
+                self.backfill(l1_provider, next_block, finalized).await?;
+                self.subscriber_metrics
+                    .backfill_duration_seconds
+                    .record(start.elapsed().as_secs_f64());
+                next_block = finalized.saturating_add(1);
+            } else {
+                self.record_seen_block(finalized, 0);
+            }
+
+            let refreshed = self.finalized_block_number(l1_provider).await?;
+            eyre::ensure!(
+                refreshed >= finalized,
+                "finalized L1 target regressed from {finalized} to {refreshed}"
+            );
+            self.config.block_tracker.record_finalized_target(refreshed);
+            if refreshed == finalized {
+                self.config
+                    .block_tracker
+                    .mark_finalized_target_ready(refreshed)?;
+                self.subscriber_metrics.current_l1_lag_blocks.set(0.0);
+                return Ok(next_block);
+            }
+            finalized = refreshed;
         }
-
-        let blocks = finalized - next_block + 1;
-        self.record_seen_block(finalized, blocks);
-        info!(
-            from = next_block,
-            to = finalized,
-            blocks,
-            "Synchronizing finalized L1 blocks"
-        );
-
-        let start = std::time::Instant::now();
-        self.backfill(l1_provider, next_block, finalized).await?;
-        self.subscriber_metrics
-            .backfill_duration_seconds
-            .record(start.elapsed().as_secs_f64());
-        self.subscriber_metrics.current_l1_lag_blocks.set(0.0);
-        Ok(finalized.saturating_add(1))
     }
 
     /// Follow finalized L1 using transport-specific head notifications as wakeups.
@@ -701,11 +758,11 @@ impl L1Subscriber {
 
         // Subscribe before the initial sync so a head published while catching
         // up remains queued as another trigger.
-        next_block = self.sync_finalized_once(l1_provider, next_block).await?;
+        next_block = self.sync_to_finalized(l1_provider, next_block).await?;
 
         while let Some(trigger) = triggers.next().await {
             trigger?;
-            next_block = self.sync_finalized_once(l1_provider, next_block).await?;
+            next_block = self.sync_to_finalized(l1_provider, next_block).await?;
         }
 
         Err(eyre::eyre!("L1 head notification stream ended"))
@@ -918,7 +975,7 @@ impl L1Subscriber {
             return Ok(());
         }
 
-        let mut deferred: Option<crate::queue::DeferredPortalWork> = None;
+        let mut deferred: Option<DeferredPortalWork> = None;
         for block_number in from..=checkpoint.number {
             let header = l1_provider
                 .get_header_by_number(block_number.into())
@@ -937,9 +994,10 @@ impl L1Subscriber {
                 header: SealedHeader::seal_slow(header.inner.inner),
                 events,
             };
-            match &mut deferred {
-                Some(work) => work.push(block),
-                None => deferred = Some(crate::queue::DeferredPortalWork::new(block)?),
+            if let Some(deferred) = &mut deferred {
+                deferred.push(block);
+            } else {
+                deferred = Some(DeferredPortalWork::new(block));
             }
         }
         let deferred = deferred.expect("the recovered deferred range is nonempty");
@@ -948,7 +1006,7 @@ impl L1Subscriber {
             "recovered deferred L1 range ends at {:?}, but the local checkpoint is {checkpoint:?}",
             deferred.last_num_hash()
         );
-        self.deposit_queue.seed_deferred(deferred)?;
+        self.deposit_queue.restore_deferred(deferred)?;
         info!(
             from,
             to = checkpoint.number,

--- a/crates/l1/src/subscriber.rs
+++ b/crates/l1/src/subscriber.rs
@@ -181,19 +181,31 @@ impl L1BlockTracker {
     }
 
     /// Wait until the exact L1 block has been validated and applied locally.
+    ///
+    /// Queue-backed subscribers enqueue each block before publishing its observation, so success
+    /// also guarantees that the deposit queue is caught up through `block`.
     pub async fn wait_for(&self, block: NumHash) -> eyre::Result<()> {
-        self.wait_for_portal_events(block).await.map(|_| ())
+        self.wait_for_observation(block, |_| ()).await
     }
 
     /// Wait for an exact L1 block and return its receipt-authenticated portal events.
     pub async fn wait_for_portal_events(&self, block: NumHash) -> eyre::Result<L1PortalEvents> {
+        self.wait_for_observation(block, |observation| observation.portal_events.clone())
+            .await
+    }
+
+    async fn wait_for_observation<T>(
+        &self,
+        block: NumHash,
+        project: impl Fn(&L1BlockObservation) -> T,
+    ) -> eyre::Result<T> {
         let mut changed = self.changed.subscribe();
         loop {
             {
                 let state = self.state.read();
                 match state.observed.get(&block.number) {
                     Some(observation) if observation.hash == block.hash => {
-                        return Ok(observation.portal_events.clone());
+                        return Ok(project(observation));
                     }
                     Some(observation) => {
                         eyre::bail!(

--- a/crates/l1/src/subscriber.rs
+++ b/crates/l1/src/subscriber.rs
@@ -16,6 +16,7 @@ struct L1BlockTrackerState {
     recent_portal_evidence: BTreeMap<u64, AuthenticatedPortalLogs>,
     latest: Option<NumHash>,
     pruned_through: Option<u64>,
+    finalized_target: Option<u64>,
 }
 
 #[derive(Debug, Clone)]
@@ -68,6 +69,23 @@ impl Default for L1BlockTracker {
 }
 
 impl L1BlockTracker {
+    /// Record the highest finalized L1 height the subscriber has been asked to ingest.
+    ///
+    /// This is published before backfill starts so the Zone engine does not mistake a partially
+    /// filled queue for the end of the finalized range. The watermark remains monotonic across
+    /// reconnects so a lagging RPC endpoint cannot move the target backwards.
+    pub fn record_finalized_target(&self, number: u64) {
+        let mut state = self.state.write();
+        state.finalized_target = Some(state.finalized_target.map_or(number, |old| old.max(number)));
+        drop(state);
+        self.changed.send_replace(());
+    }
+
+    /// Return the highest finalized L1 height announced by the subscriber.
+    pub fn finalized_target(&self) -> Option<u64> {
+        self.state.read().finalized_target
+    }
+
     /// Initialize the last L1 height already represented by canonical local zone state.
     pub fn initialize_consumed_through(&self, number: u64) {
         let mut state = self.state.write();
@@ -642,6 +660,7 @@ impl L1Subscriber {
         next_block: u64,
     ) -> eyre::Result<u64> {
         let finalized = self.finalized_block_number(l1_provider).await?;
+        self.config.block_tracker.record_finalized_target(finalized);
         if next_block > finalized {
             self.record_seen_block(finalized, 0);
             return Ok(next_block);

--- a/crates/l1/src/subscriber.rs
+++ b/crates/l1/src/subscriber.rs
@@ -383,6 +383,9 @@ pub struct L1SubscriberConfig {
     pub encryption_keys: Option<crate::EncryptionKeyRing>,
     /// Whether to retain authenticated Portal logs for external observers.
     pub retain_portal_evidence: bool,
+    /// First L1 block whose portal work was crossed by canonical checkpoint-only Zone blocks.
+    /// Startup reconstructs this suffix before following new finalized blocks.
+    pub deferred_work_start: Option<u64>,
 }
 
 pub(crate) trait LocalTempoCheckpointReader: Send + Sync {
@@ -872,12 +875,57 @@ impl L1Subscriber {
     /// ingestion failures as fatal.
     pub async fn run(&self) -> eyre::Result<()> {
         let provider = self.connect().await?;
+        self.recover_deferred_work(&provider).await?;
         let triggers = self.head_triggers(&provider).await?;
         info!(
             portal = %self.config.portal_address,
             "Following finalized L1 blocks"
         );
         self.follow_finalized(&provider, triggers).await
+    }
+
+    async fn recover_deferred_work(
+        &self,
+        l1_provider: &impl Provider<TempoNetwork>,
+    ) -> eyre::Result<()> {
+        let Some(from) = self.config.deferred_work_start else {
+            return Ok(());
+        };
+        if self.deposit_queue.last_enqueued().is_some() {
+            return Ok(());
+        }
+        let checkpoint = self.local_state.latest_tempo_checkpoint()?;
+        if from > checkpoint.number {
+            return Ok(());
+        }
+
+        let mut blocks = Vec::with_capacity((checkpoint.number - from + 1) as usize);
+        for block_number in from..=checkpoint.number {
+            let header = l1_provider
+                .get_header_by_number(block_number.into())
+                .await?
+                .ok_or_else(|| eyre::eyre!("L1 header not found for block {block_number}"))?;
+            let block_hash = header.hash();
+            let receipts = fetch_and_verify_receipts_for_header(
+                l1_provider,
+                NumHash::new(block_number, block_hash),
+                header.receipts_root(),
+                header.logs_bloom(),
+            )
+            .await?;
+            let (events, _, _) = self.extract_events(block_number, &receipts)?;
+            blocks.push(L1BlockDeposits {
+                header: SealedHeader::seal_slow(header.inner.inner),
+                events,
+            });
+        }
+        self.deposit_queue.seed_deferred(blocks)?;
+        info!(
+            from,
+            to = checkpoint.number,
+            "Recovered portal work crossed by checkpoint-only Zone blocks"
+        );
+        Ok(())
     }
 
     /// Extract portal events and raw-cache mutation barriers from fetched receipts.

--- a/crates/l1/src/subscriber.rs
+++ b/crates/l1/src/subscriber.rs
@@ -918,7 +918,7 @@ impl L1Subscriber {
             return Ok(());
         }
 
-        let mut blocks = Vec::with_capacity((checkpoint.number - from + 1) as usize);
+        let mut deferred: Option<crate::queue::DeferredPortalWork> = None;
         for block_number in from..=checkpoint.number {
             let header = l1_provider
                 .get_header_by_number(block_number.into())
@@ -933,12 +933,22 @@ impl L1Subscriber {
             )
             .await?;
             let (events, _, _) = self.extract_events(block_number, &receipts)?;
-            blocks.push(L1BlockDeposits {
+            let block = L1BlockDeposits {
                 header: SealedHeader::seal_slow(header.inner.inner),
                 events,
-            });
+            };
+            match &mut deferred {
+                Some(work) => work.push(block),
+                None => deferred = Some(crate::queue::DeferredPortalWork::new(block)?),
+            }
         }
-        self.deposit_queue.seed_deferred(blocks)?;
+        let deferred = deferred.expect("the recovered deferred range is nonempty");
+        eyre::ensure!(
+            deferred.last_num_hash() == checkpoint,
+            "recovered deferred L1 range ends at {:?}, but the local checkpoint is {checkpoint:?}",
+            deferred.last_num_hash()
+        );
+        self.deposit_queue.seed_deferred(deferred)?;
         info!(
             from,
             to = checkpoint.number,

--- a/crates/l1/src/tests.rs
+++ b/crates/l1/src/tests.rs
@@ -172,6 +172,7 @@ fn test_subscriber(local_state: Arc<dyn LocalTempoCheckpointReader>) -> L1Subscr
             leadership_sink: None,
             encryption_keys: None,
             retain_portal_evidence: false,
+            deferred_work_start: None,
         },
         local_state,
         deposit_queue: DepositQueue::default(),
@@ -1311,6 +1312,111 @@ fn confirm_through_is_idempotent_and_drains_stale_entries() {
     queue.confirm_through(anchor).unwrap();
     assert!(queue.peek().is_none());
     queue.confirm_through(anchor).unwrap();
+}
+
+#[test]
+fn canonical_import_reconciliation_is_idempotent_across_checkpoint_and_full_blocks() {
+    let queue = DepositQueue::new();
+    let first = SealedHeader::seal_slow(make_test_header(1));
+    let second = SealedHeader::seal_slow(make_chained_header(2, first.hash()));
+    let third = SealedHeader::seal_slow(make_chained_header(3, second.hash()));
+    for header in [&first, &second, &third] {
+        queue
+            .try_enqueue_sealed(header.clone(), L1PortalEvents::default())
+            .unwrap();
+    }
+
+    queue.defer_through(second.num_hash()).unwrap();
+    queue.defer_through(second.num_hash()).unwrap();
+    assert_eq!(queue.peek().unwrap().header.num_hash(), third.num_hash());
+    assert_eq!(
+        queue
+            .operational_work(&queue.peek().unwrap())
+            .unwrap()
+            .len(),
+        3
+    );
+
+    queue.confirm_operational_through(third.num_hash()).unwrap();
+    queue.confirm_operational_through(third.num_hash()).unwrap();
+    assert!(queue.peek().is_none());
+
+    let fourth = SealedHeader::seal_slow(make_chained_header(4, third.hash()));
+    let fifth = SealedHeader::seal_slow(make_chained_header(5, fourth.hash()));
+    queue
+        .try_enqueue_sealed(fourth.clone(), L1PortalEvents::default())
+        .unwrap();
+    queue.defer_through(fourth.num_hash()).unwrap();
+    queue
+        .try_enqueue_sealed(fifth, L1PortalEvents::default())
+        .unwrap();
+
+    // A late replay of block 3 must preserve block 4's newer deferred work.
+    queue.confirm_operational_through(third.num_hash()).unwrap();
+    assert_eq!(
+        queue
+            .operational_work(&queue.peek().unwrap())
+            .unwrap()
+            .len(),
+        2
+    );
+}
+
+#[test]
+fn deferred_checkpoint_work_survives_until_operational_confirmation() {
+    let queue = DepositQueue::new();
+    let h10 = make_test_header(10);
+    let h11 = make_chained_header(11, header_hash(&h10));
+    let h12 = make_chained_header(12, header_hash(&h11));
+    for header in [h10, h11, h12] {
+        queue
+            .try_enqueue_sealed(seal(header), L1PortalEvents::default())
+            .unwrap();
+    }
+
+    let first = queue.peek().unwrap();
+    queue.defer(first.header.num_hash()).unwrap();
+    let second = queue.peek().unwrap();
+    queue.defer(second.header.num_hash()).unwrap();
+    let current = queue.peek().unwrap();
+    let work = queue.operational_work(&current).unwrap();
+    assert_eq!(
+        work.iter()
+            .map(|block| block.header.number())
+            .collect::<Vec<_>>(),
+        vec![10, 11, 12]
+    );
+
+    queue
+        .confirm_operational(current.header.num_hash())
+        .unwrap();
+    assert!(queue.peek().is_none());
+}
+
+#[test]
+fn restart_can_seed_deferred_checkpoint_work() {
+    let queue = DepositQueue::new();
+    let h10 = make_test_header(10);
+    let h11 = make_chained_header(11, header_hash(&h10));
+    queue
+        .seed_deferred(vec![
+            L1BlockDeposits {
+                header: seal(h10),
+                events: L1PortalEvents::default(),
+            },
+            L1BlockDeposits {
+                header: seal(h11),
+                events: L1PortalEvents::default(),
+            },
+        ])
+        .unwrap();
+
+    let h12 = make_chained_header(12, queue.last_enqueued().unwrap().hash);
+    queue
+        .try_enqueue_sealed(seal(h12), L1PortalEvents::default())
+        .unwrap();
+    let current = queue.peek().unwrap();
+    assert_eq!(queue.operational_work(&current).unwrap().len(), 3);
 }
 
 #[test]

--- a/crates/l1/src/tests.rs
+++ b/crates/l1/src/tests.rs
@@ -1346,7 +1346,7 @@ fn canonical_import_reconciliation_is_idempotent_across_checkpoint_and_full_bloc
             .operational_work(&queue.peek().unwrap())
             .unwrap()
             .len(),
-        3
+        2
     );
 
     queue.confirm_operational_through(third.num_hash()).unwrap();
@@ -1396,7 +1396,7 @@ fn deferred_checkpoint_work_survives_until_operational_confirmation() {
         work.iter()
             .map(|block| block.header.number())
             .collect::<Vec<_>>(),
-        vec![10, 11, 12]
+        vec![11, 12]
     );
 
     queue
@@ -1410,25 +1410,140 @@ fn restart_can_seed_deferred_checkpoint_work() {
     let queue = DepositQueue::new();
     let h10 = make_test_header(10);
     let h11 = make_chained_header(11, header_hash(&h10));
-    queue
-        .seed_deferred(vec![
-            L1BlockDeposits {
-                header: seal(h10),
-                events: L1PortalEvents::default(),
-            },
-            L1BlockDeposits {
-                header: seal(h11),
-                events: L1PortalEvents::default(),
-            },
-        ])
-        .unwrap();
+    let mut deferred = crate::queue::DeferredPortalWork::new(L1BlockDeposits {
+        header: seal(h10),
+        events: L1PortalEvents::default(),
+    })
+    .unwrap();
+    deferred.push(L1BlockDeposits {
+        header: seal(h11),
+        events: L1PortalEvents::default(),
+    });
+    queue.seed_deferred(deferred).unwrap();
 
     let h12 = make_chained_header(12, queue.last_enqueued().unwrap().hash);
     queue
         .try_enqueue_sealed(seal(h12), L1PortalEvents::default())
         .unwrap();
     let current = queue.peek().unwrap();
-    assert_eq!(queue.operational_work(&current).unwrap().len(), 3);
+    assert_eq!(queue.operational_work(&current).unwrap().len(), 2);
+}
+
+#[test]
+fn deferred_empty_blocks_use_constant_space() {
+    let mut queue = PendingDeposits::default();
+    let mut parent_hash = B256::ZERO;
+    for number in 1..=10_000 {
+        let header = if number == 1 {
+            make_test_header(number)
+        } else {
+            make_chained_header(number, parent_hash)
+        };
+        let header = seal(header);
+        let anchor = header.num_hash();
+        parent_hash = anchor.hash;
+        queue
+            .try_enqueue(header, L1PortalEvents::default())
+            .unwrap();
+        queue.defer(anchor).unwrap();
+    }
+
+    assert_eq!(queue.deferred_event_block_len(), 0);
+    assert_eq!(queue.deferred_range(), Some((1, 10_000)));
+}
+
+#[test]
+fn compacted_deferred_work_releases_only_a_confirmed_prefix() {
+    let mut queue = PendingDeposits::default();
+    let tokens: Vec<_> = (1..=4)
+        .map(|index| EnabledToken {
+            token: Address::repeat_byte(index),
+            name: format!("Token {index}"),
+            symbol: format!("T{index}"),
+            currency: "USD".into(),
+        })
+        .collect();
+    let mut parent_hash = B256::ZERO;
+    let mut anchors = Vec::new();
+    for (index, token) in tokens[..3].iter().enumerate() {
+        let number = index as u64 + 1;
+        let header = if number == 1 {
+            make_test_header(number)
+        } else {
+            make_chained_header(number, parent_hash)
+        };
+        let header = seal(header);
+        let anchor = header.num_hash();
+        parent_hash = anchor.hash;
+        queue
+            .try_enqueue(
+                header,
+                L1PortalEvents {
+                    enabled_tokens: vec![token.clone()],
+                    ..Default::default()
+                },
+            )
+            .unwrap();
+        queue.defer(anchor).unwrap();
+        anchors.push(anchor);
+    }
+
+    queue.confirm_operational_through(anchors[1]).unwrap();
+    assert_eq!(queue.deferred_range(), Some((3, 3)));
+
+    let current = seal(make_chained_header(4, parent_hash));
+    queue
+        .try_enqueue(
+            current,
+            L1PortalEvents {
+                enabled_tokens: vec![tokens[3].clone()],
+                ..Default::default()
+            },
+        )
+        .unwrap();
+    let work = queue.operational_work(queue.peek().unwrap()).unwrap();
+    assert_eq!(work.len(), 2);
+    assert_eq!(work[0].events.enabled_tokens[0].token, tokens[2].token);
+    assert_eq!(work[1].events.enabled_tokens[0].token, tokens[3].token);
+}
+
+#[test]
+fn deferred_work_enforces_token_capacity_before_removing_the_front() {
+    let mut queue = PendingDeposits::default();
+    let mut parent_hash = B256::ZERO;
+    for index in 0..=zone_primitives::constants::MAX_UNPROCESSED_TOKEN_ENABLEMENTS {
+        let number = index as u64 + 1;
+        let header = if number == 1 {
+            make_test_header(number)
+        } else {
+            make_chained_header(number, parent_hash)
+        };
+        let header = seal(header);
+        let anchor = header.num_hash();
+        parent_hash = anchor.hash;
+        queue
+            .try_enqueue(
+                header,
+                L1PortalEvents {
+                    enabled_tokens: vec![EnabledToken {
+                        token: Address::repeat_byte(number as u8),
+                        name: format!("Token {number}"),
+                        symbol: format!("T{number}"),
+                        currency: "USD".into(),
+                    }],
+                    ..Default::default()
+                },
+            )
+            .unwrap();
+
+        if index < zone_primitives::constants::MAX_UNPROCESSED_TOKEN_ENABLEMENTS {
+            queue.defer(anchor).unwrap();
+        } else {
+            let err = queue.defer(anchor).unwrap_err();
+            assert!(err.to_string().contains("protocol capacity"));
+            assert_eq!(queue.peek().unwrap().header.num_hash(), anchor);
+        }
+    }
 }
 
 #[test]

--- a/crates/l1/src/tests.rs
+++ b/crates/l1/src/tests.rs
@@ -375,9 +375,33 @@ fn l1_block_tracker_finalized_target_is_monotonic() {
     assert_eq!(tracker.finalized_target(), None);
 
     tracker.record_finalized_target(200);
+    assert_eq!(
+        tracker.finalized_target(),
+        Some(FinalizedTarget {
+            number: 200,
+            ready: false,
+        })
+    );
+    tracker.mark_finalized_target_ready(200).unwrap();
     tracker.record_finalized_target(199);
+    tracker.record_finalized_target(200);
 
-    assert_eq!(tracker.finalized_target(), Some(200));
+    assert_eq!(
+        tracker.finalized_target(),
+        Some(FinalizedTarget {
+            number: 200,
+            ready: true,
+        })
+    );
+
+    tracker.record_finalized_target(201);
+    assert_eq!(
+        tracker.finalized_target(),
+        Some(FinalizedTarget {
+            number: 201,
+            ready: false,
+        })
+    );
 }
 
 #[test]
@@ -787,12 +811,14 @@ async fn test_follow_finalized_uses_new_heads_to_sync_missing_finalized_range() 
     // Initial sync through finalized block 10.
     asserter.push_success(&Some(header_response(header_10.clone())));
     push_header_and_empty_receipts(&asserter, header_10);
+    asserter.push_success(&Some(header_response(make_test_header(10))));
 
     // One newHeads notification wakes the subscriber. The finalized tag has
     // advanced by two blocks, so both missing blocks must be ingested.
     asserter.push_success(&Some(header_response(header_12.clone())));
     push_header_and_empty_receipts(&asserter, header_11);
-    push_header_and_empty_receipts(&asserter, header_12);
+    push_header_and_empty_receipts(&asserter, header_12.clone());
+    asserter.push_success(&Some(header_response(header_12)));
 
     let err = subscriber
         .follow_finalized(
@@ -847,15 +873,65 @@ async fn test_sync_finalized_once_does_not_refetch_current_cursor() {
     let l1_provider =
         ProviderBuilder::new_with_network::<TempoNetwork>().connect_mocked_client(asserter.clone());
     asserter.push_success(&Some(header_response(make_test_header(10))));
+    asserter.push_success(&Some(header_response(make_test_header(10))));
 
     let next = subscriber
-        .sync_finalized_once(&l1_provider, 11)
+        .sync_to_finalized(&l1_provider, 11)
         .await
         .unwrap();
 
     assert_eq!(next, 11);
-    assert_eq!(subscriber.config.block_tracker.finalized_target(), Some(10));
+    assert_eq!(
+        subscriber.config.block_tracker.finalized_target(),
+        Some(FinalizedTarget {
+            number: 10,
+            ready: true,
+        })
+    );
     assert!(subscriber.deposit_queue.drain().is_empty());
+    assert!(asserter.read_q().is_empty());
+}
+
+#[tokio::test]
+async fn test_sync_finalized_once_extends_a_moving_finalized_target_until_stable() {
+    let subscriber = test_subscriber(Arc::new(SequenceLocalTempoCheckpointReader::new([9])));
+    let asserter = Asserter::new();
+    let l1_provider =
+        ProviderBuilder::new_with_network::<TempoNetwork>().connect_mocked_client(asserter.clone());
+
+    let header_10 = make_test_header(10);
+    let header_11 = make_chained_header(11, header_hash(&header_10));
+    let header_12 = make_chained_header(12, header_hash(&header_11));
+
+    asserter.push_success(&Some(header_response(header_10.clone())));
+    push_header_and_empty_receipts(&asserter, header_10);
+    asserter.push_success(&Some(header_response(header_12.clone())));
+    push_header_and_empty_receipts(&asserter, header_11);
+    push_header_and_empty_receipts(&asserter, header_12.clone());
+    asserter.push_success(&Some(header_response(header_12)));
+
+    let next = subscriber
+        .sync_to_finalized(&l1_provider, 10)
+        .await
+        .unwrap();
+
+    assert_eq!(next, 13);
+    assert_eq!(
+        subscriber
+            .deposit_queue
+            .drain()
+            .iter()
+            .map(|block| block.header.number())
+            .collect::<Vec<_>>(),
+        vec![10, 11, 12]
+    );
+    assert_eq!(
+        subscriber.config.block_tracker.finalized_target(),
+        Some(FinalizedTarget {
+            number: 12,
+            ready: true,
+        })
+    );
     assert!(asserter.read_q().is_empty());
 }
 
@@ -1387,9 +1463,9 @@ fn deferred_checkpoint_work_survives_until_operational_confirmation() {
     }
 
     let first = queue.peek().unwrap();
-    queue.defer(first.header.num_hash()).unwrap();
+    queue.defer_through(first.header.num_hash()).unwrap();
     let second = queue.peek().unwrap();
-    queue.defer(second.header.num_hash()).unwrap();
+    queue.defer_through(second.header.num_hash()).unwrap();
     let current = queue.peek().unwrap();
     let work = queue.operational_work(&current).unwrap();
     assert_eq!(
@@ -1413,13 +1489,12 @@ fn restart_can_seed_deferred_checkpoint_work() {
     let mut deferred = crate::queue::DeferredPortalWork::new(L1BlockDeposits {
         header: seal(h10),
         events: L1PortalEvents::default(),
-    })
-    .unwrap();
+    });
     deferred.push(L1BlockDeposits {
         header: seal(h11),
         events: L1PortalEvents::default(),
     });
-    queue.seed_deferred(deferred).unwrap();
+    queue.restore_deferred(deferred).unwrap();
 
     let h12 = make_chained_header(12, queue.last_enqueued().unwrap().hash);
     queue
@@ -1445,7 +1520,7 @@ fn deferred_empty_blocks_use_constant_space() {
         queue
             .try_enqueue(header, L1PortalEvents::default())
             .unwrap();
-        queue.defer(anchor).unwrap();
+        queue.defer_through(anchor).unwrap();
     }
 
     assert_eq!(queue.deferred_event_block_len(), 0);
@@ -1484,7 +1559,7 @@ fn compacted_deferred_work_releases_only_a_confirmed_prefix() {
                 },
             )
             .unwrap();
-        queue.defer(anchor).unwrap();
+        queue.defer_through(anchor).unwrap();
         anchors.push(anchor);
     }
 
@@ -1505,45 +1580,6 @@ fn compacted_deferred_work_releases_only_a_confirmed_prefix() {
     assert_eq!(work.len(), 2);
     assert_eq!(work[0].events.enabled_tokens[0].token, tokens[2].token);
     assert_eq!(work[1].events.enabled_tokens[0].token, tokens[3].token);
-}
-
-#[test]
-fn deferred_work_enforces_token_capacity_before_removing_the_front() {
-    let mut queue = PendingDeposits::default();
-    let mut parent_hash = B256::ZERO;
-    for index in 0..=zone_primitives::constants::MAX_UNPROCESSED_TOKEN_ENABLEMENTS {
-        let number = index as u64 + 1;
-        let header = if number == 1 {
-            make_test_header(number)
-        } else {
-            make_chained_header(number, parent_hash)
-        };
-        let header = seal(header);
-        let anchor = header.num_hash();
-        parent_hash = anchor.hash;
-        queue
-            .try_enqueue(
-                header,
-                L1PortalEvents {
-                    enabled_tokens: vec![EnabledToken {
-                        token: Address::repeat_byte(number as u8),
-                        name: format!("Token {number}"),
-                        symbol: format!("T{number}"),
-                        currency: "USD".into(),
-                    }],
-                    ..Default::default()
-                },
-            )
-            .unwrap();
-
-        if index < zone_primitives::constants::MAX_UNPROCESSED_TOKEN_ENABLEMENTS {
-            queue.defer(anchor).unwrap();
-        } else {
-            let err = queue.defer(anchor).unwrap_err();
-            assert!(err.to_string().contains("protocol capacity"));
-            assert_eq!(queue.peek().unwrap().header.num_hash(), anchor);
-        }
-    }
 }
 
 #[test]
@@ -1984,7 +2020,7 @@ async fn sync_classifies_corrupt_recognized_portal_log_as_fenced() {
     asserter.push_success(&Some(vec![receipt]));
 
     let err = subscriber
-        .sync_finalized_once(&l1_provider, 10)
+        .sync_to_finalized(&l1_provider, 10)
         .await
         .unwrap_err();
     assert!(is_fenced_ingestion_error(&err));
@@ -2043,10 +2079,11 @@ async fn sync_applies_leadership_transition_before_enqueueing_the_activation_blo
     asserter.push_success(&Some(header_response(header_10.clone())));
     asserter.push_success(&Some(header_response(header_10.clone())));
     asserter.push_success(&Some(vec![receipt]));
+    asserter.push_success(&Some(header_response(header_10)));
 
     assert_eq!(
         subscriber
-            .sync_finalized_once(&l1_provider, 10)
+            .sync_to_finalized(&l1_provider, 10)
             .await
             .unwrap(),
         11
@@ -2091,7 +2128,7 @@ async fn sync_fences_the_block_when_the_leadership_sink_rejects_the_transition()
     asserter.push_success(&Some(vec![receipt]));
 
     let err = subscriber
-        .sync_finalized_once(&l1_provider, 10)
+        .sync_to_finalized(&l1_provider, 10)
         .await
         .unwrap_err();
     assert!(err.to_string().contains("leadership transition"));

--- a/crates/l1/src/tests.rs
+++ b/crates/l1/src/tests.rs
@@ -1524,62 +1524,6 @@ fn deferred_empty_blocks_use_constant_space() {
     }
 
     assert_eq!(queue.deferred_event_block_len(), 0);
-    assert_eq!(queue.deferred_range(), Some((1, 10_000)));
-}
-
-#[test]
-fn compacted_deferred_work_releases_only_a_confirmed_prefix() {
-    let mut queue = PendingDeposits::default();
-    let tokens: Vec<_> = (1..=4)
-        .map(|index| EnabledToken {
-            token: Address::repeat_byte(index),
-            name: format!("Token {index}"),
-            symbol: format!("T{index}"),
-            currency: "USD".into(),
-        })
-        .collect();
-    let mut parent_hash = B256::ZERO;
-    let mut anchors = Vec::new();
-    for (index, token) in tokens[..3].iter().enumerate() {
-        let number = index as u64 + 1;
-        let header = if number == 1 {
-            make_test_header(number)
-        } else {
-            make_chained_header(number, parent_hash)
-        };
-        let header = seal(header);
-        let anchor = header.num_hash();
-        parent_hash = anchor.hash;
-        queue
-            .try_enqueue(
-                header,
-                L1PortalEvents {
-                    enabled_tokens: vec![token.clone()],
-                    ..Default::default()
-                },
-            )
-            .unwrap();
-        queue.defer_through(anchor).unwrap();
-        anchors.push(anchor);
-    }
-
-    queue.confirm_operational_through(anchors[1]).unwrap();
-    assert_eq!(queue.deferred_range(), Some((3, 3)));
-
-    let current = seal(make_chained_header(4, parent_hash));
-    queue
-        .try_enqueue(
-            current,
-            L1PortalEvents {
-                enabled_tokens: vec![tokens[3].clone()],
-                ..Default::default()
-            },
-        )
-        .unwrap();
-    let work = queue.operational_work(queue.peek().unwrap()).unwrap();
-    assert_eq!(work.len(), 2);
-    assert_eq!(work[0].events.enabled_tokens[0].token, tokens[2].token);
-    assert_eq!(work[1].events.enabled_tokens[0].token, tokens[3].token);
 }
 
 #[test]

--- a/crates/l1/src/tests.rs
+++ b/crates/l1/src/tests.rs
@@ -1385,7 +1385,7 @@ fn external_enqueue_accepts_duplicate_producers() {
 }
 
 #[test]
-fn confirm_through_is_idempotent_and_drains_stale_entries() {
+fn confirm_operational_through_is_idempotent_and_drains_stale_entries() {
     let queue = DepositQueue::new();
     let h10 = make_test_header(10);
     let h11 = make_chained_header(11, header_hash(&h10));
@@ -1397,9 +1397,9 @@ fn confirm_through_is_idempotent_and_drains_stale_entries() {
             .unwrap();
     }
 
-    queue.confirm_through(anchor).unwrap();
+    queue.confirm_operational_through(anchor).unwrap();
     assert!(queue.peek().is_none());
-    queue.confirm_through(anchor).unwrap();
+    queue.confirm_operational_through(anchor).unwrap();
 }
 
 #[test]
@@ -1583,14 +1583,14 @@ fn compacted_deferred_work_releases_only_a_confirmed_prefix() {
 }
 
 #[test]
-fn confirm_through_rejects_a_conflicting_anchor() {
+fn confirm_operational_through_rejects_a_conflicting_anchor() {
     let queue = DepositQueue::new();
     queue
         .try_enqueue_sealed(seal(make_test_header(10)), L1PortalEvents::default())
         .unwrap();
 
     let err = queue
-        .confirm_through(NumHash::new(10, B256::repeat_byte(0xab)))
+        .confirm_operational_through(NumHash::new(10, B256::repeat_byte(0xab)))
         .expect_err("a different hash at the same height must fail");
     assert!(err.to_string().contains("deposit queue holds L1 block 10"));
     assert_eq!(queue.peek().unwrap().header.number(), 10);

--- a/crates/l1/src/tests.rs
+++ b/crates/l1/src/tests.rs
@@ -1417,13 +1417,7 @@ fn canonical_import_reconciliation_is_idempotent_across_checkpoint_and_full_bloc
     queue.defer_through(second.num_hash()).unwrap();
     queue.defer_through(second.num_hash()).unwrap();
     assert_eq!(queue.peek().unwrap().header.num_hash(), third.num_hash());
-    assert_eq!(
-        queue
-            .operational_work(&queue.peek().unwrap())
-            .unwrap()
-            .len(),
-        2
-    );
+    assert_eq!(queue.operational_work(third.num_hash()).unwrap().len(), 2);
 
     queue.confirm_operational_through(third.num_hash()).unwrap();
     queue.confirm_operational_through(third.num_hash()).unwrap();
@@ -1441,13 +1435,8 @@ fn canonical_import_reconciliation_is_idempotent_across_checkpoint_and_full_bloc
 
     // A late replay of block 3 must preserve block 4's newer deferred work.
     queue.confirm_operational_through(third.num_hash()).unwrap();
-    assert_eq!(
-        queue
-            .operational_work(&queue.peek().unwrap())
-            .unwrap()
-            .len(),
-        2
-    );
+    let fifth = queue.peek().unwrap().header.num_hash();
+    assert_eq!(queue.operational_work(fifth).unwrap().len(), 2);
 }
 
 #[test]
@@ -1467,7 +1456,7 @@ fn deferred_checkpoint_work_survives_until_operational_confirmation() {
     let second = queue.peek().unwrap();
     queue.defer_through(second.header.num_hash()).unwrap();
     let current = queue.peek().unwrap();
-    let work = queue.operational_work(&current).unwrap();
+    let work = queue.operational_work(current.header.num_hash()).unwrap();
     assert_eq!(
         work.iter()
             .map(|block| block.header.number())
@@ -1501,7 +1490,13 @@ fn restart_can_seed_deferred_checkpoint_work() {
         .try_enqueue_sealed(seal(h12), L1PortalEvents::default())
         .unwrap();
     let current = queue.peek().unwrap();
-    assert_eq!(queue.operational_work(&current).unwrap().len(), 2);
+    assert_eq!(
+        queue
+            .operational_work(current.header.num_hash())
+            .unwrap()
+            .len(),
+        2
+    );
 }
 
 #[test]

--- a/crates/l1/src/tests.rs
+++ b/crates/l1/src/tests.rs
@@ -370,6 +370,17 @@ async fn l1_block_tracker_backpressures_at_one_hour_lookahead() {
 }
 
 #[test]
+fn l1_block_tracker_finalized_target_is_monotonic() {
+    let tracker = L1BlockTracker::default();
+    assert_eq!(tracker.finalized_target(), None);
+
+    tracker.record_finalized_target(200);
+    tracker.record_finalized_target(199);
+
+    assert_eq!(tracker.finalized_target(), Some(200));
+}
+
+#[test]
 fn l1_block_tracker_rejects_first_observation_above_persisted_successor() {
     let tracker = L1BlockTracker::default();
     tracker.initialize_consumed_through(10);
@@ -843,6 +854,7 @@ async fn test_sync_finalized_once_does_not_refetch_current_cursor() {
         .unwrap();
 
     assert_eq!(next, 11);
+    assert_eq!(subscriber.config.block_tracker.finalized_target(), Some(10));
     assert!(subscriber.deposit_queue.drain().is_empty());
     assert!(asserter.read_q().is_empty());
 }

--- a/crates/node/src/engine.rs
+++ b/crates/node/src/engine.rs
@@ -60,11 +60,11 @@ use zone_l1::{DepositQueue, EncryptionKeyRing, FinalizedTarget, L1BlockDeposits,
 use zone_p2p::{LeadershipSchedule, P2pPeerId};
 use zone_payload::{TempoImport, ZonePayloadAttributes, ZonePayloadTypes};
 
-/// Full-block production permit backed by the effective leadership schedule.
+/// Per-anchor production permit backed by the effective leadership schedule.
 ///
-/// Full blocks require the leader assigned to their imported Tempo header. Checkpoint-only blocks
-/// are leader-neutral and bypass this permit. An optimistic override is open-ended until the next
-/// finalized portal transition supplies the ordinary-authority boundary.
+/// Every Zone block requires the leader assigned to its final imported Tempo header. An optimistic
+/// override is open-ended until the next finalized portal transition supplies the
+/// ordinary-authority boundary.
 #[derive(Debug, Clone)]
 pub struct ProductionPermit {
     schedule: LeadershipSchedule,
@@ -80,7 +80,7 @@ impl ProductionPermit {
         }
     }
 
-    /// Decide whether this node may produce the full zone block embedding `tempo_anchor`.
+    /// Decide whether this node may produce the Zone block embedding `tempo_anchor`.
     ///
     /// `None` authorizes production; `Some(exit)` is the reason the engine must stop.
     pub fn check(&self, tempo_anchor: u64) -> Option<EngineExit> {
@@ -198,6 +198,16 @@ struct AvailableTempoImport {
     l1_block: L1BlockDeposits,
     checkpoint_headers: Vec<SealedHeader<TempoHeader>>,
     wall_clock_timestamp_millis: u64,
+}
+
+impl AvailableTempoImport {
+    /// Historical Tempo anchor whose leader must produce this Zone block.
+    fn leader_anchor(&self) -> u64 {
+        self.checkpoint_headers
+            .last()
+            .unwrap_or(&self.l1_block.header)
+            .number()
+    }
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -548,14 +558,9 @@ impl AvailableBlockDrain for ZoneEngine {
     }
 
     fn permit(&self, block: &Self::Block) -> Option<EngineExit> {
-        if !block.checkpoint_headers.is_empty() {
-            // TIP-1096 assigns no leader to checkpoint-only blocks. Leader authority resumes at
-            // the final full block, whose single imported Tempo header is checked below.
-            return None;
-        }
         self.production_permit
             .as_ref()
-            .and_then(|permit| permit.check(block.l1_block.header.number()))
+            .and_then(|permit| permit.check(block.leader_anchor()))
     }
 
     async fn advance_one(&mut self, block: Self::Block) -> eyre::Result<()> {
@@ -622,6 +627,20 @@ mod tests {
 
     fn finalized_target(number: u64, ready: bool) -> Option<FinalizedTarget> {
         Some(FinalizedTarget { number, ready })
+    }
+
+    #[test]
+    fn checkpoint_import_uses_final_header_as_leader_anchor() {
+        let available = AvailableTempoImport {
+            l1_block: L1BlockDeposits {
+                header: header(90, 90),
+                events: Default::default(),
+            },
+            checkpoint_headers: vec![header(90, 90), header(110, 110)],
+            wall_clock_timestamp_millis: 110_000,
+        };
+
+        assert_eq!(available.leader_anchor(), 110);
     }
 
     #[test]

--- a/crates/node/src/engine.rs
+++ b/crates/node/src/engine.rs
@@ -343,7 +343,9 @@ impl ZoneEngine {
         let tempo_import = if checkpoint_only {
             TempoImport::CheckpointOnly(checkpoint_headers)
         } else {
-            let portal_work = self.deposit_queue.operational_work(&l1_block)?;
+            let portal_work = self
+                .deposit_queue
+                .operational_work(l1_block.header.num_hash())?;
             TempoImport::Full(Box::new(
                 L1BlockDeposits::prepare_many(
                     portal_work,

--- a/crates/node/src/engine.rs
+++ b/crates/node/src/engine.rs
@@ -50,20 +50,21 @@ use std::{
     sync::Arc,
     time::{Duration, SystemTime, UNIX_EPOCH},
 };
+use tempo_chainspec::spec::TempoHardforks as _;
 use tempo_primitives::TempoHeader;
 use tokio_util::sync::CancellationToken;
 use tracing::{error, info};
 
-use zone_chainspec::{ZoneChainSpec, ZoneHardforks};
+use zone_chainspec::ZoneChainSpec;
 use zone_l1::{DepositQueue, EncryptionKeyRing, L1BlockDeposits, L1BlockTracker};
 use zone_p2p::{LeadershipSchedule, P2pPeerId};
 use zone_payload::{TempoImport, ZonePayloadAttributes, ZonePayloadTypes};
 
-/// Per-anchor production permit backed by the effective leadership schedule.
+/// Full-block production permit backed by the effective leadership schedule.
 ///
-/// The permit is a single schedule lookup: produce anchor `N` only if the portal schedule or a
-/// forced-recovery override assigns `N` to this node. An optimistic override is open-ended until
-/// the next finalized portal transition supplies the ordinary-authority boundary.
+/// Full blocks require the leader assigned to their imported Tempo header. Checkpoint-only blocks
+/// are leader-neutral and bypass this permit. An optimistic override is open-ended until the next
+/// finalized portal transition supplies the ordinary-authority boundary.
 #[derive(Debug, Clone)]
 pub struct ProductionPermit {
     schedule: LeadershipSchedule,
@@ -79,7 +80,7 @@ impl ProductionPermit {
         }
     }
 
-    /// Decide whether this node may produce the zone block embedding `tempo_anchor`.
+    /// Decide whether this node may produce the full zone block embedding `tempo_anchor`.
     ///
     /// `None` authorizes production; `Some(exit)` is the reason the engine must stop.
     pub fn check(&self, tempo_anchor: u64) -> Option<EngineExit> {
@@ -324,8 +325,8 @@ impl ZoneEngine {
         let queued_headers = self
             .deposit_queue
             .peek_headers(zone_primitives::constants::MAX_TEMPO_HEADERS_PER_ZONE_BLOCK + 1);
-        // Do not checkpoint across the Z1 activation boundary. A pre-Z1 queue front must be
-        // imported operationally before a later Z1 header can enable advanceTempoHeaders.
+        // Do not checkpoint across the T12 activation boundary. A pre-T12 queue front must be
+        // imported operationally before a later T12 header can enable advanceTempoHeaders.
         let checkpoint_count = checkpoint_header_count(
             &self.chain_spec,
             &queued_headers,
@@ -338,13 +339,13 @@ impl ZoneEngine {
 
         let (timestamp_secs, timestamp_millis_part) = if self
             .chain_spec
-            .zone_hardfork_at(final_header.timestamp())
-            .is_z1()
+            .tempo_hardfork_at(final_header.timestamp())
+            .is_t12()
         {
-            // Z1 locks the Zone block timestamp to the final imported Tempo header.
+            // T12 locks the Zone block timestamp to the final imported Tempo header.
             (final_header.timestamp(), final_header.timestamp_millis_part)
         } else {
-            // Before Z1, the L1 timestamp remains a lower bound. Use wall-clock time to avoid
+            // Before T12, the L1 timestamp remains a lower bound. Use wall-clock time to avoid
             // backdating transactions during catch-up, and keep consecutive blocks monotonic.
             let wall_clock_timestamp_millis = SystemTime::now()
                 .duration_since(UNIX_EPOCH)?
@@ -456,7 +457,7 @@ fn checkpoint_header_count(
 ) -> usize {
     if !queued_headers
         .first()
-        .is_some_and(|header| chain_spec.zone_hardfork_at(header.timestamp()).is_z1())
+        .is_some_and(|header| chain_spec.tempo_hardfork_at(header.timestamp()).is_t12())
     {
         return 0;
     }
@@ -483,6 +484,19 @@ impl AvailableBlockDrain for ZoneEngine {
     }
 
     fn permit(&self, block: &Self::Block) -> Option<EngineExit> {
+        let queued_headers = self
+            .deposit_queue
+            .peek_headers(zone_primitives::constants::MAX_TEMPO_HEADERS_PER_ZONE_BLOCK + 1);
+        if checkpoint_header_count(
+            &self.chain_spec,
+            &queued_headers,
+            self.l1_block_tracker.finalized_target(),
+        ) > 0
+        {
+            // TIP-1096 assigns no leader to checkpoint-only blocks. Leader authority resumes at
+            // the final full block, whose single imported Tempo header is checked below.
+            return None;
+        }
         self.production_permit
             .as_ref()
             .and_then(|permit| permit.check(block.header.number()))
@@ -525,7 +539,7 @@ mod tests {
         assert_eq!(zone_timestamp_millis(1_000, 2_000, 2_000), 2_001);
     }
 
-    fn z1_spec(activation: u64) -> ZoneChainSpec {
+    fn t12_spec(activation: u64) -> ZoneChainSpec {
         use reth_chainspec::EthChainSpec as _;
         let mut genesis = tempo_chainspec::spec::DEV.genesis().clone();
         genesis.config.chain_id =
@@ -534,7 +548,7 @@ mod tests {
         genesis
             .config
             .extra_fields
-            .insert_value("z1Time".into(), activation)
+            .insert_value("t12Time".into(), activation)
             .unwrap();
         ZoneChainSpec::from_genesis(genesis).unwrap()
     }
@@ -551,8 +565,8 @@ mod tests {
     }
 
     #[test]
-    fn checkpoint_batching_does_not_cross_z1_activation() {
-        let spec = z1_spec(100);
+    fn checkpoint_batching_does_not_cross_t12_activation() {
+        let spec = t12_spec(100);
         assert_eq!(
             checkpoint_header_count(&spec, &[header(1, 99), header(2, 100)], Some(2)),
             0
@@ -569,7 +583,7 @@ mod tests {
 
     #[test]
     fn checkpoint_batching_uses_announced_finalized_target() {
-        let spec = z1_spec(100);
+        let spec = t12_spec(100);
 
         // Backfill has announced 100 missing blocks, but only the first is verified and queued.
         // It must remain a checkpoint-only import instead of becoming a premature full block.

--- a/crates/node/src/engine.rs
+++ b/crates/node/src/engine.rs
@@ -54,8 +54,8 @@ use tempo_primitives::TempoHeader;
 use tokio_util::sync::CancellationToken;
 use tracing::{error, info};
 
-use zone_chainspec::ZoneChainSpec;
-use zone_l1::{DepositQueue, EncryptionKeyRing, L1BlockDeposits, L1BlockTracker, PreparedL1Block};
+use zone_chainspec::{ZoneChainSpec, ZoneHardforks};
+use zone_l1::{DepositQueue, EncryptionKeyRing, L1BlockDeposits, L1BlockTracker};
 use zone_p2p::{LeadershipSchedule, P2pPeerId};
 use zone_payload::{TempoImport, ZonePayloadAttributes, ZonePayloadTypes};
 
@@ -314,15 +314,6 @@ impl ZoneEngine {
         }
     }
 
-    /// Decrypt deposits and ABI-encode them into a [`PreparedL1Block`] ready for
-    /// the payload builder. Mint-recipient policy is enforced during upstream TIP-20 execution
-    /// against the finalized L1 anchor.
-    async fn prepare_l1_block(&self, l1_block: L1BlockDeposits) -> eyre::Result<PreparedL1Block> {
-        l1_block
-            .prepare(&self.encryption_keys, self.portal_address)
-            .await
-    }
-
     /// Advance the chain by one block.
     ///
     /// Wraps the given L1 block into [`ZonePayloadAttributes`], sends FCU
@@ -330,24 +321,52 @@ impl ZoneEngine {
     /// via `newPayload`. Only confirms (removes) the L1 block from the
     /// deposit queue after `newPayload` succeeds.
     async fn advance(&mut self, l1_block: L1BlockDeposits) -> eyre::Result<()> {
-        let l1_num_hash = l1_block.header.num_hash();
+        let queued_headers = self
+            .deposit_queue
+            .peek_headers(zone_primitives::constants::MAX_TEMPO_HEADERS_PER_ZONE_BLOCK + 1);
+        // Do not checkpoint across the Z1 activation boundary. A pre-Z1 queue front must be
+        // imported operationally before a later Z1 header can enable advanceTempoHeaders.
+        let checkpoint_count = checkpoint_header_count(&self.chain_spec, &queued_headers);
+        let checkpoint_headers = &queued_headers[..checkpoint_count];
+        let checkpoint_only = !checkpoint_headers.is_empty();
+        let final_header = checkpoint_headers.last().unwrap_or(&l1_block.header);
+        let l1_num_hash = final_header.num_hash();
 
-        // The L1 timestamp is a lower bound so a Zone block anchored after an L1 timestamp-based
-        // fork cannot predate it. Use wall-clock time to avoid backdating transactions during
-        // catch-up, and advance by at least one millisecond to keep consecutive blocks monotonic.
-        let wall_clock_timestamp_millis = SystemTime::now()
-            .duration_since(UNIX_EPOCH)?
-            .as_millis()
-            .try_into()?;
-        let timestamp_millis = zone_timestamp_millis(
-            l1_block.header.timestamp_millis(),
-            self.last_header.timestamp_millis(),
-            wall_clock_timestamp_millis,
-        );
-        let timestamp_secs = timestamp_millis / 1000;
-        let timestamp_millis_part = timestamp_millis % 1000;
+        let (timestamp_secs, timestamp_millis_part) = if self
+            .chain_spec
+            .zone_hardfork_at(final_header.timestamp())
+            .is_z1()
+        {
+            // Z1 locks the Zone block timestamp to the final imported Tempo header.
+            (final_header.timestamp(), final_header.timestamp_millis_part)
+        } else {
+            // Before Z1, the L1 timestamp remains a lower bound. Use wall-clock time to avoid
+            // backdating transactions during catch-up, and keep consecutive blocks monotonic.
+            let wall_clock_timestamp_millis = SystemTime::now()
+                .duration_since(UNIX_EPOCH)?
+                .as_millis()
+                .try_into()?;
+            let timestamp_millis = zone_timestamp_millis(
+                l1_block.header.timestamp_millis(),
+                self.last_header.timestamp_millis(),
+                wall_clock_timestamp_millis,
+            );
+            (timestamp_millis / 1000, timestamp_millis % 1000)
+        };
 
-        let l1_block = self.prepare_l1_block(l1_block).await?;
+        let tempo_import = if checkpoint_only {
+            TempoImport::CheckpointOnly(checkpoint_headers.to_vec())
+        } else {
+            let portal_work = self.deposit_queue.operational_work(&l1_block)?;
+            TempoImport::Full(Box::new(
+                L1BlockDeposits::prepare_many(
+                    portal_work,
+                    &self.encryption_keys,
+                    self.portal_address,
+                )
+                .await?,
+            ))
+        };
 
         let attributes = ZonePayloadAttributes {
             inner: EthPayloadAttributes {
@@ -366,7 +385,7 @@ impl ZoneEngine {
                 target_gas_limit: None,
             },
             timestamp_millis_part,
-            tempo_import: TempoImport::Full(Box::new(l1_block)),
+            tempo_import,
         };
 
         // Send FCU with payload attributes through the engine API to trigger
@@ -401,7 +420,13 @@ impl ZoneEngine {
 
         // newPayload succeeded — remove the exact finalized L1 block that
         // produced it. A mismatch indicates an internal consumer-ordering bug.
-        self.deposit_queue.confirm(l1_num_hash)?;
+        if checkpoint_only {
+            for header in checkpoint_headers {
+                self.deposit_queue.defer(header.num_hash())?;
+            }
+        } else {
+            self.deposit_queue.confirm_operational(l1_num_hash)?;
+        }
         self.l1_block_tracker.prune_through(l1_num_hash.number);
         if let Some(permit) = &self.production_permit {
             permit.record_applied_anchor(l1_num_hash.number);
@@ -420,6 +445,22 @@ impl ZoneEngine {
     }
 }
 
+fn checkpoint_header_count(
+    chain_spec: &ZoneChainSpec,
+    queued_headers: &[SealedHeader<TempoHeader>],
+) -> usize {
+    if !queued_headers
+        .first()
+        .is_some_and(|header| chain_spec.zone_hardfork_at(header.timestamp()).is_z1())
+    {
+        return 0;
+    }
+    queued_headers
+        .len()
+        .saturating_sub(1)
+        .min(zone_primitives::constants::MAX_TEMPO_HEADERS_PER_ZONE_BLOCK)
+}
+
 impl AvailableBlockDrain for ZoneEngine {
     type Block = L1BlockDeposits;
 
@@ -428,7 +469,6 @@ impl AvailableBlockDrain for ZoneEngine {
     }
 
     fn permit(&self, block: &Self::Block) -> Option<EngineExit> {
-        // No permit is legacy single-sequencer mode: production is always authorized.
         self.production_permit
             .as_ref()
             .and_then(|permit| permit.check(block.header.number()))
@@ -469,6 +509,45 @@ mod tests {
     #[test]
     fn zone_timestamp_advances_past_parent_when_catching_up_in_same_millisecond() {
         assert_eq!(zone_timestamp_millis(1_000, 2_000, 2_000), 2_001);
+    }
+
+    fn z1_spec(activation: u64) -> ZoneChainSpec {
+        use reth_chainspec::EthChainSpec as _;
+        let mut genesis = tempo_chainspec::spec::DEV.genesis().clone();
+        genesis.config.chain_id =
+            zone_primitives::constants::zone_chain_id(tempo_chainspec::spec::DEV.chain().id(), 1)
+                .unwrap();
+        genesis
+            .config
+            .extra_fields
+            .insert_value("z1Time".into(), activation)
+            .unwrap();
+        ZoneChainSpec::from_genesis(genesis).unwrap()
+    }
+
+    fn header(number: u64, timestamp: u64) -> SealedHeader<TempoHeader> {
+        SealedHeader::seal_slow(TempoHeader {
+            inner: alloy_consensus::Header {
+                number,
+                timestamp,
+                ..Default::default()
+            },
+            ..Default::default()
+        })
+    }
+
+    #[test]
+    fn checkpoint_batching_does_not_cross_z1_activation() {
+        let spec = z1_spec(100);
+        assert_eq!(
+            checkpoint_header_count(&spec, &[header(1, 99), header(2, 100)]),
+            0
+        );
+        assert_eq!(
+            checkpoint_header_count(&spec, &[header(2, 100), header(3, 101)]),
+            1
+        );
+        assert_eq!(checkpoint_header_count(&spec, &[header(2, 100)]), 0);
     }
 
     struct PausedDrain {

--- a/crates/node/src/engine.rs
+++ b/crates/node/src/engine.rs
@@ -62,9 +62,10 @@ use zone_payload::{TempoImport, ZonePayloadAttributes, ZonePayloadTypes};
 
 /// Per-anchor production permit backed by the effective leadership schedule.
 ///
-/// Every Zone block requires the leader assigned to its final imported Tempo header. An optimistic
-/// override is open-ended until the next finalized portal transition supplies the
-/// ordinary-authority boundary.
+/// The permit is a single schedule lookup: produce a Zone block only if the portal schedule or a
+/// forced-recovery override assigns this node as leader for the block's first imported Tempo
+/// header. An optimistic override is open-ended until the next finalized portal transition
+/// supplies the ordinary-authority boundary.
 #[derive(Debug, Clone)]
 pub struct ProductionPermit {
     schedule: LeadershipSchedule,
@@ -80,7 +81,7 @@ impl ProductionPermit {
         }
     }
 
-    /// Decide whether this node may produce the Zone block embedding `tempo_anchor`.
+    /// Decide whether this node may produce the zone block embedding `tempo_anchor`.
     ///
     /// `None` authorizes production; `Some(exit)` is the reason the engine must stop.
     pub fn check(&self, tempo_anchor: u64) -> Option<EngineExit> {
@@ -492,7 +493,7 @@ impl AvailableTempoImport {
     /// Historical Tempo anchor whose leader must produce this Zone block.
     fn leader_anchor(&self) -> u64 {
         self.checkpoint_headers
-            .last()
+            .first()
             .unwrap_or(&self.l1_block.header)
             .number()
     }
@@ -632,7 +633,7 @@ mod tests {
     }
 
     #[test]
-    fn checkpoint_import_uses_final_header_as_leader_anchor() {
+    fn checkpoint_import_uses_first_header_as_leader_anchor() {
         let available = AvailableTempoImport {
             l1_block: L1BlockDeposits {
                 header: header(90, 90),
@@ -642,7 +643,7 @@ mod tests {
             wall_clock_timestamp_millis: 110_000,
         };
 
-        assert_eq!(available.leader_anchor(), 110);
+        assert_eq!(available.leader_anchor(), 90);
     }
 
     #[test]

--- a/crates/node/src/engine.rs
+++ b/crates/node/src/engine.rs
@@ -212,7 +212,9 @@ impl AvailableTempoImport {
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 enum TempoImportDecision {
+    /// Wait until the queued L1 tip activates the hardfork required by the next Zone block.
     WaitForHardforkMatch,
+    /// Wait until the subscriber confirms the queued finalized target did not advance.
     WaitForFinalizedTarget,
     /// Import the full block with `advanceTempo`.
     ImportFull,

--- a/crates/node/src/engine.rs
+++ b/crates/node/src/engine.rs
@@ -119,7 +119,7 @@ trait AvailableBlockDrain {
     type Block;
 
     /// Returns the next available block without consuming it.
-    fn next_available(&self) -> Option<Self::Block>;
+    fn next_available(&self) -> eyre::Result<Option<Self::Block>>;
 
     /// Checks the leadership permit for one available block.
     ///
@@ -147,7 +147,7 @@ where
         if stop.is_cancelled() {
             return Ok(Some(EngineExit::Cancelled));
         }
-        let Some(block) = drain.next_available() else {
+        let Some(block) = drain.next_available()? else {
             return Ok(None);
         };
         if let Some(exit) = drain.permit(&block) {
@@ -191,6 +191,20 @@ pub struct ZoneEngine {
     portal_address: Address,
     /// Optional per-anchor leadership permit. `None` runs the legacy single-sequencer mode.
     production_permit: Option<ProductionPermit>,
+}
+
+#[derive(Debug)]
+struct AvailableTempoImport {
+    l1_block: L1BlockDeposits,
+    checkpoint_headers: Vec<SealedHeader<TempoHeader>>,
+    wall_clock_timestamp_millis: u64,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum TempoImportDecision {
+    WaitForHardforkMatch,
+    Full,
+    CheckpointOnly(usize),
 }
 
 impl ZoneEngine {
@@ -321,46 +335,26 @@ impl ZoneEngine {
     /// with those attributes, waits for the payload to be built, then submits
     /// via `newPayload`. Only confirms (removes) the L1 block from the
     /// deposit queue after `newPayload` succeeds.
-    async fn advance(&mut self, l1_block: L1BlockDeposits) -> eyre::Result<()> {
-        let queued_headers = self
-            .deposit_queue
-            .peek_headers(zone_primitives::constants::MAX_TEMPO_HEADERS_PER_ZONE_BLOCK + 1);
-        // Do not checkpoint across the T12 activation boundary. A pre-T12 queue front must be
-        // imported operationally before a later T12 header can enable advanceTempoHeaders.
-        let checkpoint_count = checkpoint_header_count(
-            &self.chain_spec,
-            &queued_headers,
-            self.l1_block_tracker.finalized_target(),
-        );
-        let checkpoint_headers = &queued_headers[..checkpoint_count];
+    async fn advance(&mut self, available: AvailableTempoImport) -> eyre::Result<()> {
+        let AvailableTempoImport {
+            l1_block,
+            checkpoint_headers,
+            wall_clock_timestamp_millis,
+        } = available;
         let checkpoint_only = !checkpoint_headers.is_empty();
         let final_header = checkpoint_headers.last().unwrap_or(&l1_block.header);
         let l1_num_hash = final_header.num_hash();
 
-        let (timestamp_secs, timestamp_millis_part) = if self
-            .chain_spec
-            .tempo_hardfork_at(final_header.timestamp())
-            .is_t12()
-        {
-            // T12 locks the Zone block timestamp to the final imported Tempo header.
-            (final_header.timestamp(), final_header.timestamp_millis_part)
-        } else {
-            // Before T12, the L1 timestamp remains a lower bound. Use wall-clock time to avoid
-            // backdating transactions during catch-up, and keep consecutive blocks monotonic.
-            let wall_clock_timestamp_millis = SystemTime::now()
-                .duration_since(UNIX_EPOCH)?
-                .as_millis()
-                .try_into()?;
-            let timestamp_millis = zone_timestamp_millis(
-                l1_block.header.timestamp_millis(),
-                self.last_header.timestamp_millis(),
-                wall_clock_timestamp_millis,
-            );
-            (timestamp_millis / 1000, timestamp_millis % 1000)
-        };
+        let timestamp_millis = zone_timestamp_millis(
+            final_header.timestamp_millis(),
+            self.last_header.timestamp_millis(),
+            wall_clock_timestamp_millis,
+        );
+        let timestamp_secs = timestamp_millis / 1000;
+        let timestamp_millis_part = timestamp_millis % 1000;
 
         let tempo_import = if checkpoint_only {
-            TempoImport::CheckpointOnly(checkpoint_headers.to_vec())
+            TempoImport::CheckpointOnly(checkpoint_headers.clone())
         } else {
             let portal_work = self.deposit_queue.operational_work(&l1_block)?;
             TempoImport::Full(Box::new(
@@ -426,7 +420,7 @@ impl ZoneEngine {
         // newPayload succeeded — remove the exact finalized L1 block that
         // produced it. A mismatch indicates an internal consumer-ordering bug.
         if checkpoint_only {
-            for header in checkpoint_headers {
+            for header in &checkpoint_headers {
                 self.deposit_queue.defer(header.num_hash())?;
             }
         } else {
@@ -450,17 +444,38 @@ impl ZoneEngine {
     }
 }
 
-fn checkpoint_header_count(
+fn tempo_import_decision(
     chain_spec: &ZoneChainSpec,
     queued_headers: &[SealedHeader<TempoHeader>],
+    latest_l1_header: &SealedHeader<TempoHeader>,
     finalized_target: Option<u64>,
-) -> usize {
-    if !queued_headers
-        .first()
-        .is_some_and(|header| chain_spec.tempo_hardfork_at(header.timestamp()).is_t12())
-    {
-        return 0;
+    parent_timestamp_millis: u64,
+    wall_clock_timestamp_millis: u64,
+) -> TempoImportDecision {
+    let Some(first_header) = queued_headers.first() else {
+        return TempoImportDecision::Full;
+    };
+    let first_l1_is_t12 = chain_spec
+        .tempo_hardfork_at(first_header.timestamp())
+        .is_t12();
+    let next_timestamp_millis = zone_timestamp_millis(
+        first_header.timestamp_millis(),
+        parent_timestamp_millis,
+        wall_clock_timestamp_millis,
+    );
+    let zone_hardfork = chain_spec.tempo_hardfork_at(next_timestamp_millis / 1000);
+    let l1_tip_hardfork = chain_spec.tempo_hardfork_at(latest_l1_header.timestamp());
+
+    // Zone execution must not activate a hardfork before L1. Wait whenever the prospective Zone
+    // block is ahead of the latest queued L1 header, but allow L1 to be ahead while the Zone
+    // imports the remaining pre-fork prefix under its currently active rules.
+    if zone_hardfork > l1_tip_hardfork {
+        return TempoImportDecision::WaitForHardforkMatch;
     }
+    if !zone_hardfork.is_t12() {
+        return TempoImportDecision::Full;
+    }
+
     // During backfill, the subscriber announces its finalized target before filling the queue.
     // Until that target is visible, every queued header may be checkpointed because a later header
     // is known to exist for the required full block. Once the target is queued (or no target is
@@ -470,36 +485,67 @@ fn checkpoint_header_count(
             .last()
             .is_some_and(|header| header.number() >= target)
     });
-    queued_headers
+    let checkpoint_count = queued_headers
         .len()
         .saturating_sub(usize::from(reserve_for_full))
         .min(zone_primitives::constants::MAX_TEMPO_HEADERS_PER_ZONE_BLOCK)
+        // Never reserve a T11 queue front for a full T12 import. This also closes the small race
+        // where the T12 successor is appended between the bounded queue snapshot and tip read.
+        .max(usize::from(!first_l1_is_t12));
+    if checkpoint_count == 0 {
+        TempoImportDecision::Full
+    } else {
+        TempoImportDecision::CheckpointOnly(checkpoint_count)
+    }
 }
 
 impl AvailableBlockDrain for ZoneEngine {
-    type Block = L1BlockDeposits;
+    type Block = AvailableTempoImport;
 
-    fn next_available(&self) -> Option<Self::Block> {
-        self.deposit_queue.peek()
-    }
-
-    fn permit(&self, block: &Self::Block) -> Option<EngineExit> {
+    fn next_available(&self) -> eyre::Result<Option<Self::Block>> {
+        let Some(l1_block) = self.deposit_queue.peek() else {
+            return Ok(None);
+        };
         let queued_headers = self
             .deposit_queue
             .peek_headers(zone_primitives::constants::MAX_TEMPO_HEADERS_PER_ZONE_BLOCK + 1);
-        if checkpoint_header_count(
+        let latest_l1_header = self
+            .deposit_queue
+            .latest_header()
+            .ok_or_eyre("L1 deposit queue lost its latest header")?;
+        let wall_clock_timestamp_millis = SystemTime::now()
+            .duration_since(UNIX_EPOCH)?
+            .as_millis()
+            .try_into()?;
+        let decision = tempo_import_decision(
             &self.chain_spec,
             &queued_headers,
+            &latest_l1_header,
             self.l1_block_tracker.finalized_target(),
-        ) > 0
-        {
+            self.last_header.timestamp_millis(),
+            wall_clock_timestamp_millis,
+        );
+        let checkpoint_headers = match decision {
+            TempoImportDecision::WaitForHardforkMatch => return Ok(None),
+            TempoImportDecision::Full => Vec::new(),
+            TempoImportDecision::CheckpointOnly(count) => queued_headers[..count].to_vec(),
+        };
+        Ok(Some(AvailableTempoImport {
+            l1_block,
+            checkpoint_headers,
+            wall_clock_timestamp_millis,
+        }))
+    }
+
+    fn permit(&self, block: &Self::Block) -> Option<EngineExit> {
+        if !block.checkpoint_headers.is_empty() {
             // TIP-1096 assigns no leader to checkpoint-only blocks. Leader authority resumes at
             // the final full block, whose single imported Tempo header is checked below.
             return None;
         }
         self.production_permit
             .as_ref()
-            .and_then(|permit| permit.check(block.header.number()))
+            .and_then(|permit| permit.check(block.l1_block.header.number()))
     }
 
     async fn advance_one(&mut self, block: Self::Block) -> eyre::Result<()> {
@@ -565,19 +611,76 @@ mod tests {
     }
 
     #[test]
-    fn checkpoint_batching_does_not_cross_t12_activation() {
+    fn t12_boundary_waits_for_l1_then_checkpoints_the_t11_prefix() {
         let spec = t12_spec(100);
+        let t11 = header(1, 99);
+        let t12 = header(2, 100);
+
         assert_eq!(
-            checkpoint_header_count(&spec, &[header(1, 99), header(2, 100)], Some(2)),
-            0
+            tempo_import_decision(
+                &spec,
+                std::slice::from_ref(&t11),
+                &t11,
+                Some(1),
+                98_000,
+                100_000
+            ),
+            TempoImportDecision::WaitForHardforkMatch
         );
         assert_eq!(
-            checkpoint_header_count(&spec, &[header(2, 100), header(3, 101)], Some(3)),
-            1
+            tempo_import_decision(
+                &spec,
+                std::slice::from_ref(&t11),
+                &t12,
+                None,
+                98_000,
+                100_000,
+            ),
+            TempoImportDecision::CheckpointOnly(1)
         );
         assert_eq!(
-            checkpoint_header_count(&spec, &[header(2, 100)], Some(2)),
-            0
+            tempo_import_decision(&spec, &[t11, t12.clone()], &t12, Some(2), 98_000, 100_000,),
+            TempoImportDecision::CheckpointOnly(1)
+        );
+        assert_eq!(
+            tempo_import_decision(
+                &spec,
+                std::slice::from_ref(&t12),
+                &t12,
+                Some(2),
+                99_000,
+                100_000
+            ),
+            TempoImportDecision::Full
+        );
+    }
+
+    #[test]
+    fn pre_t12_zone_block_imports_the_t11_front_normally() {
+        let spec = t12_spec(100);
+        let t11 = header(1, 99);
+        assert_eq!(
+            tempo_import_decision(
+                &spec,
+                std::slice::from_ref(&t11),
+                &t11,
+                Some(1),
+                98_000,
+                99_000
+            ),
+            TempoImportDecision::Full
+        );
+    }
+
+    #[test]
+    fn hardfork_gate_does_not_wait_when_l1_is_ahead_of_the_zone() {
+        let spec = t12_spec(100);
+        let t11 = header(1, 99);
+        let t12 = header(2, 100);
+
+        assert_eq!(
+            tempo_import_decision(&spec, &[t11], &t12, Some(2), 98_000, 99_000),
+            TempoImportDecision::Full
         );
     }
 
@@ -587,9 +690,17 @@ mod tests {
 
         // Backfill has announced 100 missing blocks, but only the first is verified and queued.
         // It must remain a checkpoint-only import instead of becoming a premature full block.
+        let first = header(100, 100);
         assert_eq!(
-            checkpoint_header_count(&spec, &[header(100, 100)], Some(199)),
-            1
+            tempo_import_decision(
+                &spec,
+                std::slice::from_ref(&first),
+                &first,
+                Some(199),
+                99_000,
+                100_000,
+            ),
+            TempoImportDecision::CheckpointOnly(1)
         );
 
         // Once all 100 are queued, reserve the target header for the full operational import and
@@ -597,7 +708,17 @@ mod tests {
         let headers = (100..=199)
             .map(|number| header(number, number))
             .collect::<Vec<_>>();
-        assert_eq!(checkpoint_header_count(&spec, &headers, Some(199)), 99);
+        assert_eq!(
+            tempo_import_decision(
+                &spec,
+                &headers,
+                headers.last().unwrap(),
+                Some(199),
+                99_000,
+                100_000,
+            ),
+            TempoImportDecision::CheckpointOnly(99)
+        );
     }
 
     struct PausedDrain {
@@ -612,8 +733,8 @@ mod tests {
     impl AvailableBlockDrain for PausedDrain {
         type Block = u64;
 
-        fn next_available(&self) -> Option<Self::Block> {
-            self.pending.front().copied()
+        fn next_available(&self) -> eyre::Result<Option<Self::Block>> {
+            Ok(self.pending.front().copied())
         }
 
         fn permit(&self, block: &Self::Block) -> Option<EngineExit> {

--- a/crates/node/src/engine.rs
+++ b/crates/node/src/engine.rs
@@ -326,7 +326,11 @@ impl ZoneEngine {
             .peek_headers(zone_primitives::constants::MAX_TEMPO_HEADERS_PER_ZONE_BLOCK + 1);
         // Do not checkpoint across the Z1 activation boundary. A pre-Z1 queue front must be
         // imported operationally before a later Z1 header can enable advanceTempoHeaders.
-        let checkpoint_count = checkpoint_header_count(&self.chain_spec, &queued_headers);
+        let checkpoint_count = checkpoint_header_count(
+            &self.chain_spec,
+            &queued_headers,
+            self.l1_block_tracker.finalized_target(),
+        );
         let checkpoint_headers = &queued_headers[..checkpoint_count];
         let checkpoint_only = !checkpoint_headers.is_empty();
         let final_header = checkpoint_headers.last().unwrap_or(&l1_block.header);
@@ -448,6 +452,7 @@ impl ZoneEngine {
 fn checkpoint_header_count(
     chain_spec: &ZoneChainSpec,
     queued_headers: &[SealedHeader<TempoHeader>],
+    finalized_target: Option<u64>,
 ) -> usize {
     if !queued_headers
         .first()
@@ -455,9 +460,18 @@ fn checkpoint_header_count(
     {
         return 0;
     }
+    // During backfill, the subscriber announces its finalized target before filling the queue.
+    // Until that target is visible, every queued header may be checkpointed because a later header
+    // is known to exist for the required full block. Once the target is queued (or no target is
+    // known), reserve the final visible header for the operational import.
+    let reserve_for_full = finalized_target.is_none_or(|target| {
+        queued_headers
+            .last()
+            .is_some_and(|header| header.number() >= target)
+    });
     queued_headers
         .len()
-        .saturating_sub(1)
+        .saturating_sub(usize::from(reserve_for_full))
         .min(zone_primitives::constants::MAX_TEMPO_HEADERS_PER_ZONE_BLOCK)
 }
 
@@ -540,14 +554,36 @@ mod tests {
     fn checkpoint_batching_does_not_cross_z1_activation() {
         let spec = z1_spec(100);
         assert_eq!(
-            checkpoint_header_count(&spec, &[header(1, 99), header(2, 100)]),
+            checkpoint_header_count(&spec, &[header(1, 99), header(2, 100)], Some(2)),
             0
         );
         assert_eq!(
-            checkpoint_header_count(&spec, &[header(2, 100), header(3, 101)]),
+            checkpoint_header_count(&spec, &[header(2, 100), header(3, 101)], Some(3)),
             1
         );
-        assert_eq!(checkpoint_header_count(&spec, &[header(2, 100)]), 0);
+        assert_eq!(
+            checkpoint_header_count(&spec, &[header(2, 100)], Some(2)),
+            0
+        );
+    }
+
+    #[test]
+    fn checkpoint_batching_uses_announced_finalized_target() {
+        let spec = z1_spec(100);
+
+        // Backfill has announced 100 missing blocks, but only the first is verified and queued.
+        // It must remain a checkpoint-only import instead of becoming a premature full block.
+        assert_eq!(
+            checkpoint_header_count(&spec, &[header(100, 100)], Some(199)),
+            1
+        );
+
+        // Once all 100 are queued, reserve the target header for the full operational import and
+        // fold the preceding 99 headers into one checkpoint-only block.
+        let headers = (100..=199)
+            .map(|number| header(number, number))
+            .collect::<Vec<_>>();
+        assert_eq!(checkpoint_header_count(&spec, &headers, Some(199)), 99);
     }
 
     struct PausedDrain {

--- a/crates/node/src/engine.rs
+++ b/crates/node/src/engine.rs
@@ -56,7 +56,7 @@ use tokio_util::sync::CancellationToken;
 use tracing::{error, info};
 
 use zone_chainspec::ZoneChainSpec;
-use zone_l1::{DepositQueue, EncryptionKeyRing, L1BlockDeposits, L1BlockTracker};
+use zone_l1::{DepositQueue, EncryptionKeyRing, FinalizedTarget, L1BlockDeposits, L1BlockTracker};
 use zone_p2p::{LeadershipSchedule, P2pPeerId};
 use zone_payload::{TempoImport, ZonePayloadAttributes, ZonePayloadTypes};
 
@@ -203,8 +203,11 @@ struct AvailableTempoImport {
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 enum TempoImportDecision {
     WaitForHardforkMatch,
-    Full,
-    CheckpointOnly(usize),
+    WaitForFinalizedTarget,
+    /// Import the full block with `advanceTempo`.
+    ImportFull,
+    /// Import specified number of checkpoint headers with `advanceTempoHeaders`.
+    ImportCheckpoints(usize),
 }
 
 impl ZoneEngine {
@@ -354,7 +357,7 @@ impl ZoneEngine {
         let timestamp_millis_part = timestamp_millis % 1000;
 
         let tempo_import = if checkpoint_only {
-            TempoImport::CheckpointOnly(checkpoint_headers.clone())
+            TempoImport::CheckpointOnly(checkpoint_headers)
         } else {
             let portal_work = self.deposit_queue.operational_work(&l1_block)?;
             TempoImport::Full(Box::new(
@@ -420,9 +423,7 @@ impl ZoneEngine {
         // newPayload succeeded — remove the exact finalized L1 block that
         // produced it. A mismatch indicates an internal consumer-ordering bug.
         if checkpoint_only {
-            for header in &checkpoint_headers {
-                self.deposit_queue.defer(header.num_hash())?;
-            }
+            self.deposit_queue.defer_through(l1_num_hash)?;
         } else {
             self.deposit_queue.confirm_operational(l1_num_hash)?;
         }
@@ -448,16 +449,14 @@ fn tempo_import_decision(
     chain_spec: &ZoneChainSpec,
     queued_headers: &[SealedHeader<TempoHeader>],
     latest_l1_header: &SealedHeader<TempoHeader>,
-    finalized_target: Option<u64>,
+    finalized_target: Option<FinalizedTarget>,
     parent_timestamp_millis: u64,
     wall_clock_timestamp_millis: u64,
 ) -> TempoImportDecision {
     let Some(first_header) = queued_headers.first() else {
-        return TempoImportDecision::Full;
+        return TempoImportDecision::ImportFull;
     };
-    let first_l1_is_t12 = chain_spec
-        .tempo_hardfork_at(first_header.timestamp())
-        .is_t12();
+    let first_l1_hardfork = chain_spec.tempo_hardfork_at(first_header.timestamp());
     let next_timestamp_millis = zone_timestamp_millis(
         first_header.timestamp_millis(),
         parent_timestamp_millis,
@@ -466,36 +465,43 @@ fn tempo_import_decision(
     let zone_hardfork = chain_spec.tempo_hardfork_at(next_timestamp_millis / 1000);
     let l1_tip_hardfork = chain_spec.tempo_hardfork_at(latest_l1_header.timestamp());
 
+    if !zone_hardfork.is_t12() {
+        return TempoImportDecision::ImportFull;
+    }
     // Zone execution must not activate a hardfork before L1. Wait whenever the prospective Zone
     // block is ahead of the latest queued L1 header, but allow L1 to be ahead while the Zone
     // imports the remaining pre-fork prefix under its currently active rules.
     if zone_hardfork > l1_tip_hardfork {
         return TempoImportDecision::WaitForHardforkMatch;
     }
-    if !zone_hardfork.is_t12() {
-        return TempoImportDecision::Full;
-    }
 
     // During backfill, the subscriber announces its finalized target before filling the queue.
-    // Until that target is visible, every queued header may be checkpointed because a later header
-    // is known to exist for the required full block. Once the target is queued (or no target is
-    // known), reserve the final visible header for the operational import.
-    let reserve_for_full = finalized_target.is_none_or(|target| {
+    // Until the announced target is visible, every queued header may be checkpointed because a
+    // later header is known to exist for the required full block. Once the target is queued,
+    // reserve it while the subscriber checks whether finalized advanced again. Only a stable
+    // target may become the operational import.
+    let target_is_visible = finalized_target.is_some_and(|target| {
         queued_headers
             .last()
-            .is_some_and(|header| header.number() >= target)
+            .is_some_and(|header| header.number() >= target.number)
     });
+    let reserve_for_full = finalized_target.is_none() || target_is_visible;
     let checkpoint_count = queued_headers
         .len()
         .saturating_sub(usize::from(reserve_for_full))
         .min(zone_primitives::constants::MAX_TEMPO_HEADERS_PER_ZONE_BLOCK)
-        // Never reserve a T11 queue front for a full T12 import. This also closes the small race
-        // where the T12 successor is appended between the bounded queue snapshot and tip read.
-        .max(usize::from(!first_l1_is_t12));
+        // Never reserve a queue front from an older hardfork for a full import under newer Zone
+        // rules. This also closes the small race where the hardfork successor is appended between
+        // the bounded queue snapshot and tip read.
+        .max(usize::from(first_l1_hardfork < zone_hardfork));
     if checkpoint_count == 0 {
-        TempoImportDecision::Full
+        if target_is_visible && finalized_target.is_some_and(|target| !target.ready) {
+            TempoImportDecision::WaitForFinalizedTarget
+        } else {
+            TempoImportDecision::ImportFull
+        }
     } else {
-        TempoImportDecision::CheckpointOnly(checkpoint_count)
+        TempoImportDecision::ImportCheckpoints(checkpoint_count)
     }
 }
 
@@ -506,7 +512,7 @@ impl AvailableBlockDrain for ZoneEngine {
         let Some(l1_block) = self.deposit_queue.peek() else {
             return Ok(None);
         };
-        let queued_headers = self
+        let mut queued_headers = self
             .deposit_queue
             .peek_headers(zone_primitives::constants::MAX_TEMPO_HEADERS_PER_ZONE_BLOCK + 1);
         let latest_l1_header = self
@@ -526,9 +532,13 @@ impl AvailableBlockDrain for ZoneEngine {
             wall_clock_timestamp_millis,
         );
         let checkpoint_headers = match decision {
-            TempoImportDecision::WaitForHardforkMatch => return Ok(None),
-            TempoImportDecision::Full => Vec::new(),
-            TempoImportDecision::CheckpointOnly(count) => queued_headers[..count].to_vec(),
+            TempoImportDecision::WaitForHardforkMatch
+            | TempoImportDecision::WaitForFinalizedTarget => return Ok(None),
+            TempoImportDecision::ImportFull => Vec::new(),
+            TempoImportDecision::ImportCheckpoints(count) => {
+                queued_headers.truncate(count);
+                queued_headers
+            }
         };
         Ok(Some(AvailableTempoImport {
             l1_block,
@@ -610,6 +620,10 @@ mod tests {
         })
     }
 
+    fn finalized_target(number: u64, ready: bool) -> Option<FinalizedTarget> {
+        Some(FinalizedTarget { number, ready })
+    }
+
     #[test]
     fn t12_boundary_waits_for_l1_then_checkpoints_the_t11_prefix() {
         let spec = t12_spec(100);
@@ -621,7 +635,7 @@ mod tests {
                 &spec,
                 std::slice::from_ref(&t11),
                 &t11,
-                Some(1),
+                finalized_target(1, true),
                 98_000,
                 100_000
             ),
@@ -636,22 +650,29 @@ mod tests {
                 98_000,
                 100_000,
             ),
-            TempoImportDecision::CheckpointOnly(1)
+            TempoImportDecision::ImportCheckpoints(1)
         );
         assert_eq!(
-            tempo_import_decision(&spec, &[t11, t12.clone()], &t12, Some(2), 98_000, 100_000,),
-            TempoImportDecision::CheckpointOnly(1)
+            tempo_import_decision(
+                &spec,
+                &[t11, t12.clone()],
+                &t12,
+                finalized_target(2, false),
+                98_000,
+                100_000,
+            ),
+            TempoImportDecision::ImportCheckpoints(1)
         );
         assert_eq!(
             tempo_import_decision(
                 &spec,
                 std::slice::from_ref(&t12),
                 &t12,
-                Some(2),
+                finalized_target(2, true),
                 99_000,
                 100_000
             ),
-            TempoImportDecision::Full
+            TempoImportDecision::ImportFull
         );
     }
 
@@ -664,11 +685,11 @@ mod tests {
                 &spec,
                 std::slice::from_ref(&t11),
                 &t11,
-                Some(1),
+                finalized_target(1, true),
                 98_000,
                 99_000
             ),
-            TempoImportDecision::Full
+            TempoImportDecision::ImportFull
         );
     }
 
@@ -679,8 +700,15 @@ mod tests {
         let t12 = header(2, 100);
 
         assert_eq!(
-            tempo_import_decision(&spec, &[t11], &t12, Some(2), 98_000, 99_000),
-            TempoImportDecision::Full
+            tempo_import_decision(
+                &spec,
+                &[t11],
+                &t12,
+                finalized_target(2, true),
+                98_000,
+                99_000,
+            ),
+            TempoImportDecision::ImportFull
         );
     }
 
@@ -696,11 +724,11 @@ mod tests {
                 &spec,
                 std::slice::from_ref(&first),
                 &first,
-                Some(199),
+                finalized_target(199, false),
                 99_000,
                 100_000,
             ),
-            TempoImportDecision::CheckpointOnly(1)
+            TempoImportDecision::ImportCheckpoints(1)
         );
 
         // Once all 100 are queued, reserve the target header for the full operational import and
@@ -713,11 +741,35 @@ mod tests {
                 &spec,
                 &headers,
                 headers.last().unwrap(),
-                Some(199),
+                finalized_target(199, false),
                 99_000,
                 100_000,
             ),
-            TempoImportDecision::CheckpointOnly(99)
+            TempoImportDecision::ImportCheckpoints(99)
+        );
+
+        let target = header(199, 199);
+        assert_eq!(
+            tempo_import_decision(
+                &spec,
+                std::slice::from_ref(&target),
+                &target,
+                finalized_target(199, false),
+                99_000,
+                100_000,
+            ),
+            TempoImportDecision::WaitForFinalizedTarget
+        );
+        assert_eq!(
+            tempo_import_decision(
+                &spec,
+                std::slice::from_ref(&target),
+                &target,
+                finalized_target(199, true),
+                99_000,
+                100_000,
+            ),
+            TempoImportDecision::ImportFull
         );
     }
 

--- a/crates/node/src/engine.rs
+++ b/crates/node/src/engine.rs
@@ -193,35 +193,6 @@ pub struct ZoneEngine {
     production_permit: Option<ProductionPermit>,
 }
 
-#[derive(Debug)]
-struct AvailableTempoImport {
-    l1_block: L1BlockDeposits,
-    checkpoint_headers: Vec<SealedHeader<TempoHeader>>,
-    wall_clock_timestamp_millis: u64,
-}
-
-impl AvailableTempoImport {
-    /// Historical Tempo anchor whose leader must produce this Zone block.
-    fn leader_anchor(&self) -> u64 {
-        self.checkpoint_headers
-            .last()
-            .unwrap_or(&self.l1_block.header)
-            .number()
-    }
-}
-
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-enum TempoImportDecision {
-    /// Wait until the queued L1 tip activates the hardfork required by the next Zone block.
-    WaitForHardforkMatch,
-    /// Wait until the subscriber confirms the queued finalized target did not advance.
-    WaitForFinalizedTarget,
-    /// Import the full block with `advanceTempo`.
-    ImportFull,
-    /// Import specified number of checkpoint headers with `advanceTempoHeaders`.
-    ImportCheckpoints(usize),
-}
-
 impl ZoneEngine {
     pub fn new(
         chain_spec: Arc<ZoneChainSpec>,
@@ -457,6 +428,88 @@ impl ZoneEngine {
     }
 }
 
+impl AvailableBlockDrain for ZoneEngine {
+    type Block = AvailableTempoImport;
+
+    fn next_available(&self) -> eyre::Result<Option<Self::Block>> {
+        let Some(l1_block) = self.deposit_queue.peek() else {
+            return Ok(None);
+        };
+        let mut queued_headers = self
+            .deposit_queue
+            .peek_headers(zone_primitives::constants::MAX_TEMPO_HEADERS_PER_ZONE_BLOCK + 1);
+        let latest_l1_header = self
+            .deposit_queue
+            .latest_header()
+            .ok_or_eyre("L1 deposit queue lost its latest header")?;
+        let wall_clock_timestamp_millis = SystemTime::now()
+            .duration_since(UNIX_EPOCH)?
+            .as_millis()
+            .try_into()?;
+        let decision = tempo_import_decision(
+            &self.chain_spec,
+            &queued_headers,
+            &latest_l1_header,
+            self.l1_block_tracker.finalized_target(),
+            self.last_header.timestamp_millis(),
+            wall_clock_timestamp_millis,
+        );
+        let checkpoint_headers = match decision {
+            TempoImportDecision::WaitForHardforkMatch
+            | TempoImportDecision::WaitForFinalizedTarget => return Ok(None),
+            TempoImportDecision::ImportFull => Vec::new(),
+            TempoImportDecision::ImportCheckpoints(count) => {
+                queued_headers.truncate(count);
+                queued_headers
+            }
+        };
+        Ok(Some(AvailableTempoImport {
+            l1_block,
+            checkpoint_headers,
+            wall_clock_timestamp_millis,
+        }))
+    }
+
+    fn permit(&self, block: &Self::Block) -> Option<EngineExit> {
+        self.production_permit
+            .as_ref()
+            .and_then(|permit| permit.check(block.leader_anchor()))
+    }
+
+    async fn advance_one(&mut self, block: Self::Block) -> eyre::Result<()> {
+        self.advance(block).await
+    }
+}
+
+#[derive(Debug)]
+struct AvailableTempoImport {
+    l1_block: L1BlockDeposits,
+    checkpoint_headers: Vec<SealedHeader<TempoHeader>>,
+    wall_clock_timestamp_millis: u64,
+}
+
+impl AvailableTempoImport {
+    /// Historical Tempo anchor whose leader must produce this Zone block.
+    fn leader_anchor(&self) -> u64 {
+        self.checkpoint_headers
+            .last()
+            .unwrap_or(&self.l1_block.header)
+            .number()
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum TempoImportDecision {
+    /// Wait until the queued L1 tip activates the hardfork required by the next Zone block.
+    WaitForHardforkMatch,
+    /// Wait until the subscriber confirms the queued finalized target did not advance.
+    WaitForFinalizedTarget,
+    /// Import the full block with `advanceTempo`.
+    ImportFull,
+    /// Import specified number of checkpoint headers with `advanceTempoHeaders`.
+    ImportCheckpoints(usize),
+}
+
 fn tempo_import_decision(
     chain_spec: &ZoneChainSpec,
     queued_headers: &[SealedHeader<TempoHeader>],
@@ -514,59 +567,6 @@ fn tempo_import_decision(
         }
     } else {
         TempoImportDecision::ImportCheckpoints(checkpoint_count)
-    }
-}
-
-impl AvailableBlockDrain for ZoneEngine {
-    type Block = AvailableTempoImport;
-
-    fn next_available(&self) -> eyre::Result<Option<Self::Block>> {
-        let Some(l1_block) = self.deposit_queue.peek() else {
-            return Ok(None);
-        };
-        let mut queued_headers = self
-            .deposit_queue
-            .peek_headers(zone_primitives::constants::MAX_TEMPO_HEADERS_PER_ZONE_BLOCK + 1);
-        let latest_l1_header = self
-            .deposit_queue
-            .latest_header()
-            .ok_or_eyre("L1 deposit queue lost its latest header")?;
-        let wall_clock_timestamp_millis = SystemTime::now()
-            .duration_since(UNIX_EPOCH)?
-            .as_millis()
-            .try_into()?;
-        let decision = tempo_import_decision(
-            &self.chain_spec,
-            &queued_headers,
-            &latest_l1_header,
-            self.l1_block_tracker.finalized_target(),
-            self.last_header.timestamp_millis(),
-            wall_clock_timestamp_millis,
-        );
-        let checkpoint_headers = match decision {
-            TempoImportDecision::WaitForHardforkMatch
-            | TempoImportDecision::WaitForFinalizedTarget => return Ok(None),
-            TempoImportDecision::ImportFull => Vec::new(),
-            TempoImportDecision::ImportCheckpoints(count) => {
-                queued_headers.truncate(count);
-                queued_headers
-            }
-        };
-        Ok(Some(AvailableTempoImport {
-            l1_block,
-            checkpoint_headers,
-            wall_clock_timestamp_millis,
-        }))
-    }
-
-    fn permit(&self, block: &Self::Block) -> Option<EngineExit> {
-        self.production_permit
-            .as_ref()
-            .and_then(|permit| permit.check(block.leader_anchor()))
-    }
-
-    async fn advance_one(&mut self, block: Self::Block) -> eyre::Result<()> {
-        self.advance(block).await
     }
 }
 

--- a/crates/node/src/node.rs
+++ b/crates/node/src/node.rs
@@ -20,11 +20,12 @@ use crate::{
     },
 };
 use alloy_chains::Chain;
-use alloy_consensus::BlockHeader as _;
-use alloy_eips::BlockNumberOrTag;
+use alloy_consensus::{BlockHeader as _, TxReceipt as _};
+use alloy_eips::{BlockHashOrNumber, BlockNumberOrTag};
 use alloy_primitives::{Address, U256};
 use alloy_provider::{DynProvider, Provider as _};
 use alloy_signer_local::PrivateKeySigner;
+use alloy_sol_types::SolEvent as _;
 use k256::SecretKey;
 use reth_chainspec::EthChainSpec;
 use reth_eth_wire_types::primitives::BasicNetworkPrimitives;
@@ -49,7 +50,8 @@ use reth_rpc_api::Web3ApiServer as _;
 use reth_rpc_builder::Identity;
 use reth_rpc_eth_api::EthApiTypes;
 use reth_storage_api::{
-    BlockNumReader, EmptyBodyStorage, HeaderProvider, StateProvider, StateProviderFactory,
+    BlockNumReader, EmptyBodyStorage, HeaderProvider, ReceiptProvider, StateProvider,
+    StateProviderFactory,
 };
 use reth_tasks::TaskExecutor;
 use reth_transaction_pool::{
@@ -77,7 +79,7 @@ use tempo_transaction_pool::{
     transaction::{TempoPoolTransactionError, TempoPooledTransaction},
     validator::{DEFAULT_MAX_TEMPO_AUTHORIZATIONS, TempoTransactionValidator},
 };
-use tempo_zone_contracts::{ZONE_INBOX_ADDRESS, ZONE_OUTBOX_ADDRESS, ZonePortal};
+use tempo_zone_contracts::{IZoneInbox, ZONE_INBOX_ADDRESS, ZONE_OUTBOX_ADDRESS, ZonePortal};
 use tokio::sync::mpsc::{Receiver, Sender};
 use tracing::{debug, info, warn};
 use zone_chainspec::ZoneChainSpec;
@@ -121,6 +123,35 @@ fn validate_configured_zone_id(
         "zone ID mismatch: {source} has {configured_zone_id}, but portal has {portal_zone_id}"
     );
     Ok(())
+}
+
+fn latest_operational_tempo_block<P>(provider: &P) -> eyre::Result<u64>
+where
+    P: BlockNumReader + ReceiptProvider + StateProviderFactory,
+{
+    let best = provider.best_block_number()?;
+    for number in (1..=best).rev() {
+        let Some(receipts) = provider.receipts_by_block(BlockHashOrNumber::Number(number))? else {
+            continue;
+        };
+        for receipt in receipts {
+            for log in receipt.logs() {
+                if log.address == ZONE_INBOX_ADDRESS
+                    && log.topics().first() == Some(&IZoneInbox::TempoAdvanced::SIGNATURE_HASH)
+                {
+                    return Ok(IZoneInbox::TempoAdvanced::decode_log(log)?.tempoBlockNumber);
+                }
+            }
+        }
+    }
+
+    let genesis_hash = provider
+        .block_hash(0)?
+        .ok_or_else(|| eyre::eyre!("zone genesis block hash is unavailable"))?;
+    Ok(provider
+        .state_by_block_hash(genesis_hash)?
+        .tempo_num_hash()?
+        .number)
 }
 
 /// Network primitives for Zone Nodes
@@ -265,6 +296,7 @@ impl ZoneNode {
             leadership_sink: None,
             encryption_keys: None,
             retain_portal_evidence: false,
+            deferred_work_start: None,
         };
 
         let l1_state_provider_config = L1StateProviderConfig {
@@ -532,6 +564,11 @@ where
         );
 
         let tempo_block_number = ctx.node.provider().latest()?.tempo_block_number()?;
+        let last_operational_tempo_block = latest_operational_tempo_block(ctx.node.provider())?;
+        if last_operational_tempo_block < tempo_block_number {
+            self.l1_config.deferred_work_start =
+                Some(last_operational_tempo_block.saturating_add(1));
+        }
         let l1_provider = alloy_provider::ProviderBuilder::new_with_network::<TempoNetwork>()
             .connect_with_config(
                 &self.l1_config.l1_rpc_url,

--- a/crates/node/src/node.rs
+++ b/crates/node/src/node.rs
@@ -127,42 +127,6 @@ fn validate_configured_zone_id(
     Ok(())
 }
 
-fn latest_operational_tempo_block<P>(provider: &P) -> eyre::Result<u64>
-where
-    P: BlockNumReader + ReceiptProvider + StateProviderFactory,
-{
-    let best = provider.best_block_number()?;
-    for number in (1..=best).rev() {
-        let Some(receipts) = provider.receipts_by_block(BlockHashOrNumber::Number(number))? else {
-            continue;
-        };
-        for receipt in receipts {
-            for log in receipt.logs() {
-                if log.address != ZONE_INBOX_ADDRESS {
-                    continue;
-                }
-                match log.topics().first() {
-                    Some(topic) if topic == &TempoAdvanced::SIGNATURE_HASH => {
-                        return Ok(TempoAdvanced::decode_log(log)?.tempoBlockNumber);
-                    }
-                    Some(topic) if topic == &LegacyTempoAdvanced::SIGNATURE_HASH => {
-                        return Ok(LegacyTempoAdvanced::decode_log(log)?.tempoBlockNumber);
-                    }
-                    _ => {}
-                }
-            }
-        }
-    }
-
-    let genesis_hash = provider
-        .block_hash(0)?
-        .ok_or_else(|| eyre::eyre!("zone genesis block hash is unavailable"))?;
-    Ok(provider
-        .state_by_block_hash(genesis_hash)?
-        .tempo_num_hash()?
-        .number)
-}
-
 /// Network primitives for Zone Nodes
 type ZoneNetworkPrimitives = BasicNetworkPrimitives<TempoPrimitives, TempoTxEnvelope>;
 
@@ -1907,6 +1871,49 @@ where
 
         Ok(transaction_pool)
     }
+}
+
+/// Returns the latest Tempo block whose portal work was processed by a full `advanceTempo` import.
+///
+/// Checkpoint-only `advanceTempoHeaders` imports move the Zone's Tempo checkpoint without consuming
+/// their deposits, withdrawals, token updates, key rotations, or leader transitions. On restart,
+/// the caller uses the block after this operational boundary as the beginning of the deferred-work
+/// recovery range. If no operational import exists after genesis, the genesis Tempo anchor is the
+/// boundary.
+fn latest_operational_tempo_block<P>(provider: &P) -> eyre::Result<u64>
+where
+    P: BlockNumReader + ReceiptProvider + StateProviderFactory,
+{
+    let best = provider.best_block_number()?;
+    for number in (1..=best).rev() {
+        let Some(receipts) = provider.receipts_by_block(BlockHashOrNumber::Number(number))? else {
+            continue;
+        };
+        for receipt in receipts {
+            for log in receipt.logs() {
+                if log.address != ZONE_INBOX_ADDRESS {
+                    continue;
+                }
+                match log.topics().first() {
+                    Some(topic) if topic == &TempoAdvanced::SIGNATURE_HASH => {
+                        return Ok(TempoAdvanced::decode_log(log)?.tempoBlockNumber);
+                    }
+                    Some(topic) if topic == &LegacyTempoAdvanced::SIGNATURE_HASH => {
+                        return Ok(LegacyTempoAdvanced::decode_log(log)?.tempoBlockNumber);
+                    }
+                    _ => {}
+                }
+            }
+        }
+    }
+
+    let genesis_hash = provider
+        .block_hash(0)?
+        .ok_or_else(|| eyre::eyre!("zone genesis block hash is unavailable"))?;
+    Ok(provider
+        .state_by_block_hash(genesis_hash)?
+        .tempo_num_hash()?
+        .number)
 }
 
 #[cfg(test)]

--- a/crates/node/src/node.rs
+++ b/crates/node/src/node.rs
@@ -80,7 +80,8 @@ use tempo_transaction_pool::{
     validator::{DEFAULT_MAX_TEMPO_AUTHORIZATIONS, TempoTransactionValidator},
 };
 use tempo_zone_contracts::{
-    LegacyTempoAdvanced, TempoAdvanced, ZONE_INBOX_ADDRESS, ZONE_OUTBOX_ADDRESS, ZonePortal,
+    LegacyTempoAdvanced, TempoAdvanced, ZONE_INBOX_ADDRESS, ZONE_OUTBOX_ADDRESS,
+    ZonePortal::{self},
 };
 use tokio::sync::mpsc::{Receiver, Sender};
 use tracing::{debug, info, warn};
@@ -1378,9 +1379,17 @@ where
                 .call()
                 .await?;
             eyre::ensure!(
-                !validity.valid,
-                "missing private decryption key for grace-valid Portal key index {key_index} at \
-                 L1 block {block_number}"
+                !validity.valid
+                // A key that has expired at the persisted checkpoint may still be needed by a deposit in the
+                // deferred Portal-work range.
+                    && self
+                        .l1_config
+                        .deferred_work_start.is_none_or(|from| validity.expiresAtBlock <= from),
+                "missing private decryption key for Portal key index {key_index} required at L1 \
+                 checkpoint {block_number} or by deferred work starting at {:?} (expires at L1 \
+                 block {})",
+                self.l1_config.deferred_work_start,
+                validity.expiresAtBlock,
             );
         }
 

--- a/crates/node/src/node.rs
+++ b/crates/node/src/node.rs
@@ -79,7 +79,9 @@ use tempo_transaction_pool::{
     transaction::{TempoPoolTransactionError, TempoPooledTransaction},
     validator::{DEFAULT_MAX_TEMPO_AUTHORIZATIONS, TempoTransactionValidator},
 };
-use tempo_zone_contracts::{IZoneInbox, ZONE_INBOX_ADDRESS, ZONE_OUTBOX_ADDRESS, ZonePortal};
+use tempo_zone_contracts::{
+    LegacyTempoAdvanced, TempoAdvanced, ZONE_INBOX_ADDRESS, ZONE_OUTBOX_ADDRESS, ZonePortal,
+};
 use tokio::sync::mpsc::{Receiver, Sender};
 use tracing::{debug, info, warn};
 use zone_chainspec::ZoneChainSpec;
@@ -136,10 +138,17 @@ where
         };
         for receipt in receipts {
             for log in receipt.logs() {
-                if log.address == ZONE_INBOX_ADDRESS
-                    && log.topics().first() == Some(&IZoneInbox::TempoAdvanced::SIGNATURE_HASH)
-                {
-                    return Ok(IZoneInbox::TempoAdvanced::decode_log(log)?.tempoBlockNumber);
+                if log.address != ZONE_INBOX_ADDRESS {
+                    continue;
+                }
+                match log.topics().first() {
+                    Some(topic) if topic == &TempoAdvanced::SIGNATURE_HASH => {
+                        return Ok(TempoAdvanced::decode_log(log)?.tempoBlockNumber);
+                    }
+                    Some(topic) if topic == &LegacyTempoAdvanced::SIGNATURE_HASH => {
+                        return Ok(LegacyTempoAdvanced::decode_log(log)?.tempoBlockNumber);
+                    }
+                    _ => {}
                 }
             }
         }

--- a/crates/node/src/replication.rs
+++ b/crates/node/src/replication.rs
@@ -702,9 +702,9 @@ pub(crate) async fn collect_follower_settlement_signatures<P>(
 
 /// Import live/backfilled blocks in canonical order on a follower.
 ///
-/// Live blocks are only imported from the leader when the sender equals
-/// `schedule.leader_for(the block's embedded anchor)`. We do this because if there are accidentally
-/// two leaders (split brain) for a block, we need to decide to import the correct one.
+/// Live full blocks are only imported when the sender equals the leader for their imported Tempo
+/// header. Checkpoint-only blocks have no designated leader and may be imported from any authorized
+/// P2P peer. The full-block check resolves accidental split brain using the finalized schedule.
 ///
 /// Backfilled blocks carry no producer claim and are judged by
 /// parent/anchor/execution/conflict validation alone. The loop exits when `stop` fires.
@@ -1161,22 +1161,21 @@ where
     let headers = tempo_import.headers();
     validate_l1_checkpoint_range(headers, local.number, local.hash, block_number)?;
     let anchor = headers.last().expect("validated nonempty range").num_hash();
-    let production_anchor = tempo_import.production_anchor();
+    let leader_anchor = tempo_import.leader_anchor();
 
-    // Anchor-aware fence for live blocks: a full block has one imported header, while a
-    // checkpoint-only block may cross leadership boundaries and is assigned to the leader of its
-    // first imported header. This gives every live block one producer without making a later
-    // transition inside a checkpoint range invalidate the block.
+    // Anchor-aware fence for live full blocks. Checkpoint-only blocks are leader-neutral and may
+    // cross leadership boundaries; leader authority resumes at the final full block and is checked
+    // against that block's single imported Tempo header.
     // Backfilled blocks carry no producer claim and are judged by parent/anchor/execution/conflict
     // validation only.
     //
     // Check once before waiting to reject an already-known invalid sender without blocking the
-    // import loop, then again after observing every imported header. The first header itself may
-    // finalize a leadership transition that changes its assigned producer.
-    validate_live_block_sender(
+    // import loop, then again after observing every imported header. The full block's imported
+    // header may itself finalize a leadership transition that changes its assigned producer.
+    validate_live_import_sender(
         schedule,
         peer_block.live_sender.as_ref(),
-        production_anchor,
+        leader_anchor,
         block_number,
     )?;
     let mut observed_headers = Vec::with_capacity(headers.len());
@@ -1207,10 +1206,10 @@ where
         };
         observed_headers.push(observed);
     }
-    validate_live_block_sender(
+    validate_live_import_sender(
         schedule,
         peer_block.live_sender.as_ref(),
-        production_anchor,
+        leader_anchor,
         block_number,
     )?;
 
@@ -1277,7 +1276,7 @@ where
     }
     schedule.record_applied_anchor(anchor.number);
 
-    info!(target: "zone::p2p", block_number, ?hash, "Imported canonical leader block");
+    info!(target: "zone::p2p", block_number, ?hash, "Imported canonical peer block");
     Ok(PeerBlockImportOutcome::Imported)
 }
 
@@ -1303,6 +1302,18 @@ fn validate_live_block_sender(
              record governs",
         ),
     }
+}
+
+fn validate_live_import_sender(
+    schedule: &LeadershipSchedule,
+    live_sender: Option<&P2pPeerId>,
+    leader_anchor: Option<u64>,
+    block_number: u64,
+) -> eyre::Result<()> {
+    let Some(anchor_number) = leader_anchor else {
+        return Ok(());
+    };
+    validate_live_block_sender(schedule, live_sender, anchor_number, block_number)
 }
 
 fn reconcile_canonical_import(
@@ -1511,15 +1522,15 @@ impl DecodedTempoImport {
         }
     }
 
-    /// Tempo anchor whose leader is the unique live producer for this Zone block.
+    /// Tempo anchor whose leader must produce this Zone block.
     ///
-    /// A checkpoint-only block may cross later leadership boundaries, so its first imported
-    /// header selects the producer. A full block contains one header and follows the same rule.
-    fn production_anchor(&self) -> u64 {
-        self.headers()
-            .first()
-            .expect("decoded Tempo imports are validated as nonempty")
-            .number()
+    /// Checkpoint-only blocks have no designated leader. A full block imports exactly one Tempo
+    /// header, whose effective leader supplies its production authority.
+    fn leader_anchor(&self) -> Option<u64> {
+        match self {
+            Self::Full { header, .. } => Some(header.number()),
+            Self::CheckpointOnly { .. } => None,
+        }
     }
 }
 
@@ -1993,7 +2004,7 @@ mod tests {
     }
 
     #[test]
-    fn checkpoint_live_producer_is_leader_of_first_imported_anchor() {
+    fn checkpoint_live_producer_is_not_leader_restricted() {
         use commonware_cryptography::{Signer as _, ed25519::PrivateKey};
         use reth_primitives_traits::SealedHeader;
         use tempo_primitives::TempoHeader;
@@ -2018,14 +2029,29 @@ mod tests {
             .to_vec();
         let tempo_import = super::DecodedTempoImport::CheckpointOnly { headers };
 
-        let production_anchor = tempo_import.production_anchor();
-        assert_eq!(production_anchor, 90);
-        validate_live_block_sender(&schedule, Some(&outgoing), production_anchor, 7).unwrap();
-        let error = validate_live_block_sender(&schedule, Some(&incoming), production_anchor, 7)
-            .expect_err(
-                "the later epoch leader must not produce a range beginning in the old epoch",
-            );
-        assert!(error.to_string().contains(&outgoing.to_string()));
+        let leader_anchor = tempo_import.leader_anchor();
+        assert_eq!(leader_anchor, None);
+        super::validate_live_import_sender(&schedule, Some(&outgoing), leader_anchor, 7).unwrap();
+        super::validate_live_import_sender(&schedule, Some(&incoming), leader_anchor, 7).unwrap();
+
+        let full_import = super::DecodedTempoImport::Full {
+            header: Box::new(SealedHeader::seal_slow(TempoHeader {
+                inner: alloy_consensus::Header {
+                    number: 110,
+                    ..Default::default()
+                },
+                ..Default::default()
+            })),
+            deposits: Vec::new(),
+            enabled_tokens: Vec::new(),
+        };
+        let leader_anchor = full_import.leader_anchor();
+        assert_eq!(leader_anchor, Some(110));
+        super::validate_live_import_sender(&schedule, Some(&incoming), leader_anchor, 8).unwrap();
+        let error =
+            super::validate_live_import_sender(&schedule, Some(&outgoing), leader_anchor, 8)
+                .expect_err("the final full block must be produced by its effective leader");
+        assert!(error.to_string().contains(&incoming.to_string()));
     }
 
     #[tokio::test]

--- a/crates/node/src/replication.rs
+++ b/crates/node/src/replication.rs
@@ -31,6 +31,7 @@ use zone_payload::{
     ZonePayloadTypes,
     abi::{IZoneInbox, ZONE_INBOX_ADDRESS},
 };
+use zone_primitives::constants::MAX_TEMPO_HEADERS_PER_ZONE_BLOCK;
 use zone_sequencer::{
     BatchAnchorConfig,
     attestation::{
@@ -1533,23 +1534,30 @@ fn decode_advance_tempo(block: &SealedBlock<Block>) -> eyre::Result<DecodedTempo
     let TempoTxEnvelope::Legacy(signed) = first_tx else {
         eyre::bail!("first transaction in peer block is not a legacy system transaction")
     };
-    if !first_tx.is_system_tx() {
-        eyre::bail!("first transaction in peer block is not a Tempo system transaction")
-    }
+    eyre::ensure!(
+        first_tx.is_system_tx(),
+        "first transaction in peer block is not a Tempo system transaction"
+    );
 
     // 2. Address is correct
-    if signed.tx().to != ZONE_INBOX_ADDRESS.into() {
-        eyre::bail!("first Tempo system transaction is not sent to IZoneInbox")
-    }
+    eyre::ensure!(
+        signed.tx().to == ZONE_INBOX_ADDRESS.into(),
+        "first Tempo system transaction is not sent to IZoneInbox"
+    );
     if signed
         .tx()
         .input
         .starts_with(&IZoneInbox::advanceTempoHeadersCall::SELECTOR)
     {
-        if block.body().transactions.len() != 1 {
-            eyre::bail!("advanceTempoHeaders must be the only transaction in its block");
-        }
+        eyre::ensure!(
+            block.body().transactions.len() == 1,
+            "advanceTempoHeaders must be the only transaction in its block"
+        );
         let call = IZoneInbox::advanceTempoHeadersCall::abi_decode(signed.tx().input.as_ref())?;
+        eyre::ensure!(
+            call.headers.len() <= MAX_TEMPO_HEADERS_PER_ZONE_BLOCK,
+            "advanceTempoHeaders has too many headers"
+        );
         let mut headers = Vec::with_capacity(call.headers.len());
         for encoded in call.headers {
             let mut input = encoded.as_ref();
@@ -1568,12 +1576,11 @@ fn decode_advance_tempo(block: &SealedBlock<Block>) -> eyre::Result<DecodedTempo
     let mut header_rlp = call.header.as_ref();
     let header = TempoHeader::decode(&mut header_rlp)
         .map_err(|err| eyre::eyre!("invalid RLP-encoded L1 header in advanceTempo: {err}"))?;
-    if !header_rlp.is_empty() {
-        eyre::bail!(
-            "advanceTempo L1 header has {} trailing bytes",
-            header_rlp.len()
-        )
-    }
+    eyre::ensure!(
+        header_rlp.is_empty(),
+        "advanceTempo L1 header has {} trailing bytes",
+        header_rlp.len()
+    );
     Ok(DecodedTempoImport::Full {
         header: Box::new(SealedHeader::seal_slow(header)),
         deposits: call.deposits,

--- a/crates/node/src/replication.rs
+++ b/crates/node/src/replication.rs
@@ -1517,10 +1517,9 @@ impl DecodedTempoImport {
 
     /// Tempo anchor whose leader must produce this Zone block.
     ///
-    /// Checkpoint-only blocks use their final imported header because that is the historical L1
-    /// block the resulting Zone block anchors to. A full block imports exactly one header.
+    /// Checkpoint-only blocks use their first imported header. A full block imports exactly one header.
     fn leader_anchor(&self) -> Option<u64> {
-        self.headers().last().map(|header| header.number())
+        self.headers().first().map(|header| header.number())
     }
 }
 
@@ -1994,7 +1993,7 @@ mod tests {
     }
 
     #[test]
-    fn checkpoint_live_producer_is_leader_at_final_imported_anchor() {
+    fn checkpoint_live_producer_is_leader_at_first_imported_anchor() {
         use commonware_cryptography::{Signer as _, ed25519::PrivateKey};
         use reth_primitives_traits::SealedHeader;
         use tempo_primitives::TempoHeader;
@@ -2024,15 +2023,15 @@ mod tests {
         let tempo_import = super::DecodedTempoImport::CheckpointOnly { headers };
 
         let leader_anchor = tempo_import.leader_anchor();
-        assert_eq!(leader_anchor, Some(110));
-        super::validate_live_import_sender(&schedule, Some(&incoming), leader_anchor, 7).unwrap();
+        assert_eq!(leader_anchor, Some(90));
+        super::validate_live_import_sender(&schedule, Some(&outgoing), leader_anchor, 7).unwrap();
         let error =
-            super::validate_live_import_sender(&schedule, Some(&outgoing), leader_anchor, 7)
-                .expect_err("the checkpoint producer must lead at its final imported anchor");
-        assert!(error.to_string().contains(&incoming.to_string()));
+            super::validate_live_import_sender(&schedule, Some(&incoming), leader_anchor, 7)
+                .expect_err("the checkpoint producer must lead at its first imported anchor");
+        assert!(error.to_string().contains(&outgoing.to_string()));
         let error = super::validate_live_import_sender(&schedule, Some(&current), leader_anchor, 7)
             .expect_err("the current leader must not own an earlier historical anchor");
-        assert!(error.to_string().contains(&incoming.to_string()));
+        assert!(error.to_string().contains(&outgoing.to_string()));
 
         let full_import = super::DecodedTempoImport::Full {
             header: Box::new(SealedHeader::seal_slow(TempoHeader {

--- a/crates/node/src/replication.rs
+++ b/crates/node/src/replication.rs
@@ -702,9 +702,9 @@ pub(crate) async fn collect_follower_settlement_signatures<P>(
 
 /// Import live/backfilled blocks in canonical order on a follower.
 ///
-/// Live full blocks are only imported when the sender equals the leader for their imported Tempo
-/// header. Checkpoint-only blocks have no designated leader and may be imported from any authorized
-/// P2P peer. The full-block check resolves accidental split brain using the finalized schedule.
+/// Live blocks are only imported when the sender equals the leader at their final imported Tempo
+/// header. For checkpoint-only blocks this is the historical L1 block they anchor to. This check
+/// resolves accidental split brain using the finalized schedule.
 ///
 /// Backfilled blocks carry no producer claim and are judged by
 /// parent/anchor/execution/conflict validation alone. The loop exits when `stop` fires.
@@ -1163,21 +1163,6 @@ where
     let anchor = headers.last().expect("validated nonempty range").num_hash();
     let leader_anchor = tempo_import.leader_anchor();
 
-    // Anchor-aware fence for live full blocks. Checkpoint-only blocks are leader-neutral and may
-    // cross leadership boundaries; leader authority resumes at the final full block and is checked
-    // against that block's single imported Tempo header.
-    // Backfilled blocks carry no producer claim and are judged by parent/anchor/execution/conflict
-    // validation only.
-    //
-    // Check once before waiting to reject an already-known invalid sender without blocking the
-    // import loop, then again after observing every imported header. The full block's imported
-    // header may itself finalize a leadership transition that changes its assigned producer.
-    validate_live_import_sender(
-        schedule,
-        peer_block.live_sender.as_ref(),
-        leader_anchor,
-        block_number,
-    )?;
     let mut observed_headers = Vec::with_capacity(headers.len());
     for header in headers {
         let observed = match wait_for_peer_anchor(
@@ -1206,6 +1191,11 @@ where
         };
         observed_headers.push(observed);
     }
+
+    // Resolve live production authority only after observing the complete imported range. The
+    // range may publish a leadership transition governing its final anchor. Checkpoint-only blocks
+    // use the leader at that final historical anchor; full blocks follow the same rule with their
+    // single header. Backfilled blocks carry no producer claim and bypass this check.
     validate_live_import_sender(
         schedule,
         peer_block.live_sender.as_ref(),
@@ -1524,13 +1514,10 @@ impl DecodedTempoImport {
 
     /// Tempo anchor whose leader must produce this Zone block.
     ///
-    /// Checkpoint-only blocks have no designated leader. A full block imports exactly one Tempo
-    /// header, whose effective leader supplies its production authority.
+    /// Checkpoint-only blocks use their final imported header because that is the historical L1
+    /// block the resulting Zone block anchors to. A full block imports exactly one header.
     fn leader_anchor(&self) -> Option<u64> {
-        match self {
-            Self::Full { header, .. } => Some(header.number()),
-            Self::CheckpointOnly { .. } => None,
-        }
+        self.headers().last().map(|header| header.number())
     }
 }
 
@@ -2004,16 +1991,20 @@ mod tests {
     }
 
     #[test]
-    fn checkpoint_live_producer_is_not_leader_restricted() {
+    fn checkpoint_live_producer_is_leader_at_final_imported_anchor() {
         use commonware_cryptography::{Signer as _, ed25519::PrivateKey};
         use reth_primitives_traits::SealedHeader;
         use tempo_primitives::TempoHeader;
 
         let outgoing = PrivateKey::from_seed(1).public_key();
         let incoming = PrivateKey::from_seed(2).public_key();
+        let current = PrivateKey::from_seed(3).public_key();
         let schedule = LeadershipSchedule::seeded(LeadershipState::new(1, outgoing.clone(), 0));
         schedule
             .publish(LeadershipState::new(2, incoming.clone(), 100))
+            .unwrap();
+        schedule
+            .publish(LeadershipState::new(3, current.clone(), 120))
             .unwrap();
 
         let headers = [90, 110]
@@ -2030,9 +2021,15 @@ mod tests {
         let tempo_import = super::DecodedTempoImport::CheckpointOnly { headers };
 
         let leader_anchor = tempo_import.leader_anchor();
-        assert_eq!(leader_anchor, None);
-        super::validate_live_import_sender(&schedule, Some(&outgoing), leader_anchor, 7).unwrap();
+        assert_eq!(leader_anchor, Some(110));
         super::validate_live_import_sender(&schedule, Some(&incoming), leader_anchor, 7).unwrap();
+        let error =
+            super::validate_live_import_sender(&schedule, Some(&outgoing), leader_anchor, 7)
+                .expect_err("the checkpoint producer must lead at its final imported anchor");
+        assert!(error.to_string().contains(&incoming.to_string()));
+        let error = super::validate_live_import_sender(&schedule, Some(&current), leader_anchor, 7)
+            .expect_err("the current leader must not own an earlier historical anchor");
+        assert!(error.to_string().contains(&incoming.to_string()));
 
         let full_import = super::DecodedTempoImport::Full {
             header: Box::new(SealedHeader::seal_slow(TempoHeader {

--- a/crates/node/src/replication.rs
+++ b/crates/node/src/replication.rs
@@ -22,7 +22,7 @@ use tempo_primitives::{Block, TempoHeader, TempoTxEnvelope};
 use tokio::sync::{mpsc, oneshot};
 use tokio_util::sync;
 use tracing::{debug, info};
-use zone_l1::{DepositQueue, L1BlockTracker, L1PortalEvents, TempoStateExt as _};
+use zone_l1::{DepositQueue, L1BlockDeposits, L1BlockTracker, L1PortalEvents, TempoStateExt as _};
 use zone_p2p::{
     BackfillCommand, BackfillRequest, BackfillResponse, LeadershipSchedule, P2pCommand, P2pEvent,
     P2pPeerId, PeerTip,
@@ -1114,6 +1114,7 @@ where
     let block_number = block.number();
     let hash = block.hash();
     let best_block = provider.best_block_number()?;
+    let tempo_import = decode_advance_tempo(&block)?;
 
     // 1. Block number is correct
     if block_number <= best_block {
@@ -1121,6 +1122,9 @@ where
             eyre::eyre!("missing local canonical header at height {block_number}")
         })?;
         if existing.hash() == hash {
+            reconcile_canonical_import(deposit_queue, &tempo_import).wrap_err_with(|| {
+                format!("cannot reconcile duplicate canonical peer block {block_number}")
+            })?;
             debug!(target: "zone::p2p", block_number, ?hash, "Ignoring duplicate peer block");
             return Ok(PeerBlockImportOutcome::Imported);
         }
@@ -1151,61 +1155,94 @@ where
 
     // 3. Require the block to advance the local Tempo checkpoint by exactly
     // one independently observed L1 block.
-    let (l1_header, portal_inputs) = decode_advance_tempo(&block)?;
     let local = provider
         .state_by_block_hash(parent.hash())?
         .tempo_num_hash()?;
-    validate_l1_checkpoint_transition(&l1_header, local.number, local.hash, block_number)?;
-    let anchor = l1_header.num_hash();
+    let headers = tempo_import.headers();
+    validate_l1_checkpoint_range(headers, local.number, local.hash, block_number)?;
+    let anchor = headers.last().expect("validated nonempty range").num_hash();
+    let production_anchor = tempo_import.production_anchor();
 
-    // Anchor-aware fence for live blocks: the sender must
-    // be the scheduled leader of the block's anchor. This stops an honest stale
-    // leader's broadcast from splitting followers.
+    // Anchor-aware fence for live blocks: a full block has one imported header, while a
+    // checkpoint-only block may cross leadership boundaries and is assigned to the leader of its
+    // first imported header. This gives every live block one producer without making a later
+    // transition inside a checkpoint range invalidate the block.
     // Backfilled blocks carry no producer claim and are judged by parent/anchor/execution/conflict
     // validation only.
     //
     // Check once before waiting to reject an already-known invalid sender without blocking the
-    // import loop. `wait_for_validated_peer_anchor` checks again after observing the anchor:
-    // the anchor itself may finalize a leadership transition that changes its assigned producer.
+    // import loop, then again after observing every imported header. The first header itself may
+    // finalize a leadership transition that changes its assigned producer.
     validate_live_block_sender(
         schedule,
         peer_block.live_sender.as_ref(),
-        anchor.number,
+        production_anchor,
         block_number,
     )?;
-    let observed = match wait_for_validated_peer_anchor(
-        l1_block_tracker,
-        schedule,
-        &portal_inputs,
-        peer_block.live_sender.as_ref(),
-        anchor,
-        block_number,
-        stop,
-        PEER_ANCHOR_WAIT_TIMEOUT,
-    )
-    .await
-    {
-        Ok(observed) => observed,
-        Err(PeerAnchorWaitError::Cancelled) => return Ok(PeerBlockImportOutcome::Cancelled),
-        Err(PeerAnchorWaitError::TimedOut {
+    let mut observed_headers = Vec::with_capacity(headers.len());
+    for header in headers {
+        let observed = match wait_for_peer_anchor(
+            l1_block_tracker,
+            header.num_hash(),
             block_number,
-            anchor,
-        }) => {
-            return Ok(PeerBlockImportOutcome::TimedOut {
+            stop,
+            PEER_ANCHOR_WAIT_TIMEOUT,
+        )
+        .await
+        {
+            Ok(observed) => observed,
+            Err(PeerAnchorWaitError::Cancelled) => {
+                return Ok(PeerBlockImportOutcome::Cancelled);
+            }
+            Err(PeerAnchorWaitError::TimedOut {
                 block_number,
                 anchor,
-            });
-        }
-        Err(PeerAnchorWaitError::Other(error)) => return Err(error),
-    };
+            }) => {
+                return Ok(PeerBlockImportOutcome::TimedOut {
+                    block_number,
+                    anchor,
+                });
+            }
+            Err(PeerAnchorWaitError::Other(error)) => return Err(error),
+        };
+        observed_headers.push(observed);
+    }
+    validate_live_block_sender(
+        schedule,
+        peer_block.live_sender.as_ref(),
+        production_anchor,
+        block_number,
+    )?;
 
     // The subscriber normally enqueues immediately after recording this observation. Enqueueing
     // here as well closes that small scheduling window and makes follower import self-contained;
     // the queue treats the subscriber's later enqueue as a duplicate. This is peer-driven, so a
     // gap must surface as a rejected block rather than aborting the node.
-    deposit_queue
-        .try_enqueue_sealed(l1_header, observed)
-        .wrap_err_with(|| format!("cannot queue the anchor of block {block_number}"))?;
+    for (header, observed) in headers
+        .iter()
+        .cloned()
+        .zip(observed_headers.iter().cloned())
+    {
+        deposit_queue
+            .try_enqueue_sealed(header, observed)
+            .wrap_err_with(|| format!("cannot queue an imported header of block {block_number}"))?;
+    }
+
+    if let DecodedTempoImport::Full {
+        deposits,
+        enabled_tokens,
+        ..
+    } = &tempo_import
+    {
+        let current = L1BlockDeposits {
+            header: headers[0].clone(),
+            events: observed_headers[0].clone(),
+        };
+        validate_full_portal_inputs(deposit_queue, &current, deposits, enabled_tokens)
+            .wrap_err_with(|| {
+                format!("peer block {block_number} does not match observed portal events")
+            })?;
+    }
 
     // 4. All txns in the block execute properly
     let payload = ZonePayloadTypes::block_to_payload(block, None);
@@ -1228,9 +1265,16 @@ where
     // behind would stall the subscriber once the lookahead window fills. Advancing the queue is
     // likewise tolerant of drift; it fails only on a genuine hash conflict.
     l1_block_tracker.prune_through(anchor.number);
-    deposit_queue
-        .confirm_through(anchor)
-        .wrap_err_with(|| format!("cannot advance the deposit queue past block {block_number}"))?;
+    match &tempo_import {
+        DecodedTempoImport::CheckpointOnly { .. } => deposit_queue
+            .defer_through(anchor)
+            .wrap_err_with(|| format!("cannot defer checkpoint work from block {block_number}"))?,
+        DecodedTempoImport::Full { .. } => deposit_queue
+            .confirm_operational_through(anchor)
+            .wrap_err_with(|| {
+                format!("cannot advance the deposit queue past block {block_number}")
+            })?,
+    }
     schedule.record_applied_anchor(anchor.number);
 
     info!(target: "zone::p2p", block_number, ?hash, "Imported canonical leader block");
@@ -1261,6 +1305,85 @@ fn validate_live_block_sender(
     }
 }
 
+fn reconcile_canonical_import(
+    deposit_queue: &DepositQueue,
+    tempo_import: &DecodedTempoImport,
+) -> eyre::Result<()> {
+    let anchor = tempo_import
+        .headers()
+        .last()
+        .expect("decoded Tempo imports are nonempty")
+        .num_hash();
+    match tempo_import {
+        DecodedTempoImport::CheckpointOnly { .. } => deposit_queue.defer_through(anchor),
+        DecodedTempoImport::Full { .. } => deposit_queue.confirm_operational_through(anchor),
+    }
+}
+
+fn validate_full_portal_inputs(
+    deposit_queue: &DepositQueue,
+    current: &L1BlockDeposits,
+    deposits: &[zone_payload::abi::QueuedDeposit],
+    enabled_tokens: &[zone_payload::abi::EnabledToken],
+) -> eyre::Result<()> {
+    let work = deposit_queue.operational_work(current)?;
+    let mut deposit_offset = 0usize;
+    let mut token_offset = 0usize;
+    for block in work {
+        let next_deposit_offset = deposit_offset
+            .checked_add(block.events.deposits.len())
+            .ok_or_else(|| eyre::eyre!("advanceTempo deposit count overflow"))?;
+        let next_token_offset = token_offset
+            .checked_add(block.events.enabled_tokens.len())
+            .ok_or_else(|| eyre::eyre!("advanceTempo token count overflow"))?;
+        eyre::ensure!(
+            next_deposit_offset <= deposits.len() && next_token_offset <= enabled_tokens.len(),
+            "advanceTempo calldata is shorter than the deferred portal event range"
+        );
+        block.events.validate_advance_tempo_inputs(
+            &deposits[deposit_offset..next_deposit_offset],
+            &enabled_tokens[token_offset..next_token_offset],
+        )?;
+        deposit_offset = next_deposit_offset;
+        token_offset = next_token_offset;
+    }
+    eyre::ensure!(
+        deposit_offset == deposits.len(),
+        "advanceTempo contains {} deposits, but observed portal events contain {deposit_offset}",
+        deposits.len()
+    );
+    eyre::ensure!(
+        token_offset == enabled_tokens.len(),
+        "advanceTempo contains {} token enables, but observed portal events contain {token_offset}",
+        enabled_tokens.len()
+    );
+    Ok(())
+}
+
+async fn wait_for_peer_anchor(
+    l1_block_tracker: &L1BlockTracker,
+    anchor: NumHash,
+    block_number: u64,
+    stop: &sync::CancellationToken,
+    wait_timeout: Duration,
+) -> Result<L1PortalEvents, PeerAnchorWaitError> {
+    tokio::select! {
+        biased;
+        () = stop.cancelled() => Err(PeerAnchorWaitError::Cancelled),
+        observed = tokio::time::timeout(
+            wait_timeout,
+            l1_block_tracker.wait_for_portal_events(anchor),
+        ) => match observed {
+            Ok(observed) => observed.map_err(PeerAnchorWaitError::Other),
+            Err(_) => Err(PeerAnchorWaitError::TimedOut {
+                block_number,
+                anchor,
+            }),
+        },
+    }
+}
+
+#[cfg(test)]
 async fn wait_for_validated_peer_anchor(
     l1_block_tracker: &L1BlockTracker,
     schedule: &LeadershipSchedule,
@@ -1271,20 +1394,8 @@ async fn wait_for_validated_peer_anchor(
     stop: &sync::CancellationToken,
     wait_timeout: Duration,
 ) -> Result<L1PortalEvents, PeerAnchorWaitError> {
-    let observed = tokio::select! {
-        biased;
-        () = stop.cancelled() => return Err(PeerAnchorWaitError::Cancelled),
-        observed = tokio::time::timeout(
-            wait_timeout,
-            l1_block_tracker.wait_for_portal_events(anchor),
-        ) => match observed {
-            Ok(observed) => observed.map_err(PeerAnchorWaitError::Other)?,
-            Err(_) => return Err(PeerAnchorWaitError::TimedOut {
-                block_number,
-                anchor,
-            }),
-        },
-    };
+    let observed =
+        wait_for_peer_anchor(l1_block_tracker, anchor, block_number, stop, wait_timeout).await?;
     portal_inputs
         .validate(&observed)
         .map_err(PeerAnchorWaitError::Other)?;
@@ -1311,40 +1422,66 @@ enum PeerAnchorWaitError {
     Other(eyre::Report),
 }
 
+#[cfg(test)]
 struct AdvanceTempoPortalInputs {
     deposits: Vec<zone_payload::abi::QueuedDeposit>,
     enabled_tokens: Vec<zone_payload::abi::EnabledToken>,
 }
 
+#[cfg(test)]
 impl AdvanceTempoPortalInputs {
     fn validate(&self, observed: &L1PortalEvents) -> eyre::Result<()> {
         observed.validate_advance_tempo_inputs(&self.deposits, &self.enabled_tokens)
     }
 }
 
-fn validate_l1_checkpoint_transition(
-    l1_header: &SealedHeader<TempoHeader>,
+fn validate_l1_checkpoint_range(
+    headers: &[SealedHeader<TempoHeader>],
     local_number: u64,
     local_hash: B256,
     zone_block_number: u64,
 ) -> eyre::Result<()> {
-    if l1_header.number() != local_number.saturating_add(1) {
-        eyre::bail!(
-            "peer block {zone_block_number} advances Tempo to L1 block {}, but local checkpoint is {}; expected {}",
-            l1_header.number(),
-            local_number,
-            local_number.saturating_add(1)
-        );
+    if headers.is_empty() {
+        eyre::bail!("peer block imports no Tempo headers");
     }
-    if l1_header.parent_hash() != local_hash {
-        eyre::bail!(
-            "advanceTempo L1 header {} does not extend the local Tempo checkpoint: embedded parent {}, local hash {}",
-            l1_header.number(),
-            l1_header.parent_hash(),
-            local_hash
-        );
+    let mut previous_number = local_number;
+    let mut previous_hash = local_hash;
+    for l1_header in headers {
+        if l1_header.number() != previous_number.saturating_add(1) {
+            eyre::bail!(
+                "peer block {zone_block_number} advances Tempo to L1 block {}, but local checkpoint is {}; expected {}",
+                l1_header.number(),
+                previous_number,
+                previous_number.saturating_add(1)
+            );
+        }
+        if l1_header.parent_hash() != previous_hash {
+            eyre::bail!(
+                "advanceTempo L1 header {} does not extend the local Tempo checkpoint: embedded parent {}, local hash {}",
+                l1_header.number(),
+                l1_header.parent_hash(),
+                previous_hash
+            );
+        }
+        previous_number = l1_header.number();
+        previous_hash = l1_header.hash();
     }
     Ok(())
+}
+
+#[cfg(test)]
+fn validate_l1_checkpoint_transition(
+    header: &SealedHeader<TempoHeader>,
+    local_number: u64,
+    local_hash: B256,
+    zone_block_number: u64,
+) -> eyre::Result<()> {
+    validate_l1_checkpoint_range(
+        core::slice::from_ref(header),
+        local_number,
+        local_hash,
+        zone_block_number,
+    )
 }
 
 /// Decode the L1 header embedded in the first `IZoneInbox.advanceTempo` system transaction.
@@ -1352,12 +1489,41 @@ fn validate_l1_checkpoint_transition(
 fn decode_advance_tempo_header(
     block: &SealedBlock<Block>,
 ) -> eyre::Result<SealedHeader<TempoHeader>> {
-    decode_advance_tempo(block).map(|(header, _)| header)
+    decode_advance_tempo(block).map(|import| import.headers().last().unwrap().clone())
 }
 
-fn decode_advance_tempo(
-    block: &SealedBlock<Block>,
-) -> eyre::Result<(SealedHeader<TempoHeader>, AdvanceTempoPortalInputs)> {
+enum DecodedTempoImport {
+    Full {
+        header: Box<SealedHeader<TempoHeader>>,
+        deposits: Vec<zone_payload::abi::QueuedDeposit>,
+        enabled_tokens: Vec<zone_payload::abi::EnabledToken>,
+    },
+    CheckpointOnly {
+        headers: Vec<SealedHeader<TempoHeader>>,
+    },
+}
+
+impl DecodedTempoImport {
+    fn headers(&self) -> &[SealedHeader<TempoHeader>] {
+        match self {
+            Self::Full { header, .. } => core::slice::from_ref(header),
+            Self::CheckpointOnly { headers } => headers,
+        }
+    }
+
+    /// Tempo anchor whose leader is the unique live producer for this Zone block.
+    ///
+    /// A checkpoint-only block may cross later leadership boundaries, so its first imported
+    /// header selects the producer. A full block contains one header and follows the same rule.
+    fn production_anchor(&self) -> u64 {
+        self.headers()
+            .first()
+            .expect("decoded Tempo imports are validated as nonempty")
+            .number()
+    }
+}
+
+fn decode_advance_tempo(block: &SealedBlock<Block>) -> eyre::Result<DecodedTempoImport> {
     // Do some basic checks
 
     // 1. `advanceTempo` is the first tx
@@ -1375,6 +1541,26 @@ fn decode_advance_tempo(
     if signed.tx().to != ZONE_INBOX_ADDRESS.into() {
         eyre::bail!("first Tempo system transaction is not sent to IZoneInbox")
     }
+    if signed
+        .tx()
+        .input
+        .starts_with(&IZoneInbox::advanceTempoHeadersCall::SELECTOR)
+    {
+        if block.body().transactions.len() != 1 {
+            eyre::bail!("advanceTempoHeaders must be the only transaction in its block");
+        }
+        let call = IZoneInbox::advanceTempoHeadersCall::abi_decode(signed.tx().input.as_ref())?;
+        let mut headers = Vec::with_capacity(call.headers.len());
+        for encoded in call.headers {
+            let mut input = encoded.as_ref();
+            let header = TempoHeader::decode(&mut input)?;
+            if !input.is_empty() {
+                eyre::bail!("advanceTempoHeaders header has trailing bytes");
+            }
+            headers.push(SealedHeader::seal_slow(header));
+        }
+        return Ok(DecodedTempoImport::CheckpointOnly { headers });
+    }
     let call = IZoneInbox::advanceTempoCall::abi_decode(signed.tx().input.as_ref())
         .map_err(|err| eyre::eyre!("first transaction does not decode as advanceTempo: {err}"))?;
 
@@ -1388,13 +1574,11 @@ fn decode_advance_tempo(
             header_rlp.len()
         )
     }
-    Ok((
-        SealedHeader::seal_slow(header),
-        AdvanceTempoPortalInputs {
-            deposits: call.deposits,
-            enabled_tokens: call.enabledTokens,
-        },
-    ))
+    Ok(DecodedTempoImport::Full {
+        header: Box::new(SealedHeader::seal_slow(header)),
+        deposits: call.deposits,
+        enabled_tokens: call.enabledTokens,
+    })
 }
 
 #[cfg(test)]
@@ -1409,23 +1593,82 @@ mod tests {
 
     use alloy_eips::NumHash;
     use futures::{StreamExt as _, stream};
+    use reth_primitives_traits::SealedHeader;
+    use tempo_primitives::TempoHeader;
     use tokio::sync::{oneshot, watch};
     use tokio_util::sync;
 
     use super::{
         AdvanceTempoPortalInputs, BackfillProgress, BroadcasterShutdown, EncodedPersistedBlock,
         MAX_PENDING_BLOCKS, PEER_ANCHOR_WAIT_TIMEOUT, PersistedBlockSource, PersistedTip,
-        broadcast_persisted_blocks, buffer_pending_block, validate_live_block_sender,
-        wait_for_validated_peer_anchor,
+        broadcast_persisted_blocks, buffer_pending_block, validate_full_portal_inputs,
+        validate_live_block_sender, wait_for_validated_peer_anchor,
     };
-    use alloy_primitives::B256;
-    use zone_l1::{L1BlockTracker, L1PortalEvents};
+    use alloy_primitives::{Address, B256};
+    use zone_l1::{DepositQueue, EnabledToken, L1BlockDeposits, L1BlockTracker, L1PortalEvents};
     use zone_p2p::{BackfillCommand, LeadershipSchedule, LeadershipState, P2pCommand};
 
     #[derive(Clone)]
     struct StartupRaceSource {
         reads: Arc<AtomicUsize>,
         tip: PersistedTip,
+    }
+
+    #[test]
+    fn full_import_validates_deferred_and_current_portal_events() {
+        let queue = DepositQueue::new();
+        let first = SealedHeader::seal_slow(TempoHeader {
+            inner: alloy_consensus::Header {
+                number: 1,
+                ..Default::default()
+            },
+            ..Default::default()
+        });
+        let second = SealedHeader::seal_slow(TempoHeader {
+            inner: alloy_consensus::Header {
+                number: 2,
+                parent_hash: first.hash(),
+                ..Default::default()
+            },
+            ..Default::default()
+        });
+        let alpha = EnabledToken {
+            token: Address::repeat_byte(0x11),
+            name: "Alpha".into(),
+            symbol: "A".into(),
+            currency: "USD".into(),
+        };
+        let beta = EnabledToken {
+            token: Address::repeat_byte(0x22),
+            name: "Beta".into(),
+            symbol: "B".into(),
+            currency: "EUR".into(),
+        };
+        queue
+            .try_enqueue_sealed(
+                first.clone(),
+                L1PortalEvents {
+                    enabled_tokens: vec![alpha.clone()],
+                    ..Default::default()
+                },
+            )
+            .unwrap();
+        queue.defer_through(first.num_hash()).unwrap();
+        let current = L1BlockDeposits {
+            header: second,
+            events: L1PortalEvents {
+                enabled_tokens: vec![beta.clone()],
+                ..Default::default()
+            },
+        };
+        queue
+            .try_enqueue_sealed(current.header.clone(), current.events.clone())
+            .unwrap();
+
+        let expected = vec![alpha.to_abi(), beta.to_abi()];
+        validate_full_portal_inputs(&queue, &current, &[], &expected).unwrap();
+        let err = validate_full_portal_inputs(&queue, &current, &[], &expected[..1]).unwrap_err();
+        assert!(err.to_string().contains("shorter"));
     }
 
     impl PersistedBlockSource for StartupRaceSource {
@@ -1747,6 +1990,42 @@ mod tests {
             super::validate_l1_checkpoint_transition(&header, 10, B256::repeat_byte(0x99), 7)
                 .unwrap_err();
         assert!(wrong_parent.to_string().contains("does not extend"));
+    }
+
+    #[test]
+    fn checkpoint_live_producer_is_leader_of_first_imported_anchor() {
+        use commonware_cryptography::{Signer as _, ed25519::PrivateKey};
+        use reth_primitives_traits::SealedHeader;
+        use tempo_primitives::TempoHeader;
+
+        let outgoing = PrivateKey::from_seed(1).public_key();
+        let incoming = PrivateKey::from_seed(2).public_key();
+        let schedule = LeadershipSchedule::seeded(LeadershipState::new(1, outgoing.clone(), 0));
+        schedule
+            .publish(LeadershipState::new(2, incoming.clone(), 100))
+            .unwrap();
+
+        let headers = [90, 110]
+            .map(|number| {
+                SealedHeader::seal_slow(TempoHeader {
+                    inner: alloy_consensus::Header {
+                        number,
+                        ..Default::default()
+                    },
+                    ..Default::default()
+                })
+            })
+            .to_vec();
+        let tempo_import = super::DecodedTempoImport::CheckpointOnly { headers };
+
+        let production_anchor = tempo_import.production_anchor();
+        assert_eq!(production_anchor, 90);
+        validate_live_block_sender(&schedule, Some(&outgoing), production_anchor, 7).unwrap();
+        let error = validate_live_block_sender(&schedule, Some(&incoming), production_anchor, 7)
+            .expect_err(
+                "the later epoch leader must not produce a range beginning in the old epoch",
+            );
+        assert!(error.to_string().contains(&outgoing.to_string()));
     }
 
     #[tokio::test]

--- a/crates/node/src/replication.rs
+++ b/crates/node/src/replication.rs
@@ -22,7 +22,9 @@ use tempo_primitives::{Block, TempoHeader, TempoTxEnvelope};
 use tokio::sync::{mpsc, oneshot};
 use tokio_util::sync;
 use tracing::{debug, info};
-use zone_l1::{DepositQueue, L1BlockDeposits, L1BlockTracker, L1PortalEvents, TempoStateExt as _};
+#[cfg(test)]
+use zone_l1::L1PortalEvents;
+use zone_l1::{DepositQueue, L1BlockTracker, TempoStateExt as _};
 use zone_p2p::{
     BackfillCommand, BackfillRequest, BackfillResponse, LeadershipSchedule, P2pCommand, P2pEvent,
     P2pPeerId, PeerTip,
@@ -1167,33 +1169,32 @@ where
     let anchor = headers.last().expect("validated nonempty range").num_hash();
     let leader_anchor = tempo_import.leader_anchor();
 
-    let mut observed_headers = Vec::with_capacity(headers.len());
-    for header in headers {
-        let observed = match wait_for_peer_anchor(
-            l1_block_tracker,
-            header.num_hash(),
+    // The subscriber enqueues each L1 block before publishing its observation, and observations
+    // are contiguous. Seeing the final anchor therefore guarantees that the queue contains the
+    // complete imported range.
+    match wait_for_peer_anchor(
+        l1_block_tracker,
+        anchor,
+        block_number,
+        stop,
+        PEER_ANCHOR_WAIT_TIMEOUT,
+    )
+    .await
+    {
+        Ok(()) => {}
+        Err(PeerAnchorWaitError::Cancelled) => {
+            return Ok(PeerBlockImportOutcome::Cancelled);
+        }
+        Err(PeerAnchorWaitError::TimedOut {
             block_number,
-            stop,
-            PEER_ANCHOR_WAIT_TIMEOUT,
-        )
-        .await
-        {
-            Ok(observed) => observed,
-            Err(PeerAnchorWaitError::Cancelled) => {
-                return Ok(PeerBlockImportOutcome::Cancelled);
-            }
-            Err(PeerAnchorWaitError::TimedOut {
+            anchor,
+        }) => {
+            return Ok(PeerBlockImportOutcome::TimedOut {
                 block_number,
                 anchor,
-            }) => {
-                return Ok(PeerBlockImportOutcome::TimedOut {
-                    block_number,
-                    anchor,
-                });
-            }
-            Err(PeerAnchorWaitError::Other(error)) => return Err(error),
-        };
-        observed_headers.push(observed);
+            });
+        }
+        Err(PeerAnchorWaitError::Other(error)) => return Err(error),
     }
 
     // Resolve live production authority only after observing the complete imported range. The
@@ -1207,31 +1208,13 @@ where
         block_number,
     )?;
 
-    // The subscriber normally enqueues immediately after recording this observation. Enqueueing
-    // here as well closes that small scheduling window and makes follower import self-contained;
-    // the queue treats the subscriber's later enqueue as a duplicate. This is peer-driven, so a
-    // gap must surface as a rejected block rather than aborting the node.
-    for (header, observed) in headers
-        .iter()
-        .cloned()
-        .zip(observed_headers.iter().cloned())
-    {
-        deposit_queue
-            .try_enqueue_sealed(header, observed)
-            .wrap_err_with(|| format!("cannot queue an imported header of block {block_number}"))?;
-    }
-
     if let DecodedTempoImport::Full {
         deposits,
         enabled_tokens,
         ..
     } = &tempo_import
     {
-        let current = L1BlockDeposits {
-            header: headers[0].clone(),
-            events: observed_headers[0].clone(),
-        };
-        validate_full_portal_inputs(deposit_queue, &current, deposits, enabled_tokens)
+        validate_full_portal_inputs(deposit_queue, anchor, deposits, enabled_tokens)
             .wrap_err_with(|| {
                 format!("peer block {block_number} does not match observed portal events")
             })?;
@@ -1327,11 +1310,11 @@ fn reconcile_canonical_import(
 
 fn validate_full_portal_inputs(
     deposit_queue: &DepositQueue,
-    current: &L1BlockDeposits,
+    anchor: NumHash,
     deposits: &[zone_payload::abi::QueuedDeposit],
     enabled_tokens: &[zone_payload::abi::EnabledToken],
 ) -> eyre::Result<()> {
-    let work = deposit_queue.operational_work(current)?;
+    let work = deposit_queue.operational_work(anchor)?;
     let mut deposit_offset = 0usize;
     let mut token_offset = 0usize;
     for block in work {
@@ -1371,13 +1354,13 @@ async fn wait_for_peer_anchor(
     block_number: u64,
     stop: &sync::CancellationToken,
     wait_timeout: Duration,
-) -> Result<L1PortalEvents, PeerAnchorWaitError> {
+) -> Result<(), PeerAnchorWaitError> {
     tokio::select! {
         biased;
         () = stop.cancelled() => Err(PeerAnchorWaitError::Cancelled),
         observed = tokio::time::timeout(
             wait_timeout,
-            l1_block_tracker.wait_for_portal_events(anchor),
+            l1_block_tracker.wait_for(anchor),
         ) => match observed {
             Ok(observed) => observed.map_err(PeerAnchorWaitError::Other),
             Err(_) => Err(PeerAnchorWaitError::TimedOut {
@@ -1399,8 +1382,11 @@ async fn wait_for_validated_peer_anchor(
     stop: &sync::CancellationToken,
     wait_timeout: Duration,
 ) -> Result<L1PortalEvents, PeerAnchorWaitError> {
-    let observed =
-        wait_for_peer_anchor(l1_block_tracker, anchor, block_number, stop, wait_timeout).await?;
+    wait_for_peer_anchor(l1_block_tracker, anchor, block_number, stop, wait_timeout).await?;
+    let observed = l1_block_tracker
+        .wait_for_portal_events(anchor)
+        .await
+        .map_err(PeerAnchorWaitError::Other)?;
     portal_inputs
         .validate(&observed)
         .map_err(PeerAnchorWaitError::Other)?;
@@ -1673,8 +1659,9 @@ mod tests {
             .unwrap();
 
         let expected = vec![alpha.to_abi(), beta.to_abi()];
-        validate_full_portal_inputs(&queue, &current, &[], &expected).unwrap();
-        let err = validate_full_portal_inputs(&queue, &current, &[], &expected[..1]).unwrap_err();
+        let anchor = current.header.num_hash();
+        validate_full_portal_inputs(&queue, anchor, &[], &expected).unwrap();
+        let err = validate_full_portal_inputs(&queue, anchor, &[], &expected[..1]).unwrap_err();
         assert!(err.to_string().contains("shorter"));
     }
 

--- a/crates/node/src/replication.rs
+++ b/crates/node/src/replication.rs
@@ -1122,6 +1122,9 @@ where
             eyre::eyre!("missing local canonical header at height {block_number}")
         })?;
         if existing.hash() == hash {
+            // This path bypasses `new_payload`, so verify the peer-supplied body against the
+            // canonical header before deriving queue mutations from it.
+            block.ensure_transaction_root_valid()?;
             reconcile_canonical_import(deposit_queue, &tempo_import).wrap_err_with(|| {
                 format!("cannot reconcile duplicate canonical peer block {block_number}")
             })?;
@@ -1153,8 +1156,8 @@ where
         );
     }
 
-    // 3. Require the block to advance the local Tempo checkpoint by exactly
-    // one independently observed L1 block.
+    // 3. Require the block to import a non-empty contiguous L1 header range
+    // beginning immediately after the local Tempo checkpoint.
     let local = provider
         .state_by_block_hash(parent.hash())?
         .tempo_num_hash()?;

--- a/crates/node/src/replication.rs
+++ b/crates/node/src/replication.rs
@@ -703,7 +703,7 @@ pub(crate) async fn collect_follower_settlement_signatures<P>(
 
 /// Import live/backfilled blocks in canonical order on a follower.
 ///
-/// Live blocks are only imported when the sender equals the leader at their final imported Tempo
+/// Live blocks are only imported when the sender equals the leader at their first imported Tempo
 /// header. For checkpoint-only blocks this is the historical L1 block they anchor to. This check
 /// resolves accidental split brain using the finalized schedule.
 ///

--- a/crates/node/tests/it/e2e.rs
+++ b/crates/node/tests/it/e2e.rs
@@ -79,7 +79,8 @@ async fn test_p2p_follower_tracks_leader_balance() -> eyre::Result<()> {
         .try_into()
         .map_err(|_| eyre::eyre!("cluster must have three nodes"))?;
 
-    let anchor = fixture.inject_empty_block(leader.deposit_queue());
+    let anchor =
+        fixture.inject_empty_block_into(&[leader.deposit_queue(), follower.deposit_queue()]);
     leader.wait_for_block_number(1, DEFAULT_TIMEOUT).await?;
 
     // Receiving the peer block is not enough: the follower must independently
@@ -99,7 +100,10 @@ async fn test_p2p_follower_tracks_leader_balance() -> eyre::Result<()> {
     let amount = 1_000_000_u128;
     let deposit = fixture.make_deposit(PATH_USD_ADDRESS, depositor, recipient, amount);
     let observed = fixture.portal_events_from_deposits(std::slice::from_ref(&deposit));
-    let anchor = fixture.inject_deposits(leader.deposit_queue(), vec![deposit]);
+    let anchor = fixture.inject_deposits_into(
+        &[leader.deposit_queue(), follower.deposit_queue()],
+        vec![deposit],
+    );
     follower
         .l1_block_tracker()
         .record_with_portal_events(anchor, observed)?;
@@ -130,7 +134,10 @@ async fn test_p2p_follower_tracks_leader_balance() -> eyre::Result<()> {
     fixture.seed_no_receive_policy(transfer_recipient)?;
     let sender_deposit = fixture.make_deposit(PATH_USD_ADDRESS, sender, sender, amount);
     let observed = fixture.portal_events_from_deposits(std::slice::from_ref(&sender_deposit));
-    let anchor = fixture.inject_deposits(leader.deposit_queue(), vec![sender_deposit]);
+    let anchor = fixture.inject_deposits_into(
+        &[leader.deposit_queue(), follower.deposit_queue()],
+        vec![sender_deposit],
+    );
     follower
         .l1_block_tracker()
         .record_with_portal_events(anchor, observed)?;
@@ -181,7 +188,8 @@ async fn test_p2p_follower_tracks_leader_balance() -> eyre::Result<()> {
     let leader_receipt = tokio::time::timeout(LEADER_INCLUSION_TIMEOUT, async {
         loop {
             let next_block = leader_provider.get_block_number().await? + 1;
-            let anchor = fixture.inject_empty_block(leader.deposit_queue());
+            let anchor = fixture
+                .inject_empty_block_into(&[leader.deposit_queue(), follower.deposit_queue()]);
             follower.l1_block_tracker().record(anchor)?;
             leader
                 .wait_for_block_number(next_block, DEFAULT_TIMEOUT)
@@ -282,7 +290,10 @@ async fn test_p2p_follower_enforces_policy_change_at_anchor_block() -> eyre::Res
     let deposit_amount: u128 = 1_000_000;
     let deposit = fixture.make_deposit(PATH_USD_ADDRESS, alice, alice, deposit_amount);
     let observed = fixture.portal_events_from_deposits(std::slice::from_ref(&deposit));
-    let anchor = fixture.inject_deposits(leader.deposit_queue(), vec![deposit]);
+    let anchor = fixture.inject_deposits_into(
+        &[leader.deposit_queue(), follower.deposit_queue()],
+        vec![deposit],
+    );
     leader
         .wait_for_balance(
             PATH_USD_ADDRESS,
@@ -354,6 +365,7 @@ async fn test_p2p_follower_enforces_policy_change_at_anchor_block() -> eyre::Res
     let anchor =
         reth_primitives_traits::SealedHeader::seal_slow(policy_block.header.clone()).num_hash();
     fixture.enqueue(&policy_block, leader.deposit_queue(), vec![]);
+    fixture.enqueue(&policy_block, follower.deposit_queue(), vec![]);
     leader.wait_for_block_number(2, DEFAULT_TIMEOUT).await?;
 
     // The leader, resolving policy at height 2, must revert Alice's transfer

--- a/crates/node/tests/it/e2e.rs
+++ b/crates/node/tests/it/e2e.rs
@@ -562,12 +562,12 @@ async fn test_zone_engine_stops_cleanly_between_blocks() -> eyre::Result<()> {
     fixture.inject_empty_blocks(zone.deposit_queue(), 10);
     let head = zone.stop_engine().await?;
 
-    // Every L1 block the engine consumed produced exactly one zone block, and nothing was
-    // half-consumed: the queue front is the next unbuilt anchor.
+    // One Zone block may checkpoint several L1 headers, but cancellation must leave the imported
+    // Tempo cursor and queue front at the same atomic boundary.
     let tempo_block_number = zone.tempo_block_number().await?;
-    assert_eq!(
-        tempo_block_number, head,
-        "each zone block imports exactly one L1 block, so the head and the Tempo cursor must agree"
+    assert!(
+        tempo_block_number >= head,
+        "the Tempo cursor cannot trail the Zone head: tempo={tempo_block_number}, zone={head}"
     );
     let next_anchor = zone
         .deposit_queue()
@@ -841,25 +841,9 @@ async fn test_withdrawal_batch_finalization() -> eyre::Result<()> {
     // Local test nodes finalize empty batches every eight zone blocks.
     const BATCH_INTERVAL_BLOCKS: u64 = 8;
 
-    fixture.inject_empty_blocks(zone.deposit_queue(), BATCH_INTERVAL_BLOCKS - 1);
-
-    let before_first_boundary = poll_until(
-        DEFAULT_TIMEOUT,
-        DEFAULT_POLL,
-        "blocks before first empty withdrawal batch boundary",
-        || {
-            let provider = zone.provider();
-            async move {
-                let number = provider.get_block_number().await?;
-                if number >= BATCH_INTERVAL_BLOCKS - 1 {
-                    Ok(Some(number))
-                } else {
-                    Ok(None)
-                }
-            }
-        },
-    )
-    .await?;
+    let before_first_boundary = fixture
+        .produce_empty_zone_blocks(&zone, BATCH_INTERVAL_BLOCKS - 1)
+        .await?;
     assert_eq!(before_first_boundary, BATCH_INTERVAL_BLOCKS - 1);
     assert_eq!(
         zone_outbox.lastBatch().call().await?.withdrawalBatchIndex,
@@ -867,7 +851,7 @@ async fn test_withdrawal_batch_finalization() -> eyre::Result<()> {
         "withdrawalBatchIndex should not advance before a block-number boundary"
     );
 
-    fixture.inject_empty_block(zone.deposit_queue());
+    fixture.produce_empty_zone_blocks(&zone, 1).await?;
     poll_until(
         DEFAULT_TIMEOUT,
         DEFAULT_POLL,
@@ -886,24 +870,10 @@ async fn test_withdrawal_batch_finalization() -> eyre::Result<()> {
     )
     .await?;
 
-    fixture.inject_empty_blocks(zone.deposit_queue(), BATCH_INTERVAL_BLOCKS - 1);
-    poll_until(
-        DEFAULT_TIMEOUT,
-        DEFAULT_POLL,
-        "intermediate empty zone blocks produced",
-        || {
-            let provider = zone.provider();
-            async move {
-                let number = provider.get_block_number().await?;
-                if number >= (2 * BATCH_INTERVAL_BLOCKS) - 1 {
-                    Ok(Some(number))
-                } else {
-                    Ok(None)
-                }
-            }
-        },
-    )
-    .await?;
+    let intermediate_height = fixture
+        .produce_empty_zone_blocks(&zone, BATCH_INTERVAL_BLOCKS - 1)
+        .await?;
+    assert_eq!(intermediate_height, (2 * BATCH_INTERVAL_BLOCKS) - 1);
 
     let intermediate_batch_index = zone_outbox.lastBatch().call().await?.withdrawalBatchIndex;
     assert_eq!(
@@ -912,7 +882,7 @@ async fn test_withdrawal_batch_finalization() -> eyre::Result<()> {
         "withdrawalBatchIndex should not advance before the next block-number boundary"
     );
 
-    fixture.inject_empty_blocks(zone.deposit_queue(), 1);
+    fixture.produce_empty_zone_blocks(&zone, 1).await?;
 
     let final_batch_index = poll_until(
         DEFAULT_TIMEOUT,

--- a/crates/node/tests/it/e2e.rs
+++ b/crates/node/tests/it/e2e.rs
@@ -1415,11 +1415,9 @@ async fn test_chain_tempo_state_ext_from_canon_notification() -> eyre::Result<()
     let (zone, mut fixture) = start_local_zone_with_fixture(10).await?;
     let mut canon_rx = zone.subscribe_to_canonical_state();
 
-    // Inject 3 empty L1 blocks — each produces a zone block.
-    fixture.inject_empty_blocks(zone.deposit_queue(), 3);
-
-    // Wait for tempoBlockNumber to reach 3 via RPC (ensures blocks are mined).
-    zone.wait_for_tempo_block_number(3, DEFAULT_TIMEOUT).await?;
+    // Pace the imports so each empty Tempo block produces a distinct Zone block and canonical
+    // notification instead of being compressed into a checkpoint-only catch-up range.
+    fixture.produce_empty_zone_blocks(&zone, 3).await?;
 
     // Drain canon notifications and collect the L1 NumHash from each committed chain.
     let mut num_hashes: Vec<NumHash> = Vec::new();

--- a/crates/node/tests/it/handoff_e2e.rs
+++ b/crates/node/tests/it/handoff_e2e.rs
@@ -34,8 +34,9 @@ const LIVE_PROPAGATION_TIMEOUT: Duration = Duration::from_secs(15);
 
 /// A crashes after producing a tip shared by every follower. Three L1 anchors pass with no zone
 /// blocks, then an operator selects B and the shared tip for forced recovery. B optimistically
-/// fills the missing anchor range before the next transition finalizes. That transition selects C,
-/// which takes over at its exact anchor without replacing any block preceding the crash.
+/// fills the missing anchor range with a checkpoint block plus a full import before the next
+/// transition finalizes. That transition selects C, which takes over at its exact anchor without
+/// replacing any block preceding the crash.
 #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
 async fn test_forced_recovery_resumes_after_leader_crash() -> eyre::Result<()> {
     reth_tracing::init_test_tracing();
@@ -97,10 +98,16 @@ async fn test_forced_recovery_resumes_after_leader_crash() -> eyre::Result<()> {
         assert!(!node.leadership().forced_recovery().unwrap().is_bounded());
     }
 
-    let optimistic_tip = recovery_start_tempo_block + 2;
-    cluster.wait_all_at(optimistic_tip, HANDOFF_TIMEOUT).await?;
+    let optimistic_zone_tip = recovery_tip_height + 2;
+    for node in &cluster.nodes {
+        node.wait_for_tempo_block_number(recovery_start_tempo_block + 2, HANDOFF_TIMEOUT)
+            .await?;
+    }
+    cluster
+        .wait_all_at(optimistic_zone_tip, HANDOFF_TIMEOUT)
+        .await?;
     let b_producer = cluster.sequencer_signers[replacement_index].address();
-    for height in recovery_start_tempo_block..=optimistic_tip {
+    for height in recovery_tip_height + 1..=optimistic_zone_tip {
         assert_eq!(
             cluster.assert_same_block(height).await?.beneficiary(),
             b_producer,
@@ -120,8 +127,9 @@ async fn test_forced_recovery_resumes_after_leader_crash() -> eyre::Result<()> {
         portal_activation_tempo_block,
     )?;
     cluster.inject_block(vec![])?;
+    let portal_activation_zone_height = optimistic_zone_tip + 1;
     cluster
-        .wait_all_at(portal_activation_tempo_block, HANDOFF_TIMEOUT)
+        .wait_all_at(portal_activation_zone_height, HANDOFF_TIMEOUT)
         .await?;
 
     // The pre-crash prefix is unchanged on both survivors.
@@ -138,7 +146,7 @@ async fn test_forced_recovery_resumes_after_leader_crash() -> eyre::Result<()> {
     // recovery state is removed.
     assert_eq!(
         cluster
-            .assert_same_block(portal_activation_tempo_block)
+            .assert_same_block(portal_activation_zone_height)
             .await?
             .beneficiary(),
         c_producer,
@@ -153,7 +161,7 @@ async fn test_forced_recovery_resumes_after_leader_crash() -> eyre::Result<()> {
 
     // Production remains live under ordinary portal authority after the recovery window.
     cluster.inject_block(vec![])?;
-    let next_height = portal_activation_tempo_block + 1;
+    let next_height = portal_activation_zone_height + 1;
     cluster.wait_all_at(next_height, HANDOFF_TIMEOUT).await?;
     assert_eq!(
         cluster.assert_same_block(next_height).await?.beneficiary(),

--- a/crates/node/tests/it/l1_e2e.rs
+++ b/crates/node/tests/it/l1_e2e.rs
@@ -222,8 +222,8 @@ async fn test_three_node_quorum_settles_real_batch_boundary() -> eyre::Result<()
     .map_err(|_| eyre::eyre!("settled zone height does not fit in u64"))?;
 
     eyre::ensure!(
-        submitted_height >= 4,
-        "settled before the configured batch boundary"
+        submitted_height > 0,
+        "batch submission did not advance the settled zone height"
     );
     eyre::ensure!(
         portal.withdrawalBatchIndex().call().await? >= 1,
@@ -297,8 +297,8 @@ async fn test_two_online_sequencers_submit_two_signature_certificate() -> eyre::
         "submitted certificate contains duplicate signature bytes"
     );
     eyre::ensure!(
-        submitted_height >= 4,
-        "settled before the configured batch boundary"
+        submitted_height > 0,
+        "batch submission did not advance the settled zone height"
     );
     cluster.wait_all_at(submitted_height, L1_TIMEOUT).await?;
     cluster.assert_same_block(submitted_height).await?;
@@ -355,23 +355,16 @@ async fn fetch_submit_batch_call(l1: &L1TestNode, tx_hash: B256) -> eyre::Result
 /// A follower signs only after it can independently reconstruct the leader's batch statement.
 /// Give follower B a conflicting exact-height Portal queue hash before the boundary. The other
 /// follower is independently prevented from replacing B's share, so A remains below the 2-of-3
-/// threshold and the Portal cannot advance.
+/// threshold at the configured boundary. Earlier catch-up boundaries may settle normally.
 #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
 async fn test_divergent_follower_does_not_create_quorum() -> eyre::Result<()> {
     reth_tracing::init_test_tracing();
 
-    // Leave enough real L1 blocks to install the divergent state before the first batch boundary.
-    let cluster = start_real_p2p_cluster(20).await?;
-    let portal = ZonePortal::new(cluster.portal_address, cluster.l1.provider());
-    let before = (
-        portal.blockHash().call().await?,
-        portal.zoneHeight().call().await?,
-        portal.withdrawalBatchIndex().call().await?,
-        portal.withdrawalQueueHead().call().await?,
-        portal.withdrawalQueueTail().call().await?,
-        portal.lastProcessedDepositNumber().call().await?,
-    );
+    const DIVERGENT_BOUNDARY: u64 = 20;
 
+    // Leave enough Zone blocks to install the divergent state before the configured boundary.
+    let cluster = start_real_p2p_cluster(DIVERGENT_BOUNDARY).await?;
+    let portal = ZonePortal::new(cluster.portal_address, cluster.l1.provider());
     // A newly started subscriber initializes its cache from the zone's L1 genesis anchor, not
     // from block zero. Its first non-contiguous coverage update resets the cache, which used to
     // race with the forged entry below and silently erase it. Wait for every member to complete
@@ -410,33 +403,19 @@ async fn test_divergent_follower_does_not_create_quorum() -> eyre::Result<()> {
     );
 
     cluster.nodes[0]
-        .wait_for_block_number(20, L1_TIMEOUT)
+        .wait_for_block_number(DIVERGENT_BOUNDARY, L1_TIMEOUT)
         .await?;
     tokio::time::sleep(Duration::from_secs(2)).await;
 
     let follower_height = cluster.nodes[1].provider().get_block_number().await?;
     eyre::ensure!(
-        follower_height < 20,
+        follower_height < DIVERGENT_BOUNDARY,
         "divergent follower unexpectedly imported the leader boundary"
     );
-    let events = portal
-        .BatchSubmitted_1_filter()
-        .from_block(0)
-        .query()
-        .await?;
     eyre::ensure!(
-        events.is_empty(),
-        "leader settled despite only its own usable signature"
+        portal.zoneHeight().call().await? < U256::from(DIVERGENT_BOUNDARY),
+        "leader settled the divergent boundary despite only its own usable signature"
     );
-    let after = (
-        portal.blockHash().call().await?,
-        portal.zoneHeight().call().await?,
-        portal.withdrawalBatchIndex().call().await?,
-        portal.withdrawalQueueHead().call().await?,
-        portal.withdrawalQueueTail().call().await?,
-        portal.lastProcessedDepositNumber().call().await?,
-    );
-    eyre::ensure!(after == before, "Portal changed despite rejected quorum");
 
     Ok(())
 }

--- a/crates/node/tests/it/l1_e2e.rs
+++ b/crates/node/tests/it/l1_e2e.rs
@@ -353,14 +353,16 @@ async fn fetch_submit_batch_call(l1: &L1TestNode, tx_hash: B256) -> eyre::Result
 }
 
 /// A follower signs only after it can independently reconstruct the leader's batch statement.
-/// Give follower B a conflicting exact-height Portal queue hash before the boundary. The other
-/// follower is independently prevented from replacing B's share, so A remains below the 2-of-3
-/// threshold at the configured boundary. Earlier catch-up boundaries may settle normally.
+/// Give both followers conflicting Portal queue hashes over the candidate operational-anchor
+/// window before the boundary. The other followers are independently prevented from replacing
+/// each other's share, so A remains below the 2-of-3 threshold at the configured boundary.
+/// Earlier catch-up boundaries may settle normally.
 #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
 async fn test_divergent_follower_does_not_create_quorum() -> eyre::Result<()> {
     reth_tracing::init_test_tracing();
 
     const DIVERGENT_BOUNDARY: u64 = 20;
+    const DIVERGENT_ANCHOR_WINDOW: u64 = 64;
 
     // Leave enough Zone blocks to install the divergent state before the configured boundary.
     let cluster = start_real_p2p_cluster(DIVERGENT_BOUNDARY).await?;
@@ -388,19 +390,25 @@ async fn test_divergent_follower_does_not_create_quorum() -> eyre::Result<()> {
         .await?;
     }
 
-    let divergent_anchor = cluster.l1.provider().get_block_number().await? + 2;
-    cluster.nodes[1].l1_state_cache().lock().set(
-        cluster.portal_address,
-        portal::slots::CURRENT_DEPOSIT_QUEUE_HASH.into(),
-        divergent_anchor,
-        B256::repeat_byte(0xD1),
-    );
-    cluster.nodes[2].l1_state_cache().lock().set(
-        cluster.portal_address,
-        portal::slots::CURRENT_DEPOSIT_QUEUE_HASH.into(),
-        divergent_anchor,
-        B256::repeat_byte(0xD2),
-    );
+    // Checkpoint-only blocks defer portal work, so a single corrupt height may be skipped before
+    // the next full import selects its operational anchor. Corrupt a bounded future window to
+    // guarantee that whichever finalized anchor closes the deferred range remains divergent.
+    let first_divergent_anchor = cluster.l1.provider().get_block_number().await? + 2;
+    let last_divergent_anchor = first_divergent_anchor + DIVERGENT_ANCHOR_WINDOW;
+    for (node, queue_hash) in [
+        (&cluster.nodes[1], B256::repeat_byte(0xD1)),
+        (&cluster.nodes[2], B256::repeat_byte(0xD2)),
+    ] {
+        let mut cache = node.l1_state_cache().lock();
+        for anchor in first_divergent_anchor..=last_divergent_anchor {
+            cache.set(
+                cluster.portal_address,
+                portal::slots::CURRENT_DEPOSIT_QUEUE_HASH.into(),
+                anchor,
+                queue_hash,
+            );
+        }
+    }
 
     cluster.nodes[0]
         .wait_for_block_number(DIVERGENT_BOUNDARY, L1_TIMEOUT)

--- a/crates/node/tests/it/stepping_e2e.rs
+++ b/crates/node/tests/it/stepping_e2e.rs
@@ -113,8 +113,10 @@ async fn test_current_tip_batch_submission_lands_in_successor_block() -> eyre::R
     let zone = ZoneTestNode::start_from_l1(l1.http_url(), l1.ws_url(), portal_address).await?;
 
     let genesis_anchor = l1.provider().get_block_number().await?;
-    for _ in 0..CURRENT_TIP_BATCH_INTERVAL {
+    for offset in 1..=CURRENT_TIP_BATCH_INTERVAL {
         l1.fund_user(l1.admin_address(), 1).await?;
+        zone.wait_for_tempo_block_number(genesis_anchor + offset, SHORT_STEPPING_TIMEOUT)
+            .await?;
     }
     let current_tip = l1.provider().get_block_number().await?;
     eyre::ensure!(
@@ -682,7 +684,7 @@ async fn test_boundary_ancestry_submission_uses_recent_anchor() -> eyre::Result<
         "ancestry submission should use a recent anchor greater than tempoBlockNumber"
     );
     eyre::ensure!(
-        inclusion_block.saturating_sub(call.tempoBlockNumber) > SHORT_EIP2935_HISTORY_WINDOW,
+        inclusion_block.saturating_sub(call.tempoBlockNumber) > SHORT_EIP2935_EFFECTIVE_WINDOW,
         "test did not submit an out-of-config-window tempo block: tempo={}, included_at={inclusion_block}",
         call.tempoBlockNumber,
     );

--- a/crates/node/tests/it/utils.rs
+++ b/crates/node/tests/it/utils.rs
@@ -3682,14 +3682,14 @@ impl P2pCluster {
         let block = self.fixture.next_block();
         let anchor = SealedHeader::seal_slow(block.header.clone()).num_hash();
         let events = self.fixture.portal_events_from_deposits(&deposits);
+        for node in &self.nodes {
+            self.fixture
+                .enqueue(&block, node.deposit_queue(), deposits.clone());
+        }
         for index in observers {
             self.nodes[*index]
                 .l1_block_tracker()
                 .record_with_portal_events(anchor, events.clone())?;
-        }
-        for node in &self.nodes {
-            self.fixture
-                .enqueue(&block, node.deposit_queue(), deposits.clone());
         }
         Ok(anchor)
     }
@@ -5271,6 +5271,16 @@ impl L1Fixture {
         anchor
     }
 
+    /// Inject the same empty L1 block into multiple queues.
+    pub(crate) fn inject_empty_block_into(&mut self, queues: &[&DepositQueue]) -> NumHash {
+        let block = self.next_block();
+        let anchor = SealedHeader::seal_slow(block.header.clone()).num_hash();
+        for queue in queues {
+            self.enqueue(&block, queue, vec![]);
+        }
+        anchor
+    }
+
     /// Inject `n` empty L1 blocks (no deposits) into the queue.
     pub(crate) fn inject_empty_blocks(&mut self, queue: &DepositQueue, n: u64) {
         for _ in 0..n {
@@ -5305,6 +5315,20 @@ impl L1Fixture {
         let anchor = SealedHeader::seal_slow(header.clone()).num_hash();
         let events = self.portal_events_from_deposits(&deposits);
         queue.enqueue(header, events);
+        anchor
+    }
+
+    /// Inject the same L1 block and deposits into multiple queues.
+    pub(crate) fn inject_deposits_into(
+        &mut self,
+        queues: &[&DepositQueue],
+        deposits: Vec<DepositFixture>,
+    ) -> NumHash {
+        let block = self.next_block();
+        let anchor = SealedHeader::seal_slow(block.header.clone()).num_hash();
+        for queue in queues {
+            self.enqueue(&block, queue, deposits.clone());
+        }
         anchor
     }
 

--- a/crates/node/tests/it/utils.rs
+++ b/crates/node/tests/it/utils.rs
@@ -3800,8 +3800,8 @@ impl RealP2pCluster {
 }
 
 /// Start a three-member P2P quorum against a real Tempo L1 and a Portal registered with the
-/// exact per-node attestation keys. The short interval keeps tests focused on the first real
-/// batch boundary instead of ordinary long-running block production.
+/// exact per-node attestation keys. The short interval bounds how long the tests wait for an
+/// empty batch boundary. A full import following checkpoint-only blocks may close a batch sooner.
 pub(crate) async fn start_real_p2p_cluster(
     withdrawal_batch_interval_blocks: u64,
 ) -> eyre::Result<RealP2pCluster> {
@@ -5276,6 +5276,22 @@ impl L1Fixture {
         for _ in 0..n {
             self.inject_empty_block(queue);
         }
+    }
+
+    /// Produce empty Zone blocks one at a time so each injected Tempo block is the current
+    /// operational import rather than part of a checkpoint-only catch-up range.
+    pub(crate) async fn produce_empty_zone_blocks(
+        &mut self,
+        zone: &ZoneTestNode,
+        count: u64,
+    ) -> eyre::Result<u64> {
+        let mut height = zone.provider().get_block_number().await?;
+        for _ in 0..count {
+            self.inject_empty_block(zone.deposit_queue());
+            height += 1;
+            zone.wait_for_block_number(height, DEFAULT_TIMEOUT).await?;
+        }
+        Ok(height)
     }
 
     /// Inject an L1 block with the given deposits into the queue.


### PR DESCRIPTION
Continuously catches the Zone up to finalized Tempo by producing bounded checkpoint-only blocks, then carrying deferred portal work into the next full import. Keeps this state consistent across T12 activation, follower replication, and restarts. Verifies the checkpoint blocks leader according to https://github.com/tempoxyz/tempo/pull/7366.