### PR TITLE
chore(ci): reduce PR feedback latency

### DIFF
--- a/.github/actionlint.yaml
+++ b/.github/actionlint.yaml
@@ -7,6 +7,7 @@ self-hosted-runner:
     - depot-ubuntu-latest
     - depot-ubuntu-latest-4
     - depot-ubuntu-latest-16
+    - depot-ubuntu-latest-32
     - depot-ubuntu-latest-arm-16
     - depot-macos-15
     - bare-metal-dual-schelk

--- a/.github/workflows/contracts.yml
+++ b/.github/workflows/contracts.yml
@@ -22,6 +22,10 @@ on:
 permissions:
   contents: read
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 env:
   CARGO_TERM_COLOR: always
   TEMPO_FOUNDRY_REF: 18a5d71d6ab621433145e5ea86dfe3dbace0763a
@@ -32,7 +36,7 @@ env:
 jobs:
   conformance:
     name: ABI and storage conformance
-    runs-on: ubuntu-latest
+    runs-on: depot-ubuntu-latest-32
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -32,12 +32,16 @@ on:
 permissions:
   contents: read
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 env:
   REGISTRY: ghcr.io/tempoxyz
   TEMPO_DEVNET_GENESIS_URL: ${{ inputs.tempo_genesis_url || 'https://devnet-assets.tempoxyz.dev/tempo-devnet-nextfork.json' }}
 
 jobs:
-  build-and-push:
+  build-images:
     name: Build and Push Docker Images
     # Private copies retain PR image builds, but must not publish shared images
     # or run the upstream's scheduled refreshes.
@@ -94,24 +98,6 @@ jobs:
             type=sha,prefix=sha-
             type=ref,event=pr
 
-      - name: Docker metadata for tempo-zone-prover
-        id: meta-tempo-zone-prover
-        uses: docker/metadata-action@80c7e94dd9b9319bd5eb7a0e0fe9291e23a2a2e9 # v6.1.0
-        with:
-          images: ${{ env.REGISTRY }}/tempo-zone-prover
-          bake-target: tempo-zone-prover
-          tags: |
-            type=schedule,pattern=nightly
-            type=raw,value=nightly,enable=${{ github.event.inputs.nightly == 'true' }}
-            type=semver,pattern={{version}}
-            type=semver,pattern={{major}}.{{minor}}
-            type=semver,pattern={{major}}
-            type=raw,value=stable,enable=${{ github.ref_type == 'tag' }}
-            type=raw,value=latest,enable={{is_default_branch}}
-            type=edge,branch=main
-            type=sha,prefix=sha-
-            type=ref,event=pr
-
       - name: Log in to Container Registry
         if: github.repository == 'tempoxyz/zones'
         uses: docker/login-action@650006c6eb7dba73a995cc03b0b2d7f5ca915bee # v4.2.0
@@ -122,22 +108,6 @@ jobs:
 
       - id: shortsha
         run: echo "shortsha=${GITHUB_SHA::7}" >> "$GITHUB_OUTPUT"
-
-      - name: Download Tempo devnet genesis
-        shell: bash
-        run: |
-          set -euo pipefail
-
-          mkdir -p .tempo-genesis
-          curl --proto '=https' --tlsv1.2 \
-            --fail-with-body --location \
-            --output .tempo-genesis/genesis.json \
-            "$TEMPO_DEVNET_GENESIS_URL"
-          jq -e '.config.chainId | type == "number"' \
-            .tempo-genesis/genesis.json >/dev/null
-
-          genesis_sha=$(sha256sum .tempo-genesis/genesis.json | cut -d' ' -f1)
-          echo "Embedding Tempo devnet genesis sha256:${genesis_sha}"
 
       - name: Build and push Docker images
         uses: depot/bake-action@1d58c2668346981089b088b7ef36755b206b20e9 # v1.13.0
@@ -157,73 +127,6 @@ jobs:
         env:
           VERGEN_GIT_SHA: ${{ github.sha }}
           VERGEN_GIT_SHA_SHORT: ${{ steps.shortsha.outputs.shortsha }}
