### PR TITLE
feat: shadow prover support for RPC followers

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -13895,6 +13895,7 @@ dependencies = [
  "alloy-signer",
  "alloy-signer-local",
  "alloy-sol-types",
+ "alloy-transport",
  "base64 0.22.1",
  "clap",
  "commonware-codec",

--- a/crates/l1/src/lib.rs
+++ b/crates/l1/src/lib.rs
@@ -16,7 +16,7 @@
 #![cfg_attr(not(test), warn(unused_crate_dependencies))]
 #![cfg_attr(docsrs, feature(doc_cfg))]
 
-use alloy_consensus::BlockHeader as _;
+use alloy_consensus::{BlockHeader as _, Sealable as _};
 use alloy_eips::{BlockNumberOrTag, NumHash};
 use alloy_network::{ReceiptResponse as _, primitives::HeaderResponse as _};
 use alloy_primitives::{Address, B256, Bloom, U256, keccak256};
@@ -98,7 +98,7 @@ pub use state::L1StateCache;
 pub use subscriber::{
     AuthenticatedPortalLogs, FinalizedBatchSubmission, L1BlockTracker, L1Subscriber,
     L1SubscriberConfig, L1SubscriberError, LeadershipSink, MAX_L1_LOOKAHEAD_BLOCKS,
-    verify_receipts_against_header,
+    extract_finalized_batch_submissions, verify_receipts_against_header,
 };
 
 #[cfg(test)]

--- a/crates/l1/src/lib.rs
+++ b/crates/l1/src/lib.rs
@@ -96,8 +96,9 @@ pub use ext::{ChainTempoStateExt, TempoStateExt};
 pub use queue::DepositQueue;
 pub use state::L1StateCache;
 pub use subscriber::{
-    AuthenticatedPortalLogs, L1BlockTracker, L1Subscriber, L1SubscriberConfig, L1SubscriberError,
-    LeadershipSink, MAX_L1_LOOKAHEAD_BLOCKS, verify_receipts_against_header,
+    AuthenticatedPortalLogs, FinalizedBatchSubmission, FinalizedBatchSubmissionSink,
+    L1BlockTracker, L1Subscriber, L1SubscriberConfig, L1SubscriberError, LeadershipSink,
+    MAX_L1_LOOKAHEAD_BLOCKS, verify_receipts_against_header,
 };
 
 #[cfg(test)]

--- a/crates/l1/src/lib.rs
+++ b/crates/l1/src/lib.rs
@@ -96,9 +96,9 @@ pub use ext::{ChainTempoStateExt, TempoStateExt};
 pub use queue::DepositQueue;
 pub use state::L1StateCache;
 pub use subscriber::{
-    AuthenticatedPortalLogs, FinalizedBatchSubmission, FinalizedBatchSubmissionSink,
-    L1BlockTracker, L1Subscriber, L1SubscriberConfig, L1SubscriberError, LeadershipSink,
-    MAX_L1_LOOKAHEAD_BLOCKS, verify_receipts_against_header,
+    AuthenticatedPortalLogs, FinalizedBatchSubmission, L1BlockTracker, L1Subscriber,
+    L1SubscriberConfig, L1SubscriberError, LeadershipSink, MAX_L1_LOOKAHEAD_BLOCKS,
+    verify_receipts_against_header,
 };
 
 #[cfg(test)]

--- a/crates/l1/src/subscriber.rs
+++ b/crates/l1/src/subscriber.rs
@@ -375,14 +375,6 @@ pub trait LeadershipSink: Send + Sync + std::fmt::Debug {
     fn apply_leader_transition(&self, transition: &crate::LeaderTransition) -> eyre::Result<()>;
 }
 
-/// Observes accepted batch submissions decoded from verified finalized receipts.
-///
-/// Unlike consensus-critical sinks, this is observational and cannot fence L1 ingestion.
-pub trait FinalizedBatchSubmissionSink: Send + Sync + std::fmt::Debug {
-    /// Observe one finalized Portal submission.
-    fn observe_finalized_batch(&self, submission: FinalizedBatchSubmission);
-}
-
 /// Configuration for the L1 subscriber.
 #[derive(Debug, Clone)]
 pub struct L1SubscriberConfig {
@@ -414,8 +406,9 @@ pub struct L1Subscriber<P> {
     pub(crate) block_tracker: L1BlockTracker,
     /// Optional sink for leadership transitions.
     pub(crate) leadership_sink: Option<Arc<dyn LeadershipSink>>,
-    /// Optional observational sink for finalized accepted batch submissions.
-    pub(crate) finalized_batch_submission_sink: Option<Arc<dyn FinalizedBatchSubmissionSink>>,
+    /// Optional observational channel for finalized accepted batch submissions.
+    pub(crate) finalized_batch_submissions:
+        Option<tokio::sync::mpsc::UnboundedSender<FinalizedBatchSubmission>>,
     /// Private encryption keys bound by finalized Portal rotation events.
     pub(crate) encryption_keys: Option<EncryptionKeyRing>,
     /// L1 subscriber metrics for connection health, backfill, and event ingestion.
@@ -467,7 +460,9 @@ where
         l1_state_cache: L1StateCache,
         block_tracker: L1BlockTracker,
         leadership_sink: Option<Arc<dyn LeadershipSink>>,
-        finalized_batch_submission_sink: Option<Arc<dyn FinalizedBatchSubmissionSink>>,
+        finalized_batch_submissions: Option<
+            tokio::sync::mpsc::UnboundedSender<FinalizedBatchSubmission>,
+        >,
         encryption_keys: Option<EncryptionKeyRing>,
     ) -> Self {
         Self {
@@ -478,7 +473,7 @@ where
             l1_state_cache,
             block_tracker,
             leadership_sink,
-            finalized_batch_submission_sink,
+            finalized_batch_submissions,
             encryption_keys,
             subscriber_metrics: Default::default(),
         }
@@ -789,9 +784,15 @@ where
                 self.block_tracker
                     .record_with_portal_events(anchor, events.clone())?;
             }
-            if let Some(sink) = &self.finalized_batch_submission_sink {
+            if let Some(sender) = &self.finalized_batch_submissions {
                 for submission in finalized_batches {
-                    sink.observe_finalized_batch(submission);
+                    if sender.send(submission).is_err() {
+                        warn!(
+                            target: "zone::l1::subscriber",
+                            "Finalized batch submission observer is unavailable"
+                        );
+                        break;
+                    }
                 }
             }
             // Publish derived L1 state only after the header has been admitted to every
@@ -891,26 +892,33 @@ where
                     if retain_receipt_logs && let Some(logs) = &mut portal_logs {
                         logs.push(log.inner.clone());
                     }
-                    if self.finalized_batch_submission_sink.is_some()
+                    if self.finalized_batch_submissions.is_some()
                         && log.topic0() == Some(&ZonePortal::BatchSubmitted::SIGNATURE_HASH)
                     {
-                        let event = ZonePortal::BatchSubmitted::decode_log(&log.inner)
-                            .wrap_err_with(|| {
-                                format!(
-                                    "failed to decode BatchSubmitted in L1 block {block_number}"
-                                )
-                            })?
-                            .data;
-                        finalized_batches.push(FinalizedBatchSubmission {
-                            block_number,
-                            transaction_hash: receipt.transaction_hash(),
-                            log_index: log.log_index.ok_or_else(|| {
-                                eyre::eyre!(
-                                    "BatchSubmitted in L1 block {block_number} has no log index"
-                                )
-                            })?,
-                            event,
-                        });
+                        match (
+                            ZonePortal::BatchSubmitted::decode_log(&log.inner),
+                            log.log_index,
+                        ) {
+                            (Ok(event), Some(log_index)) => {
+                                finalized_batches.push(FinalizedBatchSubmission {
+                                    block_number,
+                                    transaction_hash: receipt.transaction_hash(),
+                                    log_index,
+                                    event: event.data,
+                                });
+                            }
+                            (Err(err), _) => warn!(
+                                target: "zone::l1::subscriber",
+                                block_number,
+                                error = ?err,
+                                "Could not decode finalized batch submission for observer"
+                            ),
+                            (_, None) => warn!(
+                                target: "zone::l1::subscriber",
+                                block_number,
+                                "Finalized batch submission has no log index"
+                            ),
+                        }
                     }
                     invalidated.insert(address);
                     if let Some(address) =

--- a/crates/l1/src/subscriber.rs
+++ b/crates/l1/src/subscriber.rs
@@ -443,7 +443,7 @@ pub struct L1Subscriber<P> {
     pub(crate) leadership_sink: Option<Arc<dyn LeadershipSink>>,
     /// Optional observational channel for finalized accepted batch submissions.
     pub(crate) finalized_batch_submissions:
-        Option<tokio::sync::mpsc::UnboundedSender<FinalizedBatchSubmission>>,
+        Option<tokio::sync::mpsc::Sender<FinalizedBatchSubmission>>,
     /// Private encryption keys bound by finalized Portal rotation events.
     pub(crate) encryption_keys: Option<EncryptionKeyRing>,
     /// L1 subscriber metrics for connection health, backfill, and event ingestion.
@@ -495,9 +495,7 @@ where
         l1_state_cache: L1StateCache,
         block_tracker: L1BlockTracker,
         leadership_sink: Option<Arc<dyn LeadershipSink>>,
-        finalized_batch_submissions: Option<
-            tokio::sync::mpsc::UnboundedSender<FinalizedBatchSubmission>,
-        >,
+        finalized_batch_submissions: Option<tokio::sync::mpsc::Sender<FinalizedBatchSubmission>>,
         encryption_keys: Option<EncryptionKeyRing>,
     ) -> Self {
         Self {
@@ -824,6 +822,7 @@ where
                 for submission in finalized_batches {
                     sender
                         .send(submission)
+                        .await
                         .map_err(|_| L1SubscriberError::Fatal {
                             block_number,
                             stage: "finalized batch observer delivery",

--- a/crates/l1/src/subscriber.rs
+++ b/crates/l1/src/subscriber.rs
@@ -822,13 +822,15 @@ where
             }
             if let Some(sender) = &self.finalized_batch_submissions {
                 for submission in finalized_batches {
-                    if sender.send(submission).is_err() {
-                        warn!(
-                            target: "zone::l1::subscriber",
-                            "Finalized batch submission observer is unavailable"
-                        );
-                        break;
-                    }
+                    sender
+                        .send(submission)
+                        .map_err(|_| L1SubscriberError::Fatal {
+                            block_number,
+                            stage: "finalized batch observer delivery",
+                            source: eyre::eyre!(
+                                "finalized batch submission observer is unavailable"
+                            ),
+                        })?;
                 }
             }
             // Publish derived L1 state only after the header has been admitted to every
@@ -918,11 +920,11 @@ where
         let mut portal_events = L1PortalEvents::default();
         let mut invalidated = HashSet::new();
         let mut portal_logs = self.config.retain_portal_evidence.then(Vec::new);
-        let finalized_batches = self
-            .finalized_batch_submissions
-            .is_some()
-            .then(|| extract_finalized_batch_submissions(block, portal_address, receipts))
-            .unwrap_or_default();
+        let finalized_batches = if self.finalized_batch_submissions.is_some() {
+            extract_finalized_batch_submissions(block, portal_address, receipts)
+        } else {
+            Vec::new()
+        };
 
         for receipt in receipts {
             let retain_receipt_logs = portal_logs.is_some() && receipt.status();

--- a/crates/l1/src/subscriber.rs
+++ b/crates/l1/src/subscriber.rs
@@ -43,14 +43,49 @@ pub struct AuthenticatedPortalLogs {
 /// One `BatchSubmitted` event from a receipt-verified finalized Tempo block.
 #[derive(Debug, Clone)]
 pub struct FinalizedBatchSubmission {
-    /// Finalized Tempo block number containing the accepted submission.
-    pub block_number: u64,
-    /// Transaction whose calldata contains the accepted quorum certificate.
-    pub transaction_hash: B256,
-    /// Canonical log index used to distinguish multiple submissions in one transaction.
+    /// Finalized Tempo block containing the accepted submission.
+    pub block: NumHash,
+    /// Receipt-trie position of the transaction containing the accepted submission.
+    pub transaction_index: u64,
+    /// Receipt-local log position used to distinguish multiple submissions in one transaction.
     pub log_index: u64,
     /// Event emitted after the Portal accepted the submission.
     pub event: ZonePortal::BatchSubmitted,
+}
+
+/// Extract `BatchSubmitted` events using receipt ordering rather than RPC metadata.
+///
+/// Callers must verify `receipts` against the supplied block's receipt root first.
+pub fn extract_finalized_batch_submissions(
+    block: NumHash,
+    portal_address: Address,
+    receipts: &[tempo_alloy::rpc::TempoTransactionReceipt],
+) -> Vec<FinalizedBatchSubmission> {
+    let mut submissions = Vec::new();
+    for (transaction_index, receipt) in receipts.iter().enumerate() {
+        for (log_index, log) in receipt.logs().iter().enumerate() {
+            if log.address() != portal_address
+                || log.topic0() != Some(&ZonePortal::BatchSubmitted::SIGNATURE_HASH)
+            {
+                continue;
+            }
+            match ZonePortal::BatchSubmitted::decode_log(&log.inner) {
+                Ok(event) => submissions.push(FinalizedBatchSubmission {
+                    block,
+                    transaction_index: transaction_index as u64,
+                    log_index: log_index as u64,
+                    event: event.data,
+                }),
+                Err(err) => warn!(
+                    target: "zone::l1::subscriber",
+                    block_number = block.number,
+                    error = ?err,
+                    "Could not decode finalized batch submission for observer"
+                ),
+            }
+        }
+    }
+    submissions
 }
 
 /// Number of consumed Tempo blocks whose authenticated Portal logs remain available to
@@ -718,10 +753,11 @@ where
 
         while let Some((header, receipts)) = fetched.try_next().await? {
             let block_number = header.number();
+            let block_hash = header.hash_slow();
             // Decoding fails closed: a decode failure of a recognized portal log aborts this
             // block before anything is enqueued or any cache advances.
             let processed_events = self
-                .extract_events(block_number, &receipts)
+                .extract_events(NumHash::new(block_number, block_hash), &receipts)
                 .inspect_err(|_| {
                     self.subscriber_metrics.decode_fence_failures.increment(1);
                 })
@@ -874,14 +910,19 @@ where
     /// event would diverge this node from its peers.
     pub(crate) fn extract_events(
         &self,
-        block_number: u64,
+        block: NumHash,
         receipts: &[tempo_alloy::rpc::TempoTransactionReceipt],
     ) -> eyre::Result<L1ProcessedEvents> {
+        let block_number = block.number;
         let portal_address = self.config.portal_address;
         let mut portal_events = L1PortalEvents::default();
         let mut invalidated = HashSet::new();
         let mut portal_logs = self.config.retain_portal_evidence.then(Vec::new);
-        let mut finalized_batches = Vec::new();
+        let finalized_batches = self
+            .finalized_batch_submissions
+            .is_some()
+            .then(|| extract_finalized_batch_submissions(block, portal_address, receipts))
+            .unwrap_or_default();
 
         for receipt in receipts {
             let retain_receipt_logs = portal_logs.is_some() && receipt.status();
@@ -891,34 +932,6 @@ where
                 if address == portal_address {
                     if retain_receipt_logs && let Some(logs) = &mut portal_logs {
                         logs.push(log.inner.clone());
-                    }
-                    if self.finalized_batch_submissions.is_some()
-                        && log.topic0() == Some(&ZonePortal::BatchSubmitted::SIGNATURE_HASH)
-                    {
-                        match (
-                            ZonePortal::BatchSubmitted::decode_log(&log.inner),
-                            log.log_index,
-                        ) {
-                            (Ok(event), Some(log_index)) => {
-                                finalized_batches.push(FinalizedBatchSubmission {
-                                    block_number,
-                                    transaction_hash: receipt.transaction_hash(),
-                                    log_index,
-                                    event: event.data,
-                                });
-                            }
-                            (Err(err), _) => warn!(
-                                target: "zone::l1::subscriber",
-                                block_number,
-                                error = ?err,
-                                "Could not decode finalized batch submission for observer"
-                            ),
-                            (_, None) => warn!(
-                                target: "zone::l1::subscriber",
-                                block_number,
-                                "Finalized batch submission has no log index"
-                            ),
-                        }
                     }
                     invalidated.insert(address);
                     if let Some(address) =

--- a/crates/l1/src/subscriber.rs
+++ b/crates/l1/src/subscriber.rs
@@ -1,6 +1,7 @@
 use super::*;
 use crate::{
-    EncryptionKeyRing, L1StateCache, metrics::L1SubscriberMetrics, state::EnabledTokenRegistry,
+    EncryptionKeyRing, L1StateCache, abi::ZonePortal, metrics::L1SubscriberMetrics,
+    state::EnabledTokenRegistry,
 };
 use eyre::{OptionExt as _, WrapErr as _};
 use std::collections::HashSet;
@@ -37,6 +38,19 @@ pub struct AuthenticatedPortalLogs {
     pub parent_hash: B256,
     /// Portal logs in canonical receipt and log order.
     pub logs: Vec<alloy_primitives::Log>,
+}
+
+/// One `BatchSubmitted` event from a receipt-verified finalized Tempo block.
+#[derive(Debug, Clone)]
+pub struct FinalizedBatchSubmission {
+    /// Finalized Tempo block number containing the accepted submission.
+    pub block_number: u64,
+    /// Transaction whose calldata contains the accepted quorum certificate.
+    pub transaction_hash: B256,
+    /// Canonical log index used to distinguish multiple submissions in one transaction.
+    pub log_index: u64,
+    /// Event emitted after the Portal accepted the submission.
+    pub event: ZonePortal::BatchSubmitted,
 }
 
 /// Number of consumed Tempo blocks whose authenticated Portal logs remain available to
@@ -335,6 +349,7 @@ type L1ProcessedEvents = (
     L1PortalEvents,
     HashSet<Address>,
     Option<Vec<alloy_primitives::Log>>,
+    Vec<FinalizedBatchSubmission>,
 );
 
 fn cache_invalidation_address(address: Address, topic0: Option<&B256>) -> Option<Address> {
@@ -358,6 +373,14 @@ fn portal_event_cache_invalidation_address(topic0: Option<&B256>) -> Option<Addr
 pub trait LeadershipSink: Send + Sync + std::fmt::Debug {
     /// Apply one decoded leadership transition.
     fn apply_leader_transition(&self, transition: &crate::LeaderTransition) -> eyre::Result<()>;
+}
+
+/// Observes accepted batch submissions decoded from verified finalized receipts.
+///
+/// Unlike consensus-critical sinks, this is observational and cannot fence L1 ingestion.
+pub trait FinalizedBatchSubmissionSink: Send + Sync + std::fmt::Debug {
+    /// Observe one finalized Portal submission.
+    fn observe_finalized_batch(&self, submission: FinalizedBatchSubmission);
 }
 
 /// Configuration for the L1 subscriber.
@@ -391,6 +414,8 @@ pub struct L1Subscriber<P> {
     pub(crate) block_tracker: L1BlockTracker,
     /// Optional sink for leadership transitions.
     pub(crate) leadership_sink: Option<Arc<dyn LeadershipSink>>,
+    /// Optional observational sink for finalized accepted batch submissions.
+    pub(crate) finalized_batch_submission_sink: Option<Arc<dyn FinalizedBatchSubmissionSink>>,
     /// Private encryption keys bound by finalized Portal rotation events.
     pub(crate) encryption_keys: Option<EncryptionKeyRing>,
     /// L1 subscriber metrics for connection health, backfill, and event ingestion.
@@ -442,6 +467,7 @@ where
         l1_state_cache: L1StateCache,
         block_tracker: L1BlockTracker,
         leadership_sink: Option<Arc<dyn LeadershipSink>>,
+        finalized_batch_submission_sink: Option<Arc<dyn FinalizedBatchSubmissionSink>>,
         encryption_keys: Option<EncryptionKeyRing>,
     ) -> Self {
         Self {
@@ -452,6 +478,7 @@ where
             l1_state_cache,
             block_tracker,
             leadership_sink,
+            finalized_batch_submission_sink,
             encryption_keys,
             subscriber_metrics: Default::default(),
         }
@@ -707,7 +734,7 @@ where
                     block_number,
                     "portal event decoding",
                 ))?;
-            let (events, invalidated, portal_logs) = processed_events;
+            let (events, invalidated, portal_logs, finalized_batches) = processed_events;
             self.record_seen_block(block_number, to.saturating_sub(block_number));
 
             let sealed = SealedHeader::seal_slow(header);
@@ -761,6 +788,11 @@ where
             } else {
                 self.block_tracker
                     .record_with_portal_events(anchor, events.clone())?;
+            }
+            if let Some(sink) = &self.finalized_batch_submission_sink {
+                for submission in finalized_batches {
+                    sink.observe_finalized_batch(submission);
+                }
             }
             // Publish derived L1 state only after the header has been admitted to every
             // configured retention sink and the contiguous observation tracker.
@@ -848,6 +880,7 @@ where
         let mut portal_events = L1PortalEvents::default();
         let mut invalidated = HashSet::new();
         let mut portal_logs = self.config.retain_portal_evidence.then(Vec::new);
+        let mut finalized_batches = Vec::new();
 
         for receipt in receipts {
             let retain_receipt_logs = portal_logs.is_some() && receipt.status();
@@ -857,6 +890,27 @@ where
                 if address == portal_address {
                     if retain_receipt_logs && let Some(logs) = &mut portal_logs {
                         logs.push(log.inner.clone());
+                    }
+                    if self.finalized_batch_submission_sink.is_some()
+                        && log.topic0() == Some(&ZonePortal::BatchSubmitted::SIGNATURE_HASH)
+                    {
+                        let event = ZonePortal::BatchSubmitted::decode_log(&log.inner)
+                            .wrap_err_with(|| {
+                                format!(
+                                    "failed to decode BatchSubmitted in L1 block {block_number}"
+                                )
+                            })?
+                            .data;
+                        finalized_batches.push(FinalizedBatchSubmission {
+                            block_number,
+                            transaction_hash: receipt.transaction_hash(),
+                            log_index: log.log_index.ok_or_else(|| {
+                                eyre::eyre!(
+                                    "BatchSubmitted in L1 block {block_number} has no log index"
+                                )
+                            })?,
+                            event,
+                        });
                     }
                     invalidated.insert(address);
                     if let Some(address) =
@@ -880,7 +934,7 @@ where
             invalidated.extend([event.token, TIP403_REGISTRY_ADDRESS]);
         }
         self.record_portal_event_metrics(&portal_events);
-        Ok((portal_events, invalidated, portal_logs))
+        Ok((portal_events, invalidated, portal_logs, finalized_batches))
     }
 
     fn record_seen_block(&self, block_number: u64, lag_blocks: u64) {

--- a/crates/l1/src/tests.rs
+++ b/crates/l1/src/tests.rs
@@ -1835,6 +1835,54 @@ async fn sync_classifies_corrupt_recognized_portal_log_as_fatal() {
     assert_eq!(subscriber.block_tracker.latest(), None);
 }
 
+#[tokio::test]
+async fn sync_fails_fatally_when_finalized_batch_observer_is_closed() {
+    let mut subscriber = test_subscriber(Arc::new(SequenceLocalTempoCheckpointReader::new([9])));
+    let (sender, receiver) = tokio::sync::mpsc::unbounded_channel();
+    drop(receiver);
+    subscriber.finalized_batch_submissions = Some(sender);
+    let portal = subscriber.config.portal_address;
+    let event = crate::abi::ZonePortal::BatchSubmitted {
+        withdrawalBatchIndex: 7,
+        withdrawalQueueIndex: U256::from(3),
+        nextProcessedDepositQueueHash: B256::repeat_byte(0x11),
+        nextBlockHash: B256::repeat_byte(0x22),
+        withdrawalQueueHash: B256::repeat_byte(0x33),
+        lastProcessedDepositNumber: 9,
+    };
+    let log = Log {
+        inner: alloy_primitives::Log {
+            address: portal,
+            data: event.encode_log_data(),
+        },
+        ..Default::default()
+    };
+    let receipt = make_receipt_with_logs(10, B256::ZERO, vec![log]);
+    let mut header_10 = make_test_header(10);
+    header_10.inner.receipts_root = calculate_test_receipts_root(std::slice::from_ref(&receipt));
+    header_10.inner.logs_bloom = *receipt.inner.inner.bloom_ref();
+
+    let asserter = Asserter::new();
+    let l1_provider =
+        ProviderBuilder::new_with_network::<TempoNetwork>().connect_mocked_client(asserter.clone());
+    asserter.push_success(&Some(header_response(header_10.clone())));
+    asserter.push_success(&Some(header_response(header_10)));
+    asserter.push_success(&Some(vec![receipt]));
+
+    let err = subscriber
+        .sync_finalized_once(&l1_provider, 10)
+        .await
+        .unwrap_err();
+    assert!(matches!(
+        err,
+        L1SubscriberError::Fatal {
+            block_number: 10,
+            stage: "finalized batch observer delivery",
+            ..
+        }
+    ));
+}
+
 #[test]
 fn ordinary_subscriber_errors_remain_retryable() {
     let error = L1SubscriberError::Other(eyre::eyre!("transient L1 RPC failure"));

--- a/crates/l1/src/tests.rs
+++ b/crates/l1/src/tests.rs
@@ -1663,17 +1663,18 @@ fn extracts_finalized_batch_submission_for_observer() {
     };
     let receipt = make_receipt_with_logs(10, B256::with_last_byte(0x10), vec![log]);
 
-    let (_, _, _, submissions) = subscriber.extract_events(10, &[receipt]).unwrap();
+    let block = NumHash::new(10, B256::with_last_byte(0x10));
+    let (_, _, _, submissions) = subscriber.extract_events(block, &[receipt]).unwrap();
 
     assert_eq!(submissions.len(), 1);
-    assert_eq!(submissions[0].block_number, 10);
-    assert_eq!(submissions[0].transaction_hash, B256::with_last_byte(0xaa));
-    assert_eq!(submissions[0].log_index, 4);
+    assert_eq!(submissions[0].block, block);
+    assert_eq!(submissions[0].transaction_index, 0);
+    assert_eq!(submissions[0].log_index, 0);
     assert_eq!(submissions[0].event.nextBlockHash, B256::repeat_byte(0x22));
 }
 
 #[test]
-fn finalized_batch_observer_errors_do_not_fence_ingestion() {
+fn finalized_batch_observer_ignores_rpc_log_metadata() {
     use alloy_sol_types::SolEvent as _;
 
     let mut subscriber = test_subscriber(Arc::new(SequenceLocalTempoCheckpointReader::new([9])));
@@ -1713,9 +1714,13 @@ fn finalized_batch_observer_errors_do_not_fence_ingestion() {
         vec![malformed, missing_index],
     );
 
-    let (_, _, _, submissions) = subscriber.extract_events(10, &[receipt]).unwrap();
+    let block = NumHash::new(10, B256::with_last_byte(0x10));
+    let (_, _, _, submissions) = subscriber.extract_events(block, &[receipt]).unwrap();
 
-    assert!(submissions.is_empty());
+    assert_eq!(submissions.len(), 1);
+    assert_eq!(submissions[0].block, block);
+    assert_eq!(submissions[0].transaction_index, 0);
+    assert_eq!(submissions[0].log_index, 1);
 }
 
 #[test]
@@ -1728,7 +1733,8 @@ fn extract_events_fails_closed_on_corrupt_recognized_portal_log() {
     let corrupt = corrupt_recognized_portal_log(portal);
     let receipt = make_receipt_with_logs(10, B256::with_last_byte(0x10), vec![corrupt]);
 
-    let err = subscriber.extract_events(10, &[receipt]).unwrap_err();
+    let block = NumHash::new(10, B256::with_last_byte(0x10));
+    let err = subscriber.extract_events(block, &[receipt]).unwrap_err();
     assert!(
         err.to_string()
             .contains("failed to decode a portal event in L1 block 10")
@@ -1746,7 +1752,7 @@ fn extract_events_fails_closed_on_corrupt_recognized_portal_log() {
         ..Default::default()
     };
     let receipt = make_receipt_with_logs(10, B256::with_last_byte(0x10), vec![unknown]);
-    let (events, _, portal_logs, _) = subscriber.extract_events(10, &[receipt]).unwrap();
+    let (events, _, portal_logs, _) = subscriber.extract_events(block, &[receipt]).unwrap();
     assert!(events.deposits.is_empty());
     assert!(events.leader_transitions.is_empty());
     assert_eq!(portal_logs.unwrap().len(), 1);
@@ -1784,7 +1790,8 @@ fn pause_events_invalidate_cached_portal_storage() {
     ];
     let receipt = make_receipt_with_logs(1, B256::with_last_byte(0x10), logs);
 
-    let (_, invalidated, _, _) = subscriber.extract_events(1, &[receipt]).unwrap();
+    let block = NumHash::new(1, B256::with_last_byte(0x10));
+    let (_, invalidated, _, _) = subscriber.extract_events(block, &[receipt]).unwrap();
     assert!(invalidated.contains(&portal));
     subscriber.update_l1_state_anchor(1, &invalidated);
     assert_eq!(

--- a/crates/l1/src/tests.rs
+++ b/crates/l1/src/tests.rs
@@ -1639,8 +1639,6 @@ fn corrupt_recognized_portal_log(portal: Address) -> Log {
 
 #[test]
 fn extracts_finalized_batch_submission_for_observer() {
-    use alloy_sol_types::SolEvent as _;
-
     let mut subscriber = test_subscriber(Arc::new(SequenceLocalTempoCheckpointReader::new([9])));
     let (sender, _receiver) = tokio::sync::mpsc::unbounded_channel();
     subscriber.finalized_batch_submissions = Some(sender);
@@ -1675,8 +1673,6 @@ fn extracts_finalized_batch_submission_for_observer() {
 
 #[test]
 fn finalized_batch_observer_ignores_rpc_log_metadata() {
-    use alloy_sol_types::SolEvent as _;
-
     let mut subscriber = test_subscriber(Arc::new(SequenceLocalTempoCheckpointReader::new([9])));
     let (sender, _receiver) = tokio::sync::mpsc::unbounded_channel();
     subscriber.finalized_batch_submissions = Some(sender);

--- a/crates/l1/src/tests.rs
+++ b/crates/l1/src/tests.rs
@@ -1639,8 +1639,8 @@ fn corrupt_recognized_portal_log(portal: Address) -> Log {
 
 #[test]
 fn extracts_finalized_batch_submission_for_observer() {
-    let mut subscriber = test_subscriber(Arc::new(SequenceLocalTempoCheckpointReader::new([9])));
-    let (sender, _receiver) = tokio::sync::mpsc::unbounded_channel();
+    let mut subscriber = test_subscriber(9);
+    let (sender, _receiver) = tokio::sync::mpsc::channel(1);
     subscriber.finalized_batch_submissions = Some(sender);
     let portal = subscriber.config.portal_address;
     let event = crate::abi::ZonePortal::BatchSubmitted {
@@ -1673,8 +1673,8 @@ fn extracts_finalized_batch_submission_for_observer() {
 
 #[test]
 fn finalized_batch_observer_ignores_rpc_log_metadata() {
-    let mut subscriber = test_subscriber(Arc::new(SequenceLocalTempoCheckpointReader::new([9])));
-    let (sender, _receiver) = tokio::sync::mpsc::unbounded_channel();
+    let mut subscriber = test_subscriber(9);
+    let (sender, _receiver) = tokio::sync::mpsc::channel(1);
     subscriber.finalized_batch_submissions = Some(sender);
     let portal = subscriber.config.portal_address;
     let malformed = Log {
@@ -1833,8 +1833,8 @@ async fn sync_classifies_corrupt_recognized_portal_log_as_fatal() {
 
 #[tokio::test]
 async fn sync_fails_fatally_when_finalized_batch_observer_is_closed() {
-    let mut subscriber = test_subscriber(Arc::new(SequenceLocalTempoCheckpointReader::new([9])));
-    let (sender, receiver) = tokio::sync::mpsc::unbounded_channel();
+    let mut subscriber = test_subscriber(9);
+    let (sender, receiver) = tokio::sync::mpsc::channel(1);
     drop(receiver);
     subscriber.finalized_batch_submissions = Some(sender);
     let portal = subscriber.config.portal_address;

--- a/crates/l1/src/tests.rs
+++ b/crates/l1/src/tests.rs
@@ -158,6 +158,7 @@ fn test_subscriber_with_checkpoint(checkpoint: NumHash) -> L1Subscriber<MockEthP
         l1_state_cache: crate::L1StateCache::new(),
         block_tracker: L1BlockTracker::default(),
         leadership_sink: None,
+        finalized_batch_submission_sink: None,
         encryption_keys: None,
         subscriber_metrics: Default::default(),
     }
@@ -1636,6 +1637,47 @@ fn corrupt_recognized_portal_log(portal: Address) -> Log {
     }
 }
 
+#[derive(Debug)]
+struct NoopFinalizedBatchSink;
+
+impl FinalizedBatchSubmissionSink for NoopFinalizedBatchSink {
+    fn observe_finalized_batch(&self, _: FinalizedBatchSubmission) {}
+}
+
+#[test]
+fn extracts_finalized_batch_submission_for_observer() {
+    use alloy_sol_types::SolEvent as _;
+
+    let mut subscriber = test_subscriber(Arc::new(SequenceLocalTempoCheckpointReader::new([9])));
+    subscriber.finalized_batch_submission_sink = Some(Arc::new(NoopFinalizedBatchSink));
+    let portal = subscriber.config.portal_address;
+    let event = crate::abi::ZonePortal::BatchSubmitted {
+        withdrawalBatchIndex: 7,
+        withdrawalQueueIndex: U256::from(3),
+        nextProcessedDepositQueueHash: B256::repeat_byte(0x11),
+        nextBlockHash: B256::repeat_byte(0x22),
+        withdrawalQueueHash: B256::repeat_byte(0x33),
+        lastProcessedDepositNumber: 9,
+    };
+    let log = Log {
+        inner: alloy_primitives::Log {
+            address: portal,
+            data: event.encode_log_data(),
+        },
+        log_index: Some(4),
+        ..Default::default()
+    };
+    let receipt = make_receipt_with_logs(10, B256::with_last_byte(0x10), vec![log]);
+
+    let (_, _, _, submissions) = subscriber.extract_events(10, &[receipt]).unwrap();
+
+    assert_eq!(submissions.len(), 1);
+    assert_eq!(submissions[0].block_number, 10);
+    assert_eq!(submissions[0].transaction_hash, B256::with_last_byte(0xaa));
+    assert_eq!(submissions[0].log_index, 4);
+    assert_eq!(submissions[0].event.nextBlockHash, B256::repeat_byte(0x22));
+}
+
 #[test]
 fn extract_events_fails_closed_on_corrupt_recognized_portal_log() {
     let mut subscriber = test_subscriber(9);
@@ -1664,7 +1706,7 @@ fn extract_events_fails_closed_on_corrupt_recognized_portal_log() {
         ..Default::default()
     };
     let receipt = make_receipt_with_logs(10, B256::with_last_byte(0x10), vec![unknown]);
-    let (events, _, portal_logs) = subscriber.extract_events(10, &[receipt]).unwrap();
+    let (events, _, portal_logs, _) = subscriber.extract_events(10, &[receipt]).unwrap();
     assert!(events.deposits.is_empty());
     assert!(events.leader_transitions.is_empty());
     assert_eq!(portal_logs.unwrap().len(), 1);
@@ -1702,7 +1744,7 @@ fn pause_events_invalidate_cached_portal_storage() {
     ];
     let receipt = make_receipt_with_logs(1, B256::with_last_byte(0x10), logs);
 
-    let (_, invalidated, _) = subscriber.extract_events(1, &[receipt]).unwrap();
+    let (_, invalidated, _, _) = subscriber.extract_events(1, &[receipt]).unwrap();
     assert!(invalidated.contains(&portal));
     subscriber.update_l1_state_anchor(1, &invalidated);
     assert_eq!(

--- a/crates/l1/src/tests.rs
+++ b/crates/l1/src/tests.rs
@@ -158,7 +158,7 @@ fn test_subscriber_with_checkpoint(checkpoint: NumHash) -> L1Subscriber<MockEthP
         l1_state_cache: crate::L1StateCache::new(),
         block_tracker: L1BlockTracker::default(),
         leadership_sink: None,
-        finalized_batch_submission_sink: None,
+        finalized_batch_submissions: None,
         encryption_keys: None,
         subscriber_metrics: Default::default(),
     }
@@ -1637,19 +1637,13 @@ fn corrupt_recognized_portal_log(portal: Address) -> Log {
     }
 }
 
-#[derive(Debug)]
-struct NoopFinalizedBatchSink;
-
-impl FinalizedBatchSubmissionSink for NoopFinalizedBatchSink {
-    fn observe_finalized_batch(&self, _: FinalizedBatchSubmission) {}
-}
-
 #[test]
 fn extracts_finalized_batch_submission_for_observer() {
     use alloy_sol_types::SolEvent as _;
 
     let mut subscriber = test_subscriber(Arc::new(SequenceLocalTempoCheckpointReader::new([9])));
-    subscriber.finalized_batch_submission_sink = Some(Arc::new(NoopFinalizedBatchSink));
+    let (sender, _receiver) = tokio::sync::mpsc::unbounded_channel();
+    subscriber.finalized_batch_submissions = Some(sender);
     let portal = subscriber.config.portal_address;
     let event = crate::abi::ZonePortal::BatchSubmitted {
         withdrawalBatchIndex: 7,
@@ -1676,6 +1670,52 @@ fn extracts_finalized_batch_submission_for_observer() {
     assert_eq!(submissions[0].transaction_hash, B256::with_last_byte(0xaa));
     assert_eq!(submissions[0].log_index, 4);
     assert_eq!(submissions[0].event.nextBlockHash, B256::repeat_byte(0x22));
+}
+
+#[test]
+fn finalized_batch_observer_errors_do_not_fence_ingestion() {
+    use alloy_sol_types::SolEvent as _;
+
+    let mut subscriber = test_subscriber(Arc::new(SequenceLocalTempoCheckpointReader::new([9])));
+    let (sender, _receiver) = tokio::sync::mpsc::unbounded_channel();
+    subscriber.finalized_batch_submissions = Some(sender);
+    let portal = subscriber.config.portal_address;
+    let malformed = Log {
+        inner: alloy_primitives::Log {
+            address: portal,
+            data: alloy_primitives::LogData::new_unchecked(
+                vec![crate::abi::ZonePortal::BatchSubmitted::SIGNATURE_HASH],
+                Bytes::from_static(b"garbage"),
+            ),
+        },
+        log_index: Some(4),
+        ..Default::default()
+    };
+    let missing_index = Log {
+        inner: alloy_primitives::Log {
+            address: portal,
+            data: crate::abi::ZonePortal::BatchSubmitted {
+                withdrawalBatchIndex: 7,
+                withdrawalQueueIndex: U256::from(3),
+                nextProcessedDepositQueueHash: B256::repeat_byte(0x11),
+                nextBlockHash: B256::repeat_byte(0x22),
+                withdrawalQueueHash: B256::repeat_byte(0x33),
+                lastProcessedDepositNumber: 9,
+            }
+            .encode_log_data(),
+        },
+        log_index: None,
+        ..Default::default()
+    };
+    let receipt = make_receipt_with_logs(
+        10,
+        B256::with_last_byte(0x10),
+        vec![malformed, missing_index],
+    );
+
+    let (_, _, _, submissions) = subscriber.extract_events(10, &[receipt]).unwrap();
+
+    assert!(submissions.is_empty());
 }
 
 #[test]

--- a/crates/node/Cargo.toml
+++ b/crates/node/Cargo.toml
@@ -74,6 +74,7 @@ alloy-rpc-types-engine.workspace = true
 alloy-rpc-types-eth.workspace = true
 alloy-signer-local.workspace = true
 alloy-sol-types.workspace = true
+alloy-transport.workspace = true
 
 # misc
 clap = { workspace = true, optional = true }

--- a/crates/node/src/cli.rs
+++ b/crates/node/src/cli.rs
@@ -19,8 +19,8 @@ use zone_p2p::{MAX_TRANSACTION_MESSAGE_SIZE, P2pConfig, Role};
 use zone_payload::DEFAULT_WITHDRAWAL_BATCH_INTERVAL_BLOCKS;
 
 use crate::{
-    ZoneNode, ZoneRedactedRpcConfig, ZoneSequencerAddOnsConfig, dev::DevCommand,
-    rpc::auth::DEFAULT_MAX_AUTH_TOKEN_VALIDITY_SECS,
+    ZoneNode, ZoneRedactedRpcConfig, ZoneSequencerAddOnsConfig, ZoneShadowProverAddOnsConfig,
+    dev::DevCommand, rpc::auth::DEFAULT_MAX_AUTH_TOKEN_VALIDITY_SECS,
 };
 use zone_checker::{CheckerConfig, CheckerExEx, CheckerMode};
 use zone_sequencer::{
@@ -277,8 +277,8 @@ async fn configure_sequencing(
         ));
     }
     eyre::ensure!(
-        !args.enable_prover || should_sequence_blocks,
-        "--sequencer.enable-prover requires a promotable sequencer node"
+        !args.enable_prover || should_sequence_blocks || rpc_only,
+        "--sequencer.enable-prover requires a sequencer or an rpc_only P2P follower"
     );
 
     if should_sequence_blocks {
@@ -299,6 +299,12 @@ async fn configure_sequencing(
                 max_in_flight_batches: args.withdrawal_max_in_flight_batches,
             },
             enable_prover: args.enable_prover,
+            prover_address: args.prover_address.clone(),
+        });
+    } else if args.enable_prover {
+        node = node.with_shadow_prover(ZoneShadowProverAddOnsConfig {
+            zone_id,
+            batch_anchor_config: BatchAnchorConfig::default(),
             prover_address: args.prover_address.clone(),
         });
     }
@@ -570,7 +576,8 @@ pub struct ZoneArgs {
     )]
     pub checker_mode: zone_checker::CheckerMode,
 
-    /// Validate finalized batch candidates with the SPF without changing settlement.
+    /// Validate finalized batch candidates with the SPF without changing settlement. On an
+    /// rpc_only follower, candidates are recovered from finalized L1 submissions.
     #[arg(long = "sequencer.enable-prover", env = "SEQUENCER_ENABLE_PROVER")]
     pub enable_prover: bool,
 

--- a/crates/node/src/cli.rs
+++ b/crates/node/src/cli.rs
@@ -19,8 +19,8 @@ use zone_p2p::{MAX_TRANSACTION_MESSAGE_SIZE, P2pConfig, Role};
 use zone_payload::DEFAULT_WITHDRAWAL_BATCH_INTERVAL_BLOCKS;
 
 use crate::{
-    ZoneNode, ZoneRedactedRpcConfig, ZoneSequencerAddOnsConfig, ZoneShadowProverAddOnsConfig,
-    dev::DevCommand, rpc::auth::DEFAULT_MAX_AUTH_TOKEN_VALIDITY_SECS,
+    ProverRuntime, ZoneNode, ZoneRedactedRpcConfig, ZoneSequencerAddOnsConfig,
+    ZoneShadowProverAddOnsConfig, dev::DevCommand, rpc::auth::DEFAULT_MAX_AUTH_TOKEN_VALIDITY_SECS,
 };
 use zone_checker::{CheckerConfig, CheckerExEx, CheckerMode};
 use zone_sequencer::{
@@ -305,7 +305,10 @@ async fn configure_sequencing(
         node = node.with_shadow_prover(ZoneShadowProverAddOnsConfig {
             zone_id,
             batch_anchor_config: BatchAnchorConfig::default(),
-            prover_address: args.prover_address.clone(),
+            prover_runtime: args
+                .prover_address
+                .clone()
+                .map_or(ProverRuntime::InProcess, ProverRuntime::Remote),
         });
     }
     if let Some(config) = p2p_config {

--- a/crates/node/src/lib.rs
+++ b/crates/node/src/lib.rs
@@ -16,9 +16,13 @@ mod replication;
 pub mod role;
 pub mod rpc;
 mod settlement_attestation;
+mod shadow_prover;
 mod tx_forwarding;
 pub mod version;
 
 pub use engine::{EngineExit, ProductionPermit, ZoneEngine};
-pub use node::{ZoneExecutorBuilder, ZoneNode, ZoneRedactedRpcConfig, ZoneSequencerAddOnsConfig};
+pub use node::{
+    ZoneExecutorBuilder, ZoneNode, ZoneRedactedRpcConfig, ZoneSequencerAddOnsConfig,
+    ZoneShadowProverAddOnsConfig,
+};
 pub use version::init_version_metadata;

--- a/crates/node/src/lib.rs
+++ b/crates/node/src/lib.rs
@@ -22,7 +22,7 @@ pub mod version;
 
 pub use engine::{EngineExit, ProductionPermit, ZoneEngine};
 pub use node::{
-    ZoneExecutorBuilder, ZoneNode, ZoneRedactedRpcConfig, ZoneSequencerAddOnsConfig,
+    ProverRuntime, ZoneExecutorBuilder, ZoneNode, ZoneRedactedRpcConfig, ZoneSequencerAddOnsConfig,
     ZoneShadowProverAddOnsConfig,
 };
 pub use version::init_version_metadata;

--- a/crates/node/src/node.rs
+++ b/crates/node/src/node.rs
@@ -18,6 +18,7 @@ use crate::{
         ZoneApiServer as _, ZoneRpc, ZoneRpcApi, operator_zone_rpc_module, rpc_connection_config,
         start_redacted_rpc,
     },
+    shadow_prover::run_finalized_batch_observer,
 };
 use alloy_chains::Chain;
 use alloy_consensus::BlockHeader as _;
@@ -99,7 +100,7 @@ use zone_primitives::constants::{decode_l1_chain_id, zone_chain_id};
 use zone_rpc::ZoneDebugApiRpcServer;
 use zone_sequencer::{
     AttestationStore, BatchAnchorConfig, ShadowProverConfig, WithdrawalBatchLimits,
-    ZoneSequencerConfig, attestation::AttestationDomain, spawn_zone_sequencer,
+    ZoneSequencerConfig, attestation::AttestationDomain, spawn_shadow_prover, spawn_zone_sequencer,
 };
 
 fn validate_zone_chain_id(parent_chain_id: u64, zone_id: u32, chain_id: u64) -> eyre::Result<()> {
@@ -198,6 +199,17 @@ pub struct ZoneSequencerAddOnsConfig {
     pub prover_address: Option<String>,
 }
 
+/// Configuration for detached shadow proving that does not require sequencer keys.
+#[derive(Debug, Clone)]
+pub struct ZoneShadowProverAddOnsConfig {
+    /// Zone ID bound into SPF public inputs.
+    pub zone_id: u32,
+    /// EIP-2935 history settings used to recover recently finalized submissions.
+    pub batch_anchor_config: BatchAnchorConfig,
+    /// Remote prover TCP address. When absent, execute the SPF in-process.
+    pub prover_address: Option<String>,
+}
+
 /// Configuration for the Zone redacted RPC server extension.
 #[derive(Debug, Clone, Default)]
 pub struct ZoneRedactedRpcConfig {
@@ -237,6 +249,8 @@ pub struct ZoneNode {
     redacted_rpc_config: ZoneRedactedRpcConfig,
     /// Optional sequencer config. When set, sequencer tasks are spawned.
     sequencer_config: Option<ZoneSequencerAddOnsConfig>,
+    /// Optional detached shadow prover config.
+    shadow_prover_config: Option<ZoneShadowProverAddOnsConfig>,
     /// Optional static Zone P2P networking config.
     p2p_config: Option<P2pConfig>,
     /// Whether a consumer outside this builder drains the deposit queue.
@@ -284,6 +298,7 @@ impl ZoneNode {
             withdrawal_reveal_encryptor: None,
             redacted_rpc_config: ZoneRedactedRpcConfig::default(),
             sequencer_config: None,
+            shadow_prover_config: None,
             p2p_config: None,
             external_deposit_consumer: false,
         }
@@ -304,6 +319,13 @@ impl ZoneNode {
     /// Set the sequencer configuration. When set, batch submission and
     /// withdrawal processing tasks are spawned during node launch.
     pub fn with_sequencer(mut self, config: ZoneSequencerAddOnsConfig) -> Self {
+        if config.enable_prover {
+            self.shadow_prover_config = Some(ZoneShadowProverAddOnsConfig {
+                zone_id: config.zone_id,
+                batch_anchor_config: config.batch_anchor_config,
+                prover_address: config.prover_address.clone(),
+            });
+        }
         let encryption_key = SecretKey::from(config.sequencer_signer.credential());
         self.withdrawal_reveal_encryptor = Some(Arc::new(SequencerWithdrawalRevealEncryptor::new(
             encryption_key.clone(),
@@ -311,6 +333,12 @@ impl ZoneNode {
         )));
         self = self.with_deposit_decryption_keys([encryption_key]);
         self.sequencer_config = Some(config);
+        self
+    }
+
+    /// Enable detached shadow proving without configuring block production or settlement keys.
+    pub fn with_shadow_prover(mut self, config: ZoneShadowProverAddOnsConfig) -> Self {
+        self.shadow_prover_config = Some(config);
         self
     }
 
@@ -441,6 +469,8 @@ where
     redacted_rpc_config: ZoneRedactedRpcConfig,
     /// Sequencer configuration.
     sequencer_config: Option<ZoneSequencerAddOnsConfig>,
+    /// Detached shadow prover configuration.
+    shadow_prover_config: Option<ZoneShadowProverAddOnsConfig>,
     /// Static Zone P2P networking configuration.
     p2p_config: Option<P2pConfig>,
     /// Whether a consumer outside this builder drains the deposit queue.
@@ -472,6 +502,7 @@ where
         portal_address: Address,
         redacted_rpc_config: ZoneRedactedRpcConfig,
         sequencer_config: Option<ZoneSequencerAddOnsConfig>,
+        shadow_prover_config: Option<ZoneShadowProverAddOnsConfig>,
         p2p_config: Option<P2pConfig>,
         external_deposit_consumer: bool,
     ) -> Self {
@@ -493,6 +524,7 @@ where
             portal_address,
             redacted_rpc_config,
             sequencer_config,
+            shadow_prover_config,
             p2p_config,
             external_deposit_consumer,
         }
@@ -588,6 +620,13 @@ where
                     portal_zone_id,
                 )?;
             }
+            if let Some(config) = self.shadow_prover_config.as_ref() {
+                validate_configured_zone_id(
+                    "shadow prover configuration",
+                    config.zone_id,
+                    portal_zone_id,
+                )?;
+            }
             if let Some(config) = self.p2p_config.as_ref() {
                 validate_configured_zone_id("P2P configuration", config.zone_id(), portal_zone_id)?;
             }
@@ -667,6 +706,7 @@ where
         task_executor.spawn_critical_task("l1-block-subscriber", Box::pin(l1_subscriber.run()));
         info!(target: "reth::cli", "L1 subscriber started with deposit enqueueing");
 
+        let rpc_only = self.p2p_config.as_ref().is_some_and(P2pConfig::is_rpc_only);
         // Start the Commonware network and the long-lived event router
         let sequencer_rpc_slot = Arc::new(std::sync::OnceLock::new());
         let p2p_runtime = if let Some(config) = self.p2p_config.take() {
@@ -680,6 +720,11 @@ where
                     self.sequencer_config
                         .as_ref()
                         .map(|config| config.batch_anchor_config)
+                        .or_else(|| {
+                            self.shadow_prover_config
+                                .as_ref()
+                                .map(|config| config.batch_anchor_config)
+                        })
                         .unwrap_or_default(),
                     self.l1_config.l1_rpc_url.clone(),
                     self.l1_config.retry_connection_interval,
@@ -744,9 +789,8 @@ where
             })
             .await?;
         let prover_config = self
-            .sequencer_config
+            .shadow_prover_config
             .as_ref()
-            .filter(|config| config.enable_prover)
             .map(|config| ShadowProverConfig {
                 parent_chain_id: l1_chain_id,
                 zone_id: config.zone_id,
@@ -754,6 +798,26 @@ where
                 debug_api: Arc::new(NodeZoneDebugApi::new(handle.eth_handlers().api.clone())),
                 prover_address: config.prover_address.clone(),
             });
+
+        if rpc_only
+            && let (Some(config), Some(runtime_config)) =
+                (self.shadow_prover_config.as_ref(), prover_config.clone())
+        {
+            let prover = spawn_shadow_prover(
+                runtime_config,
+                self.portal_address,
+                config.batch_anchor_config,
+                provider.clone(),
+                l1_provider.clone(),
+            );
+            tokio::spawn(run_finalized_batch_observer(
+                self.portal_address,
+                config.batch_anchor_config,
+                provider.clone(),
+                l1_provider.clone(),
+                prover,
+            ));
+        }
 
         Self::launch_redacted_rpc(
             self.redacted_rpc_config,
@@ -1618,6 +1682,7 @@ where
             self.portal_address,
             self.redacted_rpc_config.clone(),
             self.sequencer_config.clone(),
+            self.shadow_prover_config.clone(),
             self.p2p_config.clone(),
             self.external_deposit_consumer,
         )

--- a/crates/node/src/node.rs
+++ b/crates/node/src/node.rs
@@ -661,9 +661,10 @@ where
         let mut finalized_batch_submission_sender = None;
         let mut finalized_batch_submissions = None;
         if rpc_only && effective_shadow_prover_config.is_some() {
-            let (sender, receiver) = tokio::sync::mpsc::unbounded_channel();
-            finalized_batch_submission_sender = Some(sender.clone());
-            finalized_batch_submissions = Some((sender, receiver));
+            let (sender, receiver) =
+                tokio::sync::mpsc::channel(zone_sequencer::SHADOW_PROVER_QUEUE_CAPACITY);
+            finalized_batch_submission_sender = Some(sender);
+            finalized_batch_submissions = Some(receiver);
         }
 
         self.resolve_and_seed_tokens(&l1_provider, tempo_block_number)
@@ -835,7 +836,7 @@ where
                         .map(ToOwned::to_owned),
                 });
 
-        if let (Some(config), Some(runtime_config), Some((recovery_sender, submissions))) = (
+        if let (Some(config), Some(runtime_config), Some(submissions)) = (
             effective_shadow_prover_config.as_ref(),
             prover_config.clone(),
             finalized_batch_submissions,
@@ -851,12 +852,11 @@ where
                 "rpc-follower-shadow-prover",
                 RpcFollowerShadowProver::new(
                     self.portal_address,
-                    config.batch_anchor_config,
                     provider.clone(),
                     l1_provider.clone(),
                     prover,
                 )
-                .run(submissions, recovery_sender),
+                .run(submissions),
             );
         }
 

--- a/crates/node/src/node.rs
+++ b/crates/node/src/node.rs
@@ -18,7 +18,7 @@ use crate::{
         ZoneApiServer as _, ZoneRpc, ZoneRpcApi, operator_zone_rpc_module, rpc_connection_config,
         start_redacted_rpc,
     },
-    shadow_prover::run_finalized_batch_observer,
+    shadow_prover::RpcFollowerShadowProver,
 };
 use alloy_chains::Chain;
 use alloy_consensus::BlockHeader as _;
@@ -824,15 +824,16 @@ where
                 provider.clone(),
                 l1_provider.clone(),
             );
-            tokio::spawn(run_finalized_batch_observer(
-                self.portal_address,
-                config.batch_anchor_config,
-                provider.clone(),
-                l1_provider.clone(),
-                prover,
-                submissions,
-                recovery_sender,
-            ));
+            tokio::spawn(
+                RpcFollowerShadowProver::new(
+                    self.portal_address,
+                    config.batch_anchor_config,
+                    provider.clone(),
+                    l1_provider.clone(),
+                    prover,
+                )
+                .run(submissions, recovery_sender),
+            );
         }
 
         Self::launch_redacted_rpc(

--- a/crates/node/src/node.rs
+++ b/crates/node/src/node.rs
@@ -719,7 +719,6 @@ where
         task_executor.spawn_critical_task("l1-block-subscriber", Box::pin(l1_subscriber.run()));
         info!(target: "reth::cli", "L1 subscriber started with deposit enqueueing");
 
-        let rpc_only = self.p2p_config.as_ref().is_some_and(P2pConfig::is_rpc_only);
         // Start the Commonware network and the long-lived event router
         let sequencer_rpc_slot = Arc::new(std::sync::OnceLock::new());
         let p2p_runtime = if let Some(config) = self.p2p_config.take() {
@@ -824,7 +823,8 @@ where
                 provider.clone(),
                 l1_provider.clone(),
             );
-            tokio::spawn(
+            task_executor.spawn_critical_task(
+                "rpc-follower-shadow-prover",
                 RpcFollowerShadowProver::new(
                     self.portal_address,
                     config.batch_anchor_config,

--- a/crates/node/src/node.rs
+++ b/crates/node/src/node.rs
@@ -18,7 +18,7 @@ use crate::{
         ZoneApiServer as _, ZoneRpc, ZoneRpcApi, operator_zone_rpc_module, rpc_connection_config,
         start_redacted_rpc,
     },
-    shadow_prover::run_finalized_batch_observer,
+    shadow_prover::{finalized_batch_submission_channel, run_finalized_batch_observer},
 };
 use alloy_chains::Chain;
 use alloy_consensus::BlockHeader as _;
@@ -633,6 +633,14 @@ where
             validate_zone_chain_id(l1_chain_id, portal_zone_id, chain_id)?;
         }
 
+        let rpc_only = self.p2p_config.as_ref().is_some_and(P2pConfig::is_rpc_only);
+        let mut finalized_batch_submissions = None;
+        if rpc_only && self.shadow_prover_config.is_some() {
+            let (sink, receiver) = finalized_batch_submission_channel();
+            finalized_batch_submission_sink = Some(sink);
+            finalized_batch_submissions = Some(receiver);
+        }
+
         self.resolve_and_seed_tokens(&l1_provider, tempo_block_number)
             .await?;
         if let Some(keys) = self.encryption_keys.clone() {
@@ -700,6 +708,7 @@ where
             self.l1_state_cache.clone(),
             self.l1_block_tracker.clone(),
             leadership_sink,
+            finalized_batch_submission_sink,
             self.encryption_keys.clone(),
         );
         let task_executor = ctx.node.task_executor().clone();
@@ -799,10 +808,11 @@ where
                 prover_address: config.prover_address.clone(),
             });
 
-        if rpc_only
-            && let (Some(config), Some(runtime_config)) =
-                (self.shadow_prover_config.as_ref(), prover_config.clone())
-        {
+        if let (Some(config), Some(runtime_config), Some(submissions)) = (
+            self.shadow_prover_config.as_ref(),
+            prover_config.clone(),
+            finalized_batch_submissions,
+        ) {
             let prover = spawn_shadow_prover(
                 runtime_config,
                 self.portal_address,
@@ -816,6 +826,7 @@ where
                 provider.clone(),
                 l1_provider.clone(),
                 prover,
+                submissions,
             ));
         }
 

--- a/crates/node/src/node.rs
+++ b/crates/node/src/node.rs
@@ -199,6 +199,24 @@ pub struct ZoneSequencerAddOnsConfig {
     pub prover_address: Option<String>,
 }
 
+/// Execution mode for the detached shadow prover.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum ProverRuntime {
+    /// Execute the SPF in this process.
+    InProcess,
+    /// Send witnesses to the prover at the given `HOST:PORT` address.
+    Remote(String),
+}
+
+impl ProverRuntime {
+    fn remote_address(&self) -> Option<&str> {
+        match self {
+            Self::InProcess => None,
+            Self::Remote(address) => Some(address),
+        }
+    }
+}
+
 /// Configuration for detached shadow proving that does not require sequencer keys.
 #[derive(Debug, Clone)]
 pub struct ZoneShadowProverAddOnsConfig {
@@ -206,8 +224,8 @@ pub struct ZoneShadowProverAddOnsConfig {
     pub zone_id: u32,
     /// EIP-2935 history settings used to recover recently finalized submissions.
     pub batch_anchor_config: BatchAnchorConfig,
-    /// Remote prover TCP address. When absent, execute the SPF in-process.
-    pub prover_address: Option<String>,
+    /// Where to execute the SPF.
+    pub prover_runtime: ProverRuntime,
 }
 
 /// Configuration for the Zone redacted RPC server extension.
@@ -633,7 +651,10 @@ where
                 .map(|config| ZoneShadowProverAddOnsConfig {
                     zone_id: config.zone_id,
                     batch_anchor_config: config.batch_anchor_config,
-                    prover_address: config.prover_address.clone(),
+                    prover_runtime: config
+                        .prover_address
+                        .clone()
+                        .map_or(ProverRuntime::InProcess, ProverRuntime::Remote),
                 })
         });
         let rpc_only = self.p2p_config.as_ref().is_some_and(P2pConfig::is_rpc_only);
@@ -808,7 +829,10 @@ where
                     zone_id: config.zone_id,
                     chain_spec: evm_chain_spec,
                     debug_api: Arc::new(NodeZoneDebugApi::new(handle.eth_handlers().api.clone())),
-                    prover_address: config.prover_address.clone(),
+                    prover_address: config
+                        .prover_runtime
+                        .remote_address()
+                        .map(ToOwned::to_owned),
                 });
 
         if let (Some(config), Some(runtime_config), Some((recovery_sender, submissions))) = (

--- a/crates/node/src/node.rs
+++ b/crates/node/src/node.rs
@@ -18,7 +18,7 @@ use crate::{
         ZoneApiServer as _, ZoneRpc, ZoneRpcApi, operator_zone_rpc_module, rpc_connection_config,
         start_redacted_rpc,
     },
-    shadow_prover::{finalized_batch_submission_channel, run_finalized_batch_observer},
+    shadow_prover::run_finalized_batch_observer,
 };
 use alloy_chains::Chain;
 use alloy_consensus::BlockHeader as _;
@@ -319,13 +319,6 @@ impl ZoneNode {
     /// Set the sequencer configuration. When set, batch submission and
     /// withdrawal processing tasks are spawned during node launch.
     pub fn with_sequencer(mut self, config: ZoneSequencerAddOnsConfig) -> Self {
-        if config.enable_prover {
-            self.shadow_prover_config = Some(ZoneShadowProverAddOnsConfig {
-                zone_id: config.zone_id,
-                batch_anchor_config: config.batch_anchor_config,
-                prover_address: config.prover_address.clone(),
-            });
-        }
         let encryption_key = SecretKey::from(config.sequencer_signer.credential());
         self.withdrawal_reveal_encryptor = Some(Arc::new(SequencerWithdrawalRevealEncryptor::new(
             encryption_key.clone(),
@@ -633,12 +626,23 @@ where
             validate_zone_chain_id(l1_chain_id, portal_zone_id, chain_id)?;
         }
 
+        let effective_shadow_prover_config = self.shadow_prover_config.clone().or_else(|| {
+            self.sequencer_config
+                .as_ref()
+                .filter(|config| config.enable_prover)
+                .map(|config| ZoneShadowProverAddOnsConfig {
+                    zone_id: config.zone_id,
+                    batch_anchor_config: config.batch_anchor_config,
+                    prover_address: config.prover_address.clone(),
+                })
+        });
         let rpc_only = self.p2p_config.as_ref().is_some_and(P2pConfig::is_rpc_only);
+        let mut finalized_batch_submission_sender = None;
         let mut finalized_batch_submissions = None;
-        if rpc_only && self.shadow_prover_config.is_some() {
-            let (sink, receiver) = finalized_batch_submission_channel();
-            finalized_batch_submission_sink = Some(sink);
-            finalized_batch_submissions = Some(receiver);
+        if rpc_only && effective_shadow_prover_config.is_some() {
+            let (sender, receiver) = tokio::sync::mpsc::unbounded_channel();
+            finalized_batch_submission_sender = Some(sender.clone());
+            finalized_batch_submissions = Some((sender, receiver));
         }
 
         self.resolve_and_seed_tokens(&l1_provider, tempo_block_number)
@@ -708,7 +712,7 @@ where
             self.l1_state_cache.clone(),
             self.l1_block_tracker.clone(),
             leadership_sink,
-            finalized_batch_submission_sink,
+            finalized_batch_submission_sender,
             self.encryption_keys.clone(),
         );
         let task_executor = ctx.node.task_executor().clone();
@@ -730,7 +734,7 @@ where
                         .as_ref()
                         .map(|config| config.batch_anchor_config)
                         .or_else(|| {
-                            self.shadow_prover_config
+                            effective_shadow_prover_config
                                 .as_ref()
                                 .map(|config| config.batch_anchor_config)
                         })
@@ -797,19 +801,19 @@ where
                 Ok(())
             })
             .await?;
-        let prover_config = self
-            .shadow_prover_config
-            .as_ref()
-            .map(|config| ShadowProverConfig {
-                parent_chain_id: l1_chain_id,
-                zone_id: config.zone_id,
-                chain_spec: evm_chain_spec,
-                debug_api: Arc::new(NodeZoneDebugApi::new(handle.eth_handlers().api.clone())),
-                prover_address: config.prover_address.clone(),
-            });
+        let prover_config =
+            effective_shadow_prover_config
+                .as_ref()
+                .map(|config| ShadowProverConfig {
+                    parent_chain_id: l1_chain_id,
+                    zone_id: config.zone_id,
+                    chain_spec: evm_chain_spec,
+                    debug_api: Arc::new(NodeZoneDebugApi::new(handle.eth_handlers().api.clone())),
+                    prover_address: config.prover_address.clone(),
+                });
 
-        if let (Some(config), Some(runtime_config), Some(submissions)) = (
-            self.shadow_prover_config.as_ref(),
+        if let (Some(config), Some(runtime_config), Some((recovery_sender, submissions))) = (
+            effective_shadow_prover_config.as_ref(),
             prover_config.clone(),
             finalized_batch_submissions,
         ) {
@@ -827,6 +831,7 @@ where
                 l1_provider.clone(),
                 prover,
                 submissions,
+                recovery_sender,
             ));
         }
 

--- a/crates/node/src/shadow_prover.rs
+++ b/crates/node/src/shadow_prover.rs
@@ -20,238 +20,327 @@ use zone_sequencer::{
 const POLL_INTERVAL: Duration = Duration::from_secs(1);
 const RECOVERY_LOG_QUERY_BLOCKS: u64 = 1_000;
 
-/// Observe finalized `submitBatch` calls and feed their exact settlement inputs to the detached
-/// prover. The Portal has already verified the included quorum certificate before emitting the
-/// event; decoding the call binds the proof job to that accepted certificate.
-pub(crate) async fn run_finalized_batch_observer<P: ZoneSequencerProvider>(
+/// Feeds finalized RPC-follower submissions and their exact settlement inputs to the detached
+/// shadow prover.
+#[derive(Clone)]
+pub(crate) struct RpcFollowerShadowProver<P> {
     portal_address: Address,
     anchor_config: BatchAnchorConfig,
     zone_provider: P,
     l1_provider: DynProvider<TempoNetwork>,
     prover: ShadowProver,
-    mut submissions: UnboundedReceiver<FinalizedBatchSubmission>,
-    recovery_sender: UnboundedSender<FinalizedBatchSubmission>,
-) {
-    let recovery_provider = l1_provider.clone();
-    tokio::spawn(async move {
-        loop {
-            if recovery_sender.is_closed() {
-                return;
+}
+
+impl<P: ZoneSequencerProvider> RpcFollowerShadowProver<P> {
+    pub(crate) fn new(
+        portal_address: Address,
+        anchor_config: BatchAnchorConfig,
+        zone_provider: P,
+        l1_provider: DynProvider<TempoNetwork>,
+        prover: ShadowProver,
+    ) -> Self {
+        Self {
+            portal_address,
+            anchor_config,
+            zone_provider,
+            l1_provider,
+            prover,
+        }
+    }
+
+    /// Observe finalized `submitBatch` calls. The Portal has already verified the included quorum
+    /// certificate before emitting the event; decoding the call binds each proof job to that
+    /// accepted certificate.
+    pub(crate) async fn run(
+        self,
+        mut submissions: UnboundedReceiver<FinalizedBatchSubmission>,
+        recovery_sender: UnboundedSender<FinalizedBatchSubmission>,
+    ) {
+        self.spawn_recovery(recovery_sender);
+
+        let mut observed = HashSet::new();
+        while let Some(submission) = submissions.recv().await {
+            let observation_id = (submission.transaction_hash, submission.log_index);
+            if observed.insert(observation_id) {
+                self.spawn_submission_retry(submission);
             }
-            match recover_recent_submissions(portal_address, anchor_config, &recovery_provider)
-                .await
-            {
-                Ok(recovered) => {
-                    for submission in recovered {
-                        if recovery_sender.send(submission).is_err() {
-                            return;
-                        }
-                    }
+        }
+    }
+
+    fn spawn_recovery(&self, recovery_sender: UnboundedSender<FinalizedBatchSubmission>) {
+        let this = self.clone();
+        tokio::spawn(async move {
+            loop {
+                if recovery_sender.is_closed() {
                     return;
                 }
-                Err(err) => {
-                    warn!(
-                        target: "zone::node::shadow_prover",
-                        error = ?err,
-                        "Failed to recover recent finalized batch submissions; retrying"
-                    );
-                    tokio::time::sleep(POLL_INTERVAL).await;
+                match this.recover_recent_submissions().await {
+                    Ok(recovered) => {
+                        for submission in recovered {
+                            if recovery_sender.send(submission).is_err() {
+                                return;
+                            }
+                        }
+                        return;
+                    }
+                    Err(err) => {
+                        warn!(
+                            target: "zone::node::shadow_prover",
+                            error = ?err,
+                            "Failed to recover recent finalized batch submissions; retrying"
+                        );
+                        tokio::time::sleep(POLL_INTERVAL).await;
+                    }
                 }
             }
-        }
-    });
-
-    let mut observed = HashSet::new();
-    while let Some(submission) = submissions.recv().await {
-        spawn_submission_retry(
-            portal_address,
-            &zone_provider,
-            &l1_provider,
-            &prover,
-            submission,
-            &mut observed,
-        );
+        });
     }
-}
 
-async fn recover_recent_submissions(
-    portal_address: Address,
-    anchor_config: BatchAnchorConfig,
-    l1_provider: &DynProvider<TempoNetwork>,
-) -> Result<Vec<FinalizedBatchSubmission>> {
-    let finalized = l1_provider
-        .get_header_by_number(BlockNumberOrTag::Finalized)
-        .await?
-        .ok_or_eyre("L1 finalized block is not available")?
-        .number();
-    let from = finalized.saturating_sub(anchor_config.history_window().saturating_sub(1));
+    async fn recover_recent_submissions(&self) -> Result<Vec<FinalizedBatchSubmission>> {
+        let finalized = self
+            .l1_provider
+            .get_header_by_number(BlockNumberOrTag::Finalized)
+            .await?
+            .ok_or_eyre("L1 finalized block is not available")?
+            .number();
+        let from = finalized.saturating_sub(self.anchor_config.history_window().saturating_sub(1));
 
-    let portal = ZonePortal::new(portal_address, l1_provider);
-    let mut recovered = Vec::new();
-    let mut page_from = from;
-    while page_from <= finalized {
-        let page_to = page_from
-            .saturating_add(RECOVERY_LOG_QUERY_BLOCKS - 1)
-            .min(finalized);
-        let events = portal
-            .BatchSubmitted_filter()
-            .from_block(page_from)
-            .to_block(page_to)
-            .query()
+        let portal = ZonePortal::new(self.portal_address, &self.l1_provider);
+        let mut recovered = Vec::new();
+        let mut page_from = from;
+        while page_from <= finalized {
+            let page_to = page_from
+                .saturating_add(RECOVERY_LOG_QUERY_BLOCKS - 1)
+                .min(finalized);
+            let events = portal
+                .BatchSubmitted_filter()
+                .from_block(page_from)
+                .to_block(page_to)
+                .query()
+                .await
+                .wrap_err_with(|| {
+                    format!("query BatchSubmitted logs in finalized range {page_from}..={page_to}")
+                })?;
+
+            for (event, log) in events {
+                let tx_hash = log
+                    .transaction_hash
+                    .ok_or_eyre("finalized BatchSubmitted log has no transaction hash")?;
+                let log_index = log
+                    .log_index
+                    .ok_or_eyre("finalized BatchSubmitted log has no log index")?;
+                recovered.push(FinalizedBatchSubmission {
+                    block_number: log
+                        .block_number
+                        .ok_or_eyre("finalized BatchSubmitted log has no block number")?,
+                    transaction_hash: tx_hash,
+                    log_index,
+                    event,
+                });
+            }
+            if page_to == finalized {
+                break;
+            }
+            page_from = page_to + 1;
+        }
+        Ok(recovered)
+    }
+
+    fn spawn_submission_retry(&self, submission: FinalizedBatchSubmission) {
+        let this = self.clone();
+        tokio::spawn(async move {
+            loop {
+                if let Err(err) = this.process_submission(&submission).await {
+                    warn!(
+                        target: "zone::node::shadow_prover",
+                        transaction_hash = %submission.transaction_hash,
+                        log_index = submission.log_index,
+                        error = ?err,
+                        "Failed to process finalized batch submission; retrying"
+                    );
+                    tokio::time::sleep(POLL_INTERVAL).await;
+                    continue;
+                }
+                return;
+            }
+        });
+    }
+
+    async fn process_submission(&self, submission: &FinalizedBatchSubmission) -> Result<()> {
+        let call = self
+            .fetch_submit_batch_calls(submission.transaction_hash)
+            .await?
+            .into_iter()
+            .find(|call| call_matches_event(call, &submission.event))
+            .ok_or_eyre(format!(
+                "submitBatch transaction {} contains no call matching log {}",
+                submission.transaction_hash, submission.log_index
+            ))?;
+        let (to, batch, anchor) = self
+            .submission_target(&call, &submission.event, submission.block_number)
             .await
             .wrap_err_with(|| {
-                format!("query BatchSubmitted logs in finalized range {page_from}..={page_to}")
+                format!(
+                    "validate finalized submitBatch transaction {}",
+                    submission.transaction_hash
+                )
             })?;
 
-        for (event, log) in events {
-            let tx_hash = log
-                .transaction_hash
-                .ok_or_eyre("finalized BatchSubmitted log has no transaction hash")?;
-            let log_index = log
-                .log_index
-                .ok_or_eyre("finalized BatchSubmitted log has no log index")?;
-            recovered.push(FinalizedBatchSubmission {
-                block_number: log
-                    .block_number
-                    .ok_or_eyre("finalized BatchSubmitted log has no block number")?,
-                transaction_hash: tx_hash,
-                log_index,
-                event,
-            });
-        }
-        if page_to == finalized {
-            break;
-        }
-        page_from = page_to + 1;
-    }
-    Ok(recovered)
-}
-
-fn spawn_submission_retry<P: ZoneSequencerProvider>(
-    portal_address: Address,
-    zone_provider: &P,
-    l1_provider: &DynProvider<TempoNetwork>,
-    prover: &ShadowProver,
-    submission: FinalizedBatchSubmission,
-    observed: &mut HashSet<(B256, u64)>,
-) {
-    let observation_id = (submission.transaction_hash, submission.log_index);
-    if !observed.insert(observation_id) {
-        return;
+        self.wait_and_enqueue(to, batch, anchor).await
     }
 
-    let zone_provider = zone_provider.clone();
-    let l1_provider = l1_provider.clone();
-    let prover = prover.clone();
-    tokio::spawn(async move {
-        loop {
-            if let Err(err) = process_submission(
-                portal_address,
-                &zone_provider,
-                &l1_provider,
-                &prover,
-                &submission,
-            )
-            .await
-            {
-                warn!(
-                    target: "zone::node::shadow_prover",
-                    transaction_hash = %submission.transaction_hash,
-                    log_index = submission.log_index,
-                    error = ?err,
-                    "Failed to process finalized batch submission; retrying"
-                );
-                tokio::time::sleep(POLL_INTERVAL).await;
+    async fn fetch_submit_batch_calls(
+        &self,
+        tx_hash: B256,
+    ) -> Result<Vec<ZonePortal::submitBatchCall>> {
+        let tx = self
+            .l1_provider
+            .client()
+            .request::<_, serde_json::Value>("eth_getTransactionByHash", (tx_hash,))
+            .await?
+            .as_object()
+            .cloned()
+            .ok_or_eyre(format!("submitBatch transaction {tx_hash} was not found"))?;
+
+        let mut candidates = Vec::new();
+        candidates.push(serde_json::Value::Object(tx.clone()));
+        if let Some(calls) = tx.get("calls").and_then(serde_json::Value::as_array) {
+            candidates.extend(calls.iter().cloned());
+        }
+
+        let mut calls = Vec::new();
+        for candidate in candidates {
+            let Some(to) = candidate
+                .get("to")
+                .and_then(serde_json::Value::as_str)
+                .and_then(|value| Address::from_str(value).ok())
+            else {
+                continue;
+            };
+            if to != self.portal_address {
                 continue;
             }
-            return;
+            let Some(input) = candidate
+                .get("input")
+                .and_then(serde_json::Value::as_str)
+                .filter(|input| *input != "0x")
+            else {
+                continue;
+            };
+            let Ok(calldata) = Bytes::from_str(input) else {
+                continue;
+            };
+            if let Ok(call) = ZonePortal::submitBatchCall::abi_decode(&calldata) {
+                calls.push(call);
+            }
         }
-    });
-}
 
-async fn process_submission<P: ZoneSequencerProvider>(
-    portal_address: Address,
-    zone_provider: &P,
-    l1_provider: &DynProvider<TempoNetwork>,
-    prover: &ShadowProver,
-    submission: &FinalizedBatchSubmission,
-) -> Result<()> {
-    let call = fetch_submit_batch_calls(l1_provider, portal_address, submission.transaction_hash)
-        .await?
-        .into_iter()
-        .find(|call| call_matches_event(call, &submission.event))
-        .ok_or_eyre(format!(
-            "submitBatch transaction {} contains no call matching log {}",
-            submission.transaction_hash, submission.log_index
-        ))?;
-    let (to, batch, anchor) = submission_target(
-        l1_provider,
-        &call,
-        &submission.event,
-        submission.block_number,
-    )
-    .await
-    .wrap_err_with(|| {
-        format!(
-            "validate finalized submitBatch transaction {}",
-            submission.transaction_hash
-        )
-    })?;
-
-    wait_and_enqueue(zone_provider.clone(), prover.clone(), to, batch, anchor).await
-}
-
-async fn fetch_submit_batch_calls(
-    provider: &DynProvider<TempoNetwork>,
-    portal: Address,
-    tx_hash: B256,
-) -> Result<Vec<ZonePortal::submitBatchCall>> {
-    let tx = provider
-        .client()
-        .request::<_, serde_json::Value>("eth_getTransactionByHash", (tx_hash,))
-        .await?
-        .as_object()
-        .cloned()
-        .ok_or_eyre(format!("submitBatch transaction {tx_hash} was not found"))?;
-
-    let mut candidates = Vec::new();
-    candidates.push(serde_json::Value::Object(tx.clone()));
-    if let Some(calls) = tx.get("calls").and_then(serde_json::Value::as_array) {
-        candidates.extend(calls.iter().cloned());
+        ensure!(
+            !calls.is_empty(),
+            "transaction {tx_hash} contains no submitBatch call to Portal {}",
+            self.portal_address
+        );
+        Ok(calls)
     }
 
-    let mut calls = Vec::new();
-    for candidate in candidates {
-        let Some(to) = candidate
-            .get("to")
-            .and_then(serde_json::Value::as_str)
-            .and_then(|value| Address::from_str(value).ok())
-        else {
-            continue;
-        };
-        if to != portal {
-            continue;
-        }
-        let Some(input) = candidate
-            .get("input")
-            .and_then(serde_json::Value::as_str)
-            .filter(|input| *input != "0x")
-        else {
-            continue;
-        };
-        let Ok(calldata) = Bytes::from_str(input) else {
-            continue;
-        };
-        if let Ok(call) = ZonePortal::submitBatchCall::abi_decode(&calldata) {
-            calls.push(call);
-        }
+    async fn submission_target(
+        &self,
+        call: &ZonePortal::submitBatchCall,
+        event: &ZonePortal::BatchSubmitted,
+        submission_block_number: u64,
+    ) -> Result<(u64, BatchData, ShadowProofAnchor)> {
+        ensure!(
+            !call.signatures.is_empty(),
+            "accepted submitBatch call has an empty quorum certificate"
+        );
+        let to =
+            u64::try_from(call.nextZoneHeight).wrap_err("submitted Zone height overflows u64")?;
+        let anchor_number =
+            submitted_anchor_number(call.tempoBlockNumber, call.recentTempoBlockNumber)?;
+        ensure!(
+            anchor_number <= submission_block_number,
+            "submitted anchor {anchor_number} is above submission block {submission_block_number}"
+        );
+        let anchor_hash = self
+            .l1_provider
+            .get_header_by_number(anchor_number.into())
+            .await?
+            .ok_or_eyre(format!(
+                "submitted Tempo anchor {anchor_number} is unavailable"
+            ))?
+            .hash_slow();
+
+        Ok((
+            to,
+            BatchData {
+                zone_height: to,
+                tempo_block_number: call.tempoBlockNumber,
+                prev_block_hash: call.blockTransition.prevBlockHash,
+                next_block_hash: call.blockTransition.nextBlockHash,
+                prev_processed_deposit_hash: call.depositQueueTransition.prevProcessedHash,
+                next_processed_deposit_hash: call.depositQueueTransition.nextProcessedHash,
+                prev_deposit_number: call.depositQueueTransition.prevDepositNumber,
+                next_deposit_number: call.depositQueueTransition.nextDepositNumber,
+                withdrawal_queue_hash: call.withdrawalQueueHash,
+                withdrawal_batch_index: event.withdrawalBatchIndex,
+            },
+            ShadowProofAnchor {
+                number: anchor_number,
+                hash: anchor_hash,
+            },
+        ))
     }
 
-    ensure!(
-        !calls.is_empty(),
-        "transaction {tx_hash} contains no submitBatch call to Portal {portal}"
-    );
-    Ok(calls)
+    async fn wait_and_enqueue(
+        &self,
+        to: u64,
+        batch: BatchData,
+        anchor: ShadowProofAnchor,
+    ) -> Result<()> {
+        let from = loop {
+            if batch.prev_block_hash.is_zero() {
+                break 1;
+            }
+            if let Some(previous) = self.zone_provider.block_number(batch.prev_block_hash)? {
+                break previous.saturating_add(1);
+            }
+            tokio::time::sleep(POLL_INTERVAL).await;
+        };
+        ensure!(from <= to, "submitted Zone range {from}..={to} is invalid");
+
+        loop {
+            let local_head = self.zone_provider.last_block_number()?;
+            if local_head >= to {
+                break;
+            }
+            tokio::time::sleep(POLL_INTERVAL).await;
+        }
+
+        ensure!(
+            self.zone_provider.block_hash(to)? == Some(batch.next_block_hash),
+            "local canonical Zone block {to} does not match finalized submission {}",
+            batch.next_block_hash
+        );
+        if from > 1 {
+            ensure!(
+                self.zone_provider.block_hash(from - 1)? == Some(batch.prev_block_hash),
+                "local parent of Zone range {from}..={to} does not match finalized submission {}",
+                batch.prev_block_hash
+            );
+        }
+
+        info!(
+            target: "zone::node::shadow_prover",
+            zone_from = from,
+            zone_to = to,
+            anchor_number = anchor.number,
+            anchor_hash = %anchor.hash,
+            "Queueing finalized quorum-certified batch for shadow proving"
+        );
+        self.prover
+            .enqueue_with_anchor(from, to, batch, anchor)
+            .await
+    }
 }
 
 fn call_matches_event(
@@ -262,102 +351,6 @@ fn call_matches_event(
         && event.nextProcessedDepositQueueHash == call.depositQueueTransition.nextProcessedHash
         && event.lastProcessedDepositNumber == call.depositQueueTransition.nextDepositNumber
         && event.withdrawalQueueHash == call.withdrawalQueueHash
-}
-
-async fn submission_target(
-    l1_provider: &DynProvider<TempoNetwork>,
-    call: &ZonePortal::submitBatchCall,
-    event: &ZonePortal::BatchSubmitted,
-    submission_block_number: u64,
-) -> Result<(u64, BatchData, ShadowProofAnchor)> {
-    ensure!(
-        !call.signatures.is_empty(),
-        "accepted submitBatch call has an empty quorum certificate"
-    );
-    let to = u64::try_from(call.nextZoneHeight).wrap_err("submitted Zone height overflows u64")?;
-    let anchor_number =
-        submitted_anchor_number(call.tempoBlockNumber, call.recentTempoBlockNumber)?;
-    ensure!(
-        anchor_number <= submission_block_number,
-        "submitted anchor {anchor_number} is above submission block {submission_block_number}"
-    );
-    let anchor_hash = l1_provider
-        .get_header_by_number(anchor_number.into())
-        .await?
-        .ok_or_eyre(format!(
-            "submitted Tempo anchor {anchor_number} is unavailable"
-        ))?
-        .hash_slow();
-
-    Ok((
-        to,
-        BatchData {
-            zone_height: to,
-            tempo_block_number: call.tempoBlockNumber,
-            prev_block_hash: call.blockTransition.prevBlockHash,
-            next_block_hash: call.blockTransition.nextBlockHash,
-            prev_processed_deposit_hash: call.depositQueueTransition.prevProcessedHash,
-            next_processed_deposit_hash: call.depositQueueTransition.nextProcessedHash,
-            prev_deposit_number: call.depositQueueTransition.prevDepositNumber,
-            next_deposit_number: call.depositQueueTransition.nextDepositNumber,
-            withdrawal_queue_hash: call.withdrawalQueueHash,
-            withdrawal_batch_index: event.withdrawalBatchIndex,
-        },
-        ShadowProofAnchor {
-            number: anchor_number,
-            hash: anchor_hash,
-        },
-    ))
-}
-
-async fn wait_and_enqueue<P: ZoneSequencerProvider>(
-    zone_provider: P,
-    prover: ShadowProver,
-    to: u64,
-    batch: BatchData,
-    anchor: ShadowProofAnchor,
-) -> Result<()> {
-    let from = loop {
-        if batch.prev_block_hash.is_zero() {
-            break 1;
-        }
-        if let Some(previous) = zone_provider.block_number(batch.prev_block_hash)? {
-            break previous.saturating_add(1);
-        }
-        tokio::time::sleep(POLL_INTERVAL).await;
-    };
-    ensure!(from <= to, "submitted Zone range {from}..={to} is invalid");
-
-    loop {
-        let local_head = zone_provider.last_block_number()?;
-        if local_head >= to {
-            break;
-        }
-        tokio::time::sleep(POLL_INTERVAL).await;
-    }
-
-    ensure!(
-        zone_provider.block_hash(to)? == Some(batch.next_block_hash),
-        "local canonical Zone block {to} does not match finalized submission {}",
-        batch.next_block_hash
-    );
-    if from > 1 {
-        ensure!(
-            zone_provider.block_hash(from - 1)? == Some(batch.prev_block_hash),
-            "local parent of Zone range {from}..={to} does not match finalized submission {}",
-            batch.prev_block_hash
-        );
-    }
-
-    info!(
-        target: "zone::node::shadow_prover",
-        zone_from = from,
-        zone_to = to,
-        anchor_number = anchor.number,
-        anchor_hash = %anchor.hash,
-        "Queueing finalized quorum-certified batch for shadow proving"
-    );
-    prover.enqueue_with_anchor(from, to, batch, anchor).await
 }
 
 fn submitted_anchor_number(tempo_block_number: u64, recent_tempo_block_number: u64) -> Result<u64> {

--- a/crates/node/src/shadow_prover.rs
+++ b/crates/node/src/shadow_prover.rs
@@ -1,0 +1,344 @@
+//! Finalized L1 batch observation for RPC-only shadow provers.
+
+use std::{collections::HashSet, str::FromStr as _, time::Duration};
+
+use alloy_consensus::{BlockHeader as _, Sealable as _};
+use alloy_eips::BlockNumberOrTag;
+use alloy_primitives::{Address, B256, Bytes};
+use alloy_provider::{DynProvider, Provider as _};
+use alloy_sol_types::SolCall as _;
+use eyre::{OptionExt as _, Result, WrapErr as _, ensure};
+use tempo_alloy::TempoNetwork;
+use tempo_zone_contracts::ZonePortal;
+use tracing::{error, info, warn};
+use zone_sequencer::{
+    BatchAnchorConfig, BatchData, ShadowProofAnchor, ShadowProver, ZoneSequencerProvider,
+};
+
+const POLL_INTERVAL: Duration = Duration::from_secs(1);
+
+/// Observe finalized `submitBatch` calls and feed their exact settlement inputs to the detached
+/// prover. The Portal has already verified the included quorum certificate before emitting the
+/// event; decoding the call binds the proof job to that accepted certificate.
+pub(crate) async fn run_finalized_batch_observer<P: ZoneSequencerProvider>(
+    portal_address: Address,
+    anchor_config: BatchAnchorConfig,
+    zone_provider: P,
+    l1_provider: DynProvider<TempoNetwork>,
+    prover: ShadowProver,
+) {
+    let mut next_block = None;
+    let mut observed = HashSet::new();
+
+    loop {
+        let result = observe_once(
+            portal_address,
+            anchor_config,
+            &zone_provider,
+            &l1_provider,
+            &prover,
+            &mut next_block,
+            &mut observed,
+        )
+        .await;
+        if let Err(err) = result {
+            warn!(
+                target: "zone::node::shadow_prover",
+                error = ?err,
+                "Failed to observe finalized batch submissions; retrying"
+            );
+        }
+        tokio::time::sleep(POLL_INTERVAL).await;
+    }
+}
+
+async fn observe_once<P: ZoneSequencerProvider>(
+    portal_address: Address,
+    anchor_config: BatchAnchorConfig,
+    zone_provider: &P,
+    l1_provider: &DynProvider<TempoNetwork>,
+    prover: &ShadowProver,
+    next_block: &mut Option<u64>,
+    observed: &mut HashSet<(B256, u64)>,
+) -> Result<()> {
+    let finalized = l1_provider
+        .get_header_by_number(BlockNumberOrTag::Finalized)
+        .await?
+        .ok_or_eyre("L1 finalized block is not available")?
+        .number();
+    let from = next_block.unwrap_or_else(|| {
+        finalized.saturating_sub(anchor_config.history_window().saturating_sub(1))
+    });
+    if from > finalized {
+        return Ok(());
+    }
+
+    let portal = ZonePortal::new(portal_address, l1_provider);
+    let events = portal
+        .BatchSubmitted_filter()
+        .from_block(from)
+        .to_block(finalized)
+        .query()
+        .await
+        .wrap_err_with(|| {
+            format!("query BatchSubmitted logs in finalized range {from}..={finalized}")
+        })?;
+
+    for (event, log) in events {
+        let tx_hash = log
+            .transaction_hash
+            .ok_or_eyre("finalized BatchSubmitted log has no transaction hash")?;
+        let log_index = log
+            .log_index
+            .ok_or_eyre("finalized BatchSubmitted log has no log index")?;
+        let observation_id = (tx_hash, log_index);
+        if observed.contains(&observation_id) {
+            continue;
+        }
+
+        let call = fetch_submit_batch_calls(l1_provider, portal_address, tx_hash)
+            .await?
+            .into_iter()
+            .find(|call| call_matches_event(call, &event))
+            .ok_or_eyre(format!(
+                "submitBatch transaction {tx_hash} contains no call matching log {log_index}"
+            ))?;
+        let (from, to, batch, anchor) =
+            submission_target(zone_provider, l1_provider, &call, &event, finalized)
+                .await
+                .wrap_err_with(|| {
+                    format!("validate finalized submitBatch transaction {tx_hash}")
+                })?;
+
+        observed.insert(observation_id);
+        let zone_provider = zone_provider.clone();
+        let prover = prover.clone();
+        tokio::spawn(async move {
+            if let Err(err) = wait_and_enqueue(zone_provider, prover, from, to, batch, anchor).await
+            {
+                error!(
+                    target: "zone::node::shadow_prover",
+                    transaction_hash = %tx_hash,
+                    error = ?err,
+                    "Could not enqueue finalized batch for shadow proving"
+                );
+            }
+        });
+    }
+
+    *next_block = Some(finalized.saturating_add(1));
+    Ok(())
+}
+
+async fn fetch_submit_batch_calls(
+    provider: &DynProvider<TempoNetwork>,
+    portal: Address,
+    tx_hash: B256,
+) -> Result<Vec<ZonePortal::submitBatchCall>> {
+    let tx = provider
+        .client()
+        .request::<_, serde_json::Value>("eth_getTransactionByHash", (tx_hash,))
+        .await?
+        .as_object()
+        .cloned()
+        .ok_or_eyre(format!("submitBatch transaction {tx_hash} was not found"))?;
+
+    let mut candidates = Vec::new();
+    candidates.push(serde_json::Value::Object(tx.clone()));
+    if let Some(calls) = tx.get("calls").and_then(serde_json::Value::as_array) {
+        candidates.extend(calls.iter().cloned());
+    }
+
+    let mut calls = Vec::new();
+    for candidate in candidates {
+        let Some(to) = candidate
+            .get("to")
+            .and_then(serde_json::Value::as_str)
+            .and_then(|value| Address::from_str(value).ok())
+        else {
+            continue;
+        };
+        if to != portal {
+            continue;
+        }
+        let Some(input) = candidate
+            .get("input")
+            .and_then(serde_json::Value::as_str)
+            .filter(|input| *input != "0x")
+        else {
+            continue;
+        };
+        let Ok(calldata) = Bytes::from_str(input) else {
+            continue;
+        };
+        if let Ok(call) = ZonePortal::submitBatchCall::abi_decode(&calldata) {
+            calls.push(call);
+        }
+    }
+
+    ensure!(
+        !calls.is_empty(),
+        "transaction {tx_hash} contains no submitBatch call to Portal {portal}"
+    );
+    Ok(calls)
+}
+
+fn call_matches_event(
+    call: &ZonePortal::submitBatchCall,
+    event: &ZonePortal::BatchSubmitted,
+) -> bool {
+    event.nextBlockHash == call.blockTransition.nextBlockHash
+        && event.nextProcessedDepositQueueHash == call.depositQueueTransition.nextProcessedHash
+        && event.lastProcessedDepositNumber == call.depositQueueTransition.nextDepositNumber
+        && event.withdrawalQueueHash == call.withdrawalQueueHash
+}
+
+async fn submission_target<P: ZoneSequencerProvider>(
+    zone_provider: &P,
+    l1_provider: &DynProvider<TempoNetwork>,
+    call: &ZonePortal::submitBatchCall,
+    event: &ZonePortal::BatchSubmitted,
+    finalized: u64,
+) -> Result<(u64, u64, BatchData, ShadowProofAnchor)> {
+    ensure!(
+        !call.signatures.is_empty(),
+        "accepted submitBatch call has an empty quorum certificate"
+    );
+    let to = u64::try_from(call.nextZoneHeight).wrap_err("submitted Zone height overflows u64")?;
+    ensure!(
+        event.nextBlockHash == call.blockTransition.nextBlockHash,
+        "BatchSubmitted next block hash does not match calldata"
+    );
+    ensure!(
+        event.nextProcessedDepositQueueHash == call.depositQueueTransition.nextProcessedHash,
+        "BatchSubmitted deposit hash does not match calldata"
+    );
+    ensure!(
+        event.lastProcessedDepositNumber == call.depositQueueTransition.nextDepositNumber,
+        "BatchSubmitted deposit number does not match calldata"
+    );
+    ensure!(
+        event.withdrawalQueueHash == call.withdrawalQueueHash,
+        "BatchSubmitted withdrawal hash does not match calldata"
+    );
+
+    let from = if call.blockTransition.prevBlockHash.is_zero() {
+        1
+    } else {
+        zone_provider
+            .block_number(call.blockTransition.prevBlockHash)?
+            .ok_or_eyre(format!(
+                "submitted previous Zone block {} is not available locally",
+                call.blockTransition.prevBlockHash
+            ))?
+            .saturating_add(1)
+    };
+    ensure!(from <= to, "submitted Zone range {from}..={to} is invalid");
+
+    let anchor_number =
+        submitted_anchor_number(call.tempoBlockNumber, call.recentTempoBlockNumber)?;
+    ensure!(
+        anchor_number <= finalized,
+        "submitted anchor {anchor_number} is above finalized L1 height {finalized}"
+    );
+    let anchor_hash = l1_provider
+        .get_header_by_number(anchor_number.into())
+        .await?
+        .ok_or_eyre(format!(
+            "submitted Tempo anchor {anchor_number} is unavailable"
+        ))?
+        .hash_slow();
+
+    Ok((
+        from,
+        to,
+        BatchData {
+            zone_height: to,
+            tempo_block_number: call.tempoBlockNumber,
+            prev_block_hash: call.blockTransition.prevBlockHash,
+            next_block_hash: call.blockTransition.nextBlockHash,
+            prev_processed_deposit_hash: call.depositQueueTransition.prevProcessedHash,
+            next_processed_deposit_hash: call.depositQueueTransition.nextProcessedHash,
+            prev_deposit_number: call.depositQueueTransition.prevDepositNumber,
+            next_deposit_number: call.depositQueueTransition.nextDepositNumber,
+            withdrawal_queue_hash: call.withdrawalQueueHash,
+            withdrawal_batch_index: event.withdrawalBatchIndex,
+        },
+        ShadowProofAnchor {
+            number: anchor_number,
+            hash: anchor_hash,
+        },
+    ))
+}
+
+async fn wait_and_enqueue<P: ZoneSequencerProvider>(
+    zone_provider: P,
+    prover: ShadowProver,
+    from: u64,
+    to: u64,
+    batch: BatchData,
+    anchor: ShadowProofAnchor,
+) -> Result<()> {
+    loop {
+        let local_head = zone_provider.last_block_number()?;
+        if local_head >= to {
+            break;
+        }
+        tokio::time::sleep(POLL_INTERVAL).await;
+    }
+
+    ensure!(
+        zone_provider.block_hash(to)? == Some(batch.next_block_hash),
+        "local canonical Zone block {to} does not match finalized submission {}",
+        batch.next_block_hash
+    );
+    if from > 1 {
+        ensure!(
+            zone_provider.block_hash(from - 1)? == Some(batch.prev_block_hash),
+            "local parent of Zone range {from}..={to} does not match finalized submission {}",
+            batch.prev_block_hash
+        );
+    }
+
+    info!(
+        target: "zone::node::shadow_prover",
+        zone_from = from,
+        zone_to = to,
+        anchor_number = anchor.number,
+        anchor_hash = %anchor.hash,
+        "Queueing finalized quorum-certified batch for shadow proving"
+    );
+    prover.enqueue_with_anchor(from, to, batch, anchor).await
+}
+
+fn submitted_anchor_number(tempo_block_number: u64, recent_tempo_block_number: u64) -> Result<u64> {
+    if recent_tempo_block_number == 0 {
+        return Ok(tempo_block_number);
+    }
+    ensure!(
+        recent_tempo_block_number > tempo_block_number,
+        "submitted ancestry anchor does not follow its Tempo checkpoint"
+    );
+    Ok(recent_tempo_block_number)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn direct_submission_anchors_to_checkpoint() {
+        assert_eq!(submitted_anchor_number(42, 0).unwrap(), 42);
+    }
+
+    #[test]
+    fn ancestry_submission_uses_committed_recent_block() {
+        assert_eq!(submitted_anchor_number(42, 100).unwrap(), 100);
+    }
+
+    #[test]
+    fn ancestry_submission_must_follow_checkpoint() {
+        assert!(submitted_anchor_number(42, 42).is_err());
+        assert!(submitted_anchor_number(42, 41).is_err());
+    }
+}

--- a/crates/node/src/shadow_prover.rs
+++ b/crates/node/src/shadow_prover.rs
@@ -1,10 +1,10 @@
 //! Finalized L1 batch observation for RPC-only shadow provers.
 
-use std::{collections::HashSet, str::FromStr as _, time::Duration};
+use std::{collections::HashSet, time::Duration};
 
 use alloy_consensus::{BlockHeader as _, Sealable as _};
 use alloy_eips::BlockNumberOrTag;
-use alloy_primitives::{Address, B256, Bytes};
+use alloy_primitives::{Address, B256, TxKind};
 use alloy_provider::{DynProvider, Provider as _};
 use alloy_sol_types::SolCall as _;
 use eyre::{OptionExt as _, Result, WrapErr as _, ensure};
@@ -74,15 +74,8 @@ impl<P: ZoneSequencerProvider> RpcFollowerShadowProver<P> {
                 if recovery_sender.is_closed() {
                     return;
                 }
-                match this.recover_recent_submissions().await {
-                    Ok(recovered) => {
-                        for submission in recovered {
-                            if recovery_sender.send(submission).is_err() {
-                                return;
-                            }
-                        }
-                        return;
-                    }
+                match this.recover_recent_submissions(&recovery_sender).await {
+                    Ok(()) => return,
                     Err(err) => {
                         warn!(
                             target: "zone::node::shadow_prover",
@@ -96,7 +89,10 @@ impl<P: ZoneSequencerProvider> RpcFollowerShadowProver<P> {
         });
     }
 
-    async fn recover_recent_submissions(&self) -> Result<Vec<FinalizedBatchSubmission>> {
+    async fn recover_recent_submissions(
+        &self,
+        recovery_sender: &UnboundedSender<FinalizedBatchSubmission>,
+    ) -> Result<()> {
         let finalized = self
             .l1_provider
             .get_header_by_number(BlockNumberOrTag::Finalized)
@@ -106,7 +102,6 @@ impl<P: ZoneSequencerProvider> RpcFollowerShadowProver<P> {
         let from = finalized.saturating_sub(self.anchor_config.history_window().saturating_sub(1));
 
         let portal = ZonePortal::new(self.portal_address, &self.l1_provider);
-        let mut recovered = Vec::new();
         let mut page_from = from;
         while page_from <= finalized {
             let page_to = page_from
@@ -129,21 +124,24 @@ impl<P: ZoneSequencerProvider> RpcFollowerShadowProver<P> {
                 let log_index = log
                     .log_index
                     .ok_or_eyre("finalized BatchSubmitted log has no log index")?;
-                recovered.push(FinalizedBatchSubmission {
+                let submission = FinalizedBatchSubmission {
                     block_number: log
                         .block_number
                         .ok_or_eyre("finalized BatchSubmitted log has no block number")?,
                     transaction_hash: tx_hash,
                     log_index,
                     event,
-                });
+                };
+                if recovery_sender.send(submission).is_err() {
+                    return Ok(());
+                }
             }
             if page_to == finalized {
                 break;
             }
             page_from = page_to + 1;
         }
-        Ok(recovered)
+        Ok(())
     }
 
     fn spawn_submission_retry(&self, submission: FinalizedBatchSubmission) {
@@ -195,45 +193,21 @@ impl<P: ZoneSequencerProvider> RpcFollowerShadowProver<P> {
     ) -> Result<Vec<ZonePortal::submitBatchCall>> {
         let tx = self
             .l1_provider
-            .client()
-            .request::<_, serde_json::Value>("eth_getTransactionByHash", (tx_hash,))
+            .get_transaction_by_hash(tx_hash)
             .await?
-            .as_object()
-            .cloned()
             .ok_or_eyre(format!("submitBatch transaction {tx_hash} was not found"))?;
 
-        let mut candidates = Vec::new();
-        candidates.push(serde_json::Value::Object(tx.clone()));
-        if let Some(calls) = tx.get("calls").and_then(serde_json::Value::as_array) {
-            candidates.extend(calls.iter().cloned());
-        }
-
-        let mut calls = Vec::new();
-        for candidate in candidates {
-            let Some(to) = candidate
-                .get("to")
-                .and_then(serde_json::Value::as_str)
-                .and_then(|value| Address::from_str(value).ok())
-            else {
-                continue;
-            };
-            if to != self.portal_address {
-                continue;
-            }
-            let Some(input) = candidate
-                .get("input")
-                .and_then(serde_json::Value::as_str)
-                .filter(|input| *input != "0x")
-            else {
-                continue;
-            };
-            let Ok(calldata) = Bytes::from_str(input) else {
-                continue;
-            };
-            if let Ok(call) = ZonePortal::submitBatchCall::abi_decode(&calldata) {
-                calls.push(call);
-            }
-        }
+        let calls = tx
+            .inner
+            .inner()
+            .calls()
+            .filter_map(|(kind, input)| {
+                if kind != TxKind::Call(self.portal_address) {
+                    return None;
+                }
+                ZonePortal::submitBatchCall::abi_decode(input).ok()
+            })
+            .collect::<Vec<_>>();
 
         ensure!(
             !calls.is_empty(),

--- a/crates/node/src/shadow_prover.rs
+++ b/crates/node/src/shadow_prover.rs
@@ -1,6 +1,6 @@
 //! Finalized L1 batch observation for RPC-only shadow provers.
 
-use std::{collections::HashSet, str::FromStr as _, time::Duration};
+use std::{collections::HashSet, str::FromStr as _, sync::Arc, time::Duration};
 
 use alloy_consensus::{BlockHeader as _, Sealable as _};
 use alloy_eips::BlockNumberOrTag;
@@ -10,12 +10,33 @@ use alloy_sol_types::SolCall as _;
 use eyre::{OptionExt as _, Result, WrapErr as _, ensure};
 use tempo_alloy::TempoNetwork;
 use tempo_zone_contracts::ZonePortal;
+use tokio::sync::mpsc::{UnboundedReceiver, UnboundedSender};
 use tracing::{error, info, warn};
+use zone_l1::{FinalizedBatchSubmission, FinalizedBatchSubmissionSink};
 use zone_sequencer::{
     BatchAnchorConfig, BatchData, ShadowProofAnchor, ShadowProver, ZoneSequencerProvider,
 };
 
 const POLL_INTERVAL: Duration = Duration::from_secs(1);
+
+#[derive(Debug)]
+struct ShadowProverSubmissionSink {
+    sender: UnboundedSender<FinalizedBatchSubmission>,
+}
+
+impl FinalizedBatchSubmissionSink for ShadowProverSubmissionSink {
+    fn observe_finalized_batch(&self, submission: FinalizedBatchSubmission) {
+        let _ = self.sender.send(submission);
+    }
+}
+
+pub(crate) fn finalized_batch_submission_channel() -> (
+    Arc<dyn FinalizedBatchSubmissionSink>,
+    UnboundedReceiver<FinalizedBatchSubmission>,
+) {
+    let (sender, receiver) = tokio::sync::mpsc::unbounded_channel();
+    (Arc::new(ShadowProverSubmissionSink { sender }), receiver)
+}
 
 /// Observe finalized `submitBatch` calls and feed their exact settlement inputs to the detached
 /// prover. The Portal has already verified the included quorum certificate before emitting the
@@ -26,52 +47,75 @@ pub(crate) async fn run_finalized_batch_observer<P: ZoneSequencerProvider>(
     zone_provider: P,
     l1_provider: DynProvider<TempoNetwork>,
     prover: ShadowProver,
+    mut submissions: UnboundedReceiver<FinalizedBatchSubmission>,
 ) {
-    let mut next_block = None;
     let mut observed = HashSet::new();
 
     loop {
-        let result = observe_once(
+        match recover_recent_submissions(portal_address, anchor_config, &l1_provider).await {
+            Ok(recovered) => {
+                for submission in recovered {
+                    if let Err(err) = queue_submission(
+                        portal_address,
+                        &zone_provider,
+                        &l1_provider,
+                        &prover,
+                        submission,
+                        &mut observed,
+                    )
+                    .await
+                    {
+                        warn!(
+                            target: "zone::node::shadow_prover",
+                            error = ?err,
+                            "Failed to recover finalized batch submission"
+                        );
+                    }
+                }
+                break;
+            }
+            Err(err) => {
+                warn!(
+                    target: "zone::node::shadow_prover",
+                    error = ?err,
+                    "Failed to recover recent finalized batch submissions; retrying"
+                );
+                tokio::time::sleep(POLL_INTERVAL).await;
+            }
+        }
+    }
+
+    while let Some(submission) = submissions.recv().await {
+        if let Err(err) = queue_submission(
             portal_address,
-            anchor_config,
             &zone_provider,
             &l1_provider,
             &prover,
-            &mut next_block,
+            submission,
             &mut observed,
         )
-        .await;
-        if let Err(err) = result {
+        .await
+        {
             warn!(
                 target: "zone::node::shadow_prover",
                 error = ?err,
-                "Failed to observe finalized batch submissions; retrying"
+                "Failed to process finalized batch submission"
             );
         }
-        tokio::time::sleep(POLL_INTERVAL).await;
     }
 }
 
-async fn observe_once<P: ZoneSequencerProvider>(
+async fn recover_recent_submissions(
     portal_address: Address,
     anchor_config: BatchAnchorConfig,
-    zone_provider: &P,
     l1_provider: &DynProvider<TempoNetwork>,
-    prover: &ShadowProver,
-    next_block: &mut Option<u64>,
-    observed: &mut HashSet<(B256, u64)>,
-) -> Result<()> {
+) -> Result<Vec<FinalizedBatchSubmission>> {
     let finalized = l1_provider
         .get_header_by_number(BlockNumberOrTag::Finalized)
         .await?
         .ok_or_eyre("L1 finalized block is not available")?
         .number();
-    let from = next_block.unwrap_or_else(|| {
-        finalized.saturating_sub(anchor_config.history_window().saturating_sub(1))
-    });
-    if from > finalized {
-        return Ok(());
-    }
+    let from = finalized.saturating_sub(anchor_config.history_window().saturating_sub(1));
 
     let portal = ZonePortal::new(portal_address, l1_provider);
     let events = portal
@@ -84,49 +128,75 @@ async fn observe_once<P: ZoneSequencerProvider>(
             format!("query BatchSubmitted logs in finalized range {from}..={finalized}")
         })?;
 
-    for (event, log) in events {
-        let tx_hash = log
-            .transaction_hash
-            .ok_or_eyre("finalized BatchSubmitted log has no transaction hash")?;
-        let log_index = log
-            .log_index
-            .ok_or_eyre("finalized BatchSubmitted log has no log index")?;
-        let observation_id = (tx_hash, log_index);
-        if observed.contains(&observation_id) {
-            continue;
-        }
+    events
+        .into_iter()
+        .map(|(event, log)| {
+            let tx_hash = log
+                .transaction_hash
+                .ok_or_eyre("finalized BatchSubmitted log has no transaction hash")?;
+            let log_index = log
+                .log_index
+                .ok_or_eyre("finalized BatchSubmitted log has no log index")?;
+            Ok(FinalizedBatchSubmission {
+                block_number: log
+                    .block_number
+                    .ok_or_eyre("finalized BatchSubmitted log has no block number")?,
+                transaction_hash: tx_hash,
+                log_index,
+                event,
+            })
+        })
+        .collect()
+}
 
-        let call = fetch_submit_batch_calls(l1_provider, portal_address, tx_hash)
-            .await?
-            .into_iter()
-            .find(|call| call_matches_event(call, &event))
-            .ok_or_eyre(format!(
-                "submitBatch transaction {tx_hash} contains no call matching log {log_index}"
-            ))?;
-        let (from, to, batch, anchor) =
-            submission_target(zone_provider, l1_provider, &call, &event, finalized)
-                .await
-                .wrap_err_with(|| {
-                    format!("validate finalized submitBatch transaction {tx_hash}")
-                })?;
-
-        observed.insert(observation_id);
-        let zone_provider = zone_provider.clone();
-        let prover = prover.clone();
-        tokio::spawn(async move {
-            if let Err(err) = wait_and_enqueue(zone_provider, prover, from, to, batch, anchor).await
-            {
-                error!(
-                    target: "zone::node::shadow_prover",
-                    transaction_hash = %tx_hash,
-                    error = ?err,
-                    "Could not enqueue finalized batch for shadow proving"
-                );
-            }
-        });
+async fn queue_submission<P: ZoneSequencerProvider>(
+    portal_address: Address,
+    zone_provider: &P,
+    l1_provider: &DynProvider<TempoNetwork>,
+    prover: &ShadowProver,
+    submission: FinalizedBatchSubmission,
+    observed: &mut HashSet<(B256, u64)>,
+) -> Result<()> {
+    let observation_id = (submission.transaction_hash, submission.log_index);
+    if observed.contains(&observation_id) {
+        return Ok(());
     }
 
-    *next_block = Some(finalized.saturating_add(1));
+    let call = fetch_submit_batch_calls(l1_provider, portal_address, submission.transaction_hash)
+        .await?
+        .into_iter()
+        .find(|call| call_matches_event(call, &submission.event))
+        .ok_or_eyre(format!(
+            "submitBatch transaction {} contains no call matching log {}",
+            submission.transaction_hash, submission.log_index
+        ))?;
+    let (to, batch, anchor) = submission_target(
+        l1_provider,
+        &call,
+        &submission.event,
+        submission.block_number,
+    )
+    .await
+    .wrap_err_with(|| {
+        format!(
+            "validate finalized submitBatch transaction {}",
+            submission.transaction_hash
+        )
+    })?;
+
+    observed.insert(observation_id);
+    let zone_provider = zone_provider.clone();
+    let prover = prover.clone();
+    tokio::spawn(async move {
+        if let Err(err) = wait_and_enqueue(zone_provider, prover, to, batch, anchor).await {
+            error!(
+                target: "zone::node::shadow_prover",
+                transaction_hash = %submission.transaction_hash,
+                error = ?err,
+                "Could not enqueue finalized batch for shadow proving"
+            );
+        }
+    });
     Ok(())
 }
 
@@ -193,13 +263,12 @@ fn call_matches_event(
         && event.withdrawalQueueHash == call.withdrawalQueueHash
 }
 
-async fn submission_target<P: ZoneSequencerProvider>(
-    zone_provider: &P,
+async fn submission_target(
     l1_provider: &DynProvider<TempoNetwork>,
     call: &ZonePortal::submitBatchCall,
     event: &ZonePortal::BatchSubmitted,
     finalized: u64,
-) -> Result<(u64, u64, BatchData, ShadowProofAnchor)> {
+) -> Result<(u64, BatchData, ShadowProofAnchor)> {
     ensure!(
         !call.signatures.is_empty(),
         "accepted submitBatch call has an empty quorum certificate"
@@ -222,19 +291,6 @@ async fn submission_target<P: ZoneSequencerProvider>(
         "BatchSubmitted withdrawal hash does not match calldata"
     );
 
-    let from = if call.blockTransition.prevBlockHash.is_zero() {
-        1
-    } else {
-        zone_provider
-            .block_number(call.blockTransition.prevBlockHash)?
-            .ok_or_eyre(format!(
-                "submitted previous Zone block {} is not available locally",
-                call.blockTransition.prevBlockHash
-            ))?
-            .saturating_add(1)
-    };
-    ensure!(from <= to, "submitted Zone range {from}..={to} is invalid");
-
     let anchor_number =
         submitted_anchor_number(call.tempoBlockNumber, call.recentTempoBlockNumber)?;
     ensure!(
@@ -250,7 +306,6 @@ async fn submission_target<P: ZoneSequencerProvider>(
         .hash_slow();
 
     Ok((
-        from,
         to,
         BatchData {
             zone_height: to,
@@ -274,11 +329,21 @@ async fn submission_target<P: ZoneSequencerProvider>(
 async fn wait_and_enqueue<P: ZoneSequencerProvider>(
     zone_provider: P,
     prover: ShadowProver,
-    from: u64,
     to: u64,
     batch: BatchData,
     anchor: ShadowProofAnchor,
 ) -> Result<()> {
+    let from = loop {
+        if batch.prev_block_hash.is_zero() {
+            break 1;
+        }
+        if let Some(previous) = zone_provider.block_number(batch.prev_block_hash)? {
+            break previous.saturating_add(1);
+        }
+        tokio::time::sleep(POLL_INTERVAL).await;
+    };
+    ensure!(from <= to, "submitted Zone range {from}..={to} is invalid");
+
     loop {
         let local_head = zone_provider.last_block_number()?;
         if local_head >= to {

--- a/crates/node/src/shadow_prover.rs
+++ b/crates/node/src/shadow_prover.rs
@@ -1,37 +1,29 @@
 //! Finalized L1 batch observation for RPC-only shadow provers.
 
-use std::{
-    collections::{BTreeSet, HashSet},
-    time::Duration,
-};
+use std::time::Duration;
 
 use alloy_consensus::{BlockHeader as _, Sealable as _, proofs::calculate_transaction_root};
-use alloy_eips::{BlockId, BlockNumberOrTag, NumHash};
 use alloy_primitives::{Address, TxKind};
 use alloy_provider::{DynProvider, Provider as _};
 use alloy_sol_types::SolCall as _;
+use alloy_transport::{RpcError, TransportError, TransportErrorKind};
 use eyre::{OptionExt as _, Result, WrapErr as _, ensure};
 use tempo_alloy::TempoNetwork;
 use tempo_primitives::TempoTxEnvelope;
 use tempo_zone_contracts::ZonePortal;
-use tokio::sync::mpsc::{UnboundedReceiver, UnboundedSender};
-use tracing::{info, warn};
-use zone_l1::{
-    FinalizedBatchSubmission, extract_finalized_batch_submissions, verify_receipts_against_header,
-};
-use zone_sequencer::{
-    BatchAnchorConfig, BatchData, ShadowProofAnchor, ShadowProver, ZoneSequencerProvider,
-};
+use tokio::sync::mpsc::Receiver;
+use tracing::{error, info, warn};
+use zone_l1::FinalizedBatchSubmission;
+use zone_sequencer::{BatchData, ShadowProofAnchor, ShadowProver, ZoneSequencerProvider};
 
 const POLL_INTERVAL: Duration = Duration::from_secs(1);
-const RECOVERY_LOG_QUERY_BLOCKS: u64 = 1_000;
+const MAX_CONNECTION_ATTEMPTS: u32 = 5;
 
 /// Feeds finalized RPC-follower submissions and their exact settlement inputs to the detached
 /// shadow prover.
 #[derive(Clone)]
 pub(crate) struct RpcFollowerShadowProver<P> {
     portal_address: Address,
-    anchor_config: BatchAnchorConfig,
     zone_provider: P,
     l1_provider: DynProvider<TempoNetwork>,
     prover: ShadowProver,
@@ -40,14 +32,12 @@ pub(crate) struct RpcFollowerShadowProver<P> {
 impl<P: ZoneSequencerProvider> RpcFollowerShadowProver<P> {
     pub(crate) fn new(
         portal_address: Address,
-        anchor_config: BatchAnchorConfig,
         zone_provider: P,
         l1_provider: DynProvider<TempoNetwork>,
         prover: ShadowProver,
     ) -> Self {
         Self {
             portal_address,
-            anchor_config,
             zone_provider,
             l1_provider,
             prover,
@@ -57,156 +47,56 @@ impl<P: ZoneSequencerProvider> RpcFollowerShadowProver<P> {
     /// Observe finalized `submitBatch` calls. The Portal has already verified the included quorum
     /// certificate before emitting the event; decoding the call binds each proof job to that
     /// accepted certificate.
-    pub(crate) async fn run(
-        self,
-        mut submissions: UnboundedReceiver<FinalizedBatchSubmission>,
-        recovery_sender: UnboundedSender<FinalizedBatchSubmission>,
-    ) {
-        self.spawn_recovery(recovery_sender);
-
-        let mut observed = HashSet::new();
+    pub(crate) async fn run(self, mut submissions: Receiver<FinalizedBatchSubmission>) {
         while let Some(submission) = submissions.recv().await {
-            let observation_id = (
-                submission.block.hash,
-                submission.transaction_index,
-                submission.log_index,
-            );
-            if observed.insert(observation_id) {
-                self.spawn_submission_retry(submission);
-            }
+            self.process_submission_with_retry(&submission).await;
         }
     }
 
-    fn spawn_recovery(&self, recovery_sender: UnboundedSender<FinalizedBatchSubmission>) {
-        let this = self.clone();
-        tokio::spawn(async move {
-            loop {
-                if recovery_sender.is_closed() {
-                    return;
-                }
-                match this.recover_recent_submissions(&recovery_sender).await {
-                    Ok(()) => return,
-                    Err(err) => {
-                        warn!(
+    async fn process_submission_with_retry(&self, submission: &FinalizedBatchSubmission) {
+        for attempt in 1..=MAX_CONNECTION_ATTEMPTS {
+            match self.process_submission(submission).await {
+                Ok(()) => return,
+                Err(err) if is_retryable_connection_error(&err) => {
+                    if attempt == MAX_CONNECTION_ATTEMPTS {
+                        error!(
                             target: "zone::node::shadow_prover",
+                            l1_block_hash = %submission.block.hash,
+                            transaction_index = submission.transaction_index,
+                            log_index = submission.log_index,
                             error = ?err,
-                            "Failed to recover recent finalized batch submissions; retrying"
+                            attempts = attempt,
+                            "Failed to process finalized batch submission; retry budget exhausted"
                         );
-                        tokio::time::sleep(POLL_INTERVAL).await;
+                        return;
                     }
-                }
-            }
-        });
-    }
-
-    async fn recover_recent_submissions(
-        &self,
-        recovery_sender: &UnboundedSender<FinalizedBatchSubmission>,
-    ) -> Result<()> {
-        let finalized = self
-            .l1_provider
-            .get_header_by_number(BlockNumberOrTag::Finalized)
-            .await?
-            .ok_or_eyre("L1 finalized block is not available")?
-            .number();
-        let from = finalized.saturating_sub(self.anchor_config.history_window().saturating_sub(1));
-
-        let portal = ZonePortal::new(self.portal_address, &self.l1_provider);
-        let mut page_from = from;
-        while page_from <= finalized {
-            let page_to = page_from
-                .saturating_add(RECOVERY_LOG_QUERY_BLOCKS - 1)
-                .min(finalized);
-            let events = portal
-                .BatchSubmitted_filter()
-                .from_block(page_from)
-                .to_block(page_to)
-                .query()
-                .await
-                .wrap_err_with(|| {
-                    format!("query BatchSubmitted logs in finalized range {page_from}..={page_to}")
-                })?;
-
-            let candidate_blocks = events
-                .into_iter()
-                .map(|(_, log)| {
-                    log.block_number
-                        .ok_or_eyre("finalized BatchSubmitted log has no block number")
-                })
-                .collect::<Result<BTreeSet<_>>>()?;
-            for block_number in candidate_blocks {
-                for submission in self
-                    .fetch_verified_submissions(block_number)
-                    .await
-                    .wrap_err_with(|| {
-                        format!("authenticate recovered submissions in block {block_number}")
-                    })?
-                {
-                    if recovery_sender.send(submission).is_err() {
-                        return Ok(());
-                    }
-                }
-            }
-            if page_to == finalized {
-                break;
-            }
-            page_from = page_to + 1;
-        }
-        Ok(())
-    }
-
-    async fn fetch_verified_submissions(
-        &self,
-        block_number: u64,
-    ) -> Result<Vec<FinalizedBatchSubmission>> {
-        let header = self
-            .l1_provider
-            .get_header_by_number(block_number.into())
-            .await?
-            .ok_or_eyre(format!("L1 block {block_number} is not available"))?;
-        ensure!(
-            header.number() == block_number,
-            "requested L1 block {block_number}, received {}",
-            header.number()
-        );
-        let block = NumHash::new(block_number, header.as_ref().hash_slow());
-        let receipts = self
-            .l1_provider
-            .get_block_receipts(BlockId::hash(block.hash))
-            .await?
-            .ok_or_eyre(format!("L1 block {} has no receipts", block.hash))?;
-        verify_receipts_against_header(
-            block,
-            header.receipts_root(),
-            header.logs_bloom(),
-            &receipts,
-        )?;
-        Ok(extract_finalized_batch_submissions(
-            block,
-            self.portal_address,
-            &receipts,
-        ))
-    }
-
-    fn spawn_submission_retry(&self, submission: FinalizedBatchSubmission) {
-        let this = self.clone();
-        tokio::spawn(async move {
-            loop {
-                if let Err(err) = this.process_submission(&submission).await {
+                    let retry_delay = POLL_INTERVAL * 2_u32.pow(attempt - 1);
                     warn!(
                         target: "zone::node::shadow_prover",
                         l1_block_hash = %submission.block.hash,
                         transaction_index = submission.transaction_index,
                         log_index = submission.log_index,
                         error = ?err,
-                        "Failed to process finalized batch submission; retrying"
+                        attempt,
+                        max_attempts = MAX_CONNECTION_ATTEMPTS,
+                        retry_delay_secs = retry_delay.as_secs(),
+                        "Connection error processing finalized batch submission; retrying"
                     );
-                    tokio::time::sleep(POLL_INTERVAL).await;
-                    continue;
+                    tokio::time::sleep(retry_delay).await;
                 }
-                return;
+                Err(err) => {
+                    error!(
+                        target: "zone::node::shadow_prover",
+                        l1_block_hash = %submission.block.hash,
+                        transaction_index = submission.transaction_index,
+                        log_index = submission.log_index,
+                        error = ?err,
+                        "Rejected finalized batch submission"
+                    );
+                    return;
+                }
             }
-        });
+        }
     }
 
     async fn process_submission(&self, submission: &FinalizedBatchSubmission) -> Result<()> {
@@ -352,6 +242,22 @@ impl<P: ZoneSequencerProvider> RpcFollowerShadowProver<P> {
         batch: BatchData,
         anchor: ShadowProofAnchor,
     ) -> Result<()> {
+        let from = self.wait_for_local_range(to, &batch).await?;
+
+        info!(
+            target: "zone::node::shadow_prover",
+            zone_from = from,
+            zone_to = to,
+            anchor_number = anchor.number,
+            anchor_hash = %anchor.hash,
+            "Queueing finalized quorum-certified batch for shadow proving"
+        );
+        self.prover
+            .enqueue_with_anchor(from, to, batch, anchor)
+            .await
+    }
+
+    async fn wait_for_local_range(&self, to: u64, batch: &BatchData) -> Result<u64> {
         let from = loop {
             if batch.prev_block_hash.is_zero() {
                 break 1;
@@ -384,17 +290,27 @@ impl<P: ZoneSequencerProvider> RpcFollowerShadowProver<P> {
             );
         }
 
-        info!(
-            target: "zone::node::shadow_prover",
-            zone_from = from,
-            zone_to = to,
-            anchor_number = anchor.number,
-            anchor_hash = %anchor.hash,
-            "Queueing finalized quorum-certified batch for shadow proving"
-        );
-        self.prover
-            .enqueue_with_anchor(from, to, batch, anchor)
-            .await
+        Ok(from)
+    }
+}
+
+fn is_retryable_connection_error(error: &eyre::Report) -> bool {
+    error.chain().any(|cause| {
+        cause
+            .downcast_ref::<TransportError>()
+            .is_some_and(is_retryable_rpc_error)
+    })
+}
+
+fn is_retryable_rpc_error(error: &TransportError) -> bool {
+    match error {
+        RpcError::ErrorResp(error) => error.is_retry_err(),
+        RpcError::UnsupportedFeature(_)
+        | RpcError::LocalUsageError(_)
+        | RpcError::SerError(_)
+        | RpcError::DeserError { .. }
+        | RpcError::Transport(TransportErrorKind::NonRetryable(_)) => false,
+        _ => true,
     }
 }
 
@@ -466,5 +382,19 @@ mod tests {
             )
             .is_err()
         );
+    }
+
+    #[test]
+    fn retries_only_retryable_transport_errors() {
+        let retryable = Err::<(), _>(TransportErrorKind::backend_gone())
+            .wrap_err("fetch finalized block")
+            .unwrap_err();
+        assert!(is_retryable_connection_error(&retryable));
+
+        let terminal = eyre::Report::new(TransportErrorKind::non_retryable_str("invalid request"));
+        assert!(!is_retryable_connection_error(&terminal));
+        assert!(!is_retryable_connection_error(&eyre::eyre!(
+            "invalid settlement"
+        )));
     }
 }

--- a/crates/node/src/shadow_prover.rs
+++ b/crates/node/src/shadow_prover.rs
@@ -1,6 +1,6 @@
 //! Finalized L1 batch observation for RPC-only shadow provers.
 
-use std::{collections::HashSet, str::FromStr as _, sync::Arc, time::Duration};
+use std::{collections::HashSet, str::FromStr as _, time::Duration};
 
 use alloy_consensus::{BlockHeader as _, Sealable as _};
 use alloy_eips::BlockNumberOrTag;
@@ -11,32 +11,14 @@ use eyre::{OptionExt as _, Result, WrapErr as _, ensure};
 use tempo_alloy::TempoNetwork;
 use tempo_zone_contracts::ZonePortal;
 use tokio::sync::mpsc::{UnboundedReceiver, UnboundedSender};
-use tracing::{error, info, warn};
-use zone_l1::{FinalizedBatchSubmission, FinalizedBatchSubmissionSink};
+use tracing::{info, warn};
+use zone_l1::FinalizedBatchSubmission;
 use zone_sequencer::{
     BatchAnchorConfig, BatchData, ShadowProofAnchor, ShadowProver, ZoneSequencerProvider,
 };
 
 const POLL_INTERVAL: Duration = Duration::from_secs(1);
-
-#[derive(Debug)]
-struct ShadowProverSubmissionSink {
-    sender: UnboundedSender<FinalizedBatchSubmission>,
-}
-
-impl FinalizedBatchSubmissionSink for ShadowProverSubmissionSink {
-    fn observe_finalized_batch(&self, submission: FinalizedBatchSubmission) {
-        let _ = self.sender.send(submission);
-    }
-}
-
-pub(crate) fn finalized_batch_submission_channel() -> (
-    Arc<dyn FinalizedBatchSubmissionSink>,
-    UnboundedReceiver<FinalizedBatchSubmission>,
-) {
-    let (sender, receiver) = tokio::sync::mpsc::unbounded_channel();
-    (Arc::new(ShadowProverSubmissionSink { sender }), receiver)
-}
+const RECOVERY_LOG_QUERY_BLOCKS: u64 = 1_000;
 
 /// Observe finalized `submitBatch` calls and feed their exact settlement inputs to the detached
 /// prover. The Portal has already verified the included quorum certificate before emitting the
@@ -48,60 +30,47 @@ pub(crate) async fn run_finalized_batch_observer<P: ZoneSequencerProvider>(
     l1_provider: DynProvider<TempoNetwork>,
     prover: ShadowProver,
     mut submissions: UnboundedReceiver<FinalizedBatchSubmission>,
+    recovery_sender: UnboundedSender<FinalizedBatchSubmission>,
 ) {
-    let mut observed = HashSet::new();
-
-    loop {
-        match recover_recent_submissions(portal_address, anchor_config, &l1_provider).await {
-            Ok(recovered) => {
-                for submission in recovered {
-                    if let Err(err) = queue_submission(
-                        portal_address,
-                        &zone_provider,
-                        &l1_provider,
-                        &prover,
-                        submission,
-                        &mut observed,
-                    )
-                    .await
-                    {
-                        warn!(
-                            target: "zone::node::shadow_prover",
-                            error = ?err,
-                            "Failed to recover finalized batch submission"
-                        );
-                    }
-                }
-                break;
+    let recovery_provider = l1_provider.clone();
+    tokio::spawn(async move {
+        loop {
+            if recovery_sender.is_closed() {
+                return;
             }
-            Err(err) => {
-                warn!(
-                    target: "zone::node::shadow_prover",
-                    error = ?err,
-                    "Failed to recover recent finalized batch submissions; retrying"
-                );
-                tokio::time::sleep(POLL_INTERVAL).await;
+            match recover_recent_submissions(portal_address, anchor_config, &recovery_provider)
+                .await
+            {
+                Ok(recovered) => {
+                    for submission in recovered {
+                        if recovery_sender.send(submission).is_err() {
+                            return;
+                        }
+                    }
+                    return;
+                }
+                Err(err) => {
+                    warn!(
+                        target: "zone::node::shadow_prover",
+                        error = ?err,
+                        "Failed to recover recent finalized batch submissions; retrying"
+                    );
+                    tokio::time::sleep(POLL_INTERVAL).await;
+                }
             }
         }
-    }
+    });
 
+    let mut observed = HashSet::new();
     while let Some(submission) = submissions.recv().await {
-        if let Err(err) = queue_submission(
+        spawn_submission_retry(
             portal_address,
             &zone_provider,
             &l1_provider,
             &prover,
             submission,
             &mut observed,
-        )
-        .await
-        {
-            warn!(
-                target: "zone::node::shadow_prover",
-                error = ?err,
-                "Failed to process finalized batch submission"
-            );
-        }
+        );
     }
 }
 
@@ -118,50 +87,95 @@ async fn recover_recent_submissions(
     let from = finalized.saturating_sub(anchor_config.history_window().saturating_sub(1));
 
     let portal = ZonePortal::new(portal_address, l1_provider);
-    let events = portal
-        .BatchSubmitted_filter()
-        .from_block(from)
-        .to_block(finalized)
-        .query()
-        .await
-        .wrap_err_with(|| {
-            format!("query BatchSubmitted logs in finalized range {from}..={finalized}")
-        })?;
+    let mut recovered = Vec::new();
+    let mut page_from = from;
+    while page_from <= finalized {
+        let page_to = page_from
+            .saturating_add(RECOVERY_LOG_QUERY_BLOCKS - 1)
+            .min(finalized);
+        let events = portal
+            .BatchSubmitted_filter()
+            .from_block(page_from)
+            .to_block(page_to)
+            .query()
+            .await
+            .wrap_err_with(|| {
+                format!("query BatchSubmitted logs in finalized range {page_from}..={page_to}")
+            })?;
 
-    events
-        .into_iter()
-        .map(|(event, log)| {
+        for (event, log) in events {
             let tx_hash = log
                 .transaction_hash
                 .ok_or_eyre("finalized BatchSubmitted log has no transaction hash")?;
             let log_index = log
                 .log_index
                 .ok_or_eyre("finalized BatchSubmitted log has no log index")?;
-            Ok(FinalizedBatchSubmission {
+            recovered.push(FinalizedBatchSubmission {
                 block_number: log
                     .block_number
                     .ok_or_eyre("finalized BatchSubmitted log has no block number")?,
                 transaction_hash: tx_hash,
                 log_index,
                 event,
-            })
-        })
-        .collect()
+            });
+        }
+        if page_to == finalized {
+            break;
+        }
+        page_from = page_to + 1;
+    }
+    Ok(recovered)
 }
 
-async fn queue_submission<P: ZoneSequencerProvider>(
+fn spawn_submission_retry<P: ZoneSequencerProvider>(
     portal_address: Address,
     zone_provider: &P,
     l1_provider: &DynProvider<TempoNetwork>,
     prover: &ShadowProver,
     submission: FinalizedBatchSubmission,
     observed: &mut HashSet<(B256, u64)>,
-) -> Result<()> {
+) {
     let observation_id = (submission.transaction_hash, submission.log_index);
-    if observed.contains(&observation_id) {
-        return Ok(());
+    if !observed.insert(observation_id) {
+        return;
     }
 
+    let zone_provider = zone_provider.clone();
+    let l1_provider = l1_provider.clone();
+    let prover = prover.clone();
+    tokio::spawn(async move {
+        loop {
+            if let Err(err) = process_submission(
+                portal_address,
+                &zone_provider,
+                &l1_provider,
+                &prover,
+                &submission,
+            )
+            .await
+            {
+                warn!(
+                    target: "zone::node::shadow_prover",
+                    transaction_hash = %submission.transaction_hash,
+                    log_index = submission.log_index,
+                    error = ?err,
+                    "Failed to process finalized batch submission; retrying"
+                );
+                tokio::time::sleep(POLL_INTERVAL).await;
+                continue;
+            }
+            return;
+        }
+    });
+}
+
+async fn process_submission<P: ZoneSequencerProvider>(
+    portal_address: Address,
+    zone_provider: &P,
+    l1_provider: &DynProvider<TempoNetwork>,
+    prover: &ShadowProver,
+    submission: &FinalizedBatchSubmission,
+) -> Result<()> {
     let call = fetch_submit_batch_calls(l1_provider, portal_address, submission.transaction_hash)
         .await?
         .into_iter()
@@ -184,20 +198,7 @@ async fn queue_submission<P: ZoneSequencerProvider>(
         )
     })?;
 
-    observed.insert(observation_id);
-    let zone_provider = zone_provider.clone();
-    let prover = prover.clone();
-    tokio::spawn(async move {
-        if let Err(err) = wait_and_enqueue(zone_provider, prover, to, batch, anchor).await {
-            error!(
-                target: "zone::node::shadow_prover",
-                transaction_hash = %submission.transaction_hash,
-                error = ?err,
-                "Could not enqueue finalized batch for shadow proving"
-            );
-        }
-    });
-    Ok(())
+    wait_and_enqueue(zone_provider.clone(), prover.clone(), to, batch, anchor).await
 }
 
 async fn fetch_submit_batch_calls(
@@ -267,35 +268,18 @@ async fn submission_target(
     l1_provider: &DynProvider<TempoNetwork>,
     call: &ZonePortal::submitBatchCall,
     event: &ZonePortal::BatchSubmitted,
-    finalized: u64,
+    submission_block_number: u64,
 ) -> Result<(u64, BatchData, ShadowProofAnchor)> {
     ensure!(
         !call.signatures.is_empty(),
         "accepted submitBatch call has an empty quorum certificate"
     );
     let to = u64::try_from(call.nextZoneHeight).wrap_err("submitted Zone height overflows u64")?;
-    ensure!(
-        event.nextBlockHash == call.blockTransition.nextBlockHash,
-        "BatchSubmitted next block hash does not match calldata"
-    );
-    ensure!(
-        event.nextProcessedDepositQueueHash == call.depositQueueTransition.nextProcessedHash,
-        "BatchSubmitted deposit hash does not match calldata"
-    );
-    ensure!(
-        event.lastProcessedDepositNumber == call.depositQueueTransition.nextDepositNumber,
-        "BatchSubmitted deposit number does not match calldata"
-    );
-    ensure!(
-        event.withdrawalQueueHash == call.withdrawalQueueHash,
-        "BatchSubmitted withdrawal hash does not match calldata"
-    );
-
     let anchor_number =
         submitted_anchor_number(call.tempoBlockNumber, call.recentTempoBlockNumber)?;
     ensure!(
-        anchor_number <= finalized,
-        "submitted anchor {anchor_number} is above finalized L1 height {finalized}"
+        anchor_number <= submission_block_number,
+        "submitted anchor {anchor_number} is above submission block {submission_block_number}"
     );
     let anchor_hash = l1_provider
         .get_header_by_number(anchor_number.into())

--- a/crates/node/src/shadow_prover.rs
+++ b/crates/node/src/shadow_prover.rs
@@ -1,18 +1,24 @@
 //! Finalized L1 batch observation for RPC-only shadow provers.
 
-use std::{collections::HashSet, time::Duration};
+use std::{
+    collections::{BTreeSet, HashSet},
+    time::Duration,
+};
 
-use alloy_consensus::{BlockHeader as _, Sealable as _};
-use alloy_eips::BlockNumberOrTag;
-use alloy_primitives::{Address, B256, TxKind};
+use alloy_consensus::{BlockHeader as _, Sealable as _, proofs::calculate_transaction_root};
+use alloy_eips::{BlockId, BlockNumberOrTag, NumHash};
+use alloy_primitives::{Address, TxKind};
 use alloy_provider::{DynProvider, Provider as _};
 use alloy_sol_types::SolCall as _;
 use eyre::{OptionExt as _, Result, WrapErr as _, ensure};
 use tempo_alloy::TempoNetwork;
+use tempo_primitives::TempoTxEnvelope;
 use tempo_zone_contracts::ZonePortal;
 use tokio::sync::mpsc::{UnboundedReceiver, UnboundedSender};
 use tracing::{info, warn};
-use zone_l1::FinalizedBatchSubmission;
+use zone_l1::{
+    FinalizedBatchSubmission, extract_finalized_batch_submissions, verify_receipts_against_header,
+};
 use zone_sequencer::{
     BatchAnchorConfig, BatchData, ShadowProofAnchor, ShadowProver, ZoneSequencerProvider,
 };
@@ -60,7 +66,11 @@ impl<P: ZoneSequencerProvider> RpcFollowerShadowProver<P> {
 
         let mut observed = HashSet::new();
         while let Some(submission) = submissions.recv().await {
-            let observation_id = (submission.transaction_hash, submission.log_index);
+            let observation_id = (
+                submission.block.hash,
+                submission.transaction_index,
+                submission.log_index,
+            );
             if observed.insert(observation_id) {
                 self.spawn_submission_retry(submission);
             }
@@ -117,23 +127,24 @@ impl<P: ZoneSequencerProvider> RpcFollowerShadowProver<P> {
                     format!("query BatchSubmitted logs in finalized range {page_from}..={page_to}")
                 })?;
 
-            for (event, log) in events {
-                let tx_hash = log
-                    .transaction_hash
-                    .ok_or_eyre("finalized BatchSubmitted log has no transaction hash")?;
-                let log_index = log
-                    .log_index
-                    .ok_or_eyre("finalized BatchSubmitted log has no log index")?;
-                let submission = FinalizedBatchSubmission {
-                    block_number: log
-                        .block_number
-                        .ok_or_eyre("finalized BatchSubmitted log has no block number")?,
-                    transaction_hash: tx_hash,
-                    log_index,
-                    event,
-                };
-                if recovery_sender.send(submission).is_err() {
-                    return Ok(());
+            let candidate_blocks = events
+                .into_iter()
+                .map(|(_, log)| {
+                    log.block_number
+                        .ok_or_eyre("finalized BatchSubmitted log has no block number")
+                })
+                .collect::<Result<BTreeSet<_>>>()?;
+            for block_number in candidate_blocks {
+                for submission in self
+                    .fetch_verified_submissions(block_number)
+                    .await
+                    .wrap_err_with(|| {
+                        format!("authenticate recovered submissions in block {block_number}")
+                    })?
+                {
+                    if recovery_sender.send(submission).is_err() {
+                        return Ok(());
+                    }
                 }
             }
             if page_to == finalized {
@@ -144,6 +155,39 @@ impl<P: ZoneSequencerProvider> RpcFollowerShadowProver<P> {
         Ok(())
     }
 
+    async fn fetch_verified_submissions(
+        &self,
+        block_number: u64,
+    ) -> Result<Vec<FinalizedBatchSubmission>> {
+        let header = self
+            .l1_provider
+            .get_header_by_number(block_number.into())
+            .await?
+            .ok_or_eyre(format!("L1 block {block_number} is not available"))?;
+        ensure!(
+            header.number() == block_number,
+            "requested L1 block {block_number}, received {}",
+            header.number()
+        );
+        let block = NumHash::new(block_number, header.as_ref().hash_slow());
+        let receipts = self
+            .l1_provider
+            .get_block_receipts(BlockId::hash(block.hash))
+            .await?
+            .ok_or_eyre(format!("L1 block {} has no receipts", block.hash))?;
+        verify_receipts_against_header(
+            block,
+            header.receipts_root(),
+            header.logs_bloom(),
+            &receipts,
+        )?;
+        Ok(extract_finalized_batch_submissions(
+            block,
+            self.portal_address,
+            &receipts,
+        ))
+    }
+
     fn spawn_submission_retry(&self, submission: FinalizedBatchSubmission) {
         let this = self.clone();
         tokio::spawn(async move {
@@ -151,7 +195,8 @@ impl<P: ZoneSequencerProvider> RpcFollowerShadowProver<P> {
                 if let Err(err) = this.process_submission(&submission).await {
                     warn!(
                         target: "zone::node::shadow_prover",
-                        transaction_hash = %submission.transaction_hash,
+                        l1_block_hash = %submission.block.hash,
+                        transaction_index = submission.transaction_index,
                         log_index = submission.log_index,
                         error = ?err,
                         "Failed to process finalized batch submission; retrying"
@@ -166,21 +211,21 @@ impl<P: ZoneSequencerProvider> RpcFollowerShadowProver<P> {
 
     async fn process_submission(&self, submission: &FinalizedBatchSubmission) -> Result<()> {
         let call = self
-            .fetch_submit_batch_calls(submission.transaction_hash)
+            .fetch_submit_batch_calls(submission)
             .await?
             .into_iter()
             .find(|call| call_matches_event(call, &submission.event))
             .ok_or_eyre(format!(
-                "submitBatch transaction {} contains no call matching log {}",
-                submission.transaction_hash, submission.log_index
+                "L1 block {} transaction {} contains no submitBatch call matching log {}",
+                submission.block.hash, submission.transaction_index, submission.log_index
             ))?;
         let (to, batch, anchor) = self
-            .submission_target(&call, &submission.event, submission.block_number)
+            .submission_target(&call, &submission.event, submission.block.number)
             .await
             .wrap_err_with(|| {
                 format!(
-                    "validate finalized submitBatch transaction {}",
-                    submission.transaction_hash
+                    "validate finalized submitBatch in L1 block {} transaction {}",
+                    submission.block.hash, submission.transaction_index
                 )
             })?;
 
@@ -189,17 +234,51 @@ impl<P: ZoneSequencerProvider> RpcFollowerShadowProver<P> {
 
     async fn fetch_submit_batch_calls(
         &self,
-        tx_hash: B256,
+        submission: &FinalizedBatchSubmission,
     ) -> Result<Vec<ZonePortal::submitBatchCall>> {
-        let tx = self
+        let block = self
             .l1_provider
-            .get_transaction_by_hash(tx_hash)
+            .get_block_by_hash(submission.block.hash)
+            .full()
             .await?
-            .ok_or_eyre(format!("submitBatch transaction {tx_hash} was not found"))?;
+            .ok_or_eyre(format!("L1 block {} was not found", submission.block.hash))?;
+        ensure!(
+            block.header.number() == submission.block.number,
+            "L1 block {} has number {}, expected {}",
+            submission.block.hash,
+            block.header.number(),
+            submission.block.number
+        );
+        ensure!(
+            block.header.as_ref().hash_slow() == submission.block.hash,
+            "L1 block response does not match authenticated hash {}",
+            submission.block.hash
+        );
+        let expected_transactions_root = block.header.transactions_root();
+        let transactions = block
+            .try_into_transactions()
+            .map_err(|_| {
+                eyre::eyre!(
+                    "L1 block {} did not return full transactions",
+                    submission.block.hash
+                )
+            })?
+            .into_iter()
+            .map(|transaction| transaction.inner.into_inner())
+            .collect::<Vec<_>>();
+        verify_transactions_root(
+            &transactions,
+            expected_transactions_root,
+            submission.block.hash,
+        )?;
+        let transaction_index = usize::try_from(submission.transaction_index)
+            .wrap_err("L1 transaction index overflows usize")?;
+        let tx = transactions.get(transaction_index).ok_or_eyre(format!(
+            "L1 block {} has no transaction at authenticated receipt index {}",
+            submission.block.hash, submission.transaction_index
+        ))?;
 
         let calls = tx
-            .inner
-            .inner()
             .calls()
             .filter_map(|(kind, input)| {
                 if kind != TxKind::Call(self.portal_address) {
@@ -211,7 +290,9 @@ impl<P: ZoneSequencerProvider> RpcFollowerShadowProver<P> {
 
         ensure!(
             !calls.is_empty(),
-            "transaction {tx_hash} contains no submitBatch call to Portal {}",
+            "L1 block {} transaction {} contains no submitBatch call to Portal {}",
+            submission.block.hash,
+            submission.transaction_index,
             self.portal_address
         );
         Ok(calls)
@@ -317,6 +398,19 @@ impl<P: ZoneSequencerProvider> RpcFollowerShadowProver<P> {
     }
 }
 
+fn verify_transactions_root(
+    transactions: &[TempoTxEnvelope],
+    expected: alloy_primitives::B256,
+    block_hash: alloy_primitives::B256,
+) -> Result<()> {
+    let computed = calculate_transaction_root(transactions);
+    ensure!(
+        computed == expected,
+        "transaction root mismatch for L1 block {block_hash}: expected {expected}, got {computed}"
+    );
+    Ok(())
+}
+
 fn call_matches_event(
     call: &ZonePortal::submitBatchCall,
     event: &ZonePortal::BatchSubmitted,
@@ -356,5 +450,21 @@ mod tests {
     fn ancestry_submission_must_follow_checkpoint() {
         assert!(submitted_anchor_number(42, 42).is_err());
         assert!(submitted_anchor_number(42, 41).is_err());
+    }
+
+    #[test]
+    fn transaction_root_authentication_rejects_mismatch() {
+        let transactions = Vec::<TempoTxEnvelope>::new();
+        let expected = calculate_transaction_root(&transactions);
+
+        verify_transactions_root(&transactions, expected, alloy_primitives::B256::ZERO).unwrap();
+        assert!(
+            verify_transactions_root(
+                &transactions,
+                alloy_primitives::B256::repeat_byte(0x42),
+                alloy_primitives::B256::ZERO,
+            )
+            .is_err()
+        );
     }
 }

--- a/crates/p2p/README.md
+++ b/crates/p2p/README.md
@@ -206,13 +206,15 @@ attestation) and `--sequencer-key-file` (it never produces a block). The shared
 sequencer key is also the zone's ECIES private key for encrypted deposits, so provisioning it on
 the internet-facing standby would put deposit recipients and memos within reach of a host
 compromise. Startup rejects that key-file flag on an `rpc_only` node rather than ignoring it.
-Add `--sequencer.enable-prover` to run the detached shadow prover on this follower, and optionally
-`--sequencer.prover-address HOST:PORT` to use a remote prover. The follower scans finalized
-`submitBatch` transactions, retains the accepted quorum certificate inputs, and proves the exact
-anchor committed by the transaction after the matching Zone range is canonical locally. This is
-observational: proof success or failure never changes settlement or the follower's RPC service.
 This key is independent from the shared `--sequencer-key-file`; reusing that shared key
 would collapse several nodes into one recoverable quorum identity.
+
+Add `--sequencer.enable-prover` to run the detached shadow prover on this follower, and optionally
+`--sequencer.prover-address HOST:PORT` to use a remote prover. The follower scans finalized
+`submitBatch` transactions, decodes the accepted quorum certificate inputs, and proves the exact
+anchor committed by the transaction after the matching Zone range is canonical locally. This is
+observational: proof success or failure never changes settlement or the follower's RPC service.
+
 The `--sequencer` flag conflicts with `--sequencer.manifest` because the
 manifest determines whether the node starts the sequencer tasks.
 

--- a/crates/p2p/README.md
+++ b/crates/p2p/README.md
@@ -206,6 +206,11 @@ attestation) and `--sequencer-key-file` (it never produces a block). The shared
 sequencer key is also the zone's ECIES private key for encrypted deposits, so provisioning it on
 the internet-facing standby would put deposit recipients and memos within reach of a host
 compromise. Startup rejects that key-file flag on an `rpc_only` node rather than ignoring it.
+Add `--sequencer.enable-prover` to run the detached shadow prover on this follower, and optionally
+`--sequencer.prover-address HOST:PORT` to use a remote prover. The follower scans finalized
+`submitBatch` transactions, retains the accepted quorum certificate inputs, and proves the exact
+anchor committed by the transaction after the matching Zone range is canonical locally. This is
+observational: proof success or failure never changes settlement or the follower's RPC service.
 This key is independent from the shared `--sequencer-key-file`; reusing that shared key
 would collapse several nodes into one recoverable quorum identity.
 The `--sequencer` flag conflicts with `--sequencer.manifest` because the

--- a/crates/sequencer/src/lib.rs
+++ b/crates/sequencer/src/lib.rs
@@ -36,7 +36,10 @@ pub use encryption_key::{
     register_encryption_key,
 };
 pub use monitor::{ZoneMonitorConfig, ZoneMonitorSharedState};
-pub use prover::{ShadowProofAnchor, ShadowProver, ShadowProverConfig, spawn_shadow_prover};
+pub use prover::{
+    SHADOW_PROVER_QUEUE_CAPACITY, ShadowProofAnchor, ShadowProver, ShadowProverConfig,
+    spawn_shadow_prover,
+};
 pub use settlement::{
     BatchAnchorConfig, BatchData, BatchSubmitter, PortalZoneAnchor, resolve_portal_zone_anchor,
 };

--- a/crates/sequencer/src/lib.rs
+++ b/crates/sequencer/src/lib.rs
@@ -36,7 +36,7 @@ pub use encryption_key::{
     register_encryption_key,
 };
 pub use monitor::{ZoneMonitorConfig, ZoneMonitorSharedState};
-pub use prover::ShadowProverConfig;
+pub use prover::{ShadowProofAnchor, ShadowProver, ShadowProverConfig, spawn_shadow_prover};
 pub use settlement::{
     BatchAnchorConfig, BatchData, BatchSubmitter, PortalZoneAnchor, resolve_portal_zone_anchor,
 };

--- a/crates/sequencer/src/prover.rs
+++ b/crates/sequencer/src/prover.rs
@@ -44,8 +44,8 @@ use zone_spf::{
 
 use crate::{BatchAnchorConfig, BatchData, ZoneSequencerProvider, metrics::ProverMetrics};
 
-/// Number of candidates allowed to wait behind the active validation.
-const SHADOW_PROVER_QUEUE_CAPACITY: usize = 2;
+/// Number of shadow proof candidates allowed to wait behind the active validation.
+pub const SHADOW_PROVER_QUEUE_CAPACITY: usize = 5;
 const RPC_CONCURRENCY: usize = 8;
 
 type L1Reads = BTreeMap<u64, BTreeMap<Address, BTreeSet<B256>>>;

--- a/crates/sequencer/src/prover.rs
+++ b/crates/sequencer/src/prover.rs
@@ -86,8 +86,17 @@ impl fmt::Debug for ShadowProverConfig {
 }
 
 #[derive(Debug, Clone)]
-pub(crate) struct ShadowProver {
+pub struct ShadowProver {
     sender: mpsc::Sender<ProverJob>,
+}
+
+/// Exact Tempo anchor committed by a finalized batch submission.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct ShadowProofAnchor {
+    /// Tempo block number used as the EIP-2935 anchor.
+    pub number: u64,
+    /// Canonical hash of the Tempo anchor block.
+    pub hash: B256,
 }
 
 #[derive(Debug)]
@@ -95,6 +104,7 @@ struct ProverJob {
     from: u64,
     to: u64,
     batch: BatchData,
+    anchor: Option<ShadowProofAnchor>,
     enqueued_at: Instant,
 }
 
@@ -171,7 +181,7 @@ impl<T: AsyncWrite + Unpin> AsyncWrite for FirstReadTimed<T> {
     }
 }
 
-pub(crate) fn spawn_shadow_prover<P: ZoneSequencerProvider>(
+pub fn spawn_shadow_prover<P: ZoneSequencerProvider>(
     config: ShadowProverConfig,
     portal: Address,
     anchor_config: BatchAnchorConfig,
@@ -290,11 +300,54 @@ pub(crate) fn spawn_shadow_prover<P: ZoneSequencerProvider>(
 
 impl ShadowProver {
     /// Queue a candidate without waiting for validation or queue capacity.
-    pub(crate) fn try_enqueue(&self, from: u64, to: u64, batch: BatchData) {
+    pub fn try_enqueue(&self, from: u64, to: u64, batch: BatchData) {
+        self.try_enqueue_job(from, to, batch, None);
+    }
+
+    /// Queue a finalized candidate using the exact anchor committed on L1.
+    pub fn try_enqueue_with_anchor(
+        &self,
+        from: u64,
+        to: u64,
+        batch: BatchData,
+        anchor: ShadowProofAnchor,
+    ) {
+        self.try_enqueue_job(from, to, batch, Some(anchor));
+    }
+
+    /// Queue a finalized candidate, waiting for capacity so authoritative L1 evidence is not
+    /// dropped while another proof is running.
+    pub async fn enqueue_with_anchor(
+        &self,
+        from: u64,
+        to: u64,
+        batch: BatchData,
+        anchor: ShadowProofAnchor,
+    ) -> Result<()> {
+        self.sender
+            .send(ProverJob {
+                from,
+                to,
+                batch,
+                anchor: Some(anchor),
+                enqueued_at: Instant::now(),
+            })
+            .await
+            .map_err(|_| eyre::eyre!("shadow prover queue is unavailable"))
+    }
+
+    fn try_enqueue_job(
+        &self,
+        from: u64,
+        to: u64,
+        batch: BatchData,
+        anchor: Option<ShadowProofAnchor>,
+    ) {
         if let Err(err) = self.sender.try_send(ProverJob {
             from,
             to,
             batch: batch.clone(),
+            anchor,
             enqueued_at: Instant::now(),
         }) {
             error!(
@@ -387,13 +440,23 @@ async fn validate_candidate<P: ZoneSequencerProvider>(
             final_tempo_header.number()
         );
 
-        let anchor = resolve_anchor(
-            &context.l1_provider,
-            final_tempo_header.number(),
-            final_tempo_header.hash_slow(),
-            context.anchor_config,
-        )
-        .await?;
+        let anchor = if let Some(anchor) = job.anchor {
+            resolve_exact_anchor(
+                &context.l1_provider,
+                final_tempo_header.number(),
+                final_tempo_header.hash_slow(),
+                anchor,
+            )
+            .await?
+        } else {
+            resolve_anchor(
+                &context.l1_provider,
+                final_tempo_header.number(),
+                final_tempo_header.hash_slow(),
+                context.anchor_config,
+            )
+            .await?
+        };
         Ok::<_, eyre::Report>((initial_tempo_header, final_tempo_header, anchor))
     }
     .await?;
@@ -918,6 +981,57 @@ async fn resolve_anchor(
         anchor_number > checkpoint_number,
         "Tempo ancestry anchor {anchor_number} does not follow checkpoint {checkpoint_number}"
     );
+    resolve_ancestry_anchor(
+        provider,
+        checkpoint_number,
+        checkpoint_hash,
+        anchor_number,
+        None,
+    )
+    .await
+}
+
+async fn resolve_exact_anchor(
+    provider: &DynProvider<TempoNetwork>,
+    checkpoint_number: u64,
+    checkpoint_hash: B256,
+    anchor: ShadowProofAnchor,
+) -> Result<Anchor> {
+    ensure!(
+        anchor.number >= checkpoint_number,
+        "submitted Tempo anchor {} precedes checkpoint {checkpoint_number}",
+        anchor.number
+    );
+    if anchor.number == checkpoint_number {
+        ensure!(
+            anchor.hash == checkpoint_hash,
+            "submitted direct Tempo anchor hash {} does not match checkpoint hash {checkpoint_hash}",
+            anchor.hash
+        );
+        return Ok(Anchor {
+            number: anchor.number,
+            hash: anchor.hash,
+            ancestry_headers: Vec::new(),
+        });
+    }
+
+    resolve_ancestry_anchor(
+        provider,
+        checkpoint_number,
+        checkpoint_hash,
+        anchor.number,
+        Some(anchor.hash),
+    )
+    .await
+}
+
+async fn resolve_ancestry_anchor(
+    provider: &DynProvider<TempoNetwork>,
+    checkpoint_number: u64,
+    checkpoint_hash: B256,
+    anchor_number: u64,
+    expected_anchor_hash: Option<B256>,
+) -> Result<Anchor> {
     let mut expected_parent = checkpoint_hash;
     let mut ancestry_headers = Vec::with_capacity((anchor_number - checkpoint_number) as usize);
     for number in checkpoint_number + 1..=anchor_number {
@@ -929,6 +1043,13 @@ async fn resolve_anchor(
         );
         expected_parent = header.hash_slow();
         ancestry_headers.push(Bytes::from(alloy_rlp::encode(&header)));
+    }
+    if let Some(expected_anchor_hash) = expected_anchor_hash {
+        ensure!(
+            expected_parent == expected_anchor_hash,
+            "submitted Tempo anchor {} hash {expected_anchor_hash} does not match canonical hash {expected_parent}",
+            anchor_number
+        );
     }
     Ok(Anchor {
         number: anchor_number,
@@ -1012,4 +1133,66 @@ fn witness_size(witness: &BatchWitness) -> usize {
                         .sum::<usize>()
             })
             .sum::<usize>()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use alloy_provider::ProviderBuilder;
+    use alloy_transport::mock::Asserter;
+
+    fn mocked_l1_provider() -> DynProvider<TempoNetwork> {
+        ProviderBuilder::new_with_network::<TempoNetwork>()
+            .connect_mocked_client(Asserter::new())
+            .erased()
+    }
+
+    #[tokio::test]
+    async fn exact_direct_anchor_uses_committed_hash_without_tip_lookup() {
+        let hash = B256::repeat_byte(0x42);
+        let anchor = resolve_exact_anchor(
+            &mocked_l1_provider(),
+            10,
+            hash,
+            ShadowProofAnchor { number: 10, hash },
+        )
+        .await
+        .unwrap();
+
+        assert_eq!(anchor.number, 10);
+        assert_eq!(anchor.hash, hash);
+        assert!(anchor.ancestry_headers.is_empty());
+    }
+
+    #[tokio::test]
+    async fn exact_direct_anchor_rejects_different_committed_hash() {
+        let result = resolve_exact_anchor(
+            &mocked_l1_provider(),
+            10,
+            B256::repeat_byte(0x42),
+            ShadowProofAnchor {
+                number: 10,
+                hash: B256::repeat_byte(0x43),
+            },
+        )
+        .await;
+
+        assert!(result.is_err());
+    }
+
+    #[tokio::test]
+    async fn exact_anchor_rejects_number_before_checkpoint() {
+        let result = resolve_exact_anchor(
+            &mocked_l1_provider(),
+            10,
+            B256::repeat_byte(0x42),
+            ShadowProofAnchor {
+                number: 9,
+                hash: B256::repeat_byte(0x41),
+            },
+        )
+        .await;
+
+        assert!(result.is_err());
+    }
 }

--- a/crates/sequencer/src/prover.rs
+++ b/crates/sequencer/src/prover.rs
@@ -300,19 +300,28 @@ pub fn spawn_shadow_prover<P: ZoneSequencerProvider>(
 
 impl ShadowProver {
     /// Queue a candidate without waiting for validation or queue capacity.
-    pub fn try_enqueue(&self, from: u64, to: u64, batch: BatchData) {
-        self.try_enqueue_job(from, to, batch, None);
-    }
-
-    /// Queue a finalized candidate using the exact anchor committed on L1.
-    pub fn try_enqueue_with_anchor(
-        &self,
-        from: u64,
-        to: u64,
-        batch: BatchData,
-        anchor: ShadowProofAnchor,
-    ) {
-        self.try_enqueue_job(from, to, batch, Some(anchor));
+    pub(crate) fn try_enqueue(&self, from: u64, to: u64, batch: BatchData) {
+        if let Err(err) = self.sender.try_send(ProverJob {
+            from,
+            to,
+            batch: batch.clone(),
+            anchor: None,
+            enqueued_at: Instant::now(),
+        }) {
+            error!(
+                target: "zone::sequencer::prover",
+                zone_from = from,
+                zone_to = to,
+                prev_block_hash = %batch.prev_block_hash,
+                next_block_hash = %batch.next_block_hash,
+                error = %err,
+                "Shadow prover queue {}; skipping finalized batch candidate",
+                match err {
+                    TrySendError::Full(_) => "full",
+                    TrySendError::Closed(_) => "unavailable",
+                },
+            );
+        }
     }
 
     /// Queue a finalized candidate, waiting for capacity so authoritative L1 evidence is not
@@ -334,36 +343,6 @@ impl ShadowProver {
             })
             .await
             .map_err(|_| eyre::eyre!("shadow prover queue is unavailable"))
-    }
-
-    fn try_enqueue_job(
-        &self,
-        from: u64,
-        to: u64,
-        batch: BatchData,
-        anchor: Option<ShadowProofAnchor>,
-    ) {
-        if let Err(err) = self.sender.try_send(ProverJob {
-            from,
-            to,
-            batch: batch.clone(),
-            anchor,
-            enqueued_at: Instant::now(),
-        }) {
-            error!(
-                target: "zone::sequencer::prover",
-                zone_from = from,
-                zone_to = to,
-                prev_block_hash = %batch.prev_block_hash,
-                next_block_hash = %batch.next_block_hash,
-                error = %err,
-                "Shadow prover queue {}; skipping finalized batch candidate",
-                match err {
-                    TrySendError::Full(_) => "full",
-                    TrySendError::Closed(_) => "unavailable",
-                },
-            );
-        }
     }
 }
 

--- a/crates/sequencer/src/prover.rs
+++ b/crates/sequencer/src/prover.rs
@@ -385,6 +385,10 @@ async fn validate_candidate<P: ZoneSequencerProvider>(
         .zone_inputs_duration_seconds
         .record(started.elapsed().as_secs_f64());
 
+    if job.anchor.is_some() {
+        validate_settlement_boundary(&zone_inputs.blocks)?;
+    }
+
     let started = Instant::now();
     let (zone_state_witness, tempo_reads) =
         zone_witnesses(context.config.debug_api.as_ref(), from, to).await?;
@@ -512,6 +516,29 @@ async fn validate_candidate<P: ZoneSequencerProvider>(
         zone_state_nodes: witness.zone_state_witness.node_pool.len(),
         tempo_state_nodes: witness.tempo_state_witness.node_pool.len(),
     })
+}
+
+/// Require an L1-settled range to close exactly one withdrawal snapshot at its final block.
+fn validate_settlement_boundary(blocks: &[ZoneBlock]) -> Result<()> {
+    let (final_block, intermediate_blocks) = blocks
+        .split_last()
+        .ok_or_eyre("settled Zone range contains no blocks")?;
+
+    if let Some(block) = intermediate_blocks
+        .iter()
+        .find(|block| block.finalize_withdrawal_batch_count.is_some())
+    {
+        bail!(
+            "intermediate Zone block {} contains finalizeWithdrawalBatch",
+            block.number
+        );
+    }
+    ensure!(
+        final_block.finalize_withdrawal_batch_count.is_some(),
+        "final Zone block {} does not contain finalizeWithdrawalBatch",
+        final_block.number
+    );
+    Ok(())
 }
 
 async fn verify_remotely(
@@ -1120,6 +1147,24 @@ mod tests {
     use alloy_provider::ProviderBuilder;
     use alloy_transport::mock::Asserter;
 
+    fn zone_block(number: u64, finalizes_withdrawals: bool) -> ZoneBlock {
+        ZoneBlock {
+            number,
+            parent_hash: B256::ZERO,
+            timestamp: 0,
+            timestamp_millis_part: 0,
+            beneficiary: Address::ZERO,
+            tempo_header_rlp: Bytes::new(),
+            deposits: Vec::new(),
+            decryptions: Vec::new(),
+            enabled_tokens: Vec::new(),
+            finalize_withdrawal_batch_count: finalizes_withdrawals
+                .then_some(alloy_primitives::U256::ZERO),
+            finalize_withdrawal_batch_encrypted_senders: Vec::new(),
+            transactions: Vec::new(),
+        }
+    }
+
     fn mocked_l1_provider() -> DynProvider<TempoNetwork> {
         ProviderBuilder::new_with_network::<TempoNetwork>()
             .connect_mocked_client(Asserter::new())
@@ -1173,5 +1218,28 @@ mod tests {
         .await;
 
         assert!(result.is_err());
+    }
+
+    #[test]
+    fn settlement_boundary_requires_finalization_in_final_block() {
+        validate_settlement_boundary(&[zone_block(10, false), zone_block(11, true)]).unwrap();
+
+        let err = validate_settlement_boundary(&[zone_block(10, false), zone_block(11, false)])
+            .unwrap_err();
+        assert!(
+            err.to_string()
+                .contains("final Zone block 11 does not contain finalizeWithdrawalBatch")
+        );
+    }
+
+    #[test]
+    fn settlement_boundary_rejects_intermediate_finalization() {
+        let err = validate_settlement_boundary(&[zone_block(10, true), zone_block(11, true)])
+            .unwrap_err();
+
+        assert!(
+            err.to_string()
+                .contains("intermediate Zone block 10 contains finalizeWithdrawalBatch")
+        );
     }
 }

--- a/docs/ZONES.md
+++ b/docs/ZONES.md
@@ -686,6 +686,8 @@ cast code 0x5A4d000000000000000000000000000000000000 --rpc-url "$ETH_RPC_URL"
 | `--zone.id` | (deprecated) | Optional compatibility check against the zone ID encoded in the genesis chain ID. |
 | `--sequencer` | false | Enable sequencer mode for block production and withdrawal batch submission |
 | `--sequencer-key-file` | (required for sequencing) | Owner-readable file or FIFO containing the sequencer private key |
+| `--sequencer.enable-prover` | false | Run detached SPF validation; supported by sequencers and `rpc_only` P2P followers |
+| `--sequencer.prover-address` | (optional) | Remote prover `HOST:PORT`; without it the SPF executes in-process |
 | `--deposit-decryption-keys-file` | (optional) | File containing additional historical or pre-provisioned deposit decryption keys, one hex key per line |
 | `--zone.batch-interval-blocks` | 120 | Zone blocks between empty withdrawal batch boundaries / L1 submissions (~1 minute at Tempo's 500 ms block time) |
 | `--zone.poll-interval-secs` | 1 | Fallback interval for reconciling the canonical Zone head when no native notification arrives |
@@ -703,6 +705,8 @@ cast code 0x5A4d000000000000000000000000000000000000 --rpc-url "$ETH_RPC_URL"
 | `L1_RPC_URL` | Yes | Certified Tempo follower WebSocket RPC URL (`wss://...`) |
 | `SEQUENCER_KEY` | For short-lived tooling | Sequencer private key for `just create-zone` and xtasks; not accepted by the node |
 | `SEQUENCER_KEY_FILE` | For sequencing | Owner-readable file or FIFO containing the sequencer private key |
+| `SEQUENCER_ENABLE_PROVER` | No | Enable detached SPF validation, including on an `rpc_only` P2P follower |
+| `SEQUENCER_PROVER_ADDRESS` | No | Remote prover `HOST:PORT` used when detached SPF validation is enabled |
 | `DEPOSIT_DECRYPTION_KEYS_FILE` | During encryption-key rotation | Additional historical or pre-provisioned deposit decryption keys, one hex key per line |
 | `ADMIN_KEY` | For portal governance | Portal admin private key for `enableToken` / deposit pause controls. `SEQUENCER_KEY` only works for legacy zones where admin == sequencer. |
 | `PRIVATE_KEY` | For transactions | Key for L1 transactions (deposits, approvals) |


### PR DESCRIPTION
## Summary

Enables RPC-only follower nodes to run the detached shadow prover without requiring sequencer or settlement keys. The follower observes finalized submitBatch transactions on L1, decodes the accepted quorum-certificate inputs, derives the exact anchor used by settlement, and waits for the corresponding Zone block range to become canonical locally before enqueueing the proof.