### PR TITLE
fix(prover): enforce canonical Tempo import calldata

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -14174,6 +14174,7 @@ dependencies = [
  "tracing",
  "zone-chainspec",
  "zone-l1",
+ "zone-precompiles",
  "zone-primitives",
  "zone-prover",
  "zone-rpc",

--- a/bin/prover/utils/src/main.rs
+++ b/bin/prover/utils/src/main.rs
@@ -26,7 +26,9 @@ use tokio::net::TcpStream;
 use tracing::{debug, info};
 use tracing_subscriber::EnvFilter;
 use zone_chainspec::{ZoneChainSpec, ZoneChainSpecParser};
-use zone_precompiles::{outbox, tempo_state};
+use zone_precompiles::{
+    is_canonical_tempo_import_calldata, is_tempo_import_calldata, outbox, tempo_state,
+};
 use zone_primitives::constants::zone_chain_id;
 use zone_prover::{
     DEFAULT_MAX_REQUEST_BYTES, PROTOCOL_VERSION, ProverConnection, VerifyRequest, VerifyResponse,
@@ -859,6 +861,14 @@ fn extract_block(block: RpcBlock) -> Result<ExtractedBlock> {
                 if tempo_import.is_some() {
                     bail!(
                         "Zone block {} contains multiple advanceTempo calls",
+                        header.number()
+                    );
+                }
+                if is_tempo_import_calldata(envelope.input())
+                    && !is_canonical_tempo_import_calldata(envelope.input())
+                {
+                    bail!(
+                        "Zone block {} contains non-canonical Tempo import calldata",
                         header.number()
                     );
                 }

--- a/crates/evm/src/executor.rs
+++ b/crates/evm/src/executor.rs
@@ -24,7 +24,7 @@ use zone_chainspec::ZoneChainSpec;
 use zone_l1::state::L1StateProvider;
 use zone_precompiles::{
     ADVANCE_TEMPO_HEADERS_SELECTOR, ADVANCE_TEMPO_SELECTOR, L1StorageReader,
-    is_finalize_withdrawal_batch_calldata,
+    is_canonical_tempo_import_calldata, is_finalize_withdrawal_batch_calldata,
 };
 use zone_primitives::constants::{ZONE_INBOX_ADDRESS, ZONE_OUTBOX_ADDRESS};
 
@@ -114,7 +114,9 @@ impl ZoneTransactionKind {
         }
 
         if tx.calls().any(|(kind, input)| {
-            kind.to() == Some(&ZONE_INBOX_ADDRESS) && input.starts_with(&ADVANCE_TEMPO_SELECTOR)
+            kind.to() == Some(&ZONE_INBOX_ADDRESS)
+                && input.starts_with(&ADVANCE_TEMPO_SELECTOR)
+                && is_canonical_tempo_import_calldata(input)
         }) {
             return Self::AdvanceTempo;
         }
@@ -122,6 +124,7 @@ impl ZoneTransactionKind {
         if tx.calls().any(|(kind, input)| {
             kind.to() == Some(&ZONE_INBOX_ADDRESS)
                 && input.starts_with(&ADVANCE_TEMPO_HEADERS_SELECTOR)
+                && is_canonical_tempo_import_calldata(input)
         }) {
             return Self::AdvanceTempoHeaders;
         }
@@ -344,7 +347,14 @@ mod tests {
     fn advance_tempo_tx() -> TempoTxEnvelope {
         system_tx(
             ZONE_INBOX_ADDRESS,
-            Bytes::copy_from_slice(&ADVANCE_TEMPO_SELECTOR),
+            IZoneInbox::advanceTempoCall {
+                header: Bytes::new(),
+                deposits: Vec::new(),
+                decryptions: Vec::new(),
+                enabledTokens: Vec::new(),
+            }
+            .abi_encode()
+            .into(),
         )
     }
 
@@ -697,6 +707,37 @@ mod tests {
                 .unwrap(),
             ZoneBlockPhase::Executing
         );
+    }
+
+    #[test]
+    fn non_canonical_tempo_imports_do_not_satisfy_block_guard() {
+        let mut advance_calldata = match advance_tempo_tx() {
+            TempoTxEnvelope::Legacy(tx) => tx.tx().input.to_vec(),
+            _ => unreachable!(),
+        };
+        advance_calldata.extend([0; 32]);
+        let advance = system_tx(ZONE_INBOX_ADDRESS, advance_calldata.into());
+
+        let mut headers_calldata = IZoneInbox::advanceTempoHeadersCall {
+            headers: vec![Bytes::new()],
+        }
+        .abi_encode();
+        headers_calldata.extend([0; 32]);
+        let headers = system_tx(ZONE_INBOX_ADDRESS, headers_calldata.into());
+
+        for tx in [&advance, &headers] {
+            assert_eq!(
+                ZoneTransactionKind::classify(tx),
+                ZoneTransactionKind::UnexpectedSystem
+            );
+            assert_eq!(
+                ZoneBlockPhase::AwaitingAdvanceTempo
+                    .validate_transaction(tx)
+                    .unwrap_err()
+                    .to_string(),
+                "advanceTempo must be the first transaction in a zone block"
+            );
+        }
     }
 
     #[test]

--- a/crates/node/src/replication.rs
+++ b/crates/node/src/replication.rs
@@ -31,6 +31,7 @@ use zone_payload::{
     ZonePayloadTypes,
     abi::{IZoneInbox, ZONE_INBOX_ADDRESS},
 };
+use zone_precompiles::{is_canonical_tempo_import_calldata, is_tempo_import_calldata};
 use zone_sequencer::{
     BatchAnchorConfig,
     attestation::{
@@ -1552,6 +1553,11 @@ fn decode_advance_tempo(block: &SealedBlock<Block>) -> eyre::Result<DecodedTempo
     if signed.tx().to != ZONE_INBOX_ADDRESS.into() {
         eyre::bail!("first Tempo system transaction is not sent to IZoneInbox")
     }
+    if is_tempo_import_calldata(signed.tx().input.as_ref())
+        && !is_canonical_tempo_import_calldata(signed.tx().input.as_ref())
+    {
+        eyre::bail!("first Tempo system transaction has non-canonical calldata");
+    }
     if signed
         .tx()
         .input
@@ -1898,6 +1904,8 @@ mod tests {
     fn rejects_malformed_advance_tempo_calldata() {
         use alloy_consensus::{Signed, TxLegacy};
         use alloy_primitives::{Bytes, U256};
+        use alloy_rlp::Encodable as _;
+        use alloy_sol_types::SolCall as _;
         use reth_primitives_traits::SealedBlock;
         use tempo_primitives::{
             Block, TempoHeader, TempoTxEnvelope, transaction::envelope::TEMPO_SYSTEM_TX_SIGNATURE,
@@ -1927,6 +1935,35 @@ mod tests {
                 .to_string()
                 .contains("does not decode as advanceTempo")
         );
+
+        let mut header = Vec::new();
+        TempoHeader::default().encode(&mut header);
+        let mut calldata = zone_payload::abi::IZoneInbox::advanceTempoCall {
+            header: header.into(),
+            deposits: Vec::new(),
+            decryptions: Vec::new(),
+            enabledTokens: Vec::new(),
+        }
+        .abi_encode();
+        calldata.extend([0; 32]);
+        let block = SealedBlock::seal_slow(Block {
+            header: TempoHeader::default(),
+            body: alloy_consensus::BlockBody {
+                transactions: vec![TempoTxEnvelope::Legacy(Signed::new_unhashed(
+                    TxLegacy {
+                        to: zone_payload::abi::ZONE_INBOX_ADDRESS.into(),
+                        value: U256::ZERO,
+                        input: calldata.into(),
+                        ..Default::default()
+                    },
+                    TEMPO_SYSTEM_TX_SIGNATURE,
+                ))],
+                ommers: vec![],
+                withdrawals: None,
+            },
+        });
+        let error = super::decode_advance_tempo_header(&block).unwrap_err();
+        assert!(error.to_string().contains("non-canonical calldata"));
     }
 
     #[test]

--- a/crates/precompiles/src/inbox/dispatch.rs
+++ b/crates/precompiles/src/inbox/dispatch.rs
@@ -25,6 +25,11 @@ impl ZoneInbox {
         if let Some(err) = charge_input_cost(&mut self.storage, calldata) {
             return err;
         }
+        if super::is_tempo_import_calldata(calldata)
+            && !super::is_canonical_tempo_import_calldata(calldata)
+        {
+            return Ok(self.storage.revert_output(Bytes::new()));
+        }
 
         dispatch!(
             calldata,

--- a/crates/precompiles/src/inbox/mod.rs
+++ b/crates/precompiles/src/inbox/mod.rs
@@ -50,6 +50,25 @@ pub const ADVANCE_TEMPO_SELECTOR: [u8; 4] = IZoneInbox::advanceTempoCall::SELECT
 /// ABI selector for the checkpoint-only `advanceTempoHeaders` system call.
 pub const ADVANCE_TEMPO_HEADERS_SELECTOR: [u8; 4] = IZoneInbox::advanceTempoHeadersCall::SELECTOR;
 
+/// Returns whether calldata is the canonical ABI encoding of a block-opening Inbox call.
+pub fn is_canonical_tempo_import_calldata(calldata: &[u8]) -> bool {
+    if calldata.starts_with(&ADVANCE_TEMPO_SELECTOR) {
+        return IZoneInbox::advanceTempoCall::abi_decode(calldata)
+            .is_ok_and(|call| call.abi_encode() == calldata);
+    }
+    if calldata.starts_with(&ADVANCE_TEMPO_HEADERS_SELECTOR) {
+        return IZoneInbox::advanceTempoHeadersCall::abi_decode(calldata)
+            .is_ok_and(|call| call.abi_encode() == calldata);
+    }
+    false
+}
+
+/// Returns whether calldata has a block-opening Inbox call selector.
+pub fn is_tempo_import_calldata(calldata: &[u8]) -> bool {
+    calldata.starts_with(&ADVANCE_TEMPO_SELECTOR)
+        || calldata.starts_with(&ADVANCE_TEMPO_HEADERS_SELECTOR)
+}
+
 /// Zone-side bridge Inbox state and deposit-processing logic.
 #[contract(addr = ZONE_INBOX_ADDRESS)]
 pub struct ZoneInbox {

--- a/crates/precompiles/src/inbox/tests.rs
+++ b/crates/precompiles/src/inbox/tests.rs
@@ -676,6 +676,24 @@ fn malformed_nested_deposit_reverts_before_l1_reads() -> eyre::Result<()> {
 }
 
 #[test]
+fn non_canonical_tempo_import_calldata_reverts() -> eyre::Result<()> {
+    let mut harness = Harness::new()?;
+    let mut advance = harness.advance_call(Vec::new(), Vec::new()).abi_encode();
+    advance.extend([0; 32]);
+    assert!(!is_canonical_tempo_import_calldata(&advance));
+    assert!(harness.call(Address::ZERO, advance)?.is_revert());
+
+    let mut headers = IZoneInbox::advanceTempoHeadersCall {
+        headers: vec![encode_header(&harness.child_header())],
+    }
+    .abi_encode();
+    headers.extend([0; 32]);
+    assert!(!is_canonical_tempo_import_calldata(&headers));
+    assert!(harness.call(Address::ZERO, headers)?.is_revert());
+    Ok(())
+}
+
+#[test]
 fn non_canonical_encrypted_deposit_is_rejected() {
     let deposit = Deposit {
         token: Address::ZERO,

--- a/crates/precompiles/src/lib.rs
+++ b/crates/precompiles/src/lib.rs
@@ -83,7 +83,10 @@ pub mod ztip20;
 
 pub use aes_gcm::AesGcmDecrypt;
 pub use chaum_pedersen::ChaumPedersenVerify;
-pub use inbox::{ADVANCE_TEMPO_HEADERS_SELECTOR, ADVANCE_TEMPO_SELECTOR, ZoneInbox};
+pub use inbox::{
+    ADVANCE_TEMPO_HEADERS_SELECTOR, ADVANCE_TEMPO_SELECTOR, ZoneInbox,
+    is_canonical_tempo_import_calldata, is_tempo_import_calldata,
+};
 pub use outbox::{ZoneOutbox, is_finalize_withdrawal_batch_calldata};
 pub use storage::{L1State, L1StateError, L1StorageReader};
 pub use tempo_contracts::precompiles::TIP403_REGISTRY_ADDRESS;

--- a/crates/sequencer/Cargo.toml
+++ b/crates/sequencer/Cargo.toml
@@ -21,6 +21,7 @@ zone-chainspec.workspace = true
 zone-l1.workspace = true
 zone-primitives.workspace = true
 zone-prover.workspace = true
+zone-precompiles = { workspace = true, features = ["std"] }
 zone-rpc.workspace = true
 zone-spf.workspace = true
 

--- a/crates/sequencer/src/prover.rs
+++ b/crates/sequencer/src/prover.rs
@@ -32,6 +32,7 @@ use tokio::{
 use tracing::{debug, error, info};
 use zone_chainspec::ZoneChainSpec;
 use zone_l1::TempoStateExt as _;
+use zone_precompiles::{is_canonical_tempo_import_calldata, is_tempo_import_calldata};
 use zone_prover::{
     DEFAULT_MAX_REQUEST_BYTES, PROTOCOL_VERSION, ProverConnection, VerifyRequest, VerifyResponse,
 };
@@ -637,6 +638,12 @@ fn extract_zone_block(block: &RecoveredBlock<Block>) -> Result<ZoneBlock> {
                 ensure!(
                     tempo_import.is_none(),
                     "Zone block {} contains multiple advanceTempo calls",
+                    header.number()
+                );
+                ensure!(
+                    !is_tempo_import_calldata(transaction.input())
+                        || is_canonical_tempo_import_calldata(transaction.input()),
+                    "Zone block {} contains non-canonical Tempo import calldata",
                     header.number()
                 );
                 let call = ZoneInbox::IZoneInboxCalls::abi_decode(transaction.input())


### PR DESCRIPTION
Reject non-canonical `advanceTempo` and `advanceTempoHeaders` calldata by requiring decoded calls to re-encode byte-for-byte. Enforce this in block execution, peer import, and both witness extraction paths.

Tests:
- `cargo test -p zone-precompiles non_canonical_tempo_import_calldata_reverts`
- `cargo test -p zone-evm non_canonical_tempo_imports_do_not_satisfy_block_guard`
- `cargo test -p zone-node rejects_malformed_advance_tempo_calldata`
- `cargo +nightly clippy -p zone-precompiles -p zone-evm -p zone-sequencer -p zone-node -p tempo-zone-prover-utils`

Prompted by: @rkrasiuk