### PR TITLE
 fix(prover): model Tempo imports by call variant

### DIFF
--- a/bin/prover/utils/src/main.rs
+++ b/bin/prover/utils/src/main.rs
@@ -862,6 +862,7 @@ fn extract_block(block: RpcBlock) -> Result<ExtractedBlock> {
                         header.number()
                     );
                 }
+                user_transactions.push(Bytes::from(envelope.encoded_2718()));
                 let call = ZoneInbox::IZoneInboxCalls::abi_decode(envelope.input()).wrap_err_with(
                     || format!("decode ZoneInbox call in Zone block {}", header.number()),
                 )?;
@@ -874,12 +875,10 @@ fn extract_block(block: RpcBlock) -> Result<ExtractedBlock> {
                         enabled_tokens = call.enabledTokens;
                     }
                     ZoneInbox::IZoneInboxCalls::advanceTempoHeaders(call) => {
-                        if call.headers.len() <= 1 {
-                            bail!(
-                                "checkpoint-only Zone block must have more than one Tempo header",
-                            );
-                        }
-                        let final_header = call.headers.last().expect("checked header count");
+                        let final_header = call
+                            .headers
+                            .last()
+                            .ok_or_eyre("checkpoint-only Zone block has no Tempo headers")?;
                         checkpoint_number = Some(decode_tempo_header(final_header)?.number());
                         for encoded in &call.headers {
                             decode_tempo_header(encoded)?;
@@ -933,7 +932,7 @@ fn extract_block(block: RpcBlock) -> Result<ExtractedBlock> {
         ))?;
 
     let has_finalization = finalize_count.is_some();
-    let user_transaction_count = user_transactions.len();
+    let user_transaction_count = user_transactions.len().saturating_sub(1);
     Ok(ExtractedBlock {
         input: ZoneBlock {
             number: header.number(),

--- a/bin/prover/utils/src/main.rs
+++ b/bin/prover/utils/src/main.rs
@@ -36,7 +36,7 @@ use zone_rpc::{
     types::{TempoStorageRead, ZoneExecutionWitness},
 };
 use zone_spf::{
-    BatchOutput, BatchWitness, PublicInputs, SpfConfig, TempoStateWitness, ZoneBlock,
+    BatchOutput, BatchWitness, PublicInputs, SpfConfig, TempoImport, TempoStateWitness, ZoneBlock,
     ZoneStateWitness, prove_zone_batch,
 };
 
@@ -325,7 +325,8 @@ async fn generate_input(args: GenerateInputArgs) -> Result<()> {
             let block = &encoded.input;
             decode_tempo_header(
                 block
-                    .tempo_headers_rlp
+                    .tempo_import
+                    .headers_rlp()
                     .last()
                     .expect("extracted Tempo header"),
             )
@@ -830,7 +831,7 @@ async fn zone_header(zone: &DynProvider<TempoNetwork>, number: u64) -> Result<Te
 fn extract_block(block: RpcBlock) -> Result<ExtractedBlock> {
     let header = block.header.as_ref().clone();
     let block_hash = header.hash_slow();
-    let transactions = match block.transactions {
+    let rpc_transactions = match block.transactions {
         BlockTransactions::Full(transactions) => transactions,
         _ => bail!(
             "Zone block {} did not return full transactions",
@@ -838,41 +839,41 @@ fn extract_block(block: RpcBlock) -> Result<ExtractedBlock> {
         ),
     };
 
-    let mut tempo_headers_rlp = None;
-    let mut deposits = Vec::new();
-    let mut decryptions = Vec::new();
-    let mut enabled_tokens = Vec::new();
+    let mut tempo_import = None;
     let mut finalize_count = None;
     let mut finalize_encrypted_senders = Vec::new();
-    let mut user_transactions = Vec::new();
+    let mut transactions = Vec::new();
+    let mut user_transaction_count = 0;
     let mut checkpoint_number = None;
 
-    for transaction in transactions {
+    for transaction in rpc_transactions {
         let envelope = transaction.into_inner();
         if !envelope.is_system_tx() {
-            user_transactions.push(Bytes::from(envelope.encoded_2718()));
+            transactions.push(Bytes::from(envelope.encoded_2718()));
+            user_transaction_count += 1;
             continue;
         }
 
         match envelope.to() {
             Some(to) if to == ZONE_INBOX_ADDRESS => {
-                if tempo_headers_rlp.is_some() {
+                if tempo_import.is_some() {
                     bail!(
                         "Zone block {} contains multiple advanceTempo calls",
                         header.number()
                     );
                 }
-                user_transactions.push(Bytes::from(envelope.encoded_2718()));
                 let call = ZoneInbox::IZoneInboxCalls::abi_decode(envelope.input()).wrap_err_with(
                     || format!("decode ZoneInbox call in Zone block {}", header.number()),
                 )?;
                 match call {
                     ZoneInbox::IZoneInboxCalls::advanceTempo(call) => {
                         checkpoint_number = Some(decode_tempo_header(&call.header)?.number());
-                        tempo_headers_rlp = Some(vec![call.header]);
-                        deposits = call.deposits;
-                        decryptions = call.decryptions;
-                        enabled_tokens = call.enabledTokens;
+                        tempo_import = Some(TempoImport::Full {
+                            header_rlp: call.header,
+                            deposits: call.deposits,
+                            decryptions: call.decryptions,
+                            enabled_tokens: call.enabledTokens,
+                        });
                     }
                     ZoneInbox::IZoneInboxCalls::advanceTempoHeaders(call) => {
                         let final_header = call
@@ -883,7 +884,9 @@ fn extract_block(block: RpcBlock) -> Result<ExtractedBlock> {
                         for encoded in &call.headers {
                             decode_tempo_header(encoded)?;
                         }
-                        tempo_headers_rlp = Some(call.headers);
+                        tempo_import = Some(TempoImport::CheckpointOnly {
+                            headers_rlp: call.headers,
+                        });
                     }
                     _ => {
                         return Err(eyre!(
@@ -924,15 +927,11 @@ fn extract_block(block: RpcBlock) -> Result<ExtractedBlock> {
         }
     }
 
-    let (tempo_headers_rlp, checkpoint_number) = tempo_headers_rlp
-        .zip(checkpoint_number)
-        .ok_or_eyre(format!(
-            "no advanceTempo call in Zone block {}",
-            header.number()
-        ))?;
+    let (tempo_import, checkpoint_number) = tempo_import.zip(checkpoint_number).ok_or_eyre(
+        format!("no advanceTempo call in Zone block {}", header.number()),
+    )?;
 
     let has_finalization = finalize_count.is_some();
-    let user_transaction_count = user_transactions.len().saturating_sub(1);
     Ok(ExtractedBlock {
         input: ZoneBlock {
             number: header.number(),
@@ -940,13 +939,10 @@ fn extract_block(block: RpcBlock) -> Result<ExtractedBlock> {
             timestamp: header.timestamp(),
             timestamp_millis_part: header.timestamp_millis_part,
             beneficiary: header.beneficiary(),
-            tempo_headers_rlp,
-            deposits,
-            decryptions,
-            enabled_tokens,
+            tempo_import,
             finalize_withdrawal_batch_count: finalize_count,
             finalize_withdrawal_batch_encrypted_senders: finalize_encrypted_senders,
-            transactions: user_transactions,
+            transactions,
         },
         block_hash,
         checkpoint_number,

--- a/crates/node/tests/it/spf.rs
+++ b/crates/node/tests/it/spf.rs
@@ -98,6 +98,14 @@ async fn spf_batch_execute() -> eyre::Result<()> {
         .get_raw_transaction_by_hash(second_transaction_hash)
         .await?
         .expect("second raw user transaction");
+    let first_system_transaction = provider
+        .get_raw_transaction_by_hash(first_built_block.transactions.hashes().next().unwrap())
+        .await?
+        .expect("first raw system transaction");
+    let second_system_transaction = provider
+        .get_raw_transaction_by_hash(second_built_block.transactions.hashes().next().unwrap())
+        .await?
+        .expect("second raw system transaction");
 
     let (state_root, zone_state_witness) = zone_state_witness(&genesis);
     assert_eq!(state_root, genesis_block.header.state_root());
@@ -132,7 +140,7 @@ async fn spf_batch_execute() -> eyre::Result<()> {
                 enabled_tokens: vec![],
                 finalize_withdrawal_batch_count: None,
                 finalize_withdrawal_batch_encrypted_senders: vec![],
-                transactions: vec![first_raw_transaction],
+                transactions: vec![first_system_transaction, first_raw_transaction],
             },
             ZoneBlock {
                 number: second_built_block.header.number(),
@@ -146,7 +154,7 @@ async fn spf_batch_execute() -> eyre::Result<()> {
                 enabled_tokens: vec![],
                 finalize_withdrawal_batch_count: Some(U256::ZERO),
                 finalize_withdrawal_batch_encrypted_senders: vec![],
-                transactions: vec![second_raw_transaction],
+                transactions: vec![second_system_transaction, second_raw_transaction],
             },
         ],
         parent_header,
@@ -260,6 +268,7 @@ struct BuiltTransactionBlock {
     zone_beneficiary: Address,
     zone_hash: B256,
     tempo_header: TempoHeader,
+    raw_system_transaction: Bytes,
     raw_user_transaction: Bytes,
     generated_witness: ZoneExecutionWitness,
 }
@@ -296,7 +305,10 @@ impl BuiltTransactionBlock {
                 enabled_tokens: vec![],
                 finalize_withdrawal_batch_count: Some(U256::ZERO),
                 finalize_withdrawal_batch_encrypted_senders: vec![],
-                transactions: vec![self.raw_user_transaction.clone()],
+                transactions: vec![
+                    self.raw_system_transaction.clone(),
+                    self.raw_user_transaction.clone(),
+                ],
             }],
             zone_state_witness,
             tempo_state_witness: TempoStateWitness {
@@ -356,6 +368,10 @@ async fn build_single_transaction_block(
         .get_raw_transaction_by_hash(user_transaction_hash)
         .await?
         .expect("raw user transaction");
+    let raw_system_transaction = provider
+        .get_raw_transaction_by_hash(built_block.transactions.hashes().next().unwrap())
+        .await?
+        .expect("raw system transaction");
     let generated_witness = provider
         .raw_request(
             "debug_zoneExecutionWitness".into(),
@@ -371,6 +387,7 @@ async fn build_single_transaction_block(
         zone_beneficiary: built_block.header.beneficiary(),
         zone_hash: built_block.header.hash,
         tempo_header: l1_block.header,
+        raw_system_transaction,
         raw_user_transaction,
         generated_witness,
     })

--- a/crates/node/tests/it/spf.rs
+++ b/crates/node/tests/it/spf.rs
@@ -28,8 +28,8 @@ use tempo_primitives::TempoHeader;
 use zone_chainspec::ZoneChainSpec;
 use zone_rpc::types::ZoneExecutionWitness;
 use zone_spf::{
-    BatchWitness, PublicInputs, SpfConfig, TempoStateWitness, ZoneBlock, ZoneStateWitness,
-    prove_zone_batch,
+    BatchWitness, PublicInputs, SpfConfig, TempoImport, TempoStateWitness, ZoneBlock,
+    ZoneStateWitness, prove_zone_batch,
 };
 
 use crate::utils::{
@@ -98,14 +98,6 @@ async fn spf_batch_execute() -> eyre::Result<()> {
         .get_raw_transaction_by_hash(second_transaction_hash)
         .await?
         .expect("second raw user transaction");
-    let first_system_transaction = provider
-        .get_raw_transaction_by_hash(first_built_block.transactions.hashes().next().unwrap())
-        .await?
-        .expect("first raw system transaction");
-    let second_system_transaction = provider
-        .get_raw_transaction_by_hash(second_built_block.transactions.hashes().next().unwrap())
-        .await?
-        .expect("second raw system transaction");
 
     let (state_root, zone_state_witness) = zone_state_witness(&genesis);
     assert_eq!(state_root, genesis_block.header.state_root());
@@ -134,13 +126,15 @@ async fn spf_batch_execute() -> eyre::Result<()> {
                 timestamp: first_built_block.header.timestamp(),
                 timestamp_millis_part: first_built_block.header.timestamp_millis_part,
                 beneficiary: first_built_block.header.beneficiary(),
-                tempo_headers_rlp: vec![Bytes::from(alloy_rlp::encode(&first_tempo_block.header))],
-                deposits: vec![],
-                decryptions: vec![],
-                enabled_tokens: vec![],
+                tempo_import: TempoImport::Full {
+                    header_rlp: Bytes::from(alloy_rlp::encode(&first_tempo_block.header)),
+                    deposits: vec![],
+                    decryptions: vec![],
+                    enabled_tokens: vec![],
+                },
                 finalize_withdrawal_batch_count: None,
                 finalize_withdrawal_batch_encrypted_senders: vec![],
-                transactions: vec![first_system_transaction, first_raw_transaction],
+                transactions: vec![first_raw_transaction],
             },
             ZoneBlock {
                 number: second_built_block.header.number(),
@@ -148,13 +142,15 @@ async fn spf_batch_execute() -> eyre::Result<()> {
                 timestamp: second_built_block.header.timestamp(),
                 timestamp_millis_part: second_built_block.header.timestamp_millis_part,
                 beneficiary: second_built_block.header.beneficiary(),
-                tempo_headers_rlp: vec![Bytes::from(alloy_rlp::encode(&second_tempo_block.header))],
-                deposits: vec![],
-                decryptions: vec![],
-                enabled_tokens: vec![],
+                tempo_import: TempoImport::Full {
+                    header_rlp: Bytes::from(alloy_rlp::encode(&second_tempo_block.header)),
+                    deposits: vec![],
+                    decryptions: vec![],
+                    enabled_tokens: vec![],
+                },
                 finalize_withdrawal_batch_count: Some(U256::ZERO),
                 finalize_withdrawal_batch_encrypted_senders: vec![],
-                transactions: vec![second_system_transaction, second_raw_transaction],
+                transactions: vec![second_raw_transaction],
             },
         ],
         parent_header,
@@ -268,7 +264,6 @@ struct BuiltTransactionBlock {
     zone_beneficiary: Address,
     zone_hash: B256,
     tempo_header: TempoHeader,
-    raw_system_transaction: Bytes,
     raw_user_transaction: Bytes,
     generated_witness: ZoneExecutionWitness,
 }
@@ -299,16 +294,15 @@ impl BuiltTransactionBlock {
                 timestamp: self.zone_timestamp,
                 timestamp_millis_part: self.zone_timestamp_millis_part,
                 beneficiary: self.zone_beneficiary,
-                tempo_headers_rlp: vec![Bytes::from(alloy_rlp::encode(&self.tempo_header))],
-                deposits: vec![],
-                decryptions: vec![],
-                enabled_tokens: vec![],
+                tempo_import: TempoImport::Full {
+                    header_rlp: Bytes::from(alloy_rlp::encode(&self.tempo_header)),
+                    deposits: vec![],
+                    decryptions: vec![],
+                    enabled_tokens: vec![],
+                },
                 finalize_withdrawal_batch_count: Some(U256::ZERO),
                 finalize_withdrawal_batch_encrypted_senders: vec![],
-                transactions: vec![
-                    self.raw_system_transaction.clone(),
-                    self.raw_user_transaction.clone(),
-                ],
+                transactions: vec![self.raw_user_transaction.clone()],
             }],
             zone_state_witness,
             tempo_state_witness: TempoStateWitness {
@@ -368,10 +362,6 @@ async fn build_single_transaction_block(
         .get_raw_transaction_by_hash(user_transaction_hash)
         .await?
         .expect("raw user transaction");
-    let raw_system_transaction = provider
-        .get_raw_transaction_by_hash(built_block.transactions.hashes().next().unwrap())
-        .await?
-        .expect("raw system transaction");
     let generated_witness = provider
         .raw_request(
             "debug_zoneExecutionWitness".into(),
@@ -387,7 +377,6 @@ async fn build_single_transaction_block(
         zone_beneficiary: built_block.header.beneficiary(),
         zone_hash: built_block.header.hash,
         tempo_header: l1_block.header,
-        raw_system_transaction,
         raw_user_transaction,
         generated_witness,
     })

--- a/crates/sequencer/src/prover.rs
+++ b/crates/sequencer/src/prover.rs
@@ -642,6 +642,7 @@ fn extract_zone_block(block: &RecoveredBlock<Block>) -> Result<ZoneBlock> {
                     "Zone block {} contains multiple advanceTempo calls",
                     header.number()
                 );
+                user_transactions.push(Bytes::from(transaction.encoded_2718()));
                 let call = ZoneInbox::IZoneInboxCalls::abi_decode(transaction.input())
                     .wrap_err_with(|| {
                         format!("decode ZoneInbox call in Zone block {}", header.number())
@@ -656,8 +657,8 @@ fn extract_zone_block(block: &RecoveredBlock<Block>) -> Result<ZoneBlock> {
                     }
                     ZoneInbox::IZoneInboxCalls::advanceTempoHeaders(call) => {
                         ensure!(
-                            call.headers.len() > 1,
-                            "checkpoint-only Zone block must have more than one header"
+                            !call.headers.is_empty(),
+                            "checkpoint-only Zone block has no headers"
                         );
                         for encoded in &call.headers {
                             decode_tempo_header(encoded)?;

--- a/crates/sequencer/src/prover.rs
+++ b/crates/sequencer/src/prover.rs
@@ -37,7 +37,7 @@ use zone_prover::{
 };
 use zone_rpc::{ZoneDebugApi, types::TempoStorageRead};
 use zone_spf::{
-    BatchOutput, BatchWitness, PublicInputs, SpfConfig, TempoStateWitness, ZoneBlock,
+    BatchOutput, BatchWitness, PublicInputs, SpfConfig, TempoImport, TempoStateWitness, ZoneBlock,
     ZoneStateWitness, prove_zone_batch,
 };
 
@@ -418,7 +418,7 @@ async fn validate_candidate<P: ZoneSequencerProvider>(
         deposits: witness
             .zone_blocks
             .iter()
-            .map(|block| block.deposits.len())
+            .map(|block| block.tempo_import.deposits().len())
             .sum(),
         withdrawals: witness
             .zone_blocks
@@ -621,28 +621,24 @@ fn build_zone_inputs<P: ZoneSequencerProvider>(
 
 fn extract_zone_block(block: &RecoveredBlock<Block>) -> Result<ZoneBlock> {
     let header = block.header();
-    let mut tempo_headers_rlp = None;
-    let mut deposits = Vec::new();
-    let mut decryptions = Vec::new();
-    let mut enabled_tokens = Vec::new();
+    let mut tempo_import = None;
     let mut finalize_count = None;
     let mut finalize_encrypted_senders = Vec::new();
-    let mut user_transactions = Vec::new();
+    let mut transactions = Vec::new();
 
     for transaction in &block.body().transactions {
         if !transaction.is_system_tx() {
-            user_transactions.push(Bytes::from(transaction.encoded_2718()));
+            transactions.push(Bytes::from(transaction.encoded_2718()));
             continue;
         }
 
         match transaction.to() {
             Some(to) if to == ZONE_INBOX_ADDRESS => {
                 ensure!(
-                    tempo_headers_rlp.is_none(),
+                    tempo_import.is_none(),
                     "Zone block {} contains multiple advanceTempo calls",
                     header.number()
                 );
-                user_transactions.push(Bytes::from(transaction.encoded_2718()));
                 let call = ZoneInbox::IZoneInboxCalls::abi_decode(transaction.input())
                     .wrap_err_with(|| {
                         format!("decode ZoneInbox call in Zone block {}", header.number())
@@ -650,10 +646,12 @@ fn extract_zone_block(block: &RecoveredBlock<Block>) -> Result<ZoneBlock> {
                 match call {
                     ZoneInbox::IZoneInboxCalls::advanceTempo(call) => {
                         decode_tempo_header(&call.header)?;
-                        tempo_headers_rlp = Some(vec![call.header]);
-                        deposits = call.deposits;
-                        decryptions = call.decryptions;
-                        enabled_tokens = call.enabledTokens;
+                        tempo_import = Some(TempoImport::Full {
+                            header_rlp: call.header,
+                            deposits: call.deposits,
+                            decryptions: call.decryptions,
+                            enabled_tokens: call.enabledTokens,
+                        });
                     }
                     ZoneInbox::IZoneInboxCalls::advanceTempoHeaders(call) => {
                         ensure!(
@@ -663,7 +661,9 @@ fn extract_zone_block(block: &RecoveredBlock<Block>) -> Result<ZoneBlock> {
                         for encoded in &call.headers {
                             decode_tempo_header(encoded)?;
                         }
-                        tempo_headers_rlp = Some(call.headers);
+                        tempo_import = Some(TempoImport::CheckpointOnly {
+                            headers_rlp: call.headers,
+                        });
                     }
                     _ => {
                         return Err(eyre::eyre!(
@@ -702,7 +702,7 @@ fn extract_zone_block(block: &RecoveredBlock<Block>) -> Result<ZoneBlock> {
         }
     }
 
-    let tempo_headers_rlp = tempo_headers_rlp.ok_or_eyre(format!(
+    let tempo_import = tempo_import.ok_or_eyre(format!(
         "no advanceTempo call in Zone block {}",
         header.number()
     ))?;
@@ -713,19 +713,17 @@ fn extract_zone_block(block: &RecoveredBlock<Block>) -> Result<ZoneBlock> {
         timestamp: header.timestamp(),
         timestamp_millis_part: header.timestamp_millis_part,
         beneficiary: header.beneficiary(),
-        tempo_headers_rlp,
-        deposits,
-        decryptions,
-        enabled_tokens,
+        tempo_import,
         finalize_withdrawal_batch_count: finalize_count,
         finalize_withdrawal_batch_encrypted_senders: finalize_encrypted_senders,
-        transactions: user_transactions,
+        transactions,
     })
 }
 
 fn final_tempo_header(block: &ZoneBlock) -> Result<TempoHeader> {
     let encoded = block
-        .tempo_headers_rlp
+        .tempo_import
+        .headers_rlp()
         .last()
         .ok_or_eyre("Zone block has no Tempo headers")?;
     decode_tempo_header(encoded)
@@ -1004,7 +1002,8 @@ fn witness_size(witness: &BatchWitness) -> usize {
             .iter()
             .map(|block| {
                 block
-                    .tempo_headers_rlp
+                    .tempo_import
+                    .headers_rlp()
                     .iter()
                     .map(|bytes| bytes.len())
                     .sum::<usize>()

--- a/crates/spf/src/execution/evm.rs
+++ b/crates/spf/src/execution/evm.rs
@@ -3,7 +3,7 @@
 use std::{borrow::Cow, collections::HashMap};
 
 use alloy_consensus::{
-    Signed, Transaction as _, TxLegacy,
+    Signed, TxLegacy,
     transaction::{Recovered, SignerRecoverable as _},
 };
 use alloy_eips::{eip2718::Decodable2718 as _, eip4895::Withdrawals};
@@ -32,7 +32,7 @@ use tempo_zone_contracts::{
 use zone_evm::{L1OverlayDB, ZoneBlockExecutor, ZoneEvmConfig};
 
 use crate::{
-    Error, ZoneBlock,
+    Error, TempoImport, ZoneBlock,
     execution::database::{TempoWitnessDatabase, WitnessDatabase},
 };
 
@@ -70,19 +70,7 @@ pub(crate) fn execute_zone_block(
         parent,
         block_index: zone_block_index,
     } = replay;
-    let (tempo_advance_transaction, user_transactions) =
-        block
-            .transactions
-            .split_first()
-            .ok_or(Error::MissingTempoAdvanceTransaction {
-                block_index: zone_block_index,
-            })?;
-    let tempo_advance_transaction = TempoTxEnvelope::decode_2718_exact(tempo_advance_transaction)
-        .map_err(|_| Error::TempoAdvanceTransactionDecoding {
-        block_index: zone_block_index,
-    })?;
-    let tempo_advance_calldata = tempo_advance_transaction.input().clone();
-    let user_transactions = decode_user_transactions(zone_block_index, user_transactions)?;
+    let user_transactions = decode_user_transactions(zone_block_index, &block.transactions)?;
     let mut transactions = Vec::with_capacity(
         1 // advanceTempo system transaction
             + user_transactions.len()
@@ -129,12 +117,25 @@ pub(crate) fn execute_zone_block(
         )
     })?;
 
-    transactions.push(execute_advance_tempo(
-        &mut executor,
-        &tempo_advance_calldata,
-        zone_block_index,
-        chain_id,
-    )?);
+    match &block.tempo_import {
+        TempoImport::Full {
+            header_rlp,
+            deposits,
+            decryptions,
+            enabled_tokens,
+        } => transactions.push(execute_advance_tempo(
+            &mut executor,
+            header_rlp,
+            deposits,
+            decryptions,
+            enabled_tokens,
+            zone_block_index,
+            chain_id,
+        )?),
+        TempoImport::CheckpointOnly { headers_rlp } => transactions.push(
+            execute_advance_tempo_headers(&mut executor, headers_rlp, zone_block_index, chain_id)?,
+        ),
+    }
     transactions.extend(execute_user_transactions(
         &mut executor,
         zone_block_index,
@@ -229,13 +230,23 @@ pub(crate) fn next_block_execution_context(
 
 fn execute_advance_tempo<'a, 'db, I>(
     executor: &mut WitnessExecutor<'a, 'db, I>,
-    calldata: &Bytes,
+    header: &Bytes,
+    deposits: &[tempo_zone_contracts::QueuedDeposit],
+    decryptions: &[tempo_zone_contracts::DecryptionData],
+    enabled_tokens: &[tempo_zone_contracts::EnabledToken],
     block_index: usize,
     chain_id: u64,
 ) -> Result<TempoTxEnvelope, Error>
 where
     I: alloy_evm::revm::Inspector<WitnessContext<'db>>,
 {
+    let calldata = IZoneInbox::advanceTempoCall {
+        header: header.clone(),
+        deposits: deposits.to_vec(),
+        decryptions: decryptions.to_vec(),
+        enabledTokens: enabled_tokens.to_vec(),
+    }
+    .abi_encode();
     let transaction = TxLegacy {
         chain_id: Some(chain_id),
         nonce: 0,
@@ -243,12 +254,46 @@ where
         gas_limit: 0,
         to: ZONE_INBOX_ADDRESS.into(),
         value: U256::ZERO,
-        input: calldata.clone(),
+        input: calldata.into(),
     };
     let transaction =
         TempoTxEnvelope::Legacy(Signed::new_unhashed(transaction, TEMPO_SYSTEM_TX_SIGNATURE));
     let recovered = Recovered::new_unchecked(transaction.clone(), TEMPO_SYSTEM_TX_SENDER);
 
+    execute_recovered_transaction(
+        executor,
+        recovered,
+        Error::AdvanceTempoExecution { block_index },
+        true,
+    )?;
+    Ok(transaction)
+}
+
+fn execute_advance_tempo_headers<'a, 'db, I>(
+    executor: &mut WitnessExecutor<'a, 'db, I>,
+    headers: &[Bytes],
+    block_index: usize,
+    chain_id: u64,
+) -> Result<TempoTxEnvelope, Error>
+where
+    I: alloy_evm::revm::Inspector<WitnessContext<'db>>,
+{
+    let calldata = IZoneInbox::advanceTempoHeadersCall {
+        headers: headers.to_vec(),
+    }
+    .abi_encode();
+    let transaction = TxLegacy {
+        chain_id: Some(chain_id),
+        nonce: 0,
+        gas_price: 0,
+        gas_limit: 0,
+        to: ZONE_INBOX_ADDRESS.into(),
+        value: U256::ZERO,
+        input: calldata.into(),
+    };
+    let transaction =
+        TempoTxEnvelope::Legacy(Signed::new_unhashed(transaction, TEMPO_SYSTEM_TX_SIGNATURE));
+    let recovered = Recovered::new_unchecked(transaction.clone(), TEMPO_SYSTEM_TX_SENDER);
     execute_recovered_transaction(
         executor,
         recovered,

--- a/crates/spf/src/execution/evm.rs
+++ b/crates/spf/src/execution/evm.rs
@@ -3,7 +3,7 @@
 use std::{borrow::Cow, collections::HashMap};
 
 use alloy_consensus::{
-    Signed, TxLegacy,
+    Signed, Transaction as _, TxLegacy,
     transaction::{Recovered, SignerRecoverable as _},
 };
 use alloy_eips::{eip2718::Decodable2718 as _, eip4895::Withdrawals};
@@ -70,7 +70,19 @@ pub(crate) fn execute_zone_block(
         parent,
         block_index: zone_block_index,
     } = replay;
-    let user_transactions = decode_user_transactions(zone_block_index, &block.transactions)?;
+    let (tempo_advance_transaction, user_transactions) =
+        block
+            .transactions
+            .split_first()
+            .ok_or(Error::MissingTempoAdvanceTransaction {
+                block_index: zone_block_index,
+            })?;
+    let tempo_advance_transaction = TempoTxEnvelope::decode_2718_exact(tempo_advance_transaction)
+        .map_err(|_| Error::TempoAdvanceTransactionDecoding {
+        block_index: zone_block_index,
+    })?;
+    let tempo_advance_calldata = tempo_advance_transaction.input().clone();
+    let user_transactions = decode_user_transactions(zone_block_index, user_transactions)?;
     let mut transactions = Vec::with_capacity(
         1 // advanceTempo system transaction
             + user_transactions.len()
@@ -117,22 +129,12 @@ pub(crate) fn execute_zone_block(
         )
     })?;
 
-    if block.tempo_headers_rlp.len() == 1 {
-        transactions.push(execute_advance_tempo(
-            &mut executor,
-            &block.tempo_headers_rlp[0],
-            block,
-            zone_block_index,
-            chain_id,
-        )?);
-    } else {
-        transactions.push(execute_advance_tempo_headers(
-            &mut executor,
-            &block.tempo_headers_rlp,
-            zone_block_index,
-            chain_id,
-        )?);
-    }
+    transactions.push(execute_advance_tempo(
+        &mut executor,
+        &tempo_advance_calldata,
+        zone_block_index,
+        chain_id,
+    )?);
     transactions.extend(execute_user_transactions(
         &mut executor,
         zone_block_index,
@@ -227,21 +229,13 @@ pub(crate) fn next_block_execution_context(
 
 fn execute_advance_tempo<'a, 'db, I>(
     executor: &mut WitnessExecutor<'a, 'db, I>,
-    header: &Bytes,
-    block: &ZoneBlock,
+    calldata: &Bytes,
     block_index: usize,
     chain_id: u64,
 ) -> Result<TempoTxEnvelope, Error>
 where
     I: alloy_evm::revm::Inspector<WitnessContext<'db>>,
 {
-    let calldata = IZoneInbox::advanceTempoCall {
-        header: header.clone(),
-        deposits: block.deposits.clone(),
-        decryptions: block.decryptions.clone(),
-        enabledTokens: block.enabled_tokens.clone(),
-    }
-    .abi_encode();
     let transaction = TxLegacy {
         chain_id: Some(chain_id),
         nonce: 0,
@@ -249,46 +243,12 @@ where
         gas_limit: 0,
         to: ZONE_INBOX_ADDRESS.into(),
         value: U256::ZERO,
-        input: calldata.into(),
+        input: calldata.clone(),
     };
     let transaction =
         TempoTxEnvelope::Legacy(Signed::new_unhashed(transaction, TEMPO_SYSTEM_TX_SIGNATURE));
     let recovered = Recovered::new_unchecked(transaction.clone(), TEMPO_SYSTEM_TX_SENDER);
 
-    execute_recovered_transaction(
-        executor,
-        recovered,
-        Error::AdvanceTempoExecution { block_index },
-        true,
-    )?;
-    Ok(transaction)
-}
-
-fn execute_advance_tempo_headers<'a, 'db, I>(
-    executor: &mut WitnessExecutor<'a, 'db, I>,
-    headers: &[Bytes],
-    block_index: usize,
-    chain_id: u64,
-) -> Result<TempoTxEnvelope, Error>
-where
-    I: alloy_evm::revm::Inspector<WitnessContext<'db>>,
-{
-    let calldata = IZoneInbox::advanceTempoHeadersCall {
-        headers: headers.to_vec(),
-    }
-    .abi_encode();
-    let transaction = TxLegacy {
-        chain_id: Some(chain_id),
-        nonce: 0,
-        gas_price: 0,
-        gas_limit: 0,
-        to: ZONE_INBOX_ADDRESS.into(),
-        value: U256::ZERO,
-        input: calldata.into(),
-    };
-    let transaction =
-        TempoTxEnvelope::Legacy(Signed::new_unhashed(transaction, TEMPO_SYSTEM_TX_SIGNATURE));
-    let recovered = Recovered::new_unchecked(transaction.clone(), TEMPO_SYSTEM_TX_SENDER);
     execute_recovered_transaction(
         executor,
         recovered,

--- a/crates/spf/src/lib.rs
+++ b/crates/spf/src/lib.rs
@@ -4,11 +4,9 @@
 //! execution. It is presently a normal Rust verifier rather than a `no_std`
 //! proving guest.
 
-use alloy_consensus::{BlockHeader as _, Sealable as _, Transaction as _};
-use alloy_eips::eip2718::Decodable2718 as _;
+use alloy_consensus::{BlockHeader as _, Sealable as _};
 use alloy_primitives::{B256, U256, keccak256};
 use alloy_rlp::Decodable as _;
-use alloy_sol_types::SolInterface as _;
 use reth_chainspec::EthChainSpec as _;
 use reth_evm::execute::BlockAssemblerInput;
 use reth_primitives_traits::SealedHeader;
@@ -16,8 +14,7 @@ use reth_storage_api::noop::NoopProvider;
 use revm::{Database as _, database::State, database_interface::bal::EvmDatabaseError};
 use tempo_chainspec::spec::TempoHardforks as _;
 use tempo_evm::{TempoBlockAssembler, TempoEvmConfig};
-use tempo_primitives::{TempoHeader, TempoPrimitives, TempoTxEnvelope};
-use tempo_zone_contracts::IZoneInbox;
+use tempo_primitives::{TempoHeader, TempoPrimitives};
 use zone_precompiles::{inbox, outbox, tempo_state};
 use zone_primitives::constants::{
     MAX_UNPROCESSED_DEPOSITS, MAX_UNPROCESSED_TOKEN_ENABLEMENTS, TEMPO_STATE_ADDRESS,
@@ -163,21 +160,22 @@ pub fn prove_zone_batch(config: &SpfConfig, witness: BatchWitness) -> Result<Bat
             });
         }
 
-        let tempo_import_kind = validate_system_inputs(block, block_index)?;
+        validate_system_inputs(block, block_index)?;
         if config
             .chain_spec()
             .tempo_hardfork_at(block.timestamp)
             .is_t12()
         {
             let is_last = block_index + 1 == witness.zone_blocks.len();
-            validate_t12_block_shape(block, is_last, tempo_import_kind)?;
+            validate_t12_block_shape(block, is_last)?;
         }
 
         // The EVM environment uses the verifier-selected fork schedule at this
         // block's timestamp. An imported Tempo header changes the L1 reader
         // used by the subsequent system and user execution in this block.
         let final_imported_header = block
-            .tempo_headers_rlp
+            .tempo_import
+            .headers_rlp()
             .last()
             .expect("validated nonempty Tempo headers");
         tempo_database = tempo_database.with_imported_checkpoint(final_imported_header)?;
@@ -430,20 +428,10 @@ fn validate_tempo_anchor(
     Ok(())
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-enum TempoImportKind {
-    Full,
-    CheckpointOnly,
-}
-
-fn validate_t12_block_shape(
-    block: &ZoneBlock,
-    is_last: bool,
-    tempo_import_kind: TempoImportKind,
-) -> Result<(), Error> {
-    let valid = match tempo_import_kind {
-        TempoImportKind::CheckpointOnly => !is_last,
-        TempoImportKind::Full => is_last && block.finalize_withdrawal_batch_count.is_some(),
+fn validate_t12_block_shape(block: &ZoneBlock, is_last: bool) -> Result<(), Error> {
+    let valid = match &block.tempo_import {
+        TempoImport::CheckpointOnly { .. } => !is_last,
+        TempoImport::Full { .. } => is_last && block.finalize_withdrawal_batch_count.is_some(),
     };
     if !valid {
         return Err(Error::InvalidT12BatchShape);
@@ -451,58 +439,30 @@ fn validate_t12_block_shape(
     Ok(())
 }
 
-fn decode_tempo_advance_call(block: &ZoneBlock, index: usize) -> Result<TempoImportKind, Error> {
-    let encoded = block
-        .transactions
-        .first()
-        .ok_or(Error::MissingTempoAdvanceTransaction { block_index: index })?;
-    let transaction = TempoTxEnvelope::decode_2718_exact(encoded)
-        .map_err(|_| Error::TempoAdvanceTransactionDecoding { block_index: index })?;
-    if !transaction.is_system_tx() || transaction.to() != Some(ZONE_INBOX_ADDRESS) {
-        return Err(Error::InvalidTempoAdvanceTransaction { block_index: index });
-    }
-    let call = IZoneInbox::IZoneInboxCalls::abi_decode(transaction.input())
-        .map_err(|_| Error::TempoAdvanceCalldataDecoding { block_index: index })?;
-    match call {
-        IZoneInbox::IZoneInboxCalls::advanceTempo(call) => {
-            if block.tempo_headers_rlp.as_slice() != core::slice::from_ref(&call.header)
-                || block.deposits != call.deposits
-                || block.decryptions != call.decryptions
-                || block.enabled_tokens != call.enabledTokens
-            {
-                return Err(Error::TempoAdvanceCalldataMismatch { block_index: index });
-            }
-            Ok(TempoImportKind::Full)
-        }
-        IZoneInbox::IZoneInboxCalls::advanceTempoHeaders(call) => {
-            if block.tempo_headers_rlp != call.headers {
-                return Err(Error::TempoAdvanceCalldataMismatch { block_index: index });
-            }
-            Ok(TempoImportKind::CheckpointOnly)
-        }
-        _ => Err(Error::UnexpectedZoneInboxCall { block_index: index }),
-    }
-}
-
-fn validate_system_inputs(block: &ZoneBlock, index: usize) -> Result<TempoImportKind, Error> {
-    if block.tempo_headers_rlp.is_empty() {
+fn validate_system_inputs(block: &ZoneBlock, index: usize) -> Result<(), Error> {
+    if block.tempo_import.headers_rlp().is_empty() {
         return Err(Error::MissingTempoHeaders { block_index: index });
     }
-    let tempo_import_kind = decode_tempo_advance_call(block, index)?;
-    if block.deposits.len() > MAX_UNPROCESSED_DEPOSITS
-        || block.enabled_tokens.len() > MAX_UNPROCESSED_TOKEN_ENABLEMENTS
-    {
-        return Err(Error::PortalWorkCapacityExceeded { block_index: index });
-    }
-    if tempo_import_kind == TempoImportKind::CheckpointOnly
-        && (!block.deposits.is_empty()
-            || !block.decryptions.is_empty()
-            || !block.enabled_tokens.is_empty()
-            || block.transactions.len() > 1
-            || block.finalize_withdrawal_batch_count.is_some()
-            || !block.finalize_withdrawal_batch_encrypted_senders.is_empty())
-    {
-        return Err(Error::InvalidCheckpointOnlyBlock { block_index: index });
+    match &block.tempo_import {
+        TempoImport::Full {
+            deposits,
+            enabled_tokens,
+            ..
+        } => {
+            if deposits.len() > MAX_UNPROCESSED_DEPOSITS
+                || enabled_tokens.len() > MAX_UNPROCESSED_TOKEN_ENABLEMENTS
+            {
+                return Err(Error::PortalWorkCapacityExceeded { block_index: index });
+            }
+        }
+        TempoImport::CheckpointOnly { .. } => {
+            if !block.transactions.is_empty()
+                || block.finalize_withdrawal_batch_count.is_some()
+                || !block.finalize_withdrawal_batch_encrypted_senders.is_empty()
+            {
+                return Err(Error::InvalidCheckpointOnlyBlock { block_index: index });
+            }
+        }
     }
     match block.finalize_withdrawal_batch_count {
         Some(count)
@@ -520,7 +480,7 @@ fn validate_system_inputs(block: &ZoneBlock, index: usize) -> Result<TempoImport
         _ => {}
     }
 
-    Ok(tempo_import_kind)
+    Ok(())
 }
 
 /// Errors emitted by the stateless state transition function.
@@ -548,24 +508,6 @@ pub enum Error {
     /// A checkpoint-only block carried operational inputs or transactions.
     #[error("checkpoint-only zone block {block_index} contains operational inputs")]
     InvalidCheckpointOnlyBlock { block_index: usize },
-    /// A Zone block omitted its opening ZoneInbox system transaction.
-    #[error("zone block {block_index} has no opening ZoneInbox transaction")]
-    MissingTempoAdvanceTransaction { block_index: usize },
-    /// A Zone block's opening transaction envelope could not be decoded.
-    #[error("failed to decode opening transaction in zone block {block_index}")]
-    TempoAdvanceTransactionDecoding { block_index: usize },
-    /// A Zone block's opening transaction was not a ZoneInbox system transaction.
-    #[error("invalid opening ZoneInbox transaction in zone block {block_index}")]
-    InvalidTempoAdvanceTransaction { block_index: usize },
-    /// A Zone block's opening system calldata could not be decoded.
-    #[error("failed to decode ZoneInbox calldata in zone block {block_index}")]
-    TempoAdvanceCalldataDecoding { block_index: usize },
-    /// Decoded ZoneInbox calldata did not match the supplied execution inputs.
-    #[error("ZoneInbox calldata does not match inputs in zone block {block_index}")]
-    TempoAdvanceCalldataMismatch { block_index: usize },
-    /// A Zone block's opening system transaction called an unsupported ZoneInbox method.
-    #[error("unexpected ZoneInbox call in zone block {block_index}")]
-    UnexpectedZoneInboxCall { block_index: usize },
     /// A block did not import any Tempo headers.
     #[error("zone block {block_index} contains no Tempo headers")]
     MissingTempoHeaders { block_index: usize },
@@ -737,13 +679,9 @@ mod tests {
     use crate::execution::evm::next_block_env_attributes;
 
     use super::*;
-    use alloy_consensus::{Header, Signed, TxLegacy};
-    use alloy_eips::{
-        eip2718::Encodable2718 as _,
-        eip2935::{HISTORY_SERVE_WINDOW, HISTORY_STORAGE_ADDRESS},
-    };
+    use alloy_consensus::Header;
+    use alloy_eips::eip2935::{HISTORY_SERVE_WINDOW, HISTORY_STORAGE_ADDRESS};
     use alloy_primitives::{Address, B256, Bytes, U256, keccak256};
-    use alloy_sol_types::SolCall as _;
     use reth_evm::ConfigureEvm;
     use reth_trie_common::{EMPTY_ROOT_HASH, LeafNode, Nibbles, TrieAccount, TrieNode};
     use revm::{
@@ -753,9 +691,7 @@ mod tests {
     use std::sync::Arc;
     use tempo_chainspec::TempoHardfork;
     use tempo_evm::TempoBlockEnv;
-    use tempo_primitives::{
-        TempoHeader, TempoTxEnvelope, transaction::envelope::TEMPO_SYSTEM_TX_SIGNATURE,
-    };
+    use tempo_primitives::TempoHeader;
     use zone_evm::ZoneEvmConfig;
     use zone_precompiles::L1StorageReader as _;
     use zone_primitives::constants::zone_chain_id;
@@ -817,41 +753,17 @@ mod tests {
         }
     }
 
-    fn system_transaction(calldata: Bytes) -> Bytes {
-        let transaction = TxLegacy {
-            chain_id: Some(1),
-            nonce: 0,
-            gas_price: 0,
-            gas_limit: 0,
-            to: ZONE_INBOX_ADDRESS.into(),
-            value: U256::ZERO,
-            input: calldata,
-        };
-        Bytes::from(
-            TempoTxEnvelope::Legacy(Signed::new_unhashed(transaction, TEMPO_SYSTEM_TX_SIGNATURE))
-                .encoded_2718(),
-        )
+    fn full_import(header_rlp: Bytes) -> TempoImport {
+        TempoImport::Full {
+            header_rlp,
+            deposits: Vec::new(),
+            decryptions: Vec::new(),
+            enabled_tokens: Vec::new(),
+        }
     }
 
-    fn advance_tempo_transaction(header: Bytes) -> Bytes {
-        system_transaction(
-            IZoneInbox::advanceTempoCall {
-                header,
-                deposits: Vec::new(),
-                decryptions: Vec::new(),
-                enabledTokens: Vec::new(),
-            }
-            .abi_encode()
-            .into(),
-        )
-    }
-
-    fn advance_tempo_headers_transaction(headers: Vec<Bytes>) -> Bytes {
-        system_transaction(
-            IZoneInbox::advanceTempoHeadersCall { headers }
-                .abi_encode()
-                .into(),
-        )
+    fn checkpoint_import(headers_rlp: Vec<Bytes>) -> TempoImport {
+        TempoImport::CheckpointOnly { headers_rlp }
     }
 
     fn witnessed_account_state(
@@ -927,18 +839,15 @@ mod tests {
                 timestamp: 100,
                 timestamp_millis_part: 0,
                 beneficiary: Address::ZERO,
-                tempo_headers_rlp: vec![Bytes::from([0x01])],
-                deposits: Vec::new(),
-                decryptions: Vec::new(),
-                enabled_tokens: Vec::new(),
+                tempo_import: full_import(Bytes::from([0x01])),
                 finalize_withdrawal_batch_count: Some(U256::ZERO),
                 finalize_withdrawal_batch_encrypted_senders: Vec::new(),
-                transactions: vec![advance_tempo_transaction(Bytes::from([0x01]))],
+                transactions: Vec::new(),
             });
         }
-        let kind = validate_system_inputs(&witness.zone_blocks[0], 0).unwrap();
+        validate_system_inputs(&witness.zone_blocks[0], 0).unwrap();
         assert_eq!(
-            validate_t12_block_shape(&witness.zone_blocks[0], false, kind),
+            validate_t12_block_shape(&witness.zone_blocks[0], false),
             Err(Error::InvalidT12BatchShape)
         );
     }
@@ -952,20 +861,14 @@ mod tests {
             timestamp: 100,
             timestamp_millis_part: 0,
             beneficiary: Address::ZERO,
-            tempo_headers_rlp: vec![Bytes::from([0x01]), Bytes::from([0x02])],
-            deposits: Vec::new(),
-            decryptions: Vec::new(),
-            enabled_tokens: Vec::new(),
+            tempo_import: checkpoint_import(vec![Bytes::from([0x01]), Bytes::from([0x02])]),
             finalize_withdrawal_batch_count: None,
             finalize_withdrawal_batch_encrypted_senders: Vec::new(),
-            transactions: vec![advance_tempo_headers_transaction(vec![
-                Bytes::from([0x01]),
-                Bytes::from([0x02]),
-            ])],
+            transactions: Vec::new(),
         });
-        let kind = validate_system_inputs(&witness.zone_blocks[0], 0).unwrap();
+        validate_system_inputs(&witness.zone_blocks[0], 0).unwrap();
         assert_eq!(
-            validate_t12_block_shape(&witness.zone_blocks[0], true, kind),
+            validate_t12_block_shape(&witness.zone_blocks[0], true),
             Err(Error::InvalidT12BatchShape)
         );
     }
@@ -980,10 +883,7 @@ mod tests {
             timestamp: 0,
             timestamp_millis_part: 0,
             beneficiary: Address::ZERO,
-            tempo_headers_rlp: Vec::new(),
-            deposits: Vec::new(),
-            decryptions: Vec::new(),
-            enabled_tokens: Vec::new(),
+            tempo_import: checkpoint_import(Vec::new()),
             finalize_withdrawal_batch_count: None,
             finalize_withdrawal_batch_encrypted_senders: Vec::new(),
             transactions: Vec::new(),
@@ -1009,10 +909,7 @@ mod tests {
             timestamp: 0,
             timestamp_millis_part: 0,
             beneficiary: Address::ZERO,
-            tempo_headers_rlp: Vec::new(),
-            deposits: Vec::new(),
-            decryptions: Vec::new(),
-            enabled_tokens: Vec::new(),
+            tempo_import: checkpoint_import(Vec::new()),
             finalize_withdrawal_batch_count: None,
             finalize_withdrawal_batch_encrypted_senders: Vec::new(),
             transactions: Vec::new(),
@@ -1276,15 +1173,10 @@ mod tests {
             timestamp: 0,
             timestamp_millis_part: 321,
             beneficiary: Address::ZERO,
-            tempo_headers_rlp: vec![witness.tempo_state_witness.initial_tempo_header_rlp.clone()],
-            deposits: Vec::new(),
-            decryptions: Vec::new(),
-            enabled_tokens: Vec::new(),
+            tempo_import: full_import(witness.tempo_state_witness.initial_tempo_header_rlp.clone()),
             finalize_withdrawal_batch_count: Some(U256::ZERO),
             finalize_withdrawal_batch_encrypted_senders: Vec::new(),
-            transactions: vec![advance_tempo_transaction(
-                witness.tempo_state_witness.initial_tempo_header_rlp.clone(),
-            )],
+            transactions: Vec::new(),
         };
 
         let config = test_config();
@@ -1320,17 +1212,14 @@ mod tests {
             timestamp: 0,
             timestamp_millis_part: 0,
             beneficiary: Address::ZERO,
-            tempo_headers_rlp: vec![Bytes::from([0x01])],
-            deposits: Vec::new(),
-            decryptions: Vec::new(),
-            enabled_tokens: Vec::new(),
+            tempo_import: full_import(Bytes::from([0x01])),
             finalize_withdrawal_batch_count: None,
             finalize_withdrawal_batch_encrypted_senders: Vec::new(),
-            transactions: vec![advance_tempo_transaction(Bytes::from([0x01]))],
+            transactions: Vec::new(),
         };
 
-        assert_eq!(validate_system_inputs(&block, 0), Ok(TempoImportKind::Full));
-        block.tempo_headers_rlp.clear();
+        assert_eq!(validate_system_inputs(&block, 0), Ok(()));
+        block.tempo_import = checkpoint_import(Vec::new());
         assert_eq!(
             validate_system_inputs(&block, 0),
             Err(Error::MissingTempoHeaders { block_index: 0 })
@@ -1346,19 +1235,13 @@ mod tests {
             timestamp: 0,
             timestamp_millis_part: 0,
             beneficiary: Address::ZERO,
-            tempo_headers_rlp: vec![Bytes::from([0x01])],
-            deposits: Vec::new(),
-            decryptions: Vec::new(),
-            enabled_tokens: Vec::new(),
+            tempo_import: checkpoint_import(vec![Bytes::from([0x01])]),
             finalize_withdrawal_batch_count: None,
             finalize_withdrawal_batch_encrypted_senders: Vec::new(),
-            transactions: vec![advance_tempo_headers_transaction(vec![Bytes::from([0x01])])],
+            transactions: Vec::new(),
         };
 
-        assert_eq!(
-            validate_system_inputs(&block, 0),
-            Ok(TempoImportKind::CheckpointOnly)
-        );
+        assert_eq!(validate_system_inputs(&block, 0), Ok(()));
     }
 
     #[test]
@@ -1370,16 +1253,10 @@ mod tests {
             timestamp: 0,
             timestamp_millis_part: 0,
             beneficiary: Address::ZERO,
-            tempo_headers_rlp: vec![Bytes::from([0x01])],
-            deposits: Vec::new(),
-            decryptions: Vec::new(),
-            enabled_tokens: Vec::new(),
+            tempo_import: full_import(Bytes::from([0x01])),
             finalize_withdrawal_batch_count: Some(U256::ZERO),
             finalize_withdrawal_batch_encrypted_senders: Vec::new(),
-            transactions: vec![
-                advance_tempo_transaction(Bytes::from([0x01])),
-                Bytes::from([0x01]),
-            ],
+            transactions: vec![Bytes::from([0x01])],
         });
 
         assert!(matches!(
@@ -1402,16 +1279,10 @@ mod tests {
             timestamp: 0,
             timestamp_millis_part: 0,
             beneficiary: Address::ZERO,
-            tempo_headers_rlp: vec![Bytes::from([0x01])],
-            deposits: Vec::new(),
-            decryptions: Vec::new(),
-            enabled_tokens: Vec::new(),
+            tempo_import: full_import(Bytes::from([0x01])),
             finalize_withdrawal_batch_count: Some(U256::ZERO),
             finalize_withdrawal_batch_encrypted_senders: Vec::new(),
-            transactions: vec![
-                advance_tempo_transaction(Bytes::from([0x01])),
-                Bytes::from([0x01]),
-            ],
+            transactions: vec![Bytes::from([0x01])],
         });
 
         assert!(matches!(

--- a/crates/spf/src/lib.rs
+++ b/crates/spf/src/lib.rs
@@ -4,9 +4,11 @@
 //! execution. It is presently a normal Rust verifier rather than a `no_std`
 //! proving guest.
 
-use alloy_consensus::{BlockHeader as _, Sealable as _};
+use alloy_consensus::{BlockHeader as _, Sealable as _, Transaction as _};
+use alloy_eips::eip2718::Decodable2718 as _;
 use alloy_primitives::{B256, U256, keccak256};
 use alloy_rlp::Decodable as _;
+use alloy_sol_types::SolInterface as _;
 use reth_chainspec::EthChainSpec as _;
 use reth_evm::execute::BlockAssemblerInput;
 use reth_primitives_traits::SealedHeader;
@@ -14,7 +16,8 @@ use reth_storage_api::noop::NoopProvider;
 use revm::{Database as _, database::State, database_interface::bal::EvmDatabaseError};
 use tempo_chainspec::spec::TempoHardforks as _;
 use tempo_evm::{TempoBlockAssembler, TempoEvmConfig};
-use tempo_primitives::{TempoHeader, TempoPrimitives};
+use tempo_primitives::{TempoHeader, TempoPrimitives, TempoTxEnvelope};
+use tempo_zone_contracts::IZoneInbox;
 use zone_precompiles::{inbox, outbox, tempo_state};
 use zone_primitives::constants::{
     MAX_UNPROCESSED_DEPOSITS, MAX_UNPROCESSED_TOKEN_ENABLEMENTS, TEMPO_STATE_ADDRESS,
@@ -58,29 +61,6 @@ pub fn prove_zone_batch(config: &SpfConfig, witness: BatchWitness) -> Result<Bat
             expected: config.portal(),
             actual: witness.public_inputs.portal,
         });
-    }
-
-    let first_t12 = witness.zone_blocks.iter().position(|block| {
-        config
-            .chain_spec()
-            .tempo_hardfork_at(block.timestamp)
-            .is_t12()
-    });
-    if let Some(first_t12) = first_t12 {
-        let t12_blocks = &witness.zone_blocks[first_t12..];
-        let full_positions: Vec<_> = t12_blocks
-            .iter()
-            .enumerate()
-            .filter_map(|(index, block)| (block.tempo_headers_rlp.len() == 1).then_some(index))
-            .collect();
-        if full_positions.len() != 1
-            || full_positions[0] + 1 != t12_blocks.len()
-            || t12_blocks
-                .last()
-                .is_some_and(|block| block.finalize_withdrawal_batch_count.is_none())
-        {
-            return Err(Error::InvalidT12BatchShape);
-        }
     }
 
     // The Zone database is backed by the parent state root and the supplied
@@ -182,7 +162,16 @@ pub fn prove_zone_batch(config: &SpfConfig, witness: BatchWitness) -> Result<Bat
                 actual: block.timestamp,
             });
         }
-        validate_system_inputs(block, block_index)?;
+
+        let tempo_import_kind = validate_system_inputs(block, block_index)?;
+        if config
+            .chain_spec()
+            .tempo_hardfork_at(block.timestamp)
+            .is_t12()
+        {
+            let is_last = block_index + 1 == witness.zone_blocks.len();
+            validate_t12_block_shape(block, is_last, tempo_import_kind)?;
+        }
 
         // The EVM environment uses the verifier-selected fork schedule at this
         // block's timestamp. An imported Tempo header changes the L1 reader
@@ -441,20 +430,75 @@ fn validate_tempo_anchor(
     Ok(())
 }
 
-fn validate_system_inputs(block: &ZoneBlock, index: usize) -> Result<(), Error> {
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum TempoImportKind {
+    Full,
+    CheckpointOnly,
+}
+
+fn validate_t12_block_shape(
+    block: &ZoneBlock,
+    is_last: bool,
+    tempo_import_kind: TempoImportKind,
+) -> Result<(), Error> {
+    let valid = match tempo_import_kind {
+        TempoImportKind::CheckpointOnly => !is_last,
+        TempoImportKind::Full => is_last && block.finalize_withdrawal_batch_count.is_some(),
+    };
+    if !valid {
+        return Err(Error::InvalidT12BatchShape);
+    }
+    Ok(())
+}
+
+fn decode_tempo_advance_call(block: &ZoneBlock, index: usize) -> Result<TempoImportKind, Error> {
+    let encoded = block
+        .transactions
+        .first()
+        .ok_or(Error::MissingTempoAdvanceTransaction { block_index: index })?;
+    let transaction = TempoTxEnvelope::decode_2718_exact(encoded)
+        .map_err(|_| Error::TempoAdvanceTransactionDecoding { block_index: index })?;
+    if !transaction.is_system_tx() || transaction.to() != Some(ZONE_INBOX_ADDRESS) {
+        return Err(Error::InvalidTempoAdvanceTransaction { block_index: index });
+    }
+    let call = IZoneInbox::IZoneInboxCalls::abi_decode(transaction.input())
+        .map_err(|_| Error::TempoAdvanceCalldataDecoding { block_index: index })?;
+    match call {
+        IZoneInbox::IZoneInboxCalls::advanceTempo(call) => {
+            if block.tempo_headers_rlp.as_slice() != core::slice::from_ref(&call.header)
+                || block.deposits != call.deposits
+                || block.decryptions != call.decryptions
+                || block.enabled_tokens != call.enabledTokens
+            {
+                return Err(Error::TempoAdvanceCalldataMismatch { block_index: index });
+            }
+            Ok(TempoImportKind::Full)
+        }
+        IZoneInbox::IZoneInboxCalls::advanceTempoHeaders(call) => {
+            if block.tempo_headers_rlp != call.headers {
+                return Err(Error::TempoAdvanceCalldataMismatch { block_index: index });
+            }
+            Ok(TempoImportKind::CheckpointOnly)
+        }
+        _ => Err(Error::UnexpectedZoneInboxCall { block_index: index }),
+    }
+}
+
+fn validate_system_inputs(block: &ZoneBlock, index: usize) -> Result<TempoImportKind, Error> {
     if block.tempo_headers_rlp.is_empty() {
         return Err(Error::MissingTempoHeaders { block_index: index });
     }
+    let tempo_import_kind = decode_tempo_advance_call(block, index)?;
     if block.deposits.len() > MAX_UNPROCESSED_DEPOSITS
         || block.enabled_tokens.len() > MAX_UNPROCESSED_TOKEN_ENABLEMENTS
     {
         return Err(Error::PortalWorkCapacityExceeded { block_index: index });
     }
-    if block.tempo_headers_rlp.len() > 1
+    if tempo_import_kind == TempoImportKind::CheckpointOnly
         && (!block.deposits.is_empty()
             || !block.decryptions.is_empty()
             || !block.enabled_tokens.is_empty()
-            || !block.transactions.is_empty()
+            || block.transactions.len() > 1
             || block.finalize_withdrawal_batch_count.is_some()
             || !block.finalize_withdrawal_batch_encrypted_senders.is_empty())
     {
@@ -476,7 +520,7 @@ fn validate_system_inputs(block: &ZoneBlock, index: usize) -> Result<(), Error> 
         _ => {}
     }
 
-    Ok(())
+    Ok(tempo_import_kind)
 }
 
 /// Errors emitted by the stateless state transition function.
@@ -504,6 +548,24 @@ pub enum Error {
     /// A checkpoint-only block carried operational inputs or transactions.
     #[error("checkpoint-only zone block {block_index} contains operational inputs")]
     InvalidCheckpointOnlyBlock { block_index: usize },
+    /// A Zone block omitted its opening ZoneInbox system transaction.
+    #[error("zone block {block_index} has no opening ZoneInbox transaction")]
+    MissingTempoAdvanceTransaction { block_index: usize },
+    /// A Zone block's opening transaction envelope could not be decoded.
+    #[error("failed to decode opening transaction in zone block {block_index}")]
+    TempoAdvanceTransactionDecoding { block_index: usize },
+    /// A Zone block's opening transaction was not a ZoneInbox system transaction.
+    #[error("invalid opening ZoneInbox transaction in zone block {block_index}")]
+    InvalidTempoAdvanceTransaction { block_index: usize },
+    /// A Zone block's opening system calldata could not be decoded.
+    #[error("failed to decode ZoneInbox calldata in zone block {block_index}")]
+    TempoAdvanceCalldataDecoding { block_index: usize },
+    /// Decoded ZoneInbox calldata did not match the supplied execution inputs.
+    #[error("ZoneInbox calldata does not match inputs in zone block {block_index}")]
+    TempoAdvanceCalldataMismatch { block_index: usize },
+    /// A Zone block's opening system transaction called an unsupported ZoneInbox method.
+    #[error("unexpected ZoneInbox call in zone block {block_index}")]
+    UnexpectedZoneInboxCall { block_index: usize },
     /// A block did not import any Tempo headers.
     #[error("zone block {block_index} contains no Tempo headers")]
     MissingTempoHeaders { block_index: usize },
@@ -675,9 +737,13 @@ mod tests {
     use crate::execution::evm::next_block_env_attributes;
 
     use super::*;
-    use alloy_consensus::Header;
-    use alloy_eips::eip2935::{HISTORY_SERVE_WINDOW, HISTORY_STORAGE_ADDRESS};
+    use alloy_consensus::{Header, Signed, TxLegacy};
+    use alloy_eips::{
+        eip2718::Encodable2718 as _,
+        eip2935::{HISTORY_SERVE_WINDOW, HISTORY_STORAGE_ADDRESS},
+    };
     use alloy_primitives::{Address, B256, Bytes, U256, keccak256};
+    use alloy_sol_types::SolCall as _;
     use reth_evm::ConfigureEvm;
     use reth_trie_common::{EMPTY_ROOT_HASH, LeafNode, Nibbles, TrieAccount, TrieNode};
     use revm::{
@@ -687,7 +753,9 @@ mod tests {
     use std::sync::Arc;
     use tempo_chainspec::TempoHardfork;
     use tempo_evm::TempoBlockEnv;
-    use tempo_primitives::TempoHeader;
+    use tempo_primitives::{
+        TempoHeader, TempoTxEnvelope, transaction::envelope::TEMPO_SYSTEM_TX_SIGNATURE,
+    };
     use zone_evm::ZoneEvmConfig;
     use zone_precompiles::L1StorageReader as _;
     use zone_primitives::constants::zone_chain_id;
@@ -696,20 +764,6 @@ mod tests {
         let tempo_chain_spec = tempo_chainspec::spec::MODERATO.clone();
         let mut genesis = tempo_chain_spec.genesis().clone();
         genesis.config.chain_id = zone_chain_id(tempo_chain_spec.chain().id(), 1).unwrap();
-        let zone_chain_spec =
-            Arc::new(zone_chainspec::ZoneChainSpec::from_genesis(genesis).unwrap());
-        SpfConfig::new(zone_chain_spec, Address::repeat_byte(0x11))
-    }
-
-    fn t12_test_config(activation: u64) -> SpfConfig {
-        let tempo_chain_spec = tempo_chainspec::spec::MODERATO.clone();
-        let mut genesis = tempo_chain_spec.genesis().clone();
-        genesis.config.chain_id = zone_chain_id(tempo_chain_spec.chain().id(), 1).unwrap();
-        genesis
-            .config
-            .extra_fields
-            .insert_value("t12Time".into(), activation)
-            .unwrap();
         let zone_chain_spec =
             Arc::new(zone_chainspec::ZoneChainSpec::from_genesis(genesis).unwrap());
         SpfConfig::new(zone_chain_spec, Address::repeat_byte(0x11))
@@ -761,6 +815,43 @@ mod tests {
             initial_tempo_header_rlp: Bytes::from(alloy_rlp::encode(header)),
             node_pool: Vec::new(),
         }
+    }
+
+    fn system_transaction(calldata: Bytes) -> Bytes {
+        let transaction = TxLegacy {
+            chain_id: Some(1),
+            nonce: 0,
+            gas_price: 0,
+            gas_limit: 0,
+            to: ZONE_INBOX_ADDRESS.into(),
+            value: U256::ZERO,
+            input: calldata,
+        };
+        Bytes::from(
+            TempoTxEnvelope::Legacy(Signed::new_unhashed(transaction, TEMPO_SYSTEM_TX_SIGNATURE))
+                .encoded_2718(),
+        )
+    }
+
+    fn advance_tempo_transaction(header: Bytes) -> Bytes {
+        system_transaction(
+            IZoneInbox::advanceTempoCall {
+                header,
+                deposits: Vec::new(),
+                decryptions: Vec::new(),
+                enabledTokens: Vec::new(),
+            }
+            .abi_encode()
+            .into(),
+        )
+    }
+
+    fn advance_tempo_headers_transaction(headers: Vec<Bytes>) -> Bytes {
+        system_transaction(
+            IZoneInbox::advanceTempoHeadersCall { headers }
+                .abi_encode()
+                .into(),
+        )
     }
 
     fn witnessed_account_state(
@@ -842,11 +933,12 @@ mod tests {
                 enabled_tokens: Vec::new(),
                 finalize_withdrawal_batch_count: Some(U256::ZERO),
                 finalize_withdrawal_batch_encrypted_senders: Vec::new(),
-                transactions: Vec::new(),
+                transactions: vec![advance_tempo_transaction(Bytes::from([0x01]))],
             });
         }
+        let kind = validate_system_inputs(&witness.zone_blocks[0], 0).unwrap();
         assert_eq!(
-            prove_zone_batch(&t12_test_config(100), witness),
+            validate_t12_block_shape(&witness.zone_blocks[0], false, kind),
             Err(Error::InvalidT12BatchShape)
         );
     }
@@ -866,10 +958,14 @@ mod tests {
             enabled_tokens: Vec::new(),
             finalize_withdrawal_batch_count: None,
             finalize_withdrawal_batch_encrypted_senders: Vec::new(),
-            transactions: Vec::new(),
+            transactions: vec![advance_tempo_headers_transaction(vec![
+                Bytes::from([0x01]),
+                Bytes::from([0x02]),
+            ])],
         });
+        let kind = validate_system_inputs(&witness.zone_blocks[0], 0).unwrap();
         assert_eq!(
-            prove_zone_batch(&t12_test_config(100), witness),
+            validate_t12_block_shape(&witness.zone_blocks[0], true, kind),
             Err(Error::InvalidT12BatchShape)
         );
     }
@@ -1186,7 +1282,9 @@ mod tests {
             enabled_tokens: Vec::new(),
             finalize_withdrawal_batch_count: Some(U256::ZERO),
             finalize_withdrawal_batch_encrypted_senders: Vec::new(),
-            transactions: Vec::new(),
+            transactions: vec![advance_tempo_transaction(
+                witness.tempo_state_witness.initial_tempo_header_rlp.clone(),
+            )],
         };
 
         let config = test_config();
@@ -1228,14 +1326,38 @@ mod tests {
             enabled_tokens: Vec::new(),
             finalize_withdrawal_batch_count: None,
             finalize_withdrawal_batch_encrypted_senders: Vec::new(),
-            transactions: Vec::new(),
+            transactions: vec![advance_tempo_transaction(Bytes::from([0x01]))],
         };
 
-        assert_eq!(validate_system_inputs(&block, 0), Ok(()));
+        assert_eq!(validate_system_inputs(&block, 0), Ok(TempoImportKind::Full));
         block.tempo_headers_rlp.clear();
         assert_eq!(
             validate_system_inputs(&block, 0),
             Err(Error::MissingTempoHeaders { block_index: 0 })
+        );
+    }
+
+    #[test]
+    fn accepts_one_header_checkpoint_only_input() {
+        let witness = minimal_batch_witness();
+        let block = ZoneBlock {
+            number: 1,
+            parent_hash: witness.parent_header.hash_slow(),
+            timestamp: 0,
+            timestamp_millis_part: 0,
+            beneficiary: Address::ZERO,
+            tempo_headers_rlp: vec![Bytes::from([0x01])],
+            deposits: Vec::new(),
+            decryptions: Vec::new(),
+            enabled_tokens: Vec::new(),
+            finalize_withdrawal_batch_count: None,
+            finalize_withdrawal_batch_encrypted_senders: Vec::new(),
+            transactions: vec![advance_tempo_headers_transaction(vec![Bytes::from([0x01])])],
+        };
+
+        assert_eq!(
+            validate_system_inputs(&block, 0),
+            Ok(TempoImportKind::CheckpointOnly)
         );
     }
 
@@ -1254,7 +1376,10 @@ mod tests {
             enabled_tokens: Vec::new(),
             finalize_withdrawal_batch_count: Some(U256::ZERO),
             finalize_withdrawal_batch_encrypted_senders: Vec::new(),
-            transactions: vec![Bytes::from([0x01])],
+            transactions: vec![
+                advance_tempo_transaction(Bytes::from([0x01])),
+                Bytes::from([0x01]),
+            ],
         });
 
         assert!(matches!(
@@ -1283,7 +1408,10 @@ mod tests {
             enabled_tokens: Vec::new(),
             finalize_withdrawal_batch_count: Some(U256::ZERO),
             finalize_withdrawal_batch_encrypted_senders: Vec::new(),
-            transactions: vec![Bytes::from([0x01])],
+            transactions: vec![
+                advance_tempo_transaction(Bytes::from([0x01])),
+                Bytes::from([0x01]),
+            ],
         });
 
         assert!(matches!(

--- a/crates/spf/src/types.rs
+++ b/crates/spf/src/types.rs
@@ -100,8 +100,7 @@ pub struct ZoneBlock {
     pub timestamp: u64,
     pub timestamp_millis_part: u64,
     pub beneficiary: Address,
-    /// RLP-encoded consecutive Tempo headers imported by this block. A full block contains exactly
-    /// one header; a checkpoint-only block contains more than one and has no operational inputs.
+    /// RLP-encoded consecutive Tempo headers imported by this block.
     #[cfg_attr(feature = "serde", serde(default))]
     pub tempo_headers_rlp: Vec<Bytes>,
     /// Deposits processed by `ZoneInbox.advanceTempo`, in calldata order.
@@ -114,7 +113,7 @@ pub struct ZoneBlock {
     pub finalize_withdrawal_batch_count: Option<U256>,
     /// Encrypted sender payloads passed to withdrawal finalization.
     pub finalize_withdrawal_batch_encrypted_senders: Vec<Bytes>,
-    /// Raw signed user transactions in execution order.
+    /// Raw system & user transactions in execution order.
     pub transactions: Vec<Bytes>,
 }
 

--- a/crates/spf/src/types.rs
+++ b/crates/spf/src/types.rs
@@ -90,6 +90,38 @@ pub struct BatchWitness {
     pub tempo_ancestry_headers: Vec<Bytes>,
 }
 
+/// Typed inputs for the opening ZoneInbox system transaction.
+#[derive(Debug, Clone, PartialEq, Eq)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "serde", serde(rename_all = "camelCase"))]
+pub enum TempoImport {
+    Full {
+        header_rlp: Bytes,
+        deposits: Vec<QueuedDeposit>,
+        decryptions: Vec<DecryptionData>,
+        enabled_tokens: Vec<EnabledToken>,
+    },
+    CheckpointOnly {
+        headers_rlp: Vec<Bytes>,
+    },
+}
+
+impl TempoImport {
+    pub fn headers_rlp(&self) -> &[Bytes] {
+        match self {
+            Self::Full { header_rlp, .. } => core::slice::from_ref(header_rlp),
+            Self::CheckpointOnly { headers_rlp } => headers_rlp,
+        }
+    }
+
+    pub fn deposits(&self) -> &[QueuedDeposit] {
+        match self {
+            Self::Full { deposits, .. } => deposits,
+            Self::CheckpointOnly { .. } => &[],
+        }
+    }
+}
+
 /// Zone block input, including its system-call inputs and raw user transactions.
 #[derive(Debug, Clone, PartialEq, Eq)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
@@ -100,20 +132,12 @@ pub struct ZoneBlock {
     pub timestamp: u64,
     pub timestamp_millis_part: u64,
     pub beneficiary: Address,
-    /// RLP-encoded consecutive Tempo headers imported by this block.
-    #[cfg_attr(feature = "serde", serde(default))]
-    pub tempo_headers_rlp: Vec<Bytes>,
-    /// Deposits processed by `ZoneInbox.advanceTempo`, in calldata order.
-    pub deposits: Vec<QueuedDeposit>,
-    /// Encrypted-deposit decryption data, in calldata order.
-    pub decryptions: Vec<DecryptionData>,
-    /// Tokens enabled by `ZoneInbox.advanceTempo`, in calldata order.
-    pub enabled_tokens: Vec<EnabledToken>,
+    pub tempo_import: TempoImport,
     /// Withdrawal count passed to finalization in this block, if any.
     pub finalize_withdrawal_batch_count: Option<U256>,
     /// Encrypted sender payloads passed to withdrawal finalization.
     pub finalize_withdrawal_batch_encrypted_senders: Vec<Bytes>,
-    /// Raw system & user transactions in execution order.
+    /// Raw signed user transactions in execution order.
     pub transactions: Vec<Bytes>,
 }
 


### PR DESCRIPTION
## Summary

Represent Zone Tempo imports with a typed `TempoImport` enum. Distinguish full `advanceTempo` imports from checkpoint-only `advanceTempoHeaders` imports. Validate T12 batch shape using the import variant.