### PR TITLE
feat(xtask): add operator agreement bisection

### DIFF
--- a/xtask/README.md
+++ b/xtask/README.md
@@ -8,4 +8,6 @@ Subcommands currently supported:
   See the [admin command documentation](src/admin/README.md).
 - `create-zone`: creates a new Zone through Tempo's native TIP-1091 ZoneFactory.
 - `generate-zone-genesis`: generates a Zone L2 genesis file.
+- `operator-agreement`: compares finalized block hashes and state roots across operator RPCs,
+  and bisects divergent history to the last agreed block.
 - `pause-portal`: pauses new deposits and L1 withdrawal processing for 30 days.

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -13,6 +13,7 @@ use crate::{
     generate_p2p_key::GenerateP2pKey,
     generate_zone_genesis::GenerateZoneGenesis,
     install_reference_zone_factory::InstallReferenceZoneFactory,
+    operator_agreement::OperatorAgreement,
     portal_access::{SetAccessMode, SetAllowedAccount, SetGateway, SetGatewayMode},
     portal_pause::PausePortal,
     set_encryption_key::SetEncryptionKey,
@@ -37,6 +38,7 @@ mod deposit;
 mod generate_p2p_key;
 mod generate_zone_genesis;
 mod install_reference_zone_factory;
+mod operator_agreement;
 mod portal_access;
 mod portal_pause;
 mod set_encryption_key;
@@ -80,6 +82,9 @@ async fn main() -> eyre::Result<()> {
         Action::InstallReferenceZoneFactory(args) => args
             .run()
             .wrap_err("failed to install reference ZoneFactory"),
+        Action::OperatorAgreement(args) => {
+            args.run().await.wrap_err("operator agreement check failed")
+        }
         Action::PausePortal(args) => args.run().await.wrap_err("failed to pause portal"),
         Action::SetAccessMode(args) => args.run().await.wrap_err("failed to set access mode"),
         Action::SetAllowedAccount(args) => {
@@ -125,6 +130,8 @@ enum Action {
     GenerateP2pKey(GenerateP2pKey),
     GenerateZoneGenesis(GenerateZoneGenesis),
     InstallReferenceZoneFactory(InstallReferenceZoneFactory),
+    /// Compare finalized block agreement across operator RPC endpoints and bisect divergence.
+    OperatorAgreement(OperatorAgreement),
     PausePortal(PausePortal),
     SetAccessMode(SetAccessMode),
     SetAllowedAccount(SetAllowedAccount),

--- a/xtask/src/operator_agreement.rs
+++ b/xtask/src/operator_agreement.rs
@@ -1,0 +1,253 @@
+//! Compares finalized Zone history across operator RPC endpoints.
+
+use std::{collections::HashSet, future::Future, time::Duration};
+
+use alloy::{
+    primitives::{B256, U64},
+    providers::{Provider, ProviderBuilder},
+};
+use eyre::{Context as _, ensure, eyre};
+use futures::future::join_all;
+use serde::Deserialize;
+use tempo_alloy::TempoNetwork;
+use tokio::time::timeout;
+
+#[derive(Debug, clap::Parser)]
+pub(crate) struct OperatorAgreement {
+    /// Operator HTTP RPC URLs to compare.
+    #[arg(value_name = "RPC", num_args = 2..)]
+    operator_rpcs: Vec<String>,
+
+    /// Timeout for each request, in seconds.
+    #[arg(long, default_value_t = 10)]
+    timeout_seconds: u64,
+}
+
+#[derive(Debug, Clone, Copy, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "camelCase")]
+struct RpcBlock {
+    number: U64,
+    hash: B256,
+    state_root: B256,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+struct AgreedBlock {
+    height: u64,
+    hash: B256,
+    state_root: B256,
+}
+
+impl From<RpcBlock> for AgreedBlock {
+    fn from(block: RpcBlock) -> Self {
+        Self {
+            height: block.number.to::<u64>(),
+            hash: block.hash,
+            state_root: block.state_root,
+        }
+    }
+}
+
+impl OperatorAgreement {
+    pub(crate) async fn run(self) -> eyre::Result<()> {
+        ensure!(
+            self.timeout_seconds > 0,
+            "--timeout-seconds must be nonzero"
+        );
+        let mut unique_rpcs = HashSet::new();
+        for rpc in &self.operator_rpcs {
+            ensure!(
+                rpc.starts_with("http://") || rpc.starts_with("https://"),
+                "operator RPC must be an http:// or https:// URL: {rpc}"
+            );
+            ensure!(unique_rpcs.insert(rpc), "duplicate operator RPC: {rpc}");
+        }
+
+        let rpc_timeout = Duration::from_secs(self.timeout_seconds);
+        let finalized =
+            sample_operator_blocks(&self.operator_rpcs, "finalized", rpc_timeout).await?;
+
+        println!("Finalized operator views");
+        print_blocks(&self.operator_rpcs, &finalized);
+
+        if agreed_block(&finalized).is_some() {
+            println!(
+                "\nAll {} operators agree at finalized Zone block {}.",
+                finalized.len(),
+                finalized[0].number
+            );
+            return Ok(());
+        }
+
+        let upper = finalized
+            .iter()
+            .map(|block| block.number.to::<u64>())
+            .min()
+            .expect("at least two finalized blocks were requested");
+        let shared =
+            sample_operator_blocks(&self.operator_rpcs, &hex_height(upper), rpc_timeout).await?;
+        if let Some(block) = agreed_block(&shared) {
+            println!(
+                "\nOperators agree at shared finalized block {}, but one or more operators have advanced beyond it.",
+                block.height
+            );
+            print_blocks(&self.operator_rpcs, &shared);
+            return Err(eyre!("operator finalized tips are lagging or inconsistent"));
+        }
+
+        let (last_agreed, first_divergent_height) = bisect_last_agreed(upper, |height| {
+            let rpcs = &self.operator_rpcs;
+            async move {
+                let blocks = sample_operator_blocks(rpcs, &hex_height(height), rpc_timeout).await?;
+                Ok(agreed_block(&blocks))
+            }
+        })
+        .await?;
+
+        println!("\nOperators have divergent finalized Zone history.");
+        match last_agreed {
+            Some(block) => {
+                println!(
+                    "Last agreed block: {} {} {}",
+                    block.height, block.hash, block.state_root
+                );
+                println!("First divergent height: {first_divergent_height}");
+            }
+            None => println!("No shared block could be proven through height {upper}."),
+        }
+
+        Err(eyre!("operator finalized history diverged"))
+    }
+}
+
+async fn sample_operator_blocks(
+    operator_rpcs: &[String],
+    block: &str,
+    rpc_timeout: Duration,
+) -> eyre::Result<Vec<RpcBlock>> {
+    let results = join_all(operator_rpcs.iter().map(|rpc| async move {
+        let request = async {
+            let provider = ProviderBuilder::new_with_network::<TempoNetwork>()
+                .connect(rpc)
+                .await
+                .wrap_err_with(|| format!("failed connecting to {rpc}"))?;
+            let response: Option<RpcBlock> = provider
+                .raw_request("eth_getBlockByNumber".into(), (block.to_owned(), false))
+                .await
+                .wrap_err_with(|| format!("eth_getBlockByNumber({block}) failed at {rpc}"))?;
+            response.ok_or_else(|| eyre!("{rpc} returned no block for {block}"))
+        };
+        timeout(rpc_timeout, request)
+            .await
+            .map_err(|_| eyre!("eth_getBlockByNumber({block}) timed out at {rpc}"))?
+    }))
+    .await;
+
+    results.into_iter().collect()
+}
+
+fn agreed_block(blocks: &[RpcBlock]) -> Option<AgreedBlock> {
+    let first = *blocks.first()?;
+    blocks
+        .iter()
+        .all(|block| *block == first)
+        .then(|| first.into())
+}
+
+async fn bisect_last_agreed<F, Fut>(
+    upper: u64,
+    mut sample: F,
+) -> eyre::Result<(Option<AgreedBlock>, u64)>
+where
+    F: FnMut(u64) -> Fut,
+    Fut: Future<Output = eyre::Result<Option<AgreedBlock>>>,
+{
+    // Zone canonical history is append-only, so nodes cannot re-converge at a
+    // later height after disagreeing without first adopting the same chain.
+    let mut low = 0;
+    let mut high = upper;
+    let mut last_agreed = None;
+    let mut first_divergent = upper;
+
+    while low <= high {
+        let middle = low + (high - low) / 2;
+        if let Some(block) = sample(middle).await? {
+            last_agreed = Some(block);
+            match middle.checked_add(1) {
+                Some(next) => low = next,
+                None => break,
+            }
+        } else {
+            first_divergent = middle;
+            match middle.checked_sub(1) {
+                Some(previous) => high = previous,
+                None => break,
+            }
+        }
+    }
+
+    Ok((last_agreed, first_divergent))
+}
+
+fn print_blocks(operator_rpcs: &[String], blocks: &[RpcBlock]) {
+    for (rpc, block) in operator_rpcs.iter().zip(blocks) {
+        println!(
+            "  {rpc}: height={} hash={} stateRoot={}",
+            block.number, block.hash, block.state_root
+        );
+    }
+}
+
+fn hex_height(height: u64) -> String {
+    format!("{height:#x}")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn block(height: u64) -> AgreedBlock {
+        AgreedBlock {
+            height,
+            hash: B256::with_last_byte(height as u8),
+            state_root: B256::with_last_byte(height as u8),
+        }
+    }
+
+    #[tokio::test]
+    async fn bisects_to_last_agreed_block() {
+        let (last_agreed, first_divergent) = bisect_last_agreed(12, |height| async move {
+            Ok((height < 9).then(|| block(height)))
+        })
+        .await
+        .unwrap();
+
+        assert_eq!(last_agreed, Some(block(8)));
+        assert_eq!(first_divergent, 9);
+    }
+
+    #[tokio::test]
+    async fn reports_divergence_at_genesis() {
+        let (last_agreed, first_divergent) = bisect_last_agreed(12, |_| async { Ok(None) })
+            .await
+            .unwrap();
+
+        assert_eq!(last_agreed, None);
+        assert_eq!(first_divergent, 0);
+    }
+
+    #[test]
+    fn complete_block_agreement_includes_state_root() {
+        let first = RpcBlock {
+            number: U64::from(8),
+            hash: B256::with_last_byte(1),
+            state_root: B256::with_last_byte(2),
+        };
+        let second = RpcBlock {
+            state_root: B256::with_last_byte(3),
+            ..first
+        };
+
+        assert!(agreed_block(&[first, second]).is_none());
+    }
+}


### PR DESCRIPTION
## Summary

- add an `operator-agreement` xtask that accepts two or more operator RPC URLs
- compare finalized height, block hash, and state root across every node
- distinguish lagging tips from divergent history and bisect divergence to the last agreed block

## Validation

- `cargo test -p tempo-xtask operator_agreement`
- `cargo +nightly fmt --all -- --check`
- `cargo +nightly clippy -p tempo-xtask --all-targets --no-deps` (passes with an existing future-incompatibility warning in `deploy_neobank_fixtures.rs`)
- `cargo run -q -p tempo-xtask -- operator-agreement --help`

Prompted by: @0xalpharush