### PR TITLE
chore: bump workspace version to 0.2.2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -11740,7 +11740,7 @@ dependencies = [
 
 [[package]]
 name = "tempo-vsock-proxy"
-version = "0.2.1"
+version = "0.2.2"
 dependencies = [
  "clap",
  "libc",
@@ -11753,7 +11753,7 @@ dependencies = [
 
 [[package]]
 name = "tempo-xtask"
-version = "0.2.1"
+version = "0.2.2"
 dependencies = [
  "alloy",
  "alloy-eips",
@@ -11793,7 +11793,7 @@ dependencies = [
 
 [[package]]
 name = "tempo-zone"
-version = "0.2.1"
+version = "0.2.2"
 dependencies = [
  "reth-cli-util",
  "reth-node-core",
@@ -11803,7 +11803,7 @@ dependencies = [
 
 [[package]]
 name = "tempo-zone-contracts"
-version = "0.2.1"
+version = "0.2.2"
 dependencies = [
  "alloy-contract",
  "alloy-network",
@@ -11822,7 +11822,7 @@ dependencies = [
 
 [[package]]
 name = "tempo-zone-prover-enclave"
-version = "0.2.1"
+version = "0.2.2"
 dependencies = [
  "alloy-consensus",
  "alloy-genesis",
@@ -11845,7 +11845,7 @@ dependencies = [
 
 [[package]]
 name = "tempo-zone-prover-utils"
-version = "0.2.1"
+version = "0.2.2"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -13698,7 +13698,7 @@ checksum = "29666d0abbfad1e3dc4dcf6144730dd3a3ab225bbbdac83319345b1b44ccfc1b"
 
 [[package]]
 name = "zone-chainspec"
-version = "0.2.1"
+version = "0.2.2"
 dependencies = [
  "alloy-eips",
  "alloy-evm",
@@ -13718,7 +13718,7 @@ dependencies = [
 
 [[package]]
 name = "zone-checker"
-version = "0.2.1"
+version = "0.2.2"
 dependencies = [
  "alloy-consensus",
  "alloy-contract",
@@ -13765,7 +13765,7 @@ dependencies = [
 
 [[package]]
 name = "zone-evm"
-version = "0.2.1"
+version = "0.2.2"
 dependencies = [
  "alloy-consensus",
  "alloy-evm",
@@ -13800,7 +13800,7 @@ dependencies = [
 
 [[package]]
 name = "zone-hardfork"
-version = "0.2.1"
+version = "0.2.2"
 dependencies = [
  "alloy-hardforks",
  "paste",
@@ -13808,7 +13808,7 @@ dependencies = [
 
 [[package]]
 name = "zone-l1"
-version = "0.2.1"
+version = "0.2.2"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -13848,7 +13848,7 @@ dependencies = [
 
 [[package]]
 name = "zone-node"
-version = "0.2.1"
+version = "0.2.2"
 dependencies = [
  "alloy",
  "alloy-chains",
@@ -13943,7 +13943,7 @@ dependencies = [
 
 [[package]]
 name = "zone-p2p"
-version = "0.2.1"
+version = "0.2.2"
 dependencies = [
  "alloy-primitives",
  "alloy-signer-local",
@@ -13967,7 +13967,7 @@ dependencies = [
 
 [[package]]
 name = "zone-payload"
-version = "0.2.1"
+version = "0.2.2"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -14008,7 +14008,7 @@ dependencies = [
 
 [[package]]
 name = "zone-precompiles"
-version = "0.2.1"
+version = "0.2.2"
 dependencies = [
  "aes-gcm",
  "alloy",
@@ -14039,7 +14039,7 @@ dependencies = [
 
 [[package]]
 name = "zone-primitives"
-version = "0.2.1"
+version = "0.2.2"
 dependencies = [
  "alloy-primitives",
  "tempo-hardfork",
@@ -14048,7 +14048,7 @@ dependencies = [
 
 [[package]]
 name = "zone-prover"
-version = "0.2.1"
+version = "0.2.2"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -14067,7 +14067,7 @@ dependencies = [
 
 [[package]]
 name = "zone-rpc"
-version = "0.2.1"
+version = "0.2.2"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -14106,7 +14106,7 @@ dependencies = [
 
 [[package]]
 name = "zone-sequencer"
-version = "0.2.1"
+version = "0.2.2"
 dependencies = [
  "alloy-chains",
  "alloy-consensus",
@@ -14152,7 +14152,7 @@ dependencies = [
 
 [[package]]
 name = "zone-spf"
-version = "0.2.1"
+version = "0.2.2"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,5 @@
 [workspace.package]
-version = "0.2.1"
+version = "0.2.2"
 edition = "2024"
 rust-version = "1.95.0"
 license = "MIT OR Apache-2.0"


### PR DESCRIPTION
## Summary

- bump the workspace package version from 0.2.1 to 0.2.2
- refresh workspace package versions in Cargo.lock

## Testing

- `cargo metadata --locked --offline --format-version 1`
- `git diff --check`
- conflict-free merge against latest `main` (`180352c3`)

Prompted by: @klkvr