### PR TITLE
chore: update GitHub STS action

### DIFF
--- a/.github/workflows/sync-from-upstream.yml
+++ b/.github/workflows/sync-from-upstream.yml
@@ -19,7 +19,7 @@ jobs:
     steps:
       - name: Fetch GitHub token via STS
         id: github-sts
-        uses: tempoxyz/gh-actions/actions/github-sts@430cf154170ed12b8c74af63038aee7d31a121d0 # main
+        uses: tempoxyz/gh-actions/actions/github-sts@8819cf80bdcb39c36c34700e3f2ecc08bde54f23 # main
         with:
           policy: sync-from-upstream
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -35,7 +35,7 @@ jobs:
           submodules: recursive
       - name: Mint read-only Earn token
         id: earn-token
-        uses: tempoxyz/gh-actions/actions/github-sts@430cf154170ed12b8c74af63038aee7d31a121d0 # main
+        uses: tempoxyz/gh-actions/actions/github-sts@8819cf80bdcb39c36c34700e3f2ecc08bde54f23 # main
         with:
           scope: tempoxyz/earn
           policy: zones-read

--- a/.github/workflows/zones-benchmark.yml
+++ b/.github/workflows/zones-benchmark.yml
@@ -510,7 +510,7 @@ jobs:
 
       - name: Mint read-only Earn token
         id: earn-token
-        uses: tempoxyz/gh-actions/actions/github-sts@430cf154170ed12b8c74af63038aee7d31a121d0 # main
+        uses: tempoxyz/gh-actions/actions/github-sts@8819cf80bdcb39c36c34700e3f2ecc08bde54f23 # main
         with:
           scope: tempoxyz/earn
           policy: zones-read


### PR DESCRIPTION
Pins every GitHub STS action use in this repository to tempoxyz/gh-actions@8819cf80bdcb39c36c34700e3f2ecc08bde54f23, including the deterministic revocation cleanup from tempoxyz/gh-actions#73 and TTL support from tempoxyz/gh-actions#74. The diff is pin-only and passes actionlint.