### PR TITLE
chore: prepare v0.2.2 release branch

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -11740,7 +11740,7 @@ dependencies = [
 
 [[package]]
 name = "tempo-vsock-proxy"
-version = "0.2.1"
+version = "0.2.2"
 dependencies = [
  "clap",
  "libc",
@@ -11753,7 +11753,7 @@ dependencies = [
 
 [[package]]
 name = "tempo-xtask"
-version = "0.2.1"
+version = "0.2.2"
 dependencies = [
  "alloy",
  "alloy-eips",
@@ -11793,7 +11793,7 @@ dependencies = [
 
 [[package]]
 name = "tempo-zone"
-version = "0.2.1"
+version = "0.2.2"
 dependencies = [
  "reth-cli-util",
  "rustls",
@@ -11802,7 +11802,7 @@ dependencies = [
 
 [[package]]
 name = "tempo-zone-contracts"
-version = "0.2.1"
+version = "0.2.2"
 dependencies = [
  "alloy-contract",
  "alloy-network",
@@ -11821,7 +11821,7 @@ dependencies = [
 
 [[package]]
 name = "tempo-zone-prover-enclave"
-version = "0.2.1"
+version = "0.2.2"
 dependencies = [
  "alloy-consensus",
  "alloy-genesis",
@@ -11844,7 +11844,7 @@ dependencies = [
 
 [[package]]
 name = "tempo-zone-prover-utils"
-version = "0.2.1"
+version = "0.2.2"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -13697,7 +13697,7 @@ checksum = "29666d0abbfad1e3dc4dcf6144730dd3a3ab225bbbdac83319345b1b44ccfc1b"
 
 [[package]]
 name = "zone-chainspec"
-version = "0.2.1"
+version = "0.2.2"
 dependencies = [
  "alloy-eips",
  "alloy-evm",
@@ -13717,7 +13717,7 @@ dependencies = [
 
 [[package]]
 name = "zone-checker"
-version = "0.2.1"
+version = "0.2.2"
 dependencies = [
  "alloy-consensus",
  "alloy-contract",
@@ -13764,7 +13764,7 @@ dependencies = [
 
 [[package]]
 name = "zone-evm"
-version = "0.2.1"
+version = "0.2.2"
 dependencies = [
  "alloy-consensus",
  "alloy-evm",
@@ -13799,7 +13799,7 @@ dependencies = [
 
 [[package]]
 name = "zone-hardfork"
-version = "0.2.1"
+version = "0.2.2"
 dependencies = [
  "alloy-hardforks",
  "paste",
@@ -13807,7 +13807,7 @@ dependencies = [
 
 [[package]]
 name = "zone-l1"
-version = "0.2.1"
+version = "0.2.2"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -13847,7 +13847,7 @@ dependencies = [
 
 [[package]]
 name = "zone-node"
-version = "0.2.1"
+version = "0.2.2"
 dependencies = [
  "alloy",
  "alloy-chains",
@@ -13942,7 +13942,7 @@ dependencies = [
 
 [[package]]
 name = "zone-p2p"
-version = "0.2.1"
+version = "0.2.2"
 dependencies = [
  "alloy-primitives",
  "alloy-signer-local",
@@ -13966,7 +13966,7 @@ dependencies = [
 
 [[package]]
 name = "zone-payload"
-version = "0.2.1"
+version = "0.2.2"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -14007,7 +14007,7 @@ dependencies = [
 
 [[package]]
 name = "zone-precompiles"
-version = "0.2.1"
+version = "0.2.2"
 dependencies = [
  "aes-gcm",
  "alloy",
@@ -14038,7 +14038,7 @@ dependencies = [
 
 [[package]]
 name = "zone-primitives"
-version = "0.2.1"
+version = "0.2.2"
 dependencies = [
  "alloy-primitives",
  "tempo-hardfork",
@@ -14047,7 +14047,7 @@ dependencies = [
 
 [[package]]
 name = "zone-prover"
-version = "0.2.1"
+version = "0.2.2"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -14066,7 +14066,7 @@ dependencies = [
 
 [[package]]
 name = "zone-rpc"
-version = "0.2.1"
+version = "0.2.2"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -14105,7 +14105,7 @@ dependencies = [
 
 [[package]]
 name = "zone-sequencer"
-version = "0.2.1"
+version = "0.2.2"
 dependencies = [
  "alloy-chains",
  "alloy-consensus",
@@ -14151,7 +14151,7 @@ dependencies = [
 
 [[package]]
 name = "zone-spf"
-version = "0.2.1"
+version = "0.2.2"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,5 @@
 [workspace.package]
-version = "0.2.1"
+version = "0.2.2"
 edition = "2024"
 rust-version = "1.95.0"
 license = "MIT OR Apache-2.0"

--- a/crates/node/src/engine.rs
+++ b/crates/node/src/engine.rs
@@ -446,31 +446,44 @@ fn zone_timestamp_millis(
         .max(parent_timestamp_millis.saturating_add(1))
 }
 
-/// Wait until the next valid Zone timestamp is no longer ahead of wall-clock time.
+/// Wait until the next valid Zone timestamp is not in the future, then return it.
 async fn paced_zone_timestamp_millis(
     l1_timestamp_millis: u64,
     parent_timestamp_millis: u64,
 ) -> eyre::Result<u64> {
-    loop {
-        let wall_clock_timestamp_millis = SystemTime::now()
+    let mut wall_clock_timestamp_millis = SystemTime::now()
+        .duration_since(UNIX_EPOCH)?
+        .as_millis()
+        .try_into()?;
+    let timestamp_millis = zone_timestamp_millis(
+        l1_timestamp_millis,
+        parent_timestamp_millis,
+        wall_clock_timestamp_millis,
+    );
+
+    // If the next Zone timestamp is ahead of wall-clock time, wait until wall-clock catches up
+    // since validation doesn't allow future timestamps.
+    if timestamp_millis > wall_clock_timestamp_millis {
+        // We'll sleep for a max of 1 second. If the delay is > 1 second, something more serious is wrong
+        // (eg. clock skew, system time jump, etc.). In this case, we'll return the timestamp anyway, and
+        // the engine will fail to produce a block (the validation will fail), which is the correct behavior.
+        tokio::time::sleep(
+            Duration::from_millis(timestamp_millis - wall_clock_timestamp_millis)
+                .min(Duration::from_secs(1)),
+        )
+        .await;
+
+        wall_clock_timestamp_millis = SystemTime::now()
             .duration_since(UNIX_EPOCH)?
             .as_millis()
             .try_into()?;
-        let timestamp_millis = zone_timestamp_millis(
-            l1_timestamp_millis,
-            parent_timestamp_millis,
-            wall_clock_timestamp_millis,
-        );
-
-        if timestamp_millis == wall_clock_timestamp_millis {
-            return Ok(timestamp_millis);
-        }
-
-        tokio::time::sleep(Duration::from_millis(
-            timestamp_millis - wall_clock_timestamp_millis,
-        ))
-        .await;
     }
+
+    Ok(zone_timestamp_millis(
+        l1_timestamp_millis,
+        parent_timestamp_millis,
+        wall_clock_timestamp_millis,
+    ))
 }
 
 #[cfg(test)]

--- a/crates/node/src/engine.rs
+++ b/crates/node/src/engine.rs
@@ -335,15 +335,11 @@ impl ZoneEngine {
         // The L1 timestamp is a lower bound so a Zone block anchored after an L1 timestamp-based
         // fork cannot predate it. Use wall-clock time to avoid backdating transactions during
         // catch-up, and advance by at least one millisecond to keep consecutive blocks monotonic.
-        let wall_clock_timestamp_millis = SystemTime::now()
-            .duration_since(UNIX_EPOCH)?
-            .as_millis()
-            .try_into()?;
-        let timestamp_millis = zone_timestamp_millis(
+        let timestamp_millis = paced_zone_timestamp_millis(
             l1_block.header.timestamp_millis(),
             self.last_header.timestamp_millis(),
-            wall_clock_timestamp_millis,
-        );
+        )
+        .await?;
         let timestamp_secs = timestamp_millis / 1000;
         let timestamp_millis_part = timestamp_millis % 1000;
 
@@ -450,6 +446,33 @@ fn zone_timestamp_millis(
         .max(parent_timestamp_millis.saturating_add(1))
 }
 
+/// Wait until the next valid Zone timestamp is no longer ahead of wall-clock time.
+async fn paced_zone_timestamp_millis(
+    l1_timestamp_millis: u64,
+    parent_timestamp_millis: u64,
+) -> eyre::Result<u64> {
+    loop {
+        let wall_clock_timestamp_millis = SystemTime::now()
+            .duration_since(UNIX_EPOCH)?
+            .as_millis()
+            .try_into()?;
+        let timestamp_millis = zone_timestamp_millis(
+            l1_timestamp_millis,
+            parent_timestamp_millis,
+            wall_clock_timestamp_millis,
+        );
+
+        if timestamp_millis == wall_clock_timestamp_millis {
+            return Ok(timestamp_millis);
+        }
+
+        tokio::time::sleep(Duration::from_millis(
+            timestamp_millis - wall_clock_timestamp_millis,
+        ))
+        .await;
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -469,6 +492,29 @@ mod tests {
     #[test]
     fn zone_timestamp_advances_past_parent_when_catching_up_in_same_millisecond() {
         assert_eq!(zone_timestamp_millis(1_000, 2_000, 2_000), 2_001);
+    }
+
+    #[tokio::test]
+    async fn paced_zone_timestamp_is_not_in_the_future() {
+        let wall_clock_timestamp_millis: u64 = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .unwrap()
+            .as_millis()
+            .try_into()
+            .unwrap();
+
+        let timestamp_millis = paced_zone_timestamp_millis(0, wall_clock_timestamp_millis)
+            .await
+            .unwrap();
+
+        assert!(timestamp_millis > wall_clock_timestamp_millis);
+        let current_timestamp_millis: u64 = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .unwrap()
+            .as_millis()
+            .try_into()
+            .unwrap();
+        assert!(timestamp_millis <= current_timestamp_millis);
     }
 
     struct PausedDrain {


### PR DESCRIPTION
Temporary validation carrier for the protected `release/v0.2.2` branch. Do not merge into `release/v0.2.1`.

Includes the zone timestamp pacing fix from #1302 and bumps the workspace version to `0.2.2`. After required checks pass, the validated head will be pushed as `release/v0.2.2` and this PR will be closed.

Prompted by: @0xKitsune