-
-      # Nitro CLI converts an image from the runner's local Docker image store.
-      - name: Load tempo-zone-prover enclave payload
-        uses: depot/bake-action@1d58c2668346981089b088b7ef36755b206b20e9 # v1.13.0
-        with:
-          files: docker/docker-bake.hcl
-          targets: tempo-zone-prover-enclave
-          set: |
-            tempo-zone-prover-enclave.tags=tempo-zone-prover-enclave:eif-source
-            tempo-zone-prover-enclave.contexts.tempo-genesis=.tempo-genesis
-          project: 0c6tg19qsp
-          load: true
-          no-cache: ${{ github.event_name == 'schedule' }}
-          pull: ${{ github.event_name == 'schedule' }}
-
-      - name: Load tempo-zone-prover EIF builder
-        uses: depot/bake-action@1d58c2668346981089b088b7ef36755b206b20e9 # v1.13.0
-        with:
-          files: docker/docker-bake.hcl
-          targets: tempo-zone-prover-eif-builder
-          set: tempo-zone-prover-eif-builder.tags=tempo-zone-prover-eif-builder:local
-          project: 0c6tg19qsp
-          load: true
-          no-cache: ${{ github.event_name == 'schedule' }}
-          pull: ${{ github.event_name == 'schedule' }}
-
-      - name: Build tempo-zone-prover EIF
-        env:
-          PROVER_IMAGE: tempo-zone-prover-enclave:eif-source
-          EIF_BUILDER_IMAGE: tempo-zone-prover-eif-builder:local
-          EIF_OUTPUT_DIR: target/tempo-zone-prover-eif
-        run: |
-          set -Eeuo pipefail
-
-          mkdir -p "$EIF_OUTPUT_DIR"
-
-          docker run --rm \
-            --platform linux/amd64 \
-            --volume /var/run/docker.sock:/var/run/docker.sock \
-            --volume "$PWD/$EIF_OUTPUT_DIR:/output" \
-            "$EIF_BUILDER_IMAGE" \
-            build-enclave \
-            --docker-uri "$PROVER_IMAGE" \
-            --output-file /output/tempo-zone-prover.eif \
-            | tee "$EIF_OUTPUT_DIR/measurements.json"
-
-      - name: Build and push tempo-zone-prover
-        uses: depot/bake-action@1d58c2668346981089b088b7ef36755b206b20e9 # v1.13.0
-        with:
-          files: |
-            docker/docker-bake.hcl
-            ${{ steps.meta-tempo-zone-prover.outputs.bake-file }}
-          targets: tempo-zone-prover
-          project: 0c6tg19qsp
-          push: >-
-            ${{ github.repository == 'tempoxyz/zones' &&
-                github.event_name != 'pull_request' &&
-                github.event_name != 'merge_group' }}
-          no-cache: ${{ github.event_name == 'schedule' }}
-          pull: ${{ github.event_name == 'schedule' }}
-
-      - name: Upload tempo-zone-prover PCR measurements
-        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
-        with:
-          name: tempo-zone-prover-measurements-${{ steps.shortsha.outputs.shortsha }}
-          path: target/tempo-zone-prover-eif/measurements.json
-          if-no-files-found: error
 
       - name: Publish Zones CI event
         if: >-
@@ -296,3 +199,136 @@ jobs:
             "${events_args[@]}" \
             -H "Content-Type: application/json" \
             -d "$payload"
