### PR TITLE
fix(rpc): require enabled-token balance for simulations

### DIFF
--- a/crates/node/src/lib.rs
+++ b/crates/node/src/lib.rs
@@ -16,6 +16,7 @@ mod replication;
 pub mod role;
 pub mod rpc;
 mod settlement_attestation;
+mod token_balance;
 mod tx_forwarding;
 pub mod version;
 

--- a/crates/node/src/node.rs
+++ b/crates/node/src/node.rs
@@ -18,6 +18,7 @@ use crate::{
         ZoneApiServer as _, ZoneRpc, ZoneRpcApi, operator_zone_rpc_module, rpc_connection_config,
         start_redacted_rpc,
     },
+    token_balance::has_enabled_token_balance,
 };
 use alloy_chains::Chain;
 use alloy_consensus::BlockHeader as _;
@@ -48,9 +49,7 @@ use reth_provider::ChainSpecProvider;
 use reth_rpc_api::Web3ApiServer as _;
 use reth_rpc_builder::Identity;
 use reth_rpc_eth_api::EthApiTypes;
-use reth_storage_api::{
-    BlockNumReader, EmptyBodyStorage, HeaderProvider, StateProvider, StateProviderFactory,
-};
+use reth_storage_api::{BlockNumReader, EmptyBodyStorage, HeaderProvider, StateProviderFactory};
 use reth_transaction_pool::{
     Pool, PoolTransaction, TransactionValidationTaskExecutor, blobstore::InMemoryBlobStore,
     error::InvalidPoolTransactionError,
@@ -61,7 +60,6 @@ use tempo_evm::{TempoInvalidTransaction, consensus::TempoConsensus};
 use tempo_node::{
     DEFAULT_AA_VALID_AFTER_MAX_SECS, engine::TempoEngineValidator, rpc::TempoEthApiBuilder,
 };
-use tempo_precompiles::tip20::TIP20Token;
 use tempo_primitives::{
     self as primitives, TempoHeader, TempoPrimitives, TempoTxEnvelope, TempoTxType,
 };
@@ -1707,28 +1705,18 @@ fn validate_has_enabled_token_balance(
     enabled_tokens: &EnabledTokenRegistry,
     sender: Address,
 ) -> Result<(), InvalidPoolTransactionError> {
-    let state = provider.latest().map_err(|err| {
-        warn!(%err, "Failed to read latest state for zone token-balance admission check");
-        InvalidPoolTransactionError::other(TempoPoolTransactionError::Evm(
-            TempoInvalidTransaction::EthInvalidTransaction(
-                "could not verify balance of an enabled zone token".into(),
-            ),
-        ))
-    })?;
-
-    for token in enabled_tokens.read().iter().copied() {
-        let slot = TIP20Token::from_address_unchecked(token).balances[sender].slot();
-        let balance = state.storage(token, slot.into()).map_err(|err| {
-            warn!(%err, %sender, "Failed to read zone token balance during pool admission");
-            InvalidPoolTransactionError::other(TempoPoolTransactionError::Evm(
-                TempoInvalidTransaction::EthInvalidTransaction(
-                    "could not verify balance of an enabled zone token".into(),
-                ),
-            ))
-        })?;
-        if balance.is_some_and(|balance| !balance.is_zero()) {
-            return Ok(());
-        }
+    let has_balance =
+        has_enabled_token_balance(provider, enabled_tokens.read().iter().copied(), sender)
+            .map_err(|err| {
+                warn!(%err, %sender, "Failed to verify zone token balance during pool admission");
+                InvalidPoolTransactionError::other(TempoPoolTransactionError::Evm(
+                    TempoInvalidTransaction::EthInvalidTransaction(
+                        "could not verify balance of an enabled zone token".into(),
+                    ),
+                ))
+            })?;
+    if has_balance {
+        return Ok(());
     }
 
     Err(InvalidPoolTransactionError::other(

--- a/crates/node/src/rpc.rs
+++ b/crates/node/src/rpc.rs
@@ -70,7 +70,9 @@ use zone_rpc::{
     },
 };
 
-use crate::{replication::PeerTipRegistry, role::SharedRoleStatus};
+use crate::{
+    replication::PeerTipRegistry, role::SharedRoleStatus, token_balance::has_enabled_token_balance,
+};
 
 /// Multi-sequencer handles for the sequencer RPC methods.
 ///
@@ -629,6 +631,8 @@ async fn prune_filter_owners<Api: EthApiTypes + 'static>(
 /// - **`from`-enforcement** — `eth_call` / `eth_estimateGas` may only
 ///   simulate from the authenticated account (`-32004` on mismatch,
 ///   auto-set when omitted); state overrides are rejected (`-32602`).
+/// - **Enabled-token admission** — RPC methods that execute user calldata
+///   require the authenticated account to hold a nonzero enabled-token balance.
 /// - **Sender verification** — `eth_sendRawTransaction` checks that the
 ///   recovered transaction sender matches the authenticated account
 ///   (`-32003` on mismatch).
@@ -739,6 +743,22 @@ impl<Api> ZoneRpc<Api>
 where
     Api: FullEthApi + EthApiTypes<NetworkTypes = TempoNetwork> + Send + Sync + 'static,
 {
+    fn enforce_enabled_token_balance(&self, account: Address) -> Result<(), JsonRpcError> {
+        let has_balance =
+            has_enabled_token_balance(self.eth.api.provider(), self.zone_tokens(), account)
+                .map_err(|error| {
+                    tracing::warn!(%error, %account, "Failed to verify Zone RPC token balance");
+                    JsonRpcError::internal("could not verify balance of an enabled zone token")
+                })?;
+
+        if !has_balance {
+            return Err(JsonRpcError::internal(
+                "sender must hold a nonzero balance of an enabled zone token",
+            ));
+        }
+        Ok(())
+    }
+
     fn block_by_id(&self, id: BlockId) -> BoxFut<'_> {
         Box::pin(async move {
             let block = EthBlocks::rpc_block(&self.eth.api, id, false)
@@ -958,6 +978,7 @@ where
             }
 
             self.enforce_authorized(&mut request, &auth)?;
+            self.enforce_enabled_token_balance(auth.caller)?;
 
             let result = EthCall::call(
                 &self.eth.api,
@@ -984,6 +1005,7 @@ where
             }
 
             self.enforce_authorized(&mut request, &auth)?;
+            self.enforce_enabled_token_balance(auth.caller)?;
 
             let result = EthCall::estimate_gas_at(
                 &self.eth.api,
@@ -1029,6 +1051,7 @@ where
     ) -> BoxFut<'_> {
         Box::pin(async move {
             self.enforce_authorized(&mut request, &auth)?;
+            self.enforce_enabled_token_balance(auth.caller)?;
 
             // Prefill the users request so the `fill_transaction` doesnt leak dynamic fee estimates via
             // missing fee fields.

--- a/crates/node/src/token_balance.rs
+++ b/crates/node/src/token_balance.rs
@@ -1,0 +1,27 @@
+use alloy_primitives::Address;
+use eyre::WrapErr;
+use reth_storage_api::{StateProvider, StateProviderFactory};
+use tempo_precompiles::tip20::TIP20Token;
+
+/// Returns whether `account` holds a nonzero balance of any enabled Zone token.
+pub(crate) fn has_enabled_token_balance(
+    provider: &impl StateProviderFactory,
+    enabled_tokens: impl IntoIterator<Item = Address>,
+    account: Address,
+) -> eyre::Result<bool> {
+    let state = provider
+        .latest()
+        .wrap_err("failed to read latest state for Zone token-balance check")?;
+
+    for token in enabled_tokens {
+        let slot = TIP20Token::from_address_unchecked(token).balances[account].slot();
+        let balance = state
+            .storage(token, slot.into())
+            .wrap_err("failed to read Zone token balance")?;
+        if balance.is_some_and(|balance| !balance.is_zero()) {
+            return Ok(true);
+        }
+    }
+
+    Ok(false)
+}

--- a/crates/node/tests/it/redacted_rpc_e2e.rs
+++ b/crates/node/tests/it/redacted_rpc_e2e.rs
@@ -8,8 +8,9 @@
 //! - Method tier enforcement (restricted/disabled/unknown methods)
 
 use crate::utils::{
-    DEFAULT_TIMEOUT, TEST_MNEMONIC, TIP20_TX_GAS, now_secs, start_zone_with_redacted_rpc,
-    start_zone_with_redacted_rpc_l1, start_zone_with_redacted_rpc_l1_with_encryption,
+    DEFAULT_TIMEOUT, RedactedRpcL1TestCtx, TEST_MNEMONIC, TIP20_TX_GAS, ZoneAccount, now_secs,
+    start_zone_with_redacted_rpc, start_zone_with_redacted_rpc_l1,
+    start_zone_with_redacted_rpc_l1_with_encryption,
 };
 use alloy::{
     primitives::{Address, B256, TxKind, U256, address, hex},
@@ -71,6 +72,24 @@ fn corrupt_token_hex(token: &str) -> String {
 
 fn address_topic(address: Address) -> String {
     format!("{:#x}", B256::left_padding_from(address.as_slice()))
+}
+
+async fn fund_l1_rpc_accounts(
+    ctx: &RedactedRpcL1TestCtx,
+    signers: &[&PrivateKeySigner],
+) -> eyre::Result<()> {
+    let depositor_signer = ctx.l1().user_signer();
+    ctx.l1()
+        .fund_user(depositor_signer.address(), 5_000_000)
+        .await?;
+    let mut depositor =
+        ZoneAccount::with_signer(depositor_signer, ctx.l1(), &ctx.zone, ctx.portal_address());
+    for signer in signers {
+        depositor
+            .deposit_to(signer.address(), 1_000_000, DEFAULT_TIMEOUT, &ctx.zone)
+            .await?;
+    }
+    Ok(())
 }
 
 fn signed_sponsored_raw_transaction(
@@ -327,6 +346,51 @@ async fn test_send_raw_transaction_requires_enabled_token_balance() -> eyre::Res
         response["result"].as_str().is_some(),
         "funded sender transaction should be accepted: {response}",
     );
+
+    Ok(())
+}
+
+/// RPC methods that execute user calldata require the caller to hold an enabled zone token.
+#[tokio::test(flavor = "multi_thread")]
+async fn test_simulation_methods_require_enabled_token_balance() -> eyre::Result<()> {
+    reth_tracing::init_test_tracing();
+
+    let mut ctx = start_zone_with_redacted_rpc().await?;
+    let user_signer = PrivateKeySigner::random();
+    let request = json!({
+        "to": format!("{:#x}", user_signer.address()),
+        "data": "0x",
+    });
+
+    for (method, params) in [
+        ("eth_call", json!([request.clone(), "latest"])),
+        ("eth_estimateGas", json!([request.clone(), "latest"])),
+        ("eth_fillTransaction", json!([request.clone()])),
+    ] {
+        let response = ctx.call_as_user(method, params, &user_signer).await?;
+        assert_eq!(
+            response["error"]["code"].as_i64(),
+            Some(-32603),
+            "{method} should reject an unfunded caller: {response}",
+        );
+        assert_eq!(
+            response["error"]["message"].as_str(),
+            Some("sender must hold a nonzero balance of an enabled zone token"),
+            "{method} should explain why the call was rejected: {response}",
+        );
+    }
+
+    ctx.inject_deposit(
+        PATH_USD_ADDRESS,
+        user_signer.address(),
+        user_signer.address(),
+        1_000_000,
+    )
+    .await?;
+    let response = ctx
+        .call_as_user("eth_call", json!([request, "latest"]), &user_signer)
+        .await?;
+    assert_eq!(response["result"].as_str(), Some("0x"));
 
     Ok(())
 }
@@ -680,8 +744,10 @@ async fn test_balance_privacy() -> eyre::Result<()> {
 async fn test_tip403_zero_caller_is_operator_only() -> eyre::Result<()> {
     reth_tracing::init_test_tracing();
 
-    let ctx = start_zone_with_redacted_rpc().await?;
+    let mut ctx = start_zone_with_redacted_rpc().await?;
     let user = PrivateKeySigner::random();
+    ctx.inject_deposit(PATH_USD_ADDRESS, user.address(), user.address(), 1_000_000)
+        .await?;
     let call = ITIP403Registry::isAuthorizedCall {
         policyId: ALLOW_ALL_POLICY_ID,
         user: user.address(),
@@ -862,6 +928,7 @@ async fn test_tip20_nonce_eth_call_privacy() -> eyre::Result<()> {
     let owner_signer = PrivateKeySigner::random();
     let owner = owner_signer.address();
     let outsider_signer = PrivateKeySigner::random();
+    fund_l1_rpc_accounts(&ctx, &[&owner_signer, &outsider_signer]).await?;
     let nonce_call = PrecompileTip20::noncesCall { owner };
     let calldata = nonce_call.abi_encode();
 
@@ -937,6 +1004,7 @@ async fn test_zone_inbox_refunds_eth_call_privacy() -> eyre::Result<()> {
     let owner_signer = PrivateKeySigner::random();
     let owner = owner_signer.address();
     let outsider_signer = PrivateKeySigner::random();
+    fund_l1_rpc_accounts(&ctx, &[&owner_signer, &outsider_signer]).await?;
 
     let refunds_call = IZoneInbox::refundsCall {
         token: ZONE_TOKEN_ADDRESS,
@@ -1028,6 +1096,7 @@ async fn test_native_account_getter_eth_call_privacy() -> eyre::Result<()> {
     let owner_signer = PrivateKeySigner::random();
     let owner = owner_signer.address();
     let outsider_signer = PrivateKeySigner::random();
+    fund_l1_rpc_accounts(&ctx, &[&owner_signer, &outsider_signer]).await?;
     let key_id = Address::repeat_byte(0x55);
 
     let calls = [


### PR DESCRIPTION
## Summary

- require a nonzero enabled-token balance before redacted RPC methods execute user calldata
- share the raw TIP-20 balance lookup with txpool admission
- cover `eth_call`, `eth_estimateGas`, and `eth_fillTransaction`

## Testing

- `cargo check -p zone-node`
- `cargo +nightly clippy -p zone-node --lib`
- `cargo test -p zone-node --test it redacted_rpc_e2e::test_simulation_methods_require_enabled_token_balance -- --exact --nocapture`
- `cargo test -p zone-node --test it eth_call_privacy -- --nocapture`

Prompted by: @0xKitsune