### PR TITLE
chore(ci): lock down sync-from-upstream STS policy

### DIFF
--- a/.github/sts/sync-from-upstream.sts.yaml
+++ b/.github/sts/sync-from-upstream.sts.yaml
@@ -1,18 +1,10 @@
-# Allow the sync-from-upstream workflow in copies of this repo (scheduled and
-# manually dispatched runs on main) to mint a short-lived token to push the
-# synced main and `release/*` branches. `workflows: write` is required because
-# the synced commits can touch .github/workflows files.
-#
-# This file is mirrored into the copies by the sync itself, where it
-# authorizes tokens scoped to the copy: zones-private-fork mirrors main
-# byte-for-byte, and zones-firedrill takes everything except its own
-# .github/workflows — so this file, not the firedrill's checkout, is where
-# its sync authorization must live. Note that its presence in this repo also
-# lets those copies' main-branch workflows mint a token scoped to
-# tempoxyz/zones, since they carry (nearly) identical contents.
+# Allow only the sync-from-upstream workflows on the main branches of the
+# zones-private-fork and zones-firedrill repositories to mint a short-lived
+# token. `workflows: write` is required because synced commits can touch
+# .github/workflows files.
 subject:
-  - repo:tempoxyz@211589300/zones-private-fork@1329742643:ref:refs/heads/main
-  - repo:tempoxyz@211589300/zones-firedrill@1330635096:ref:refs/heads/main
+  - repo:tempoxyz@211589300/zones-private-fork@1329742643:job_workflow_ref:tempoxyz/zones-private-fork/.github/workflows/sync-from-upstream.yml@refs/heads/main
+  - repo:tempoxyz@211589300/zones-firedrill@1330635096:job_workflow_ref:tempoxyz/zones-firedrill/.github/workflows/sync-from-upstream.yml@refs/heads/main
 permissions:
   contents: write
   workflows: write

--- a/.github/workflows/sync-from-upstream.yml
+++ b/.github/workflows/sync-from-upstream.yml
@@ -19,7 +19,7 @@ jobs:
     steps:
       - name: Fetch GitHub token via STS
         id: github-sts
-        uses: tempoxyz/gh-actions/actions/github-sts@92f7d8fd211faca8a38e892ebe84225d0ea2a0b3 # main
+        uses: tempoxyz/gh-actions/actions/github-sts@430cf154170ed12b8c74af63038aee7d31a121d0 # main
         with:
           policy: sync-from-upstream
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -35,7 +35,7 @@ jobs:
           submodules: recursive
       - name: Mint read-only Earn token
         id: earn-token
-        uses: tempoxyz/gh-actions/actions/github-sts@92f7d8fd211faca8a38e892ebe84225d0ea2a0b3 # main
+        uses: tempoxyz/gh-actions/actions/github-sts@430cf154170ed12b8c74af63038aee7d31a121d0 # main
         with:
           scope: tempoxyz/earn
           policy: zones-read

--- a/.github/workflows/zones-benchmark.yml
+++ b/.github/workflows/zones-benchmark.yml
@@ -509,7 +509,7 @@ jobs:
 
       - name: Mint read-only Earn token
         id: earn-token
-        uses: tempoxyz/gh-actions/actions/github-sts@92f7d8fd211faca8a38e892ebe84225d0ea2a0b3 # main
+        uses: tempoxyz/gh-actions/actions/github-sts@430cf154170ed12b8c74af63038aee7d31a121d0 # main
         with:
           scope: tempoxyz/earn
           policy: zones-read


### PR DESCRIPTION
Ports the applicable change from tempoxyz/tempo#7356 to Zones.

Restricts STS token minting to `.github/workflows/sync-from-upstream.yml` on the `main` branches of `zones-private-fork` and `zones-firedrill`, preventing other workflows in those repositories from receiving `contents` and `workflows` write access.

The unrelated Rust formatting change from the source PR is intentionally excluded.

Validation:
- Parsed the policy as YAML and verified the expected subjects and permissions
- Confirmed the policy file blob exactly matches the source PR target
- `git diff --check`