### PR TITLE
fix(prover): request V2 multiproofs

### DIFF
--- a/bin/prover/utils/src/main.rs
+++ b/bin/prover/utils/src/main.rs
@@ -1085,7 +1085,7 @@ async fn tempo_state_witness(
                 .client()
                 .request::<_, Vec<EIP1186AccountProofResponse>>(
                     "eth_getMultiProof",
-                    (targets, BlockId::number(block)),
+                    (targets, BlockId::number(block), true),
                 )
                 .await
                 .wrap_err_with(|| format!("eth_getMultiProof at Tempo block {block}"))?;

--- a/crates/sequencer/src/prover.rs
+++ b/crates/sequencer/src/prover.rs
@@ -814,7 +814,7 @@ async fn tempo_state_witness(
                 .client()
                 .request::<_, Vec<EIP1186AccountProofResponse>>(
                     "eth_getMultiProof",
-                    (targets, BlockId::number(block)),
+                    (targets, BlockId::number(block), true),
                 )
                 .await
                 .wrap_err_with(|| format!("eth_getMultiProof at Tempo block {block}"))


### PR DESCRIPTION
## Summary

- request V2 multiproofs when building Tempo state witnesses
- apply the opt-in to the sequencer prover and prover utility call sites

Follows https://github.com/paradigmxyz/reth/pull/26851.

## Testing

- `cargo +nightly fmt --all -- --check`
- `cargo check -p tempo-zone-prover-utils -p zone-sequencer`

Prompted by: @shekhirin