+
+  build-prover:
+    name: Build and Push Prover Image
+    # Build the prover in parallel with the primary images. Private copies
+    # retain PR validation, but do not publish or run scheduled refreshes.
+    if: >-
+      github.repository == 'tempoxyz/zones' ||
+      (github.event_name != 'schedule' && github.event_name != 'push')
+    runs-on: depot-ubuntu-latest-16
+    permissions:
+      contents: read
+      packages: write
+      id-token: write
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
+          submodules: recursive
+
+      - uses: depot/setup-action@15c09a5f77a0840ad4bce955686522a257853461 # v1.7.1
+
+      - name: Docker metadata for tempo-zone-prover
+        id: meta-tempo-zone-prover
+        uses: docker/metadata-action@80c7e94dd9b9319bd5eb7a0e0fe9291e23a2a2e9 # v6.1.0
+        with:
+          images: ${{ env.REGISTRY }}/tempo-zone-prover
+          bake-target: tempo-zone-prover
+          tags: |
+            type=schedule,pattern=nightly
+            type=raw,value=nightly,enable=${{ github.event.inputs.nightly == 'true' }}
+            type=semver,pattern={{version}}
+            type=semver,pattern={{major}}.{{minor}}
+            type=semver,pattern={{major}}
+            type=raw,value=stable,enable=${{ github.ref_type == 'tag' }}
+            type=raw,value=latest,enable={{is_default_branch}}
+            type=edge,branch=main
+            type=sha,prefix=sha-
+            type=ref,event=pr
+
+      - name: Log in to Container Registry
+        if: github.repository == 'tempoxyz/zones'
+        uses: docker/login-action@650006c6eb7dba73a995cc03b0b2d7f5ca915bee # v4.2.0
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - id: shortsha
+        run: echo "shortsha=${GITHUB_SHA::7}" >> "$GITHUB_OUTPUT"
+
+      - name: Download Tempo devnet genesis
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          mkdir -p .tempo-genesis
+          curl --proto '=https' --tlsv1.2 \
+            --fail-with-body --location \
+            --output .tempo-genesis/genesis.json \
+            "$TEMPO_DEVNET_GENESIS_URL"
+          jq -e '.config.chainId | type == "number"' \
+            .tempo-genesis/genesis.json >/dev/null
+
+          genesis_sha=$(sha256sum .tempo-genesis/genesis.json | cut -d' ' -f1)
+          echo "Embedding Tempo devnet genesis sha256:${genesis_sha}"
+
+      # Nitro CLI converts an image from the runner's local Docker image store.
+      - name: Load tempo-zone-prover enclave payload
+        uses: depot/bake-action@1d58c2668346981089b088b7ef36755b206b20e9 # v1.13.0
+        with:
+          files: docker/docker-bake.hcl
+          targets: tempo-zone-prover-enclave
+          set: |
+            tempo-zone-prover-enclave.tags=tempo-zone-prover-enclave:eif-source
+            tempo-zone-prover-enclave.contexts.tempo-genesis=.tempo-genesis
+          project: 0c6tg19qsp
+          load: true
+          no-cache: ${{ github.event_name == 'schedule' }}
+          pull: ${{ github.event_name == 'schedule' }}
+
+      - name: Load tempo-zone-prover EIF builder
+        uses: depot/bake-action@1d58c2668346981089b088b7ef36755b206b20e9 # v1.13.0
+        with:
+          files: docker/docker-bake.hcl
+          targets: tempo-zone-prover-eif-builder
+          set: tempo-zone-prover-eif-builder.tags=tempo-zone-prover-eif-builder:local
+          project: 0c6tg19qsp
+          load: true
+          no-cache: ${{ github.event_name == 'schedule' }}
+          pull: ${{ github.event_name == 'schedule' }}
+
+      - name: Build tempo-zone-prover EIF
+        env:
+          PROVER_IMAGE: tempo-zone-prover-enclave:eif-source
+          EIF_BUILDER_IMAGE: tempo-zone-prover-eif-builder:local
+          EIF_OUTPUT_DIR: target/tempo-zone-prover-eif
+        run: |
+          set -Eeuo pipefail
+
+          mkdir -p "$EIF_OUTPUT_DIR"
+
+          docker run --rm \
+            --platform linux/amd64 \
+            --volume /var/run/docker.sock:/var/run/docker.sock \
+            --volume "$PWD/$EIF_OUTPUT_DIR:/output" \
+            "$EIF_BUILDER_IMAGE" \
+            build-enclave \
+            --docker-uri "$PROVER_IMAGE" \
+            --output-file /output/tempo-zone-prover.eif \
+            | tee "$EIF_OUTPUT_DIR/measurements.json"
+
+      - name: Build and push tempo-zone-prover
+        uses: depot/bake-action@1d58c2668346981089b088b7ef36755b206b20e9 # v1.13.0
+        with:
+          files: |
+            docker/docker-bake.hcl
+            ${{ steps.meta-tempo-zone-prover.outputs.bake-file }}
+          targets: tempo-zone-prover
+          project: 0c6tg19qsp
+          push: >-
+            ${{ github.repository == 'tempoxyz/zones' &&
+                github.event_name != 'pull_request' &&
+                github.event_name != 'merge_group' }}
+          no-cache: ${{ github.event_name == 'schedule' }}
+          pull: ${{ github.event_name == 'schedule' }}
+
+      - name: Upload tempo-zone-prover PCR measurements
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: tempo-zone-prover-measurements-${{ steps.shortsha.outputs.shortsha }}
+          path: target/tempo-zone-prover-eif/measurements.json
+          if-no-files-found: error

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -18,6 +18,7 @@ jobs:
       contents: read
     uses: tempoxyz/gh-actions/.github/workflows/rust-lint.yml@98b1081dcf34361b576aca2ab3041772708582ef
     with:
