### PR TITLE
fix(node): validate peer block body commitments

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -13882,6 +13882,7 @@ dependencies = [
  "reqwest",
  "reth-chain-state",
  "reth-chainspec",
+ "reth-consensus-common",
  "reth-eth-wire-types",
  "reth-ethereum",
  "reth-evm",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -146,6 +146,7 @@ reth-chainspec = { git = "https://github.com/paradigmxyz/reth", rev = "10aa6a512
 reth-cli = { git = "https://github.com/paradigmxyz/reth", rev = "10aa6a512ba7c4f5f01ff489b1f513da0745821f" }
 reth-cli-util = { git = "https://github.com/paradigmxyz/reth", rev = "10aa6a512ba7c4f5f01ff489b1f513da0745821f" }
 reth-consensus = { git = "https://github.com/paradigmxyz/reth", rev = "10aa6a512ba7c4f5f01ff489b1f513da0745821f" }
+reth-consensus-common = { git = "https://github.com/paradigmxyz/reth", rev = "10aa6a512ba7c4f5f01ff489b1f513da0745821f" }
 reth-codecs = { version = "0.6.0", default-features = false }
 reth-db = { git = "https://github.com/paradigmxyz/reth", rev = "10aa6a512ba7c4f5f01ff489b1f513da0745821f" }
 reth-engine-local = { git = "https://github.com/paradigmxyz/reth", rev = "10aa6a512ba7c4f5f01ff489b1f513da0745821f" }

--- a/crates/node/Cargo.toml
+++ b/crates/node/Cargo.toml
@@ -35,6 +35,7 @@ zone-checker = { workspace = true, optional = true }
 # reth
 reth-chain-state.workspace = true
 reth-chainspec.workspace = true
+reth-consensus-common.workspace = true
 reth-eth-wire-types.workspace = true
 reth-ethereum = { workspace = true, features = [
   "node",

--- a/crates/node/src/replication.rs
+++ b/crates/node/src/replication.rs
@@ -1104,13 +1104,19 @@ where
 {
     // Check the received block
     let mut input = peer_block.encoded.as_slice();
-    let block = Block::decode(&mut input)
+    let block = SealedBlock::<Block>::decode_sealed(&mut input)
         .map_err(|err| eyre::eyre!("invalid RLP-encoded zone block: {err}"))?;
     if !input.is_empty() {
         eyre::bail!("encoded zone block has {} trailing bytes", input.len());
     }
 
-    let block = SealedBlock::seal_slow(block);
+    reth_consensus_common::validation::validate_body_against_header(block.body(), block.header())
+        .map_err(|err| {
+        eyre::eyre!(
+            "zone block body does not match hashed header {}: {err}",
+            block.hash()
+        )
+    })?;
     let block_number = block.number();
     let hash = block.hash();
     let best_block = provider.best_block_number()?;
@@ -1503,6 +1509,45 @@ mod tests {
                 encoded: vec![number as u8],
             })
         }
+    }
+
+    #[test]
+    fn rejects_same_hash_peer_block_with_missing_withdrawals() {
+        use reth_primitives_traits::{BlockBody as _, SealedBlock};
+        use tempo_primitives::{Block, TempoHeader};
+
+        let body = alloy_consensus::BlockBody {
+            transactions: vec![],
+            ommers: vec![],
+            withdrawals: Some(Default::default()),
+        };
+        let header = TempoHeader {
+            inner: alloy_consensus::Header {
+                transactions_root: body.calculate_tx_root(),
+                ommers_hash: body.calculate_ommers_root(),
+                withdrawals_root: body.calculate_withdrawals_root(),
+                ..Default::default()
+            },
+            ..Default::default()
+        };
+        let valid = SealedBlock::seal_slow(Block { header, body });
+        let valid_hash = valid.hash();
+        reth_consensus_common::validation::validate_body_against_header(
+            valid.body(),
+            valid.header(),
+        )
+        .unwrap();
+
+        let mut mismatched = valid.into_block();
+        mismatched.body.withdrawals = None;
+        let mismatched = SealedBlock::seal_slow(mismatched);
+
+        assert_eq!(mismatched.hash(), valid_hash);
+        reth_consensus_common::validation::validate_body_against_header(
+            mismatched.body(),
+            mismatched.header(),
+        )
+        .unwrap_err();
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- decode replicated peer blocks with `decode_sealed`, preserving the exact received header hash
- validate transaction, ommer, and withdrawal commitments before submitting the block to the Engine API
- add a regression test for two body encodings that share a header hash but disagree on withdrawals

## Why

A peer block can retain the same hashed header while omitting the withdrawals body field. Passing that mismatched body into the Engine API can mark the shared header hash invalid, causing a later valid representation to be rejected. Validate the body/header relationship at the replication boundary before it can reach that cache.

## Testing

- `cargo test -p zone-node replication::tests --lib`
- `cargo fmt --check --all`
- `git diff --check origin/main...HEAD`