### PR TITLE
feat(node): raise Zone account pool capacity

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -11796,6 +11796,7 @@ name = "tempo-zone"
 version = "0.2.1"
 dependencies = [
  "reth-cli-util",
+ "reth-node-core",
  "rustls",
  "zone-node",
 ]

--- a/bin/tempo-zone/Cargo.toml
+++ b/bin/tempo-zone/Cargo.toml
@@ -18,6 +18,7 @@ zone-node = { workspace = true, features = ["cli"] }
 
 # reth
 reth-cli-util.workspace = true
+reth-node-core.workspace = true
 
 # tls
 rustls = { version = "0.23", features = ["aws-lc-rs"] }

--- a/bin/tempo-zone/src/defaults.rs
+++ b/bin/tempo-zone/src/defaults.rs
@@ -1,0 +1,12 @@
+use reth_node_core::args::DefaultTxPoolValues;
+
+/// Match Tempo's per-account pool capacity so independent expiring-nonce
+/// transactions from one Zone account are not constrained by Reth's default.
+const MAX_ACCOUNT_SLOTS: usize = 150_000;
+
+pub(crate) fn init_defaults() {
+    DefaultTxPoolValues::default()
+        .with_max_account_slots(MAX_ACCOUNT_SLOTS)
+        .try_init()
+        .expect("failed to initialize transaction pool defaults");
+}

--- a/bin/tempo-zone/src/main.rs
+++ b/bin/tempo-zone/src/main.rs
@@ -1,6 +1,8 @@
 //! Tempo Zone L2 Node.
 #![cfg_attr(not(test), warn(unused_crate_dependencies))]
 
+mod defaults;
+
 use zone_node::cli::ZoneCli;
 
 #[global_allocator]
@@ -18,6 +20,7 @@ fn main() {
     }
 
     zone_node::init_version_metadata();
+    defaults::init_defaults();
 
     if let Err(err) = ZoneCli::parse().run() {
         eprintln!("Error: {err:?}");


### PR DESCRIPTION
Reth defaults to 16 pending transactions per account, which is too low for Zone accounts sending independent expiring-nonce transactions. This raises the Zone default to 150,000, matching Tempo.

Operators can still override it with `--txpool.max-account-slots`. The global pool limits are unchanged.