### PR TITLE
fix: bound ABI decoding

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -208,9 +208,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-dyn-abi"
-version = "1.6.1"
+version = "1.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9a04eb4abc2b5074a18e687ee63918f407cc7990083cba9b999445f839796060"
+checksum = "d9f1a3f2206f2ba4206fdeeddce6640eed3e26b8a13ac41444adb66b76d8e650"
 dependencies = [
  "alloy-json-abi",
  "alloy-primitives",
@@ -375,9 +375,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-json-abi"
-version = "1.6.1"
+version = "1.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6cee30dd4c2f4b23f434fdf675e7bf9681b86768141277266c6f548ef25cba0a"
+checksum = "208699c66c453fbb4c50d2e602f8ceff8a5f1fa48ac8b6ee3b6357fdc93da311"
 dependencies = [
  "alloy-primitives",
  "alloy-sol-type-parser",
@@ -441,9 +441,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-primitives"
-version = "1.6.1"
+version = "1.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f007e257069855bdf21d27762fd3f3705a613f805c9a08309bf353503f081d71"
+checksum = "9c902f0ca3f8353c41e3e1ec3cf26be49412525bc48ab9d3c4710d7be4f01832"
 dependencies = [
  "alloy-rlp",
  "arbitrary",
@@ -807,9 +807,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-sol-macro"
-version = "1.6.1"
+version = "1.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b5655c38d5f84955bf727b2eeb62fddd91ebb98fd1d7ae6eb77f73ea88f9b9cf"
+checksum = "fdcbd48d60e029be4a325c3a2f1312761caea4ed249f18ba9e8ed24ca1bf01e6"
 dependencies = [
  "alloy-sol-macro-expander",
  "alloy-sol-macro-input",
@@ -821,9 +821,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-sol-macro-expander"
-version = "1.6.1"
+version = "1.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6277c780e07b76951e09a59788dde230d1582612324177d11a43a61e21a6bb83"
+checksum = "59c9f7c535f99a7e7b64cc520968b09ed14cec3715572fcc277cfbff602808cd"
 dependencies = [
  "alloy-json-abi",
  "alloy-sol-macro-input",
@@ -840,9 +840,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-sol-macro-input"
-version = "1.6.1"
+version = "1.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9762b2ad3e5a0c09886de54fe549ab0056681df843cb082e2df7e1c0eb270d30"
+checksum = "1abd404fbc12f543823005146b73fd07621bdc0baaa950d26995c543a9d73811"
 dependencies = [
  "alloy-json-abi",
  "const-hex",
@@ -858,9 +858,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-sol-type-parser"
-version = "1.6.1"
+version = "1.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "da4c7130f0f01f4719678bda3db3bc7267fc2f7f9d0565e3bd964cd2bb45050d"
+checksum = "40a7fd71864526bfeca8903010d5bb7fd28a0a4f5cc55818304c9cad8f0d63ab"
 dependencies = [
  "serde",
  "winnow 1.0.4",
@@ -868,9 +868,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-sol-types"
-version = "1.6.1"
+version = "1.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d96e74d6213180f78dbdccddce8af02a639c160c94b0a543fa35c77c58b8a7fc"
+checksum = "adfc2ba3fb0e865de4934bcad6d37fc51e9ffcd5294be1322eab38e4494e051b"
 dependencies = [
  "alloy-json-abi",
  "alloy-primitives",
@@ -1039,7 +1039,7 @@ version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -1050,7 +1050,7 @@ checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
 dependencies = [
  "anstyle",
  "once_cell_polyfill",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -3632,7 +3632,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -4022,8 +4022,8 @@ dependencies = [
  "libc",
  "log",
  "rustversion",
- "windows-link 0.2.1",
- "windows-result 0.4.1",
+ "windows-link 0.1.3",
+ "windows-result 0.3.4",
 ]
 
 [[package]]
@@ -4605,7 +4605,7 @@ dependencies = [
  "js-sys",
  "log",
  "wasm-bindgen",
- "windows-core 0.62.2",
+ "windows-core 0.61.2",
 ]
 
 [[package]]
@@ -5956,7 +5956,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -6938,7 +6938,7 @@ dependencies = [
  "once_cell",
  "socket2",
  "tracing",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -10402,7 +10402,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -10482,7 +10482,7 @@ dependencies = [
  "security-framework",
  "security-framework-sys",
  "webpki-root-certs 1.0.8",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -11084,7 +11084,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c3d1e2c7f27f8d4cb10542a02c49005dbd6e93095799d6f3be745fae9f8fedd4"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -11234,9 +11234,9 @@ dependencies = [
 
 [[package]]
 name = "syn-solidity"
-version = "1.6.1"
+version = "1.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "083be3061e64d362cbe6ef12cfe1307ba3884326d8856448fe8a120fa2c44ebf"
+checksum = "e452eb8cb83fc8b81597eb07c8d39f770d04905af9c5bffce8bea7213df29960"
 dependencies = [
  "paste",
  "proc-macro2",
@@ -11346,13 +11346,13 @@ dependencies = [
  "getrandom 0.4.3",
  "once_cell",
  "rustix",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
 name = "tempo-alloy"
 version = "1.10.1"
-source = "git+https://github.com/tempoxyz/tempo?rev=9f7fc9295ea3fa3b49ec2b0a9e524a8b2cb202b1#9f7fc9295ea3fa3b49ec2b0a9e524a8b2cb202b1"
+source = "git+https://github.com/tempoxyz/tempo?rev=b8359703665bd5f230068ecd68b0420b25a84e74#b8359703665bd5f230068ecd68b0420b25a84e74"
 dependencies = [
  "alloy-consensus",
  "alloy-contract",
@@ -11398,7 +11398,7 @@ dependencies = [
 [[package]]
 name = "tempo-chainspec"
 version = "1.10.1"
-source = "git+https://github.com/tempoxyz/tempo?rev=9f7fc9295ea3fa3b49ec2b0a9e524a8b2cb202b1#9f7fc9295ea3fa3b49ec2b0a9e524a8b2cb202b1"
+source = "git+https://github.com/tempoxyz/tempo?rev=b8359703665bd5f230068ecd68b0420b25a84e74#b8359703665bd5f230068ecd68b0420b25a84e74"
 dependencies = [
  "alloy-eips",
  "alloy-evm",
@@ -11421,7 +11421,7 @@ dependencies = [
 [[package]]
 name = "tempo-contracts"
 version = "1.10.1"
-source = "git+https://github.com/tempoxyz/tempo?rev=9f7fc9295ea3fa3b49ec2b0a9e524a8b2cb202b1#9f7fc9295ea3fa3b49ec2b0a9e524a8b2cb202b1"
+source = "git+https://github.com/tempoxyz/tempo?rev=b8359703665bd5f230068ecd68b0420b25a84e74#b8359703665bd5f230068ecd68b0420b25a84e74"
 dependencies = [
  "alloy-contract",
  "alloy-primitives",
@@ -11433,7 +11433,7 @@ dependencies = [
 [[package]]
 name = "tempo-dkg-onchain-artifacts"
 version = "1.11.0"
-source = "git+https://github.com/tempoxyz/tempo?rev=9f7fc9295ea3fa3b49ec2b0a9e524a8b2cb202b1#9f7fc9295ea3fa3b49ec2b0a9e524a8b2cb202b1"
+source = "git+https://github.com/tempoxyz/tempo?rev=b8359703665bd5f230068ecd68b0420b25a84e74#b8359703665bd5f230068ecd68b0420b25a84e74"
 dependencies = [
  "bytes",
  "commonware-codec",
@@ -11445,7 +11445,7 @@ dependencies = [
 [[package]]
 name = "tempo-evm"
 version = "1.11.0"
-source = "git+https://github.com/tempoxyz/tempo?rev=9f7fc9295ea3fa3b49ec2b0a9e524a8b2cb202b1#9f7fc9295ea3fa3b49ec2b0a9e524a8b2cb202b1"
+source = "git+https://github.com/tempoxyz/tempo?rev=b8359703665bd5f230068ecd68b0420b25a84e74#b8359703665bd5f230068ecd68b0420b25a84e74"
 dependencies = [
  "alloy-consensus",
  "alloy-evm",
@@ -11480,7 +11480,7 @@ dependencies = [
 [[package]]
 name = "tempo-hardfork"
 version = "1.10.1"
-source = "git+https://github.com/tempoxyz/tempo?rev=9f7fc9295ea3fa3b49ec2b0a9e524a8b2cb202b1#9f7fc9295ea3fa3b49ec2b0a9e524a8b2cb202b1"
+source = "git+https://github.com/tempoxyz/tempo?rev=b8359703665bd5f230068ecd68b0420b25a84e74#b8359703665bd5f230068ecd68b0420b25a84e74"
 dependencies = [
  "alloy-eips",
  "alloy-evm",
@@ -11492,7 +11492,7 @@ dependencies = [
 [[package]]
 name = "tempo-node"
 version = "1.11.0"
-source = "git+https://github.com/tempoxyz/tempo?rev=9f7fc9295ea3fa3b49ec2b0a9e524a8b2cb202b1#9f7fc9295ea3fa3b49ec2b0a9e524a8b2cb202b1"
+source = "git+https://github.com/tempoxyz/tempo?rev=b8359703665bd5f230068ecd68b0420b25a84e74#b8359703665bd5f230068ecd68b0420b25a84e74"
 dependencies = [
  "alloy",
  "alloy-eips",
@@ -11552,7 +11552,7 @@ dependencies = [
 [[package]]
 name = "tempo-payload-builder"
 version = "1.11.0"
-source = "git+https://github.com/tempoxyz/tempo?rev=9f7fc9295ea3fa3b49ec2b0a9e524a8b2cb202b1#9f7fc9295ea3fa3b49ec2b0a9e524a8b2cb202b1"
+source = "git+https://github.com/tempoxyz/tempo?rev=b8359703665bd5f230068ecd68b0420b25a84e74#b8359703665bd5f230068ecd68b0420b25a84e74"
 dependencies = [
  "alloy-consensus",
  "alloy-eip7928",
@@ -11590,7 +11590,7 @@ dependencies = [
 [[package]]
 name = "tempo-payload-types"
 version = "1.11.0"
-source = "git+https://github.com/tempoxyz/tempo?rev=9f7fc9295ea3fa3b49ec2b0a9e524a8b2cb202b1#9f7fc9295ea3fa3b49ec2b0a9e524a8b2cb202b1"
+source = "git+https://github.com/tempoxyz/tempo?rev=b8359703665bd5f230068ecd68b0420b25a84e74#b8359703665bd5f230068ecd68b0420b25a84e74"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -11610,7 +11610,7 @@ dependencies = [
 [[package]]
 name = "tempo-precompiles"
 version = "1.11.0"
-source = "git+https://github.com/tempoxyz/tempo?rev=9f7fc9295ea3fa3b49ec2b0a9e524a8b2cb202b1#9f7fc9295ea3fa3b49ec2b0a9e524a8b2cb202b1"
+source = "git+https://github.com/tempoxyz/tempo?rev=b8359703665bd5f230068ecd68b0420b25a84e74#b8359703665bd5f230068ecd68b0420b25a84e74"
 dependencies = [
  "alloy",
  "alloy-evm",
@@ -11637,7 +11637,7 @@ dependencies = [
 [[package]]
 name = "tempo-precompiles-macros"
 version = "1.11.0"
-source = "git+https://github.com/tempoxyz/tempo?rev=9f7fc9295ea3fa3b49ec2b0a9e524a8b2cb202b1#9f7fc9295ea3fa3b49ec2b0a9e524a8b2cb202b1"
+source = "git+https://github.com/tempoxyz/tempo?rev=b8359703665bd5f230068ecd68b0420b25a84e74#b8359703665bd5f230068ecd68b0420b25a84e74"
 dependencies = [
  "alloy",
  "proc-macro2",
@@ -11648,7 +11648,7 @@ dependencies = [
 [[package]]
 name = "tempo-primitives"
 version = "1.10.1"
-source = "git+https://github.com/tempoxyz/tempo?rev=9f7fc9295ea3fa3b49ec2b0a9e524a8b2cb202b1#9f7fc9295ea3fa3b49ec2b0a9e524a8b2cb202b1"
+source = "git+https://github.com/tempoxyz/tempo?rev=b8359703665bd5f230068ecd68b0420b25a84e74#b8359703665bd5f230068ecd68b0420b25a84e74"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -11680,7 +11680,7 @@ dependencies = [
 [[package]]
 name = "tempo-revm"
 version = "1.11.0"
-source = "git+https://github.com/tempoxyz/tempo?rev=9f7fc9295ea3fa3b49ec2b0a9e524a8b2cb202b1#9f7fc9295ea3fa3b49ec2b0a9e524a8b2cb202b1"
+source = "git+https://github.com/tempoxyz/tempo?rev=b8359703665bd5f230068ecd68b0420b25a84e74#b8359703665bd5f230068ecd68b0420b25a84e74"
 dependencies = [
  "alloy-consensus",
  "alloy-evm",
@@ -11703,7 +11703,7 @@ dependencies = [
 [[package]]
 name = "tempo-transaction-pool"
 version = "1.11.0"
-source = "git+https://github.com/tempoxyz/tempo?rev=9f7fc9295ea3fa3b49ec2b0a9e524a8b2cb202b1#9f7fc9295ea3fa3b49ec2b0a9e524a8b2cb202b1"
+source = "git+https://github.com/tempoxyz/tempo?rev=b8359703665bd5f230068ecd68b0420b25a84e74#b8359703665bd5f230068ecd68b0420b25a84e74"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -13030,7 +13030,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -14137,6 +14137,7 @@ dependencies = [
  "tempo-alloy",
  "tempo-chainspec",
  "tempo-contracts",
+ "tempo-precompiles",
  "tempo-primitives",
  "tempo-zone-contracts",
  "tokio",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -101,26 +101,26 @@ incremental = false
 
 [workspace.dependencies]
 # tempo (from upstream)
-tempo-alloy = { git = "https://github.com/tempoxyz/tempo", rev = "9f7fc9295ea3fa3b49ec2b0a9e524a8b2cb202b1" }
-tempo-chainspec = { git = "https://github.com/tempoxyz/tempo", rev = "9f7fc9295ea3fa3b49ec2b0a9e524a8b2cb202b1", default-features = false }
-tempo-consensus = { git = "https://github.com/tempoxyz/tempo", rev = "9f7fc9295ea3fa3b49ec2b0a9e524a8b2cb202b1", default-features = false }
-tempo-contracts = { git = "https://github.com/tempoxyz/tempo", rev = "9f7fc9295ea3fa3b49ec2b0a9e524a8b2cb202b1", default-features = false, features = [
+tempo-alloy = { git = "https://github.com/tempoxyz/tempo", rev = "b8359703665bd5f230068ecd68b0420b25a84e74" }
+tempo-chainspec = { git = "https://github.com/tempoxyz/tempo", rev = "b8359703665bd5f230068ecd68b0420b25a84e74", default-features = false }
+tempo-consensus = { git = "https://github.com/tempoxyz/tempo", rev = "b8359703665bd5f230068ecd68b0420b25a84e74", default-features = false }
+tempo-contracts = { git = "https://github.com/tempoxyz/tempo", rev = "b8359703665bd5f230068ecd68b0420b25a84e74", default-features = false, features = [
   "serde",
 ] }
-tempo-evm = { git = "https://github.com/tempoxyz/tempo", rev = "9f7fc9295ea3fa3b49ec2b0a9e524a8b2cb202b1", default-features = false }
-tempo-hardfork = { git = "https://github.com/tempoxyz/tempo", rev = "9f7fc9295ea3fa3b49ec2b0a9e524a8b2cb202b1", default-features = false }
-tempo-node = { git = "https://github.com/tempoxyz/tempo", rev = "9f7fc9295ea3fa3b49ec2b0a9e524a8b2cb202b1" }
-tempo-payload-types = { git = "https://github.com/tempoxyz/tempo", rev = "9f7fc9295ea3fa3b49ec2b0a9e524a8b2cb202b1", default-features = false }
-tempo-precompiles = { git = "https://github.com/tempoxyz/tempo", rev = "9f7fc9295ea3fa3b49ec2b0a9e524a8b2cb202b1", default-features = false }
-tempo-precompiles-macros = { git = "https://github.com/tempoxyz/tempo", rev = "9f7fc9295ea3fa3b49ec2b0a9e524a8b2cb202b1" }
-tempo-primitives = { git = "https://github.com/tempoxyz/tempo", rev = "9f7fc9295ea3fa3b49ec2b0a9e524a8b2cb202b1", default-features = false, features = [
+tempo-evm = { git = "https://github.com/tempoxyz/tempo", rev = "b8359703665bd5f230068ecd68b0420b25a84e74", default-features = false }
+tempo-hardfork = { git = "https://github.com/tempoxyz/tempo", rev = "b8359703665bd5f230068ecd68b0420b25a84e74", default-features = false }
+tempo-node = { git = "https://github.com/tempoxyz/tempo", rev = "b8359703665bd5f230068ecd68b0420b25a84e74" }
+tempo-payload-types = { git = "https://github.com/tempoxyz/tempo", rev = "b8359703665bd5f230068ecd68b0420b25a84e74", default-features = false }
+tempo-precompiles = { git = "https://github.com/tempoxyz/tempo", rev = "b8359703665bd5f230068ecd68b0420b25a84e74", default-features = false }
+tempo-precompiles-macros = { git = "https://github.com/tempoxyz/tempo", rev = "b8359703665bd5f230068ecd68b0420b25a84e74" }
+tempo-primitives = { git = "https://github.com/tempoxyz/tempo", rev = "b8359703665bd5f230068ecd68b0420b25a84e74", default-features = false, features = [
   "reth",
   "serde",
   "serde-bincode-compat",
   "reth-codec",
 ] }
-tempo-revm = { git = "https://github.com/tempoxyz/tempo", rev = "9f7fc9295ea3fa3b49ec2b0a9e524a8b2cb202b1", default-features = false }
-tempo-transaction-pool = { git = "https://github.com/tempoxyz/tempo", rev = "9f7fc9295ea3fa3b49ec2b0a9e524a8b2cb202b1", default-features = false }
+tempo-revm = { git = "https://github.com/tempoxyz/tempo", rev = "b8359703665bd5f230068ecd68b0420b25a84e74", default-features = false }
+tempo-transaction-pool = { git = "https://github.com/tempoxyz/tempo", rev = "b8359703665bd5f230068ecd68b0420b25a84e74", default-features = false }
 
 # zones
 tempo-zone-contracts = { path = "crates/contracts", default-features = false }
@@ -197,9 +197,9 @@ alloy-contract = { version = "2.3.0", default-features = false }
 alloy-eips = { version = "2.3.0", default-features = false }
 alloy-evm = { version = "0.38.0", default-features = false }
 alloy-genesis = { version = "2.3.0", default-features = false }
-alloy-json-abi = "1.6.1"
+alloy-json-abi = "1.7.1"
 alloy-network = { version = "2.3.0", default-features = false }
-alloy-primitives = { version = "1.6.1", default-features = false }
+alloy-primitives = { version = "1.7.1", default-features = false }
 alloy-provider = { version = "2.3.0", default-features = false }
 alloy-rlp = { version = "0.3.16", default-features = false }
 alloy-rpc-client = "2.3.0"
@@ -208,7 +208,7 @@ alloy-rpc-types-engine = "2.3.0"
 alloy-rpc-types-eth = { version = "2.3.0" }
 alloy-signer = "2.3.0"
 alloy-signer-local = "2.3.0"
-alloy-sol-types = { version = "1.6.1", default-features = false }
+alloy-sol-types = { version = "1.7.1", default-features = false }
 alloy-transport = "2.3.0"
 
 # commonware

--- a/bin/prover/utils/src/main.rs
+++ b/bin/prover/utils/src/main.rs
@@ -26,7 +26,7 @@ use tokio::net::TcpStream;
 use tracing::{debug, info};
 use tracing_subscriber::EnvFilter;
 use zone_chainspec::{ZoneChainSpec, ZoneChainSpecParser};
-use zone_precompiles::{outbox, tempo_state};
+use zone_precompiles::{dispatch::abi_decoder_config, outbox, tempo_state};
 use zone_primitives::constants::zone_chain_id;
 use zone_prover::{
     DEFAULT_MAX_REQUEST_BYTES, PROTOCOL_VERSION, ProverConnection, VerifyRequest, VerifyResponse,
@@ -854,10 +854,13 @@ fn extract_block(block: RpcBlock) -> Result<ExtractedBlock> {
                         header.number()
                     );
                 }
-                let call = ZoneInbox::advanceTempoCall::abi_decode(envelope.input())
-                    .wrap_err_with(|| {
-                        format!("decode advanceTempo in Zone block {}", header.number())
-                    })?;
+                let call = ZoneInbox::advanceTempoCall::abi_decode_with_config(
+                    envelope.input(),
+                    abi_decoder_config(),
+                )
+                .wrap_err_with(|| {
+                    format!("decode advanceTempo in Zone block {}", header.number())
+                })?;
                 checkpoint_number = Some(decode_tempo_header(&call.header)?.number());
                 tempo_header_rlp = Some(call.header);
                 deposits = call.deposits;
@@ -871,13 +874,16 @@ fn extract_block(block: RpcBlock) -> Result<ExtractedBlock> {
                         header.number()
                     );
                 }
-                let call = ZoneOutbox::finalizeWithdrawalBatchCall::abi_decode(envelope.input())
-                    .wrap_err_with(|| {
-                        format!(
-                            "decode finalizeWithdrawalBatch in Zone block {}",
-                            header.number()
-                        )
-                    })?;
+                let call = ZoneOutbox::finalizeWithdrawalBatchCall::abi_decode_with_config(
+                    envelope.input(),
+                    abi_decoder_config(),
+                )
+                .wrap_err_with(|| {
+                    format!(
+                        "decode finalizeWithdrawalBatch in Zone block {}",
+                        header.number()
+                    )
+                })?;
                 if call.blockNumber != header.number() {
                     bail!(
                         "finalization in Zone block {} declares block {}",

--- a/crates/node/src/replication.rs
+++ b/crates/node/src/replication.rs
@@ -18,6 +18,7 @@ use std::{
     time::Duration,
 };
 use tempo_alloy::TempoNetwork;
+use tempo_precompiles::dispatch::abi_decoder_config;
 use tempo_primitives::{Block, TempoHeader, TempoTxEnvelope};
 use tokio::sync::{mpsc, oneshot};
 use tokio_util::sync;
@@ -1375,8 +1376,11 @@ fn decode_advance_tempo(
     if signed.tx().to != ZONE_INBOX_ADDRESS.into() {
         eyre::bail!("first Tempo system transaction is not sent to IZoneInbox")
     }
-    let call = IZoneInbox::advanceTempoCall::abi_decode(signed.tx().input.as_ref())
-        .map_err(|err| eyre::eyre!("first transaction does not decode as advanceTempo: {err}"))?;
+    let call = IZoneInbox::advanceTempoCall::abi_decode_with_config(
+        signed.tx().input.as_ref(),
+        abi_decoder_config(),
+    )
+    .map_err(|err| eyre::eyre!("first transaction does not decode as advanceTempo: {err}"))?;
 
     // 3. the system tx is valid.
     let mut header_rlp = call.header.as_ref();

--- a/crates/precompiles/src/account_keychain.rs
+++ b/crates/precompiles/src/account_keychain.rs
@@ -3,6 +3,7 @@
 use alloy_primitives::Address;
 use alloy_sol_types::SolInterface;
 use tempo_contracts::precompiles::IAccountKeychain;
+use tempo_precompiles::dispatch::abi_decoder_config;
 
 use crate::{
     execution::{CallCheck, CallRules},
@@ -15,7 +16,10 @@ pub(crate) struct AccountKeychainRules;
 
 impl CallRules for AccountKeychainRules {
     fn admit(&self, data: &[u8], caller: Address) -> CallCheck {
-        let Ok(call) = IAccountKeychain::IAccountKeychainCalls::abi_decode(data) else {
+        let Ok(call) = IAccountKeychain::IAccountKeychainCalls::abi_decode_with_config(
+            data,
+            abi_decoder_config(),
+        ) else {
             // Preserve the upstream error and gas behavior for malformed or unknown calldata.
             return CallCheck::Continue;
         };
@@ -160,6 +164,45 @@ mod tests {
                 outsider,
             );
         });
+    }
+
+    #[test]
+    fn aliased_set_allowed_calls_is_bounded() {
+        fn word(value: usize) -> [u8; 32] {
+            let mut out = [0_u8; 32];
+            out[24..].copy_from_slice(&(value as u64).to_be_bytes());
+            out
+        }
+
+        let width = 500;
+        let mut data = Vec::new();
+        data.extend(IAccountKeychain::setAllowedCallsCall::SELECTOR);
+        data.extend(word(0));
+        data.extend(word(64));
+        data.extend(word(width));
+        for _ in 0..width {
+            data.extend(word(width * 32));
+        }
+        data.extend(word(1));
+        data.extend(word(64));
+        data.extend(word(width));
+        for _ in 0..width {
+            data.extend(word(width * 32));
+        }
+        let mut selector = [0_u8; 32];
+        selector[..4].copy_from_slice(&[0xde, 0xad, 0xbe, 0xef]);
+        data.extend(selector);
+        data.extend(word(64));
+        data.extend(word(width));
+        for i in 0..width {
+            data.extend(word(i + 1));
+        }
+
+        assert_eq!(data.len(), 48_292);
+        assert!(matches!(
+            AccountKeychainRules.admit(&data, Address::ZERO),
+            CallCheck::Continue
+        ));
     }
 
     #[test]

--- a/crates/precompiles/src/lib.rs
+++ b/crates/precompiles/src/lib.rs
@@ -59,7 +59,10 @@ pub mod outbox;
 /// Zone dispatch helpers: generic typed operations plus Tempo's concrete metadata helper.
 pub mod dispatch {
     pub use tempo_precompiles::{
-        dispatch::typed::{mutate, mutate_void, view},
+        dispatch::{
+            abi_decoder_config,
+            typed::{mutate, mutate_void, view},
+        },
         metadata,
     };
 }

--- a/crates/precompiles/src/outbox/mod.rs
+++ b/crates/precompiles/src/outbox/mod.rs
@@ -10,6 +10,7 @@ use alloy_primitives::{Address, B256, Bytes, U256};
 use alloy_sol_types::SolCall;
 use tempo_precompiles::{
     Result as TempoResult,
+    dispatch::abi_decoder_config,
     error::TempoPrecompileError,
     storage::{ContractStorage, Handler, Mapping},
     tip20::{ITIP20, TIP20Error, TIP20Token},
@@ -34,7 +35,10 @@ const WITHDRAWAL_BASE_GAS: u64 = 50_000;
 
 /// Returns whether `calldata` is a canonical `finalizeWithdrawalBatch` call.
 pub fn is_finalize_withdrawal_batch_calldata(calldata: &[u8]) -> bool {
-    let Ok(call) = IZoneOutbox::finalizeWithdrawalBatchCall::abi_decode(calldata) else {
+    let Ok(call) = IZoneOutbox::finalizeWithdrawalBatchCall::abi_decode_with_config(
+        calldata,
+        abi_decoder_config(),
+    ) else {
         return false;
     };
     call.abi_encode() == calldata

--- a/crates/sequencer/Cargo.toml
+++ b/crates/sequencer/Cargo.toml
@@ -15,6 +15,7 @@ workspace = true
 tempo-alloy.workspace = true
 tempo-chainspec.workspace = true
 tempo-contracts.workspace = true
+tempo-precompiles.workspace = true
 tempo-primitives.workspace = true
 tempo-zone-contracts = { workspace = true, features = ["std", "serde", "rpc"] }
 zone-chainspec.workspace = true

--- a/crates/sequencer/src/prover.rs
+++ b/crates/sequencer/src/prover.rs
@@ -20,6 +20,7 @@ use eyre::{Context as _, OptionExt as _, Result, bail, ensure};
 use futures::{StreamExt as _, TryStreamExt as _, stream};
 use reth_primitives_traits::RecoveredBlock;
 use tempo_alloy::TempoNetwork;
+use tempo_precompiles::dispatch::abi_decoder_config;
 use tempo_primitives::{Block, TempoHeader};
 use tempo_zone_contracts::{
     IZoneInbox as ZoneInbox, IZoneOutbox as ZoneOutbox, ZONE_INBOX_ADDRESS, ZONE_OUTBOX_ADDRESS,
@@ -642,10 +643,13 @@ fn extract_zone_block(block: &RecoveredBlock<Block>) -> Result<ZoneBlock> {
                     "Zone block {} contains multiple advanceTempo calls",
                     header.number()
                 );
-                let call = ZoneInbox::advanceTempoCall::abi_decode(transaction.input())
-                    .wrap_err_with(|| {
-                        format!("decode advanceTempo in Zone block {}", header.number())
-                    })?;
+                let call = ZoneInbox::advanceTempoCall::abi_decode_with_config(
+                    transaction.input(),
+                    abi_decoder_config(),
+                )
+                .wrap_err_with(|| {
+                    format!("decode advanceTempo in Zone block {}", header.number())
+                })?;
                 decode_tempo_header(&call.header).wrap_err_with(|| {
                     format!("decode Tempo checkpoint in Zone block {}", header.number())
                 })?;
@@ -660,13 +664,16 @@ fn extract_zone_block(block: &RecoveredBlock<Block>) -> Result<ZoneBlock> {
                     "Zone block {} contains multiple finalizeWithdrawalBatch calls",
                     header.number()
                 );
-                let call = ZoneOutbox::finalizeWithdrawalBatchCall::abi_decode(transaction.input())
-                    .wrap_err_with(|| {
-                        format!(
-                            "decode finalizeWithdrawalBatch in Zone block {}",
-                            header.number()
-                        )
-                    })?;
+                let call = ZoneOutbox::finalizeWithdrawalBatchCall::abi_decode_with_config(
+                    transaction.input(),
+                    abi_decoder_config(),
+                )
+                .wrap_err_with(|| {
+                    format!(
+                        "decode finalizeWithdrawalBatch in Zone block {}",
+                        header.number()
+                    )
+                })?;
                 ensure!(
                     call.blockNumber == header.number(),
                     "finalization in Zone block {} declares block {}",

--- a/crates/sequencer/src/settlement.rs
+++ b/crates/sequencer/src/settlement.rs
@@ -45,6 +45,7 @@ use parking_lot::RwLock;
 use reth_storage_api::BlockNumReader;
 use schnellru::{ByLength, LruMap};
 use tempo_alloy::{TempoNetwork, provider::ext::TempoProviderExt, rpc::TempoCallBuilderExt};
+use tempo_precompiles::dispatch::abi_decoder_config;
 use tempo_primitives::{Block, TempoReceipt};
 use tokio_util::sync;
 use tracing::{info, instrument, warn};
@@ -1628,15 +1629,17 @@ pub(crate) async fn fetch_finalized_batch<P: ZoneSequencerProvider>(
                 target.block_number
             )
         })?;
-    let encrypted_senders =
-        abi::IZoneOutbox::finalizeWithdrawalBatchCall::abi_decode(finalize_tx.input().as_ref())
-            .map_err(|err| {
-                eyre::eyre!(
-                    "failed to decode finalizeWithdrawalBatch calldata for {}: {err}",
-                    target.tx_hash
-                )
-            })?
-            .encryptedSenders;
+    let encrypted_senders = abi::IZoneOutbox::finalizeWithdrawalBatchCall::abi_decode_with_config(
+        finalize_tx.input().as_ref(),
+        abi_decoder_config(),
+    )
+    .map_err(|err| {
+        eyre::eyre!(
+            "failed to decode finalizeWithdrawalBatch calldata for {}: {err}",
+            target.tx_hash
+        )
+    })?
+    .encryptedSenders;
 
     if encrypted_senders.len() != requests.len() {
         return Err(eyre::eyre!(


### PR DESCRIPTION
## Summary

- bump Tempo from `9f7fc929` to the focused [`b8359703`](https://github.com/tempoxyz/tempo/commit/b8359703665bd5f230068ecd68b0420b25a84e74) backport of [tempo#7364](https://github.com/tempoxyz/tempo/pull/7364)
- apply the shared 16 MiB ABI decoder limit to Zone decoding paths outside Tempo's precompile dispatcher
- add a regression test for aliased nested AccountKeychain calldata

## Validation

- `cargo check -p zone-precompiles -p zone-sequencer -p zone-node -p tempo-zone-prover-utils`
- `cargo test -p zone-precompiles aliased_set_allowed_calls_is_bounded --lib`
- `cargo +nightly fmt --all -- --check`
- `cargo +nightly clippy -p zone-precompiles -p zone-sequencer -p zone-node -p tempo-zone-prover-utils --all-targets`

Prompted by: @0xKitsune
