### PR TITLE
refactor(node): deprecate manifestless startup

### DIFF
--- a/Justfile
+++ b/Justfile
@@ -231,7 +231,7 @@ demo-swap-and-deposit name amount="100000000" tick="0" rpc=zone_rpc:
         --tick "{{tick}}"
 
 [group('zone')]
-[doc('Starts a Tempo Zone L2 node, subscribing to L1 deposits. Pass the zone name used in create-zone. Use profile=release for production.')]
+[doc('Starts a manifest-backed Tempo Zone node. Requires SEQUENCER_MANIFEST, P2P_KEY, and SECP256K1_KEY. Use profile=release for production.')]
 zone-up name reset="false" profile="dev" args="":
     #!/bin/bash
     set -euo pipefail
@@ -249,6 +249,9 @@ zone-up name reset="false" profile="dev" args="":
     PORTAL=$(jq -r '.portal' "$ZONE_JSON")
     ANCHOR_BLOCK=$(jq -r '.tempoAnchorBlock' "$ZONE_JSON")
     ZONE_ID=$(jq -r '.zoneId' "$ZONE_JSON")
+    MANIFEST="${SEQUENCER_MANIFEST:?Set SEQUENCER_MANIFEST to the Zone topology manifest}"
+    P2P_KEY_FILE="${P2P_KEY:?Set P2P_KEY to this node's Ed25519 identity key}"
+    SECP256K1_KEY_FILE="${SECP256K1_KEY:?Set SECP256K1_KEY to this node's settlement key}"
     SEQ_KEY_FILE="${SEQUENCER_KEY_FILE:-}"
     if [[ -z "$SEQ_KEY_FILE" ]] && ! jq -e '.sequencerKey? | strings | select(length > 0)' "$ZONE_JSON" > /dev/null; then
         echo "Error: SEQUENCER_KEY_FILE env var not set and no sequencer key found in $ZONE_JSON" >&2
@@ -267,7 +270,7 @@ zone-up name reset="false" profile="dev" args="":
     elif [[ "{{profile}}" != "dev" ]]; then
         PROFILE_FLAG="--profile {{profile}}"
     fi
-    cargo run $PROFILE_FLAG --bin tempo-zone -- \
+    env -u SEQUENCER cargo run $PROFILE_FLAG --bin tempo-zone -- \
                       node \
                       --chain "$GENESIS_JSON" \
                       --l1.rpc-url "${L1_RPC_URL:?Set L1_RPC_URL env var (wss://...)}" \
@@ -279,7 +282,10 @@ zone-up name reset="false" profile="dev" args="":
                       --http.api all \
                       --datadir "$DATADIR" \
                       --log.file.directory "$DATADIR/logs" \
-                      --sequencer \
+                      --sequencer.manifest "$MANIFEST" \
+                      --p2p.key "$P2P_KEY_FILE" \
+                      --secp256k1.key "$SECP256K1_KEY_FILE" \
+                      --sequencer.role leader \
                       --sequencer-key-file "$SEQ_KEY_FILE" \
                       {{args}}
 
@@ -955,7 +961,9 @@ deploy-zone name token="" access_enforced="false" gateway_enforced="false":
     cargo build --bin tempo-zone --release
     DATADIR="/tmp/tempo-zone-{{name}}"
     rm -rf "$DATADIR" || true
-    exec cargo run --release --bin tempo-zone -- \
+    exec env -u SEQUENCER_MANIFEST -u P2P_KEY -u SECP256K1_KEY \
+        -u SEQUENCER_ROLE -u P2P_BYPASS_IP_CHECK \
+        cargo run --release --bin tempo-zone -- \
                       node \
                       --chain "$OUTPUT/genesis.json" \
                       --l1.rpc-url "$L1_RPC" \

--- a/contrib/bench/provision-topology.sh
+++ b/contrib/bench/provision-topology.sh
@@ -973,6 +973,8 @@ provision_up() {
     # default sparse-trie pruning can make a multi-transaction Zone payload
     # disagree with the root obtained during final validation.
     start_process zone "$ZONE_BIN" "${ZONES_BENCH_ZONE_CPUS:-8-13,24-29}" "$log_dir/zone.log" \
+        env -u SEQUENCER_MANIFEST -u P2P_KEY -u SECP256K1_KEY \
+            -u SEQUENCER_ROLE -u P2P_BYPASS_IP_CHECK \
         "$ZONE_BIN" node \
         --chain "$zone_genesis" --datadir "$zone_db" \
         --l1.rpc-url ws://127.0.0.1:8545 \

--- a/crates/node/src/cli.rs
+++ b/crates/node/src/cli.rs
@@ -337,6 +337,16 @@ async fn configure_sequencing(
     }
 
     let rpc_only = p2p_config.as_ref().is_some_and(P2pConfig::is_rpc_only);
+    eyre::ensure!(
+        signer.is_some() || args.sequencer || p2p_config.is_some(),
+        "--sequencer.manifest is required for node startup"
+    );
+    if args.sequencer {
+        warn!(
+            target: "reth::cli",
+            "--sequencer is deprecated; configure --sequencer.manifest, --p2p.key, and --secp256k1.key"
+        );
+    }
     let sequencing = signer.is_some()
         || args.sequencer
         || p2p_config
@@ -631,11 +641,15 @@ pub struct ZoneArgs {
     )]
     pub redacted_rpc_max_auth_token_validity_secs: u64,
 
