### PR TITLE
feat(checker): verify Portal balance conservation

### DIFF
--- a/crates/checker/DESIGN.md
+++ b/crates/checker/DESIGN.md
@@ -81,7 +81,25 @@ ghost account_total(token) == sum of ghost account balances(token)
 
 ### Portal collateral
 
-For every enabled token at the exact imported Tempo block:
+For every successful Tempo receipt, Portal-affecting TIP-20 transfers must
+satisfy:
+
+```text
+observed outflow == protocol-authorized outflow
+observed inflow  >= protocol-required inflow
+```
+
+The excess inbound amount is unattributed surplus. At every imported Tempo
+block, custody must also conserve exactly:
+
+```text
+Portal custody(tip) == Portal custody(parent)
+                     + observed inflow
+                     - observed outflow
+```
+
+This prevents existing or newly donated surplus from masking an unauthorized
+loss. The checker then separately enforces solvency for every enabled token:
 
 ```text
 Portal custody >= account_total
@@ -90,6 +108,10 @@ Portal custody >= account_total
                 + pending_tempo_refunds
                 + pending_zone_refunds
 ```
+
+Protocol fees are included in the receipt movements. The checker derives them
+from authenticated Portal events and verifies the matching TIP-20 transfers;
+the persisted ghost-state schema is unchanged.
 
 ## Event authentication
 

--- a/crates/checker/README.md
+++ b/crates/checker/README.md
@@ -38,8 +38,10 @@ affect the aggregate solvency model are retained. Genesis bridge cursors are
 checked only to establish the empty bootstrap baseline.
 
 It then reads affected balances and every enabled token's supply from the exact
-Zone post-state. Portal custody is read at both the imported Tempo block and its
-parent. The required invariants are:
+Zone post-state. Portal custody is verified at both the imported Tempo block and
+its parent. The tip read is retained after durable verification and reused as
+the next block's parent; startup, coordinate mismatches, and newly enabled
+tokens fall back to exact parent reads. The required invariants are:
 
 ```text
 Zone balance(account, token) == derived entitlement(account, token)

--- a/crates/checker/README.md
+++ b/crates/checker/README.md
@@ -16,6 +16,8 @@ For every canonical Zone block, the checker independently derives:
 - Each enabled token's expected Zone supply from those entitlements.
 - Portal liabilities for circulating supply, pending deposits, pending
   withdrawals, and pending refunds.
+- Every Portal custody outflow and the exact custody change across each imported
+  Tempo block, including protocol fees.
 - The recipient and amount of every Inbox mint from its authenticated bridge
   lifecycle event.
 - Every user withdrawal's exact TIP-20 debit and burn, including sponsored
@@ -36,14 +38,22 @@ affect the aggregate solvency model are retained. Genesis bridge cursors are
 checked only to establish the empty bootstrap baseline.
 
 It then reads affected balances and every enabled token's supply from the exact
-Zone post-state and reads Portal custody at the exact imported Tempo block. The
-required invariants are:
+Zone post-state. Portal custody is read at both the imported Tempo block and its
+parent. The required invariants are:
 
 ```text
 Zone balance(account, token) == derived entitlement(account, token)
 Zone totalSupply(token)      == sum of derived entitlements(token)