+      clippy-runner: depot-ubuntu-latest-32
       rust-toolchain: nightly-2026-02-21
 
   lint-success:

--- a/.github/workflows/sync-from-upstream.yml
+++ b/.github/workflows/sync-from-upstream.yml
@@ -19,7 +19,7 @@ jobs:
     steps:
       - name: Fetch GitHub token via STS
         id: github-sts
-        uses: tempoxyz/gh-actions/actions/github-sts@8819cf80bdcb39c36c34700e3f2ecc08bde54f23 # main
+        uses: tempoxyz/gh-actions/actions/github-sts@b473b85e603b33b46b7b13502a4e37ab2e44081f # main
         with:
           policy: sync-from-upstream
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -35,7 +35,7 @@ jobs:
           submodules: recursive
       - name: Mint read-only Earn token
         id: earn-token
-        uses: tempoxyz/gh-actions/actions/github-sts@8819cf80bdcb39c36c34700e3f2ecc08bde54f23 # main
+        uses: tempoxyz/gh-actions/actions/github-sts@b473b85e603b33b46b7b13502a4e37ab2e44081f # main
         with:
           scope: tempoxyz/earn
           policy: zones-read
@@ -104,7 +104,7 @@ jobs:
           compression-level: 0
 
   test:
-    name: test (${{ matrix.partition }}/4)
+    name: test (${{ matrix.partition }}/8)
     runs-on: depot-ubuntu-latest-16
     needs: build-test-artifacts
     timeout-minutes: 20
@@ -113,7 +113,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        partition: [1, 2, 3, 4]
+        partition: [1, 2, 3, 4, 5, 6, 7, 8]
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
@@ -140,7 +140,7 @@ jobs:
             --archive-file nextest-archive.tar.zst \
             --workspace-remap "$GITHUB_WORKSPACE" \
             --profile ci \
-            --partition hash:${{ matrix.partition }}/4
+            --partition hash:${{ matrix.partition }}/8
 
   test-success:
     name: test success

--- a/.github/workflows/zones-benchmark.yml
+++ b/.github/workflows/zones-benchmark.yml
@@ -510,7 +510,7 @@ jobs:
 
       - name: Mint read-only Earn token
         id: earn-token
-        uses: tempoxyz/gh-actions/actions/github-sts@8819cf80bdcb39c36c34700e3f2ecc08bde54f23 # main
+        uses: tempoxyz/gh-actions/actions/github-sts@b473b85e603b33b46b7b13502a4e37ab2e44081f # main
         with:
           scope: tempoxyz/earn
           policy: zones-read


### PR DESCRIPTION
## Summary

- run contract conformance and clippy compile paths on 32-core Depot runners
- expand nextest from four to eight parallel shards
- build the primary and Nitro prover image families in parallel
- cancel stale Docker and Contracts runs when a PR receives a new commit
- register the 32-core runner with actionlint and refresh drifted STS pins so workflow scanning remains green

## Measured results

Final live PR run compared with recent equivalent baselines:

| Critical path | Before | After | Change |
| --- | ---: | ---: | ---: |
| Contract conformance | 12m16s | 3m37s | -71% |
| Clippy | 3m32s | 2m23s | -33% |
| Docker | 7m01s | 5m11s | -26% |
| Tests | 10m33s | 8m47s | -17% |

The 32-core test archive experiment did not improve its measured runtime, so the final patch keeps that job on the existing 16-core runner.

## Validation

- final-head Test, Contracts, Lint, Docker, actionlint, and zizmor checks pass
- `actionlint`
- `zizmor --strict-collection --min-severity high .` (no findings)
- `git diff --check`

Prompted by: @shekhirin