-    /// Enable legacy single-sequencer mode without a multi-sequencer manifest.
+    /// Deprecated manifestless node startup.
+    ///
+    /// Use `--dev` for local development, or configure `--sequencer.manifest`, `--p2p.key`, and
+    /// `--secp256k1.key` for a networked node.
     #[arg(
         long = "sequencer",
         env = "SEQUENCER",
-        conflicts_with = "sequencer_manifest"
+        conflicts_with = "sequencer_manifest",
+        help = "Deprecated: start a node without a sequencer manifest"
     )]
     pub sequencer: bool,
 

--- a/crates/p2p/README.md
+++ b/crates/p2p/README.md
@@ -32,8 +32,8 @@ unavailable, or skipped Portal epochs make the recovery boundary ambiguous.
 After a normal Portal transition ends recovery, a restart skips the completed stale directive and
 logs a removal warning. Operators should still remove the directive from every manifest promptly.
 
-If a manifest is not specified, `tempo-zone` retains its existing single-sequencer startup
-behavior.
+The manifestless `--sequencer` startup path is deprecated. Use `tempo-zone node --dev` for local
+development.
 
 ## Roles
 
@@ -215,7 +215,7 @@ Add `--sequencer.enable-prover` to run the detached shadow prover on this follow
 anchor committed by the transaction after the matching Zone range is canonical locally. This is
 observational: proof success or failure never changes settlement or the follower's RPC service.
 
-The `--sequencer` flag conflicts with `--sequencer.manifest` because the
+The deprecated `--sequencer` flag conflicts with `--sequencer.manifest` because the
 manifest determines whether the node starts the sequencer tasks.
 
 DNS peer addresses do not provide a stable egress IP for Commonware's inbound

--- a/docs/ZONES.md
+++ b/docs/ZONES.md
@@ -668,7 +668,8 @@ cast code 0x5A4d000000000000000000000000000000000000 --rpc-url "$ETH_RPC_URL"
 | `--l1.rpc-url` | (required) | Certified Tempo follower WebSocket RPC URL |
 | `--l1.portal-address` | (from zone.json) | ZonePortal contract on L1 |
 | `--zone.id` | (deprecated) | Optional compatibility check against the zone ID encoded in the genesis chain ID. |
-| `--sequencer` | false | Enable sequencer mode for block production and withdrawal batch submission |
+| `--sequencer` | false | Deprecated manifestless node startup. Use `tempo-zone node --dev` locally or `--sequencer.manifest` for a node. |
+| `--sequencer.manifest` | (required for networked nodes) | Static Zone P2P topology and settlement membership |
 | `--sequencer-key-file` | (required for sequencing) | Owner-readable file or FIFO containing the sequencer private key |
 | `--sequencer.enable-prover` | false | Run detached SPF validation; supported by sequencers and `rpc_only` P2P followers |
 | `--sequencer.prover-address` | (optional) | Remote prover `HOST:PORT`; without it the SPF executes in-process |


### PR DESCRIPTION
This PR makes `just zone-up` use a sequencer manifest and deprecates legacy `--sequencer` startup, while keeping that flag available for existing launchers.

Normal CLI startup requires a manifest or the explicit legacy flag; embedded dev startup uses the signer supplied by #1325. Validation stays at the CLI/operator boundary so external-engine test harnesses continue to work. Legacy deployment and benchmark launches clear conflicting P2P environment variables, and manifest-backed `zone-up` clears an ambient `SEQUENCER` flag.

Review stack: `main` → #1325 → **#1318**. Review this diff against `kit/cleanup-dev`; merge #1325 first, then retarget this PR to `main`.

Validation: node CLI tests, `bash -n contrib/bench/provision-topology.sh`, Justfile parsing, and diff/format checks passed. CI lint (including Clippy) passed.
