### PR TITLE
fix(prover): support terminal extension proofs

### DIFF
--- a/crates/spf/src/execution/database.rs
+++ b/crates/spf/src/execution/database.rs
@@ -4,7 +4,7 @@ use std::sync::{Arc, Mutex};
 
 use alloy_consensus::BlockHeader as _;
 use alloy_eips::eip2935::{HISTORY_SERVE_WINDOW, HISTORY_STORAGE_ADDRESS};
-use alloy_primitives::{Address, B256, Bytes, U256, keccak256};
+use alloy_primitives::{Address, B256, U256, keccak256};
 use alloy_rlp::Decodable as _;
 use revm::{
     Database,
@@ -16,7 +16,8 @@ use tempo_primitives::TempoHeader;
 use zone_precompiles::{L1StateError, L1StorageReader};
 
 use crate::{
-    Error, StatelessSparseTrieError, TempoStateWitness, ZoneStateWitness, mpt::StatelessSparseTrie,
+    Error, StatelessSparseTrieError, TempoStateWitness, ZoneStateWitness,
+    mpt::{StatelessSparseTrie, StatelessTrieReader},
 };
 
 /// Errors emitted while resolving an execution read against a witness.
@@ -171,15 +172,15 @@ impl Database for WitnessDatabase {
 
 /// Tempo state reader for the checkpoint header supplied in the witness.
 ///
-/// When the shared node pool includes that checkpoint's root, it owns a fully
-/// revealed immutable sparse trie. Otherwise it remains inactive and rejects
-/// any Tempo storage read as an incomplete witness.
+/// When the shared node pool includes that checkpoint's root, reads are authenticated by walking
+/// the standard MPT proof nodes directly. Otherwise it remains inactive and rejects any Tempo
+/// storage read as an incomplete witness.
 #[derive(Clone, Debug)]
 pub struct TempoWitnessDatabase {
-    state: Option<Arc<StatelessSparseTrie>>,
+    state_root: Option<B256>,
     tempo_block_hash: B256,
     tempo_block_number: u64,
-    node_pool: Arc<Vec<Bytes>>,
+    node_pool: Arc<StatelessTrieReader>,
     missing_read: Arc<Mutex<Option<MissingTempoStorageRead>>>,
 }
 
@@ -193,12 +194,12 @@ pub(crate) struct MissingTempoStorageRead {
 impl TempoWitnessDatabase {
     /// Construct the reader for the initial Tempo checkpoint.
     pub fn from_tempo_state_witness(witness: TempoStateWitness) -> Result<Self, Error> {
-        let node_pool = Arc::new(witness.node_pool);
-        let (state, tempo_block_hash, tempo_block_number) =
+        let node_pool = Arc::new(StatelessTrieReader::new(&witness.node_pool)?);
+        let (state_root, tempo_block_hash, tempo_block_number) =
             checkpoint_state(&witness.initial_tempo_header_rlp, node_pool.as_ref())?;
 
         Ok(Self {
-            state,
+            state_root,
             tempo_block_hash,
             tempo_block_number,
             node_pool,
@@ -213,11 +214,11 @@ impl TempoWitnessDatabase {
         self,
         header_rlp: &alloy_primitives::Bytes,
     ) -> Result<Self, Error> {
-        let (state, tempo_block_hash, tempo_block_number) =
+        let (state_root, tempo_block_hash, tempo_block_number) =
             checkpoint_state(header_rlp, self.node_pool.as_ref())?;
 
         Ok(Self {
-            state,
+            state_root,
             tempo_block_hash,
             tempo_block_number,
             node_pool: self.node_pool,
@@ -252,8 +253,8 @@ impl TempoWitnessDatabase {
 
 fn checkpoint_state(
     header_rlp: &[u8],
-    node_pool: &[Bytes],
-) -> Result<(Option<Arc<StatelessSparseTrie>>, B256, u64), Error> {
+    node_pool: &StatelessTrieReader,
+) -> Result<(Option<B256>, B256, u64), Error> {
     let mut encoded_header = header_rlp;
     let header = TempoHeader::decode(&mut encoded_header)
         .map_err(|_| WitnessDatabaseError::InvalidTempoHeader)?;
@@ -262,13 +263,9 @@ fn checkpoint_state(
     }
 
     let state_root = header.state_root();
-    let state = match StatelessSparseTrie::new(state_root, node_pool) {
-        Ok(state) => Some(Arc::new(state)),
-        Err(StatelessSparseTrieError::MissingStateRootNode { .. }) => None,
-        Err(error) => return Err(error.into()),
-    };
+    let state_root = node_pool.contains_root(state_root).then_some(state_root);
 
-    Ok((state, keccak256(header_rlp), header.number()))
+    Ok((state_root, keccak256(header_rlp), header.number()))
 }
 
 impl L1StorageReader for TempoWitnessDatabase {
@@ -287,7 +284,7 @@ impl L1StorageReader for TempoWitnessDatabase {
             ));
         }
 
-        let state = self.state.as_ref().ok_or_else(|| {
+        let state_root = self.state_root.ok_or_else(|| {
             self.record_missing_read(account, slot, tempo_block_number);
             storage_unavailable(
                 account,
@@ -296,7 +293,10 @@ impl L1StorageReader for TempoWitnessDatabase {
                 "witness does not include the checkpoint state root",
             )
         })?;
-        let value = match state.storage(account, U256::from_be_bytes(slot.0)) {
+        let value = match self
+            .node_pool
+            .storage(state_root, account, U256::from_be_bytes(slot.0))
+        {
             Ok(value) => value,
             Err(
                 error @ (StatelessSparseTrieError::IncompleteAccountProof { .. }

--- a/crates/spf/src/lib.rs
+++ b/crates/spf/src/lib.rs
@@ -598,7 +598,10 @@ mod tests {
     use alloy_eips::eip2935::{HISTORY_SERVE_WINDOW, HISTORY_STORAGE_ADDRESS};
     use alloy_primitives::{Address, B256, Bytes, U256, keccak256};
     use reth_evm::ConfigureEvm;
-    use reth_trie_common::{EMPTY_ROOT_HASH, LeafNode, Nibbles, TrieAccount, TrieNode};
+    use reth_trie_common::{
+        BranchNode, EMPTY_ROOT_HASH, ExtensionNode, LeafNode, Nibbles, RlpNode, TrieAccount,
+        TrieMask, TrieNode,
+    };
     use revm::{
         DatabaseCommit as _,
         database::{State, states::bundle_state::BundleRetention},
@@ -994,7 +997,7 @@ mod tests {
     }
 
     #[test]
-    fn fully_reveals_the_active_tempo_checkpoint() {
+    fn reads_the_active_tempo_checkpoint() {
         let account = Address::repeat_byte(0x34);
         let slot = U256::from(7);
         let value = U256::from(11);
@@ -1017,6 +1020,107 @@ mod tests {
         let database = TempoWitnessDatabase::from_tempo_state_witness(TempoStateWitness {
             initial_tempo_header_rlp: Bytes::from(alloy_rlp::encode(header)),
             node_pool: zone_witness.node_pool,
+        })
+        .unwrap();
+
+        assert_eq!(
+            database
+                .read_l1_storage(account, B256::from(slot.to_be_bytes::<32>()), 9)
+                .unwrap(),
+            B256::from(value.to_be_bytes::<32>())
+        );
+    }
+
+    #[test]
+    fn accepts_a_tempo_exclusion_proof_ending_at_an_extension() {
+        let account = Address::repeat_byte(0x35);
+        let slot = U256::from(7);
+        let slot_path = Nibbles::unpack(keccak256(slot.to_be_bytes::<32>()));
+        let extension_key = Nibbles::from_nibbles([
+            (slot_path.get_unchecked(0) + 1) % 16,
+            slot_path.get_unchecked(1),
+        ]);
+        let extension = TrieNode::Extension(ExtensionNode::new(
+            extension_key,
+            RlpNode::word_rlp(&B256::repeat_byte(0x42)),
+        ));
+        let encoded_extension = Bytes::from(alloy_rlp::encode(extension));
+        let storage_root = keccak256(&encoded_extension);
+
+        let trie_account = TrieAccount {
+            storage_root,
+            ..Default::default()
+        };
+        let account_leaf = TrieNode::Leaf(LeafNode::new(
+            Nibbles::unpack(keccak256(account)),
+            alloy_rlp::encode(trie_account),
+        ));
+        let encoded_account = Bytes::from(alloy_rlp::encode(account_leaf));
+        let state_root = keccak256(&encoded_account);
+        let header = TempoHeader {
+            inner: Header {
+                number: 9,
+                state_root,
+                ..Default::default()
+            },
+            ..Default::default()
+        };
+        let database = TempoWitnessDatabase::from_tempo_state_witness(TempoStateWitness {
+            initial_tempo_header_rlp: Bytes::from(alloy_rlp::encode(header)),
+            // A normal exclusion proof stops at the extension. Its hashed child branch is not
+            // needed to prove that the requested path diverges from the extension key.
+            node_pool: vec![encoded_account, encoded_extension],
+        })
+        .unwrap();
+
+        assert_eq!(
+            database
+                .read_l1_storage(account, B256::from(slot.to_be_bytes::<32>()), 9)
+                .unwrap(),
+            B256::ZERO
+        );
+    }
+
+    #[test]
+    fn resolves_a_tempo_inclusion_proof_through_a_branch() {
+        let account = Address::repeat_byte(0x36);
+        let slot = U256::from(8);
+        let value = U256::from(12);
+
+        let storage_leaf = TrieNode::Leaf(LeafNode::new(
+            Nibbles::unpack(keccak256(slot.to_be_bytes::<32>())),
+            alloy_rlp::encode(value),
+        ));
+        let encoded_storage = Bytes::from(alloy_rlp::encode(storage_leaf));
+        let storage_root = keccak256(&encoded_storage);
+
+        let account_path = Nibbles::unpack(keccak256(account));
+        let account_leaf = TrieNode::Leaf(LeafNode::new(
+            account_path.slice(1..),
+            alloy_rlp::encode(TrieAccount {
+                storage_root,
+                ..Default::default()
+            }),
+        ));
+        let encoded_account = Bytes::from(alloy_rlp::encode(account_leaf));
+        let account_nibble = account_path.get_unchecked(0);
+        let account_branch = TrieNode::Branch(BranchNode::new(
+            vec![RlpNode::from_rlp(&encoded_account)],
+            TrieMask::new(1 << account_nibble),
+        ));
+        let encoded_branch = Bytes::from(alloy_rlp::encode(account_branch));
+        let state_root = keccak256(&encoded_branch);
+        let header = TempoHeader {
+            inner: Header {
+                number: 9,
+                state_root,
+                ..Default::default()
+            },
+            ..Default::default()
+        };
+        let database = TempoWitnessDatabase::from_tempo_state_witness(TempoStateWitness {
+            initial_tempo_header_rlp: Bytes::from(alloy_rlp::encode(header)),
+            node_pool: vec![encoded_branch, encoded_account, encoded_storage],
         })
         .unwrap();
 

--- a/crates/spf/src/mpt.rs
+++ b/crates/spf/src/mpt.rs
@@ -2,14 +2,156 @@
 //!
 //! The construction and read pattern is adapted from
 //! [`paradigmxyz/stateless`'s `StatelessSparseTrie`](https://github.com/paradigmxyz/stateless/blob/3d2fc174df31f5b0d5d4d831dc7e1607ea541531/crates/tries/src/default.rs).
-//! A flat witness is indexed by node hash, revealed into Reth's
-//! [`reth_trie_sparse::SparseStateTrie`], and checked against the committed
-//! pre-state root before it can serve reads.
+//! Zone state witnesses are revealed into Reth's [`reth_trie_sparse::SparseStateTrie`] so they can
+//! be updated during execution. Tempo state witnesses use a read-only hash-indexed trie, which can
+//! consume standard MPT proofs without imposing the sparse trie's internal node representation.
 
 use alloy_primitives::{Address, B256, Bytes, U256, keccak256, map::B256Map};
 use alloy_rlp::Decodable;
-use reth_trie_common::{DecodedMultiProofV2, EMPTY_ROOT_HASH, HashedPostState, TrieAccount};
+use reth_trie_common::{
+    DecodedMultiProofV2, EMPTY_ROOT_HASH, HashedPostState, Nibbles, RlpNode, TrieAccount, TrieNode,
+};
 use reth_trie_sparse::{LeafUpdate, RevealableSparseTrie, SparseStateTrie, TrieNodeEpoch};
+
+/// Read-only MPT node pool used to authenticate Tempo state reads.
+#[derive(Debug)]
+pub(crate) struct StatelessTrieReader {
+    nodes: B256Map<Bytes>,
+}
+
+impl StatelessTrieReader {
+    /// Index a flat witness by node hash.
+    pub(crate) fn new(node_pool: &[Bytes]) -> Result<Self, StatelessSparseTrieError> {
+        let mut nodes = B256Map::default();
+        for node in node_pool {
+            let node_hash = keccak256(node);
+            if nodes.insert(node_hash, node.clone()).is_some() {
+                return Err(StatelessSparseTrieError::DuplicateNodeHash { node_hash });
+            }
+        }
+        Ok(Self { nodes })
+    }
+
+    /// Returns whether this witness can start a proof at `root`.
+    pub(crate) fn contains_root(&self, root: B256) -> bool {
+        root == EMPTY_ROOT_HASH || self.nodes.contains_key(&root)
+    }
+
+    /// Return a proven storage value, or zero for a valid account or storage exclusion proof.
+    pub(crate) fn storage(
+        &self,
+        state_root: B256,
+        address: Address,
+        slot: U256,
+    ) -> Result<U256, StatelessSparseTrieError> {
+        let account = self
+            .value(state_root, keccak256(address))
+            .map_err(|error| map_lookup_error(error, address, None))?
+            .map(|value| decode_account(&value, address))
+            .transpose()?;
+        let Some(account) = account else {
+            return Ok(U256::ZERO);
+        };
+        if account.storage_root == EMPTY_ROOT_HASH {
+            return Ok(U256::ZERO);
+        }
+
+        self.value(account.storage_root, keccak256(slot.to_be_bytes::<32>()))
+            .map_err(|error| map_lookup_error(error, address, Some(slot)))?
+            .map(|value| decode_storage_value(&value, address, slot))
+            .transpose()
+            .map(Option::unwrap_or_default)
+    }
+
+    /// Walk a single MPT path. A mismatching leaf or extension and an empty branch child are valid
+    /// exclusion proofs; a missing hashed child means the supplied witness is incomplete.
+    fn value(&self, root: B256, key: B256) -> Result<Option<Vec<u8>>, TrieLookupError> {
+        if root == EMPTY_ROOT_HASH {
+            return Ok(None);
+        }
+
+        let key = Nibbles::unpack(key);
+        let mut offset = 0;
+        let mut encoded = self
+            .nodes
+            .get(&root)
+            .cloned()
+            .ok_or(TrieLookupError::Incomplete)?;
+
+        // A canonical path consumes at least one nibble at every branch or extension, so a
+        // 64-nibble key cannot contain more than 65 nodes.
+        for _ in 0..=key.len() {
+            let mut input = encoded.as_ref();
+            let node = TrieNode::decode(&mut input).map_err(|_| TrieLookupError::Invalid)?;
+            if !input.is_empty() {
+                return Err(TrieLookupError::Invalid);
+            }
+
+            match node {
+                TrieNode::EmptyRoot => return Ok(None),
+                TrieNode::Leaf(leaf) => {
+                    return Ok((key.slice(offset..) == leaf.key).then_some(leaf.value));
+                }
+                TrieNode::Extension(extension) => {
+                    if extension.key.is_empty() || !key.slice(offset..).starts_with(&extension.key)
+                    {
+                        return Ok(None);
+                    }
+                    offset += extension.key.len();
+                    encoded = self.resolve_child(&extension.child)?;
+                }
+                TrieNode::Branch(branch) => {
+                    if offset == key.len() {
+                        return Ok(None);
+                    }
+                    let nibble = key.get_unchecked(offset);
+                    let branch = branch.as_ref();
+                    let child = branch
+                        .children()
+                        .find_map(|(index, child)| (index == nibble).then_some(child).flatten());
+                    let Some(child) = child else { return Ok(None) };
+                    offset += 1;
+                    encoded = self.resolve_child(child)?;
+                }
+            }
+        }
+
+        Err(TrieLookupError::Invalid)
+    }
+
+    fn resolve_child(&self, child: &RlpNode) -> Result<Bytes, TrieLookupError> {
+        if let Some(hash) = child.as_hash() {
+            self.nodes
+                .get(&hash)
+                .cloned()
+                .ok_or(TrieLookupError::Incomplete)
+        } else {
+            Ok(Bytes::copy_from_slice(child.as_ref()))
+        }
+    }
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+enum TrieLookupError {
+    Incomplete,
+    Invalid,
+}
+
+fn map_lookup_error(
+    error: TrieLookupError,
+    account: Address,
+    slot: Option<U256>,
+) -> StatelessSparseTrieError {
+    match (error, slot) {
+        (TrieLookupError::Invalid, _) => StatelessSparseTrieError::InvalidNodeEncoding,
+        (TrieLookupError::Incomplete, Some(slot)) => {
+            StatelessSparseTrieError::IncompleteStorageProof { account, slot }
+        }
+        (TrieLookupError::Incomplete, None) => {
+            StatelessSparseTrieError::IncompleteAccountProof { account }
+        }
+    }
+}
 
 /// Fully revealed, root-bound stateless trie.
 #[derive(Debug)]


### PR DESCRIPTION
## Summary

- authenticate Tempo reads with a read-only MPT walker instead of converting standard RPC proofs into Reth's mutable sparse-trie format
- accept exclusion proofs that terminate at a standalone extension node without requiring its child branch
- keep Zone post-state root computation on the mutable sparse trie

## Testing

- `cargo test -p zone-spf --locked`
- `cargo +nightly clippy -p zone-spf --all-targets --all-features --locked`
- `cargo +nightly fmt --all -- --check`

Context: [reth#26851](https://github.com/paradigmxyz/reth/pull/26851)

Prompted by: @rkrasiuk