+Portal custody(tip)          == Portal custody(parent) + observed inflow - observed outflow
 Portal custody(token)        >= supply + deposits + withdrawals + refunds
 ```
+
+Receipt-local TIP-20 transfers must cover every protocol-required inflow and
+must exactly match every protocol-authorized outflow. Additional inbound
+transfers are accepted as unattributed surplus; they cannot authorize or hide
+an unrelated outflow. Fee amounts emitted by the Portal are included in these
+custody movements, so enabling nonzero fees requires no checker database
+migration or historical backfill.
 
 The checker reads all enabled-token supplies every block and reads balances for
 accounts touched by that block. Its durable entitlement ledger carries earlier

--- a/crates/checker/src/accounting/mod.rs
+++ b/crates/checker/src/accounting/mod.rs
@@ -14,6 +14,26 @@ pub(crate) struct AccountKey {
     pub(crate) account: Address,
 }
 
+/// One observed Portal balance transition.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) struct PortalBalanceChange {
+    pub(crate) token: Address,
+    pub(crate) parent_balance: U256,
+    pub(crate) actual: U256,
+    pub(crate) inflow: U256,
+    pub(crate) outflow: U256,
+}
+
+impl PortalBalanceChange {
+    fn expected(&self) -> Result<U256, AccountingError> {
+        self.parent_balance
+            .checked_add(self.inflow)
+            .ok_or(AccountingError::Overflow)?
+            .checked_sub(self.outflow)
+            .ok_or(AccountingError::Underflow)
+    }
+}
+
 impl AccountKey {
     pub(crate) const fn new(token: Address, account: Address) -> Self {
         Self { token, account }
@@ -237,6 +257,24 @@ impl State {
         Ok(())
     }
 
+    /// Verify exact Portal balance changes across one imported Tempo block.
+    pub(crate) fn verify_portal_balance_changes(
+        &self,
+        balances: impl IntoIterator<Item = PortalBalanceChange>,
+    ) -> Result<(), AccountingError> {
+        for balance in balances {
+            let expected = balance.expected()?;
+            if balance.actual != expected {
+                return Err(AccountingError::CustodyMismatch {
+                    token: balance.token,
+                    expected,
+                    actual: balance.actual,
+                });
+            }
+        }
+        Ok(())
+    }
+
     fn apply_effect(
         &mut self,
         effect: Effect,
@@ -443,6 +481,12 @@ pub(crate) enum AccountingError {
         token: Address,
         required: U256,
         available: U256,
+    },
+    #[error("token {token} custody mismatch: expected {expected}, observed {actual}")]
+    CustodyMismatch {
+        token: Address,
+        expected: U256,
+        actual: U256,
     },
 }
 

--- a/crates/checker/src/accounting/tests.rs
+++ b/crates/checker/src/accounting/tests.rs
@@ -2,7 +2,10 @@ use std::collections::BTreeMap;
 
 use alloy_primitives::{Address, U256};
 
-use super::{AccountKey, AccountingError, BalanceChange, Effect, LiabilityKind, State, TokenState};
+use super::{
+    AccountKey, AccountingError, BalanceChange, Effect, LiabilityKind, PortalBalanceChange, State,
+    TokenState,
+};
 
 fn address(byte: u8) -> Address {
     Address::repeat_byte(byte)
@@ -224,6 +227,41 @@ fn checks_full_portal_liability() {
     assert!(matches!(
         state.verify_portal_balances([(token, U256::from(161))]),
         Err(AccountingError::CollateralShortfall { .. })
+    ));
+}
+
+#[test]
+fn custody_conservation_detects_a_loss_hidden_by_surplus() {
+    let token = address(1);
+    let mut state = state_with_tokens([token]);
+    state
+        .apply(&[Effect::Account {
+            key: AccountKey::new(token, address(2)),
+            change: BalanceChange::Credit(U256::from(100)),
+        }])
+        .unwrap();
+
+    state
+        .verify_portal_balances([(token, U256::from(103))])
+        .unwrap();
+    state
+        .verify_portal_balance_changes([PortalBalanceChange {
+            token,
+            parent_balance: U256::from(100),
+            actual: U256::from(103),
+            inflow: U256::from(10),
+            outflow: U256::from(7),
+        }])
+        .unwrap();
+    assert!(matches!(
+        state.verify_portal_balance_changes([PortalBalanceChange {
+            token,
+            parent_balance: U256::from(110),
+            actual: U256::from(103),
+            inflow: U256::ZERO,
+            outflow: U256::ZERO,
+        }]),
+        Err(AccountingError::CustodyMismatch { .. })
     ));
 }
 

--- a/crates/checker/src/l1/custody.rs
+++ b/crates/checker/src/l1/custody.rs
@@ -1,0 +1,196 @@
+use std::collections::{BTreeMap, BTreeSet};
+
+use alloy_primitives::{Address, Log, U256};
+use tempo_contracts::precompiles::ITIP20;
+use zone_l1::is_portal_transfer;
+
+use super::events::{CustodyEffect, L1PortalEvent};
+use crate::decode_event;
+
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+pub(crate) struct CustodyMovement {
+    pub(crate) inflow: U256,
+    pub(crate) outflow: U256,
+    pub(crate) unattributed_inflow: U256,
+}
+
+impl CustodyMovement {
+    /// Add one receipt's movement.
+    pub(super) fn merge(&mut self, other: Self) -> eyre::Result<()> {
+        let inflow = self
+            .inflow
+            .checked_add(other.inflow)
+            .ok_or_else(|| eyre::eyre!("custody inflow overflow"))?;
+        let outflow = self
+            .outflow
+            .checked_add(other.outflow)
+            .ok_or_else(|| eyre::eyre!("custody outflow overflow"))?;
+        let unattributed_inflow = self
+            .unattributed_inflow
+            .checked_add(other.unattributed_inflow)
+            .ok_or_else(|| eyre::eyre!("unattributed inflow overflow"))?;
+        *self = Self {
+            inflow,
+            outflow,
+            unattributed_inflow,
+        };
+        Ok(())
+    }
+}
+
+#[derive(Default)]
+struct ExpectedMovement {
+    inflow: U256,
+    outflow: U256,
+}
+
+/// Reconcile one receipt's Portal events and TIP-20 transfers.
+pub(super) fn reconcile_receipt<'a>(
+    portal: Address,
+    events: &[L1PortalEvent],
+    logs: impl IntoIterator<Item = &'a Log>,
+    block: u64,
+    receipt: u64,
+) -> eyre::Result<BTreeMap<Address, CustodyMovement>> {
+    let add = |value: &mut U256, amount: U256| -> eyre::Result<()> {
+        *value = value
+            .checked_add(amount)
+            .ok_or_else(|| eyre::eyre!("custody movement overflow"))?;
+        Ok(())
+    };
+    let mut expected = BTreeMap::<Address, ExpectedMovement>::new();
+    for event in events {
+        let CustodyEffect {
+            token,
+            inflow,
+            outflow,
+        } = event.custody_effect();
+        let movement = expected.entry(token).or_default();
+        add(&mut movement.inflow, inflow)?;
+        add(&mut movement.outflow, outflow)?;
+    }
+
+    let mut observed = BTreeMap::<Address, CustodyMovement>::new();
+    for log in logs {
+        if !is_portal_transfer(log, portal) {
+            continue;
+        }
+        let transfer = decode_event::<ITIP20::Transfer>(log, "Transfer", block)?;
+        let movement = observed.entry(log.address).or_default();
+        if transfer.to == portal {
+            add(&mut movement.inflow, transfer.amount)?;
+        }
+        if transfer.from == portal {
+            add(&mut movement.outflow, transfer.amount)?;
+        }
+    }
+
+    let tokens = expected
+        .keys()
+        .chain(observed.keys())
+        .copied()
+        .collect::<BTreeSet<_>>();
+    for token in tokens {
+        let expected = expected.remove(&token).unwrap_or_default();
+        let movement = observed.entry(token).or_default();
+        eyre::ensure!(
+            movement.outflow == expected.outflow,
+            "Portal outflow mismatch for {token} in Tempo block {block} receipt {receipt}: expected {}, observed {}",
+            expected.outflow,
+            movement.outflow
+        );
+        eyre::ensure!(
+            movement.inflow >= expected.inflow,
+            "Portal inflow mismatch for {token} in Tempo block {block} receipt {receipt}: expected at least {}, observed {}",
+            expected.inflow,
+            movement.inflow
+        );
+        movement.unattributed_inflow = movement.inflow - expected.inflow;
+    }
+    Ok(observed)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use alloy_sol_types::SolEvent;
+    use tempo_primitives::TempoAddressExt;
+
+    fn token(suffix: u8) -> Address {
+        let mut bytes = [0u8; 20];
+        bytes[..12].copy_from_slice(&Address::TIP20_PREFIX);
+        bytes[19] = suffix;
+        Address::from(bytes)
+    }
+
+    fn transfer(token: Address, from: Address, to: Address, amount: u64) -> Log {
+        Log {
+            address: token,
+            data: ITIP20::Transfer {
+                from,
+                to,
+                amount: U256::from(amount),
+            }
+            .encode_log_data(),
+        }
+    }
+
+    #[test]
+    fn accepts_and_reports_unattributed_inflow() {
+        let portal = Address::repeat_byte(1);
+        let token = token(2);
+        let sender = Address::repeat_byte(3);
+        let donor = Address::repeat_byte(4);
+        let admin = Address::repeat_byte(5);
+        let event = L1PortalEvent::DepositMade {
+            token,
+            net_amount: 100,
+            fee: 5,
+            deposit_number: 1,
+        };
+        let logs = [
+            transfer(token, sender, portal, 105),
+            transfer(token, portal, admin, 5),
+            transfer(token, donor, portal, 10),
+        ];
+
+        let movement = reconcile_receipt(portal, &[event], &logs, 1, 0).unwrap()[&token];
+        assert_eq!(movement.inflow, U256::from(115));
+        assert_eq!(movement.outflow, U256::from(5));
+        assert_eq!(movement.unattributed_inflow, U256::from(10));
+    }
+
+    #[test]
+    fn rejects_outflow_even_when_inflow_is_larger() {
+        let portal = Address::repeat_byte(1);
+        let token = token(2);
+        let logs = [
+            transfer(token, Address::repeat_byte(3), portal, 10),
+            transfer(token, portal, Address::repeat_byte(4), 7),
+        ];
+
+        assert!(reconcile_receipt(portal, &[], &logs, 1, 0).is_err());
+    }
+
+    #[test]
+    fn ignores_unrelated_malformed_transfers() {
+        let portal = Address::repeat_byte(1);
+        let log = Log {
+            address: token(2),
+            data: alloy_primitives::LogData::new_unchecked(
+                vec![
+                    ITIP20::Transfer::SIGNATURE_HASH,
+                    Address::repeat_byte(3).into_word(),
+                    Address::repeat_byte(4).into_word(),
+                ],
+                Default::default(),
+            ),
+        };
+
+        assert!(
+            reconcile_receipt(portal, &[], [&log], 1, 0)
+                .unwrap()
+                .is_empty()
+        );
+    }
+}

--- a/crates/checker/src/l1/events.rs
+++ b/crates/checker/src/l1/events.rs
@@ -1,9 +1,7 @@
 //! Decoded L1 Portal events with their canonical receipt provenance.
 
-use alloy_network::ReceiptResponse as _;
-use alloy_primitives::{Address, Log};
+use alloy_primitives::{Address, Log, U256};
 use alloy_sol_types::SolEvent;
-use tempo_alloy::rpc::TempoTransactionReceipt;
 use tempo_zone_contracts::ZonePortal;
 
 use crate::decode_event;
@@ -15,6 +13,7 @@ pub(crate) enum L1PortalEvent {
     DepositMade {
         token: Address,
         net_amount: u128,
+        fee: u128,
         deposit_number: u64,
     },
     /// A TIP-20 token newly enabled for bridging.
@@ -47,6 +46,70 @@ pub(crate) enum L1PortalEvent {
     },
 }
 
+pub(super) struct CustodyEffect {
+    pub(super) token: Address,
+    pub(super) inflow: U256,
+    pub(super) outflow: U256,
+}
+
+impl L1PortalEvent {
+    /// Return the Portal custody movement required by this event.
+    pub(super) fn custody_effect(&self) -> CustodyEffect {
+        match *self {
+            Self::DepositMade {
+                token,
+                net_amount,
+                fee,
+                ..
+            } => CustodyEffect {
+                token,
+                inflow: U256::from(net_amount) + U256::from(fee),
+                outflow: U256::from(fee),
+            },
+            Self::WithdrawalProcessed {
+                token,
+                amount,
+                callback_success: true,
+                ..
+            } => CustodyEffect {
+                token,
+                inflow: U256::ZERO,
+                outflow: U256::from(amount),
+            },
+            Self::DepositBounceBack {
+                token,
+                amount,
+                bounceback_fee,
+            } => CustodyEffect {
+                token,
+                inflow: U256::ZERO,
+                outflow: U256::from(amount) + U256::from(bounceback_fee),
+            },
+            Self::DepositBounceBackPending {
+                token,
+                bounceback_fee,
+                ..
+            } => CustodyEffect {
+                token,
+                inflow: U256::ZERO,
+                outflow: U256::from(bounceback_fee),
+            },
+            Self::RefundClaimed { token, amount, .. } => CustodyEffect {
+                token,
+                inflow: U256::ZERO,
+                outflow: U256::from(amount),
+            },
+            Self::TokenEnabled { token }
+            | Self::WithdrawalProcessed { token, .. }
+            | Self::WithdrawalBounceBack { token, .. } => CustodyEffect {
+                token,
+                inflow: U256::ZERO,
+                outflow: U256::ZERO,
+            },
+        }
+    }
+}
+
 /// Builds ordered event evidence while receipts are visited once.
 #[derive(Default)]
 pub(super) struct EventCollector {
@@ -61,26 +124,6 @@ impl EventCollector {
             portal,
             ..Default::default()
         }
-    }
-
-    /// Decode recognized Portal logs from one canonical receipt.
-    ///
-    /// Failed receipts are skipped entirely. Only logs from `portal` are
-    /// decoded. Recognized-but-irrelevant topics (pausing, admin, gas-rate
-    /// updates, etc.) are ignored; a truly unrecognized topic fails closed. A
-    /// known event that fails ABI decoding returns a contextual error.
-    pub(super) fn extract_receipt(
-        &mut self,
-        receipt: &TempoTransactionReceipt,
-        block: u64,
-    ) -> eyre::Result<()> {
-        if !receipt.status() {
-            return Ok(());
-        }
-        for log in receipt.logs() {
-            self.extract_log(&log.inner, block)?;
-        }
-        Ok(())
     }
 
     /// Decode one receipt-authenticated log when it was emitted by the configured Portal.
@@ -119,6 +162,7 @@ fn decode_portal_event(log: &Log, block: u64) -> eyre::Result<Option<L1PortalEve
             L1PortalEvent::DepositMade {
                 token: e.token,
                 net_amount: e.netAmount,
+                fee: e.fee,
                 deposit_number: e.depositNumber,
             }
         }
@@ -234,6 +278,7 @@ fn decode_portal_event(log: &Log, block: u64) -> eyre::Result<Option<L1PortalEve
 mod tests {
     use super::*;
     use alloy_consensus::ReceiptWithBloom;
+    use alloy_network::ReceiptResponse as _;
     use alloy_primitives::{B256, Bloom, U256, address};
     use alloy_rpc_types_eth::TransactionReceipt;
     use tempo_alloy::rpc::TempoTransactionReceipt;
@@ -372,7 +417,11 @@ mod tests {
     fn collect(receipts: &[TempoTransactionReceipt]) -> eyre::Result<Vec<L1PortalEvent>> {
         let mut collector = EventCollector::new(PORTAL);
         for receipt in receipts {
-            collector.extract_receipt(receipt, BLOCK)?;
+            if receipt.status() {
+                for log in receipt.logs() {
+                    collector.extract_log(&log.inner, BLOCK)?;
+                }
+            }
         }
         Ok(collector.finish())
     }
@@ -486,11 +535,7 @@ mod tests {
                 vec![noise, withdrawal(), token()],
             ),
         ];
-        let mut collector = EventCollector::new(PORTAL);
-        for receipt in &receipts {
-            collector.extract_receipt(receipt, BLOCK).unwrap();
-        }
-        let events = collector.finish();
+        let events = collect(&receipts).unwrap();
 
         assert_eq!(events.len(), 3);
         assert!(matches!(events[0], L1PortalEvent::DepositMade { .. }));

--- a/crates/checker/src/l1/mod.rs
+++ b/crates/checker/src/l1/mod.rs
@@ -1,10 +1,13 @@
 //! Collection of all temporary evidence for one anchored Tempo/L1 block.
 
+mod custody;
 mod events;
+
+use std::collections::BTreeMap;
 
 use alloy_consensus::BlockHeader as _;
 use alloy_eips::{BlockId, BlockNumHash};
-use alloy_network::{BlockResponse as _, primitives::HeaderResponse as _};
+use alloy_network::{BlockResponse as _, ReceiptResponse as _, primitives::HeaderResponse as _};
 use alloy_primitives::{Address, B256, Bloom, Sealable as _, U256};
 use alloy_provider::{DynProvider, Provider};
 use alloy_transport::{RpcError, TransportError, TransportErrorKind};
@@ -18,6 +21,8 @@ use zone_l1::L1BlockTracker;
 
 use crate::AttemptError;
 
+pub(crate) use custody::CustodyMovement;
+use custody::reconcile_receipt;
 use events::EventCollector;
 pub(crate) use events::L1PortalEvent;
 
@@ -58,6 +63,7 @@ impl From<L1ReadError> for AttemptError {
 pub(crate) struct L1BlockEvidence {
     block: BlockNumHash,
     events: Vec<L1PortalEvent>,
+    custody: BTreeMap<Address, CustodyMovement>,
 }
 
 /// Header fields bound to the hash reported by the Tempo RPC.
@@ -97,6 +103,18 @@ impl L1BlockEvidence {
     pub(crate) fn portal_events(&self) -> impl Iterator<Item = &L1PortalEvent> {
         self.events.iter()
     }
+
+    pub(crate) fn custody(&self, token: Address) -> CustodyMovement {
+        self.custody.get(&token).copied().unwrap_or_default()
+    }
+
+    pub(crate) fn custody_movements(
+        &self,
+    ) -> impl Iterator<Item = (Address, CustodyMovement)> + '_ {
+        self.custody
+            .iter()
+            .map(|(&token, &movement)| (token, movement))
+    }
 }
 
 /// Fetch the exact anchored Tempo block that extends `parent`.
@@ -108,7 +126,7 @@ pub(crate) async fn collect_l1_block_at(
     expected: BlockNumHash,
 ) -> Result<L1BlockEvidence, L1ReadError> {
     if let Some(evidence) = tracker
-        .authenticated_portal_logs(expected)
+        .authenticated_portal_evidence(expected)
         .map_err(finding)?
     {
         return collect_tracked_l1_block_evidence(portal, parent, evidence);
@@ -119,7 +137,7 @@ pub(crate) async fn collect_l1_block_at(
 fn collect_tracked_l1_block_evidence(
     portal: Address,
     parent: BlockNumHash,
-    evidence: zone_l1::AuthenticatedPortalLogs,
+    evidence: zone_l1::AuthenticatedPortalEvidence,
 ) -> Result<L1BlockEvidence, L1ReadError> {
     let expected_number = parent.number.checked_add(1).ok_or_else(|| {
         disable(eyre::eyre!(
@@ -133,15 +151,22 @@ fn collect_tracked_l1_block_evidence(
             evidence.block.number
         )));
     }
-    let mut collector = EventCollector::new(portal);
-    for log in &evidence.logs {
-        collector
-            .extract_log(log, evidence.block.number)
-            .map_err(finding)?;
+    let mut events = Vec::new();
+    let mut custody = BTreeMap::new();
+    for receipt in &evidence.receipts {
+        collect_receipt_evidence(
+            portal,
+            evidence.block.number,
+            receipt.receipt_index,
+            receipt.logs.iter(),
+            &mut events,
+            &mut custody,
+        )?;
     }
     Ok(L1BlockEvidence {
         block: evidence.block,
-        events: collector.finish(),
+        events,
+        custody,
     })
 }
 
@@ -240,14 +265,53 @@ fn collect_l1_block_evidence(
     receipts: &[TempoTransactionReceipt],
 ) -> Result<L1BlockEvidence, L1ReadError> {
     let number = block.number;
-    let mut event_collector = EventCollector::new(portal);
-    for receipt in receipts {
-        event_collector
-            .extract_receipt(receipt, number)
+    let mut events = Vec::new();
+    let mut custody = BTreeMap::new();
+    for (receipt_index, receipt) in receipts.iter().enumerate() {
+        if !receipt.status() {
+            continue;
+        }
+        collect_receipt_evidence(
+            portal,
+            number,
+            receipt_index as u64,
+            receipt.logs().iter().map(|log| &log.inner),
+            &mut events,
+            &mut custody,
+        )?;
+    }
+    Ok(L1BlockEvidence {
+        block,
+        events,
+        custody,
+    })
+}
+
+/// Collect Portal events and custody movements from one receipt.
+fn collect_receipt_evidence<'a>(
+    portal: Address,
+    block: u64,
+    receipt: u64,
+    logs: impl Clone + IntoIterator<Item = &'a alloy_primitives::Log>,
+    events: &mut Vec<L1PortalEvent>,
+    custody: &mut BTreeMap<Address, CustodyMovement>,
+) -> Result<(), L1ReadError> {
+    let mut collector = EventCollector::new(portal);
+    for log in logs.clone() {
+        collector.extract_log(log, block).map_err(finding)?;
+    }
+    let receipt_events = collector.finish();
+    let movement =
+        reconcile_receipt(portal, &receipt_events, logs, block, receipt).map_err(finding)?;
+    for (token, movement) in movement {
+        custody
+            .entry(token)
+            .or_default()
+            .merge(movement)
             .map_err(finding)?;
     }
-    let events = event_collector.finish();
-    Ok(L1BlockEvidence { block, events })
+    events.extend(receipt_events);
+    Ok(())
 }
 
 fn classify_contract_error(error: alloy_contract::Error) -> L1ReadError {
@@ -354,10 +418,13 @@ mod tests {
             }
             .encode_log_data(),
         };
-        let tracked = zone_l1::AuthenticatedPortalLogs {
+        let tracked = zone_l1::AuthenticatedPortalEvidence {
             block: NumHash::new(BLOCK, HASH),
             parent_hash: parent.hash,
-            logs: vec![log],
+            receipts: vec![zone_l1::AuthenticatedPortalReceipt {
+                receipt_index: 0,
+                logs: vec![log],
+            }],
         };
 
         let evidence = collect_tracked_l1_block_evidence(portal, parent, tracked).unwrap();
@@ -370,10 +437,10 @@ mod tests {
 
     #[test]
     fn tracked_evidence_rejects_non_contiguous_parent() {
-        let tracked = zone_l1::AuthenticatedPortalLogs {
+        let tracked = zone_l1::AuthenticatedPortalEvidence {
             block: NumHash::new(BLOCK, HASH),
             parent_hash: B256::repeat_byte(0xff),
-            logs: vec![],
+            receipts: vec![],
         };
         let result = collect_tracked_l1_block_evidence(
             Address::ZERO,

--- a/crates/checker/src/runtime.rs
+++ b/crates/checker/src/runtime.rs
@@ -148,6 +148,7 @@ where
         metrics.recovery_rebuilds_total.increment(1);
     }
     metrics.update(&snapshot);
+    let mut portal_balance_cache = PortalBalanceCache::default();
 
     ctx.catch_up_notifications_with_head(ExExHead::new(snapshot.metadata.verified_zone.into()))?;
     ctx.send_finished_height(snapshot.metadata.verified_zone.into())?;
@@ -155,6 +156,7 @@ where
     while let Some(notification) = ctx.notifications.try_next().await? {
         if !matches!(&notification, ExExNotification::ChainCommitted { .. }) {
             snapshot = store.reset(&checkpoint)?;
+            portal_balance_cache.clear();
             metrics.recovery_rebuilds_total.increment(1);
             metrics.update(&snapshot);
             ctx.catch_up_notifications_with_head(ExExHead::new(bootstrap.zone().into()))?;
@@ -173,14 +175,18 @@ where
         metrics.update(&snapshot);
 
         let previous_verified = snapshot.metadata.verified_zone.number;
+        let verification = VerificationContext {
+            config: &config,
+            metrics,
+            l1: &l1,
+            store: &store,
+        };
         match process_notification(
             &notification,
             ctx.provider(),
-            &l1,
-            &store,
             snapshot,
-            &config,
-            metrics,
+            &mut portal_balance_cache,
+            &verification,
         )
         .await
         {
@@ -296,6 +302,75 @@ enum BlockError {
 struct VerificationContext<'a> {
     config: &'a CheckerConfig,
     metrics: &'a CheckerMetrics,
+    l1: &'a DynProvider<TempoNetwork>,
+    store: &'a Store,
+}
+
+/// Last Portal balances tied to a durably verified Tempo coordinate.
+#[derive(Default)]
+struct PortalBalanceCache {
+    verified: Option<VerifiedPortalBalances>,
+}
+
+struct VerifiedPortalBalances {
+    tempo: BlockNumHash,
+    balances: BTreeMap<alloy_primitives::Address, alloy_primitives::U256>,
+}
+
+impl PortalBalanceCache {
+    /// Return balances only for the exact verified Tempo coordinate.
+    fn balances_at(
+        &self,
+        tempo: BlockNumHash,
+    ) -> Option<&BTreeMap<alloy_primitives::Address, alloy_primitives::U256>> {
+        self.verified
+            .as_ref()
+            .filter(|verified| verified.tempo == tempo)
+            .map(|verified| &verified.balances)
+    }
+
+    /// Return tokens not covered by the exact cached coordinate.
+    fn missing_tokens(
+        &self,
+        tempo: BlockNumHash,
+        tokens: &BTreeSet<alloy_primitives::Address>,
+    ) -> BTreeSet<alloy_primitives::Address> {
+        let cached = self.balances_at(tempo);
+        tokens
+            .iter()
+            .filter(|token| cached.is_none_or(|balances| !balances.contains_key(*token)))
+            .copied()
+            .collect()
+    }
+
+    /// Replace the cache after durable block verification.
+    fn promote(
+        &mut self,
+        tempo: BlockNumHash,
+        balances: BTreeMap<alloy_primitives::Address, alloy_primitives::U256>,
+    ) {
+        self.verified = Some(VerifiedPortalBalances { tempo, balances });
+    }
+
+    /// Discard balances when rebuilding verified state.
+    fn clear(&mut self) {
+        self.verified = None;
+    }
+}
+
+/// Cached and newly fetched parent balances for one verification.
+struct ParentPortalBalances<'a> {
+    cached: Option<&'a BTreeMap<alloy_primitives::Address, alloy_primitives::U256>>,
+    fetched: BTreeMap<alloy_primitives::Address, alloy_primitives::U256>,
+}
+
+impl ParentPortalBalances<'_> {
+    fn get(&self, token: &alloy_primitives::Address) -> Option<alloy_primitives::U256> {
+        self.fetched
+            .get(token)
+            .or_else(|| self.cached.and_then(|balances| balances.get(token)))
+            .copied()
+    }
 }
 
 fn record_retry_attempt(
@@ -343,11 +418,9 @@ impl Backoff {
 async fn process_notification<N, P>(
     notification: &ExExNotification<N>,
     provider: &P,
-    l1: &DynProvider<TempoNetwork>,
-    store: &Store,
     snapshot: Snapshot,
-    config: &CheckerConfig,
-    metrics: &CheckerMetrics,
+    portal_balance_cache: &mut PortalBalanceCache,
+    context: &VerificationContext<'_>,
 ) -> Result<Box<Snapshot>, BlockError>
 where
     N: CheckedPrimitives,
@@ -363,13 +436,19 @@ where
             )));
         }
     };
-    let context = VerificationContext { config, metrics };
     for (block, receipts) in new.blocks_and_receipts() {
         if already_applied(&current, block.header().number(), block.hash())? {
             continue;
         }
-        current =
-            verify_block::<N, _>(provider, l1, store, current, &context, block, receipts).await?;
+        current = verify_block::<N, _>(
+            provider,
+            current,
+            portal_balance_cache,
+            context,
+            block,
+            receipts,
+        )
+        .await?;
     }
     Ok(Box::new(current))
 }
@@ -395,9 +474,8 @@ fn already_applied(
 /// collateral, persisting the result on success.
 async fn verify_block<N, P>(
     provider: &P,
-    l1: &DynProvider<TempoNetwork>,
-    store: &Store,
     prior: Snapshot,
+    portal_balance_cache: &mut PortalBalanceCache,
     context: &VerificationContext<'_>,
     block: &RecoveredBlock<N::Block>,
     receipts: &[N::Receipt],
@@ -421,8 +499,7 @@ where
     validate_tempo_advance(tempo_parent.number, tempo.number).map_err(fail)?;
     let mut l1_backoff = Backoff::new();
     let tempo_block =
-        collect_l1_block_with_retry(l1, tempo_parent, tempo, zone, context, &mut l1_backoff)
-            .await?;
+        collect_l1_block_with_retry(tempo_parent, tempo, zone, context, &mut l1_backoff).await?;
     let mut block_effects = effects::from_tempo(&tempo_block);
     block_effects.extend(effects::from_zone(&l2));
     let candidate = CandidateTransition::derive(
@@ -481,18 +558,7 @@ where
         )
         .map_err(|error| fail(error.into()))?;
 
-    let parent_balances = collect_portal_balances_with_retry(
-        l1,
-        &tokens,
-        tempo_parent.hash,
-        zone,
-        context,
-        &mut l1_backoff,
-        "parent Portal balance acquisition",
-    )
-    .await?;
     let balances = collect_portal_balances_with_retry(
-        l1,
         &tokens,
         tempo.hash,
         zone,
@@ -501,44 +567,85 @@ where
         "Portal balance acquisition",
     )
     .await?;
-    let balance_changes = tokens
-        .iter()
-        .map(|token| {
-            let movement = tempo_block.custody(*token);
-            let parent_balance = parent_balances.get(token).copied().ok_or_else(|| {
-                BlockError::Disable(eyre::eyre!(
-                    "parent Portal balance result omitted token {token}"
-                ))
-            })?;
-            let actual = balances.get(token).copied().ok_or_else(|| {
-                BlockError::Disable(eyre::eyre!("Portal balance result omitted token {token}"))
-            })?;
-            Ok(crate::accounting::PortalBalanceChange {
-                token: *token,
-                parent_balance,
-                actual,
-                inflow: movement.inflow,
-                outflow: movement.outflow,
+    {
+        let parent_balances = resolve_parent_portal_balances(
+            &tokens,
+            tempo_parent,
+            zone,
+            context,
+            &mut l1_backoff,
+            portal_balance_cache,
+        )
+        .await?;
+        let balance_changes = tokens
+            .iter()
+            .map(|token| {
+                let movement = tempo_block.custody(*token);
+                let parent_balance = parent_balances.get(token).ok_or_else(|| {
+                    BlockError::Disable(eyre::eyre!(
+                        "parent Portal balance result omitted token {token}"
+                    ))
+                })?;
+                let actual = balances.get(token).copied().ok_or_else(|| {
+                    BlockError::Disable(eyre::eyre!("Portal balance result omitted token {token}"))
+                })?;
+                Ok(crate::accounting::PortalBalanceChange {
+                    token: *token,
+                    parent_balance,
+                    actual,
+                    inflow: movement.inflow,
+                    outflow: movement.outflow,
+                })
             })
-        })
-        .collect::<Result<Vec<_>, BlockError>>()?;
-    state
-        .verify_portal_balance_changes(balance_changes)
-        .map_err(|error| fail(error.into()))?;
+            .collect::<Result<Vec<_>, BlockError>>()?;
+        state
+            .verify_portal_balance_changes(balance_changes)
+            .map_err(|error| fail(error.into()))?;
+    }
     state
         .verify_portal_balances(balances.iter().map(|(&token, &balance)| (token, balance)))
         .map_err(|error| fail(error.into()))?;
 
-    let next = store
+    let next = context
+        .store
         .apply(candidate)
         .map_err(|error| BlockError::Disable(error.into()))?;
+    portal_balance_cache.promote(tempo, balances);
     telemetry::log_verified_activity(&tempo_block, &l2, zone);
     Ok(next)
 }
 
+/// Resolve parent balances from the verified cache, querying only missing tokens.
+async fn resolve_parent_portal_balances<'a>(
+    tokens: &BTreeSet<alloy_primitives::Address>,
+    tempo: BlockNumHash,
+    zone: BlockRef,
+    context: &VerificationContext<'_>,
+    backoff: &mut Backoff,
+    cache: &'a PortalBalanceCache,
+) -> Result<ParentPortalBalances<'a>, BlockError> {
+    let missing = cache.missing_tokens(tempo, tokens);
+    let fetched = if missing.is_empty() {
+        BTreeMap::new()
+    } else {
+        collect_portal_balances_with_retry(
+            &missing,
+            tempo.hash,
+            zone,
+            context,
+            backoff,
+            "parent Portal balance acquisition",
+        )
+        .await?
+    };
+    Ok(ParentPortalBalances {
+        cached: cache.balances_at(tempo),
+        fetched,
+    })
+}
+
 /// Read exact Portal balances using the block retry policy.
 async fn collect_portal_balances_with_retry(
-    l1: &DynProvider<TempoNetwork>,
     tokens: &BTreeSet<alloy_primitives::Address>,
     block: alloy_primitives::B256,
     zone: BlockRef,
@@ -546,7 +653,12 @@ async fn collect_portal_balances_with_retry(
     backoff: &mut Backoff,
     operation: &str,
 ) -> Result<BTreeMap<alloy_primitives::Address, alloy_primitives::U256>, BlockError> {
-    let VerificationContext { config, metrics } = context;
+    let VerificationContext {
+        config,
+        metrics,
+        l1,
+        ..
+    } = context;
     loop {
         match portal_balances(l1, config.portal_address, tokens.iter().copied(), block).await {
             Ok(balances) => return Ok(balances.into_iter().collect()),
@@ -568,14 +680,18 @@ fn classify_block_l1_error(error: L1ReadError, zone: BlockRef) -> BlockError {
 }
 
 async fn collect_l1_block_with_retry(
-    l1: &DynProvider<TempoNetwork>,
     parent: BlockNumHash,
     expected: BlockNumHash,
     zone: BlockRef,
     context: &VerificationContext<'_>,
     backoff: &mut Backoff,
 ) -> Result<crate::l1::L1BlockEvidence, BlockError> {
-    let VerificationContext { config, metrics } = context;
+    let VerificationContext {
+        config,
+        metrics,
+        l1,
+        ..
+    } = context;
     loop {
         match collect_l1_block_at(
             l1,
@@ -715,5 +831,43 @@ mod tests {
         .expect_err("the final attempt must disable the checker");
         assert_eq!(attempts, MAX_STATE_ATTEMPTS);
         assert!(error.to_string().contains("retry budget exhausted"));
+    }
+
+    #[test]
+    fn portal_balance_cache_requires_exact_coordinate_and_reports_missing_tokens() {
+        let tempo = BlockNumHash::new(20, alloy_primitives::B256::repeat_byte(1));
+        let cached = alloy_primitives::Address::repeat_byte(2);
+        let missing = alloy_primitives::Address::repeat_byte(3);
+        let tokens = BTreeSet::from([cached, missing]);
+        let mut cache = PortalBalanceCache::default();
+        cache.promote(
+            tempo,
+            BTreeMap::from([(cached, alloy_primitives::U256::from(10))]),
+        );
+
+        assert_eq!(
+            cache
+                .balances_at(tempo)
+                .and_then(|balances| balances.get(&cached)),
+            Some(&alloy_primitives::U256::from(10))
+        );
+        assert_eq!(
+            cache.missing_tokens(tempo, &tokens),
+            BTreeSet::from([missing])
+        );
+
+        let parent = ParentPortalBalances {
+            cached: cache.balances_at(tempo),
+            fetched: BTreeMap::from([(missing, alloy_primitives::U256::from(20))]),
+        };
+        assert_eq!(parent.get(&cached), Some(alloy_primitives::U256::from(10)));
+        assert_eq!(parent.get(&missing), Some(alloy_primitives::U256::from(20)));
+
+        let other = BlockNumHash::new(20, alloy_primitives::B256::repeat_byte(4));
+        assert!(cache.balances_at(other).is_none());
+        assert_eq!(cache.missing_tokens(other, &tokens), tokens);
+
+        cache.clear();
+        assert_eq!(cache.missing_tokens(tempo, &tokens), tokens);
     }
 }

--- a/crates/checker/src/runtime.rs
+++ b/crates/checker/src/runtime.rs
@@ -1,6 +1,10 @@
 //! Durable notification processing and observe-only failure isolation.
 
-use std::{collections::BTreeSet, future::Future, time::Duration};
+use std::{
+    collections::{BTreeMap, BTreeSet},
+    future::Future,
+    time::Duration,
+};
 
 use alloy_consensus::BlockHeader as _;
 use alloy_eips::BlockNumHash;
@@ -403,7 +407,7 @@ where
     P: BlockNumReader + ChainSpecProvider + StateProviderFactory,
     P::ChainSpec: TempoHardforks,
 {
-    let VerificationContext { config, metrics } = context;
+    let VerificationContext { metrics, .. } = context;
     let number = block.number();
     let hash = block.hash();
     let parent_hash = block.parent_hash();
@@ -477,30 +481,52 @@ where
         )
         .map_err(|error| fail(error.into()))?;
 
-    let balances = loop {
-        match portal_balances(
-            l1,
-            config.portal_address,
-            tokens.iter().copied(),
-            tempo.hash,
-        )
-        .await
-        {
-            Ok(balances) => break balances,
-            Err(L1ReadError::Unavailable(error)) => {
-                record_l1_retry(
-                    metrics,
-                    &mut l1_backoff,
-                    &error,
-                    "Portal balance acquisition",
-                )?;
-                l1_backoff.wait().await;
-            }
-            Err(error) => return Err(classify_block_l1_error(error, zone)),
-        }
-    };
+    let parent_balances = collect_portal_balances_with_retry(
+        l1,
+        &tokens,
+        tempo_parent.hash,
+        zone,
+        context,
+        &mut l1_backoff,
+        "parent Portal balance acquisition",
+    )
+    .await?;
+    let balances = collect_portal_balances_with_retry(
+        l1,
+        &tokens,
+        tempo.hash,
+        zone,
+        context,
+        &mut l1_backoff,
+        "Portal balance acquisition",
+    )
+    .await?;
+    let balance_changes = tokens
+        .iter()
+        .map(|token| {
+            let movement = tempo_block.custody(*token);
+            let parent_balance = parent_balances.get(token).copied().ok_or_else(|| {
+                BlockError::Disable(eyre::eyre!(
+                    "parent Portal balance result omitted token {token}"
+                ))
+            })?;
+            let actual = balances.get(token).copied().ok_or_else(|| {
+                BlockError::Disable(eyre::eyre!("Portal balance result omitted token {token}"))
+            })?;
+            Ok(crate::accounting::PortalBalanceChange {
+                token: *token,
+                parent_balance,
+                actual,
+                inflow: movement.inflow,
+                outflow: movement.outflow,
+            })
+        })
+        .collect::<Result<Vec<_>, BlockError>>()?;
     state
-        .verify_portal_balances(balances)
+        .verify_portal_balance_changes(balance_changes)
+        .map_err(|error| fail(error.into()))?;
+    state
+        .verify_portal_balances(balances.iter().map(|(&token, &balance)| (token, balance)))
         .map_err(|error| fail(error.into()))?;
 
     let next = store
@@ -508,6 +534,29 @@ where
         .map_err(|error| BlockError::Disable(error.into()))?;
     telemetry::log_verified_activity(&tempo_block, &l2, zone);
     Ok(next)
+}
+
+/// Read exact Portal balances using the block retry policy.
+async fn collect_portal_balances_with_retry(
+    l1: &DynProvider<TempoNetwork>,
+    tokens: &BTreeSet<alloy_primitives::Address>,
+    block: alloy_primitives::B256,
+    zone: BlockRef,
+    context: &VerificationContext<'_>,
+    backoff: &mut Backoff,
+    operation: &str,
+) -> Result<BTreeMap<alloy_primitives::Address, alloy_primitives::U256>, BlockError> {
+    let VerificationContext { config, metrics } = context;
+    loop {
+        match portal_balances(l1, config.portal_address, tokens.iter().copied(), block).await {
+            Ok(balances) => return Ok(balances.into_iter().collect()),
+            Err(L1ReadError::Unavailable(error)) => {
+                record_l1_retry(metrics, backoff, &error, operation)?;
+                backoff.wait().await;
+            }
+            Err(error) => return Err(classify_block_l1_error(error, zone)),
+        }
+    }
 }
 
 fn classify_block_l1_error(error: L1ReadError, zone: BlockRef) -> BlockError {

--- a/crates/checker/src/telemetry.rs
+++ b/crates/checker/src/telemetry.rs
@@ -168,6 +168,20 @@ impl CheckerMetrics {
 /// Log authenticated protocol activity after a Zone block is verified.
 pub(crate) fn log_verified_activity(tempo: &L1BlockEvidence, l2: &L2BlockEvidence, zone: BlockRef) {
     let tempo_ref = BlockRef::from(tempo.block());
+    for (token, movement) in tempo.custody_movements() {
+        if !movement.unattributed_inflow.is_zero() {
+            tracing::info!(
+                target: "zone::checker",
+                zone_block = zone.number,
+                zone_hash = %zone.hash,
+                tempo_block = tempo_ref.number,
+                tempo_hash = %tempo_ref.hash,
+                %token,
+                amount = %movement.unattributed_inflow,
+                "observed unattributed Portal inflow"
+            );
+        }
+    }
     for (index, event) in (0u64..).zip(tempo.portal_events()) {
         log_tempo_event(
             event,
@@ -187,12 +201,14 @@ fn log_tempo_event(event: &L1PortalEvent, context: &ActivityContext) {
         L1PortalEvent::DepositMade {
             token,
             net_amount,
+            fee,
             deposit_number,
         } => activity_log!(
             context,
             activity_event::PORTAL_DEPOSIT_ACCOUNTED,
             %token,
             amount = %net_amount,
+            %fee,
             deposit_number,
             "accounted authenticated Portal deposit"
         ),

--- a/crates/l1/src/lib.rs
+++ b/crates/l1/src/lib.rs
@@ -96,8 +96,9 @@ pub use ext::{ChainTempoStateExt, TempoStateExt};
 pub use queue::DepositQueue;
 pub use state::L1StateCache;
 pub use subscriber::{
-    AuthenticatedPortalLogs, L1BlockTracker, L1Subscriber, L1SubscriberConfig, LeadershipSink,
-    MAX_L1_LOOKAHEAD_BLOCKS, verify_receipts_against_header,
+    AuthenticatedPortalEvidence, AuthenticatedPortalReceipt, L1BlockTracker, L1Subscriber,
+    L1SubscriberConfig, LeadershipSink, MAX_L1_LOOKAHEAD_BLOCKS, is_portal_transfer,
+    verify_receipts_against_header,
 };
 
 #[cfg(test)]

--- a/crates/l1/src/subscriber.rs
+++ b/crates/l1/src/subscriber.rs
@@ -1,10 +1,11 @@
 use super::*;
 use eyre::WrapErr as _;
-use std::collections::HashSet;
-use tempo_contracts::precompiles::{ITIP20::TransferPolicyUpdate, TIP403_REGISTRY_ADDRESS};
+use std::collections::{BTreeMap, HashSet};
+use tempo_contracts::precompiles::{
+    ITIP20::{Transfer, TransferPolicyUpdate},
+    TIP403_REGISTRY_ADDRESS,
+};
 use tempo_primitives::is_tip20_prefix;
-
-use std::collections::BTreeMap;
 
 /// Maximum number of authenticated L1 blocks the subscriber may retain ahead of the Zone
 /// consumer's imported Tempo checkpoint (approximately one hour at Tempo's 500ms block time).
@@ -13,7 +14,7 @@ pub const MAX_L1_LOOKAHEAD_BLOCKS: u64 = 7_200;
 #[derive(Debug, Default)]
 struct L1BlockTrackerState {
     observed: BTreeMap<u64, L1BlockObservation>,
-    recent_portal_evidence: BTreeMap<u64, AuthenticatedPortalLogs>,
+    recent_portal_evidence: BTreeMap<u64, AuthenticatedPortalEvidence>,
     latest: Option<NumHash>,
     pruned_through: Option<u64>,
 }
@@ -22,18 +23,27 @@ struct L1BlockTrackerState {
 struct L1BlockObservation {
     hash: B256,
     portal_events: L1PortalEvents,
-    portal_evidence: Option<AuthenticatedPortalLogs>,
+    portal_evidence: Option<AuthenticatedPortalEvidence>,
 }
 
-/// Receipt-root-authenticated Portal logs for one finalized Tempo block.
+/// Relevant logs from one successful receipt.
 #[derive(Debug, Clone)]
-pub struct AuthenticatedPortalLogs {
+pub struct AuthenticatedPortalReceipt {
+    /// Receipt position in the block.
+    pub receipt_index: u64,
+    /// Portal events and TIP-20 transfers involving the Portal.
+    pub logs: Vec<alloy_primitives::Log>,
+}
+
+/// Receipt-root-authenticated Portal evidence for one finalized Tempo block.
+#[derive(Debug, Clone)]
+pub struct AuthenticatedPortalEvidence {
     /// Exact finalized Tempo block containing the logs.
     pub block: NumHash,
     /// Parent hash from the authenticated Tempo header.
     pub parent_hash: B256,
-    /// Portal logs in canonical receipt and log order.
-    pub logs: Vec<alloy_primitives::Log>,
+    /// Relevant successful receipts in canonical order.
+    pub receipts: Vec<AuthenticatedPortalReceipt>,
 }
 
 /// Number of consumed Tempo blocks whose authenticated Portal logs remain available to
@@ -175,14 +185,14 @@ impl L1BlockTracker {
         }
     }
 
-    /// Return retained receipt-authenticated Portal logs for an exact Tempo block.
+    /// Return retained receipt-authenticated Portal evidence for an exact Tempo block.
     ///
     /// This is intentionally non-blocking. Callers replaying older history can fall back to an
     /// archival provider when the bounded recent cache no longer contains the block.
-    pub fn authenticated_portal_logs(
+    pub fn authenticated_portal_evidence(
         &self,
         block: NumHash,
-    ) -> eyre::Result<Option<AuthenticatedPortalLogs>> {
+    ) -> eyre::Result<Option<AuthenticatedPortalEvidence>> {
         let state = self.state.read();
         if let Some(observation) = state.observed.get(&block.number) {
             eyre::ensure!(
@@ -221,18 +231,18 @@ impl L1BlockTracker {
         self.record_observation(block, portal_events, None)
     }
 
-    /// Record an L1 anchor together with decoded events and authenticated raw Portal logs.
+    /// Record an L1 anchor with decoded events and authenticated Portal transfer evidence.
     pub fn record_with_portal_evidence(
         &self,
         block: NumHash,
         parent_hash: B256,
         portal_events: L1PortalEvents,
-        logs: Vec<alloy_primitives::Log>,
+        receipts: Vec<AuthenticatedPortalReceipt>,
     ) -> eyre::Result<()> {
-        let evidence = AuthenticatedPortalLogs {
+        let evidence = AuthenticatedPortalEvidence {
             block,
             parent_hash,
-            logs,
+            receipts,
         };
         self.record_observation(block, portal_events, Some(evidence))
     }
@@ -241,7 +251,7 @@ impl L1BlockTracker {
         &self,
         block: NumHash,
         portal_events: L1PortalEvents,
-        portal_evidence: Option<AuthenticatedPortalLogs>,
+        portal_evidence: Option<AuthenticatedPortalEvidence>,
     ) -> eyre::Result<()> {
         let mut state = self.state.write();
         if let Some(observation) = state.observed.get(&block.number) {
@@ -331,8 +341,18 @@ const HTTP_POLL_INTERVAL: std::time::Duration = std::time::Duration::from_millis
 type L1ProcessedEvents = (
     L1PortalEvents,
     HashSet<Address>,
-    Option<Vec<alloy_primitives::Log>>,
+    Option<Vec<AuthenticatedPortalReceipt>>,
 );
+
+/// Return whether a TIP-20 transfer moves value into or out of `portal`.
+pub fn is_portal_transfer(log: &alloy_primitives::Log, portal: Address) -> bool {
+    if !is_tip20_prefix(log.address) || log.topics().first() != Some(&Transfer::SIGNATURE_HASH) {
+        return false;
+    }
+    let portal = portal.into_word();
+    let topics = log.topics();
+    topics.get(1) == Some(&portal) || topics.get(2) == Some(&portal)
+}
 
 fn cache_invalidation_address(address: Address, topic0: Option<&B256>) -> Option<Address> {
     (address == TIP403_REGISTRY_ADDRESS
@@ -771,12 +791,12 @@ impl L1Subscriber {
                     self.subscriber_metrics.decode_fence_failures.increment(1);
                     FencedIngestionError::new(block_number, "portal event decoding", err)
                 })?;
-            let (events, invalidated, portal_logs) = processed_events;
+            let (events, invalidated, portal_receipts) = processed_events;
             self.record_seen_block(block_number, to.saturating_sub(block_number));
 
             let sealed = SealedHeader::seal_slow(header);
             let anchor = sealed.num_hash();
-            let portal_evidence = portal_logs.map(|logs| (sealed.parent_hash(), logs));
+            let portal_evidence = portal_receipts.map(|receipts| (sealed.parent_hash(), receipts));
             // Publish the leadership transition _before_ the activation block becomes
             // consumable.
             if let Some(sink) = &self.config.leadership_sink {
@@ -816,12 +836,12 @@ impl L1Subscriber {
                 .wrap_err_with(|| {
                     format!("unexpected discontinuity while enqueueing L1 block {block_number}")
                 })?;
-            if let Some((parent_hash, logs)) = portal_evidence {
+            if let Some((parent_hash, receipts)) = portal_evidence {
                 self.config.block_tracker.record_with_portal_evidence(
                     anchor,
                     parent_hash,
                     events.clone(),
-                    logs,
+                    receipts,
                 )?;
             } else {
                 self.config
@@ -892,17 +912,21 @@ impl L1Subscriber {
         let portal_address = self.config.portal_address;
         let mut portal_events = L1PortalEvents::default();
         let mut invalidated = HashSet::new();
-        let mut portal_logs = self.config.retain_portal_evidence.then(Vec::new);
+        let mut portal_receipts = self.config.retain_portal_evidence.then(Vec::new);
 
-        for receipt in receipts {
-            let retain_receipt_logs = portal_logs.is_some() && receipt.status();
+        for (receipt_index, receipt) in receipts.iter().enumerate() {
+            let mut retained = Vec::new();
+            let retain_receipt_logs = portal_receipts.is_some() && receipt.status();
             for log in receipt.logs() {
                 let address = log.address();
 
+                if retain_receipt_logs
+                    && (address == portal_address || is_portal_transfer(&log.inner, portal_address))
+                {
+                    retained.push(log.inner.clone());
+                }
+
                 if address == portal_address {
-                    if retain_receipt_logs && let Some(logs) = &mut portal_logs {
-                        logs.push(log.inner.clone());
-                    }
                     invalidated.insert(address);
                     if let Some(address) =
                         portal_event_cache_invalidation_address(log.topics().first())
@@ -918,6 +942,14 @@ impl L1Subscriber {
                     invalidated.extend([address, log.address()]);
                 }
             }
+            if !retained.is_empty()
+                && let Some(receipts) = &mut portal_receipts
+            {
+                receipts.push(AuthenticatedPortalReceipt {
+                    receipt_index: receipt_index as u64,
+                    logs: retained,
+                });
+            }
         }
 
         // Enabling may migrate token-local policy storage into TIP-403.
@@ -925,7 +957,7 @@ impl L1Subscriber {
             invalidated.extend([event.token, TIP403_REGISTRY_ADDRESS]);
         }
         self.record_portal_event_metrics(&portal_events);
-        Ok((portal_events, invalidated, portal_logs))
+        Ok((portal_events, invalidated, portal_receipts))
     }
 
     fn record_seen_block(&self, block_number: u64, lag_blocks: u64) {

--- a/crates/l1/src/tests.rs
+++ b/crates/l1/src/tests.rs
@@ -11,7 +11,7 @@ use std::{
     time::Duration,
 };
 use tempo_alloy::rpc::{TempoHeaderResponse, TempoTransactionReceipt};
-use tempo_contracts::precompiles::TIP403_REGISTRY_ADDRESS;
+use tempo_contracts::precompiles::{ITIP20, TIP403_REGISTRY_ADDRESS};
 use tempo_primitives::{TempoReceipt, TempoTxType};
 
 #[derive(Deserialize)]
@@ -210,7 +210,7 @@ async fn l1_block_tracker_returns_receipt_authenticated_portal_events() {
 }
 
 #[test]
-fn l1_block_tracker_retains_authenticated_portal_logs_after_consumption() {
+fn l1_block_tracker_retains_authenticated_portal_evidence_after_consumption() {
     let tracker = L1BlockTracker::default();
     let anchor = NumHash::new(10, B256::with_last_byte(0x10));
     let parent_hash = B256::with_last_byte(0x09);
@@ -225,21 +225,28 @@ fn l1_block_tracker_retains_authenticated_portal_logs_after_consumption() {
             anchor,
             parent_hash,
             L1PortalEvents::default(),
-            vec![log.clone()],
+            vec![AuthenticatedPortalReceipt {
+                receipt_index: 0,
+                logs: vec![log.clone()],
+            }],
         )
         .unwrap();
 
-    let observed = tracker.authenticated_portal_logs(anchor).unwrap().unwrap();
+    let observed = tracker
+        .authenticated_portal_evidence(anchor)
+        .unwrap()
+        .unwrap();
     assert_eq!(observed.parent_hash, parent_hash);
-    assert_eq!(observed.logs, vec![log.clone()]);
+    assert_eq!(observed.receipts[0].logs, vec![log.clone()]);
 
     tracker.prune_through(anchor.number);
     assert_eq!(tracker.observed_hash(anchor.number), None);
     assert_eq!(
         tracker
-            .authenticated_portal_logs(anchor)
+            .authenticated_portal_evidence(anchor)
             .unwrap()
             .unwrap()
+            .receipts[0]
             .logs,
         vec![log]
     );
@@ -1679,11 +1686,24 @@ fn extract_events_fails_closed_on_corrupt_recognized_portal_log() {
         },
         ..Default::default()
     };
-    let receipt = make_receipt_with_logs(10, B256::with_last_byte(0x10), vec![unknown]);
-    let (events, _, portal_logs) = subscriber.extract_events(10, &[receipt]).unwrap();
+    let token = address!("0x20c0000000000000000000000000000000000001");
+    let transfer = Log {
+        inner: alloy_primitives::Log {
+            address: token,
+            data: ITIP20::Transfer {
+                from: Address::repeat_byte(1),
+                to: portal,
+                amount: U256::ONE,
+            }
+            .encode_log_data(),
+        },
+        ..Default::default()
+    };
+    let receipt = make_receipt_with_logs(10, B256::with_last_byte(0x10), vec![unknown, transfer]);
+    let (events, _, portal_receipts) = subscriber.extract_events(10, &[receipt]).unwrap();
     assert!(events.deposits.is_empty());
     assert!(events.leader_transitions.is_empty());
-    assert_eq!(portal_logs.unwrap().len(), 1);
+    assert_eq!(portal_receipts.unwrap()[0].logs.len(), 2);
 }
 
 #[test]


### PR DESCRIPTION
## Summary

Adds receipt-level Portal custody reconciliation and exact balance conservation checks.

The existing solvency check verifies that Portal custody covers bridge liabilities. However, excess collateral could hide an unauthorized loss while the Portal still appears solvent. This change additionally verifies that every balance change is explained by authenticated custody movements.

## Checks

For each successful Tempo receipt:

- Observed outflows must exactly match protocol-authorized outflows.
- Observed inflows must cover protocol-required inflows.
- Additional inbound transfers are treated as unattributed surplus and cannot authorize an unrelated outflow.

For every imported Tempo block and enabled token:

```text
Portal balance(tip)
  = Portal balance(parent)
  + observed inflows
  - authorized outflows
```

This detects missing deposits, incorrect withdrawals or refunds, and otherwise unexplained custody losses.

## Fees

Fee amounts are included in the expected custody movements. Fees are currently always zero, so this does not change current accounting results, but the invariant remains valid when nonzero fees are enabled.

No checker database migration or historical backfill is required.

## Performance

Verified tip balances are cached and reused as the next block’s parent balances. This avoids additional steady-state L1 queries; full parent reads are required only on startup, recovery, cache mismatch, or for newly enabled tokens.