### PR TITLE
fix(ci): skip upstream sync outside organization

### DIFF
--- a/.github/workflows/sync-from-upstream.yml
+++ b/.github/workflows/sync-from-upstream.yml
@@ -12,7 +12,7 @@ permissions: {}
 
 jobs:
   sync:
-    if: ${{ github.repository != 'tempoxyz/zones' }}
+    if: ${{ github.repository_owner == 'tempoxyz' && github.repository != 'tempoxyz/zones' }}
     runs-on: ubuntu-latest
     permissions:
       id-token: write


### PR DESCRIPTION
Skips the sync job unless the repository owner is tempoxyz, while preserving the guard that disables it in the upstream repository.

This prevents forks outside the organization from reaching GitHub STS.