### PR TITLE
refactor(l1): simplify L1 subscriber startup

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -13832,7 +13832,6 @@ dependencies = [
  "reth-primitives-traits",
  "reth-provider",
  "reth-storage-api",
- "reth-tasks",
  "schnellru",
  "serde",
  "serde_json",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -13839,6 +13839,7 @@ dependencies = [
  "tempo-contracts",
  "tempo-primitives",
  "tempo-zone-contracts",
+ "thiserror 2.0.18",
  "tokio",
  "tracing",
  "url",

--- a/crates/l1/Cargo.toml
+++ b/crates/l1/Cargo.toml
@@ -47,6 +47,7 @@ metrics.workspace = true
 parking_lot.workspace = true
 schnellru.workspace = true
 serde = { workspace = true, features = ["derive"] }
+thiserror.workspace = true
 tokio.workspace = true
 tracing.workspace = true
 url = "2"

--- a/crates/l1/Cargo.toml
+++ b/crates/l1/Cargo.toml
@@ -25,7 +25,6 @@ reth-metrics.workspace = true
 reth-primitives-traits.workspace = true
 reth-provider.workspace = true
 reth-storage-api.workspace = true
-reth-tasks.workspace = true
 
 # alloy
 alloy-consensus.workspace = true

--- a/crates/l1/src/lib.rs
+++ b/crates/l1/src/lib.rs
@@ -96,8 +96,8 @@ pub use ext::{ChainTempoStateExt, TempoStateExt};
 pub use queue::DepositQueue;
 pub use state::L1StateCache;
 pub use subscriber::{
-    AuthenticatedPortalLogs, L1BlockTracker, L1Subscriber, L1SubscriberConfig, LeadershipSink,
-    MAX_L1_LOOKAHEAD_BLOCKS, verify_receipts_against_header,
+    AuthenticatedPortalLogs, L1BlockTracker, L1Subscriber, L1SubscriberConfig, L1SubscriberError,
+    LeadershipSink, MAX_L1_LOOKAHEAD_BLOCKS, verify_receipts_against_header,
 };
 
 #[cfg(test)]

--- a/crates/l1/src/subscriber.rs
+++ b/crates/l1/src/subscriber.rs
@@ -1,5 +1,5 @@
 use super::*;
-use eyre::WrapErr as _;
+use eyre::{OptionExt as _, WrapErr as _};
 use std::collections::HashSet;
 use tempo_contracts::precompiles::{ITIP20::TransferPolicyUpdate, TIP403_REGISTRY_ADDRESS};
 use tempo_primitives::is_tip20_prefix;
@@ -562,12 +562,12 @@ impl L1Subscriber {
         &self,
         l1_provider: &impl Provider<TempoNetwork>,
     ) -> Result<u64, L1SubscriberError> {
-        l1_provider
+        Ok(l1_provider
             .get_header_by_number(BlockNumberOrTag::Finalized)
             .await
             .inspect_err(|_| self.subscriber_metrics.fetch_failures.increment(1))?
             .map(|header| header.number())
-            .ok_or_else(|| eyre::eyre!("L1 finalized block is not available").into())
+            .ok_or_eyre("L1 finalized block is not available")?)
     }
 
     /// Synchronize all missing blocks through the current finalized L1 head.
@@ -653,16 +653,17 @@ impl L1Subscriber {
                     block_tracker.wait_for_capacity(block_number).await?;
                     let start = std::time::Instant::now();
                     let fetch_failures = &subscriber_metrics.fetch_failures;
-                    let header_resp = async {
-                        let header = provider.get_header_by_number(block_number.into()).await?;
-                        Ok::<_, L1SubscriberError>(header.ok_or_else(|| {
-                            eyre::eyre!("L1 header not found for block {block_number}")
-                        })?)
-                    }
-                    .await
-                    .inspect_err(|_| {
-                        fetch_failures.increment(1);
-                    })?;
+                    let header_resp =
+                        async {
+                            let header = provider.get_header_by_number(block_number.into()).await?;
+                            Ok::<_, L1SubscriberError>(header.ok_or_eyre(format!(
+                                "L1 header not found for block {block_number}"
+                            ))?)
+                        }
+                        .await
+                        .inspect_err(|_| {
+                            fetch_failures.increment(1);
+                        })?;
                     let block_hash = header_resp.hash();
                     let block = NumHash::new(block_number, block_hash);
                     let expected_receipts_root = header_resp.receipts_root();
@@ -966,7 +967,9 @@ async fn fetch_and_verify_receipts_for_header(
     let receipts = provider
         .get_block_receipts(BlockId::hash(block_hash))
         .await?
-        .ok_or_else(|| eyre::eyre!("no receipts for block {block_number} ({block_hash})"))?;
+        .ok_or_eyre(format!(
+            "no receipts for block {block_number} ({block_hash})"
+        ))?;
     verify_receipts_against_header(
         block,
         expected_receipts_root,

--- a/crates/l1/src/subscriber.rs
+++ b/crates/l1/src/subscriber.rs
@@ -435,8 +435,6 @@ impl L1SubscriberError {
     }
 }
 
-type L1SubscriberResult<T> = Result<T, L1SubscriberError>;
-
 impl L1Subscriber {
     /// Create an L1 subscriber.
     pub fn new<P>(
@@ -461,7 +459,7 @@ impl L1Subscriber {
     ///
     /// The transport (HTTP or WebSocket) is auto-detected from the URL scheme.
     #[instrument(skip(self), fields(l1_rpc_url = %self.config.l1_rpc_url))]
-    async fn connect(&self) -> L1SubscriberResult<DynProvider<TempoNetwork>> {
+    async fn connect(&self) -> Result<DynProvider<TempoNetwork>, L1SubscriberError> {
         info!(url = %self.config.l1_rpc_url, "Connecting to L1 node");
 
         let url: url::Url = self.config.l1_rpc_url.parse().map_err(eyre::Report::from)?;
@@ -484,20 +482,20 @@ impl L1Subscriber {
         Ok(provider)
     }
 
-    /// Return transport-appropriate L1 head notifications as unit triggers.
+    /// Subscribe to transport-appropriate L1 head notifications.
     ///
     /// WebSocket connections use `newHeads`. When pubsub is unavailable, HTTP
     /// connections fall back to `eth_newBlockFilter` / `eth_getFilterChanges`.
-    /// Trigger payloads are ignored because block selection always comes from
+    /// Header payloads are ignored because block selection always comes from
     /// the L1 `finalized` tag.
-    pub(crate) async fn head_triggers<'a>(
+    pub(crate) async fn subscribe_block_headers<'a>(
         &self,
         provider: &'a DynProvider<TempoNetwork>,
-    ) -> L1SubscriberResult<Pin<Box<dyn Stream<Item = eyre::Result<()>> + Send + 'a>>> {
+    ) -> Result<Pin<Box<dyn Stream<Item = ()> + Send + 'a>>, L1SubscriberError> {
         match provider.subscribe_blocks().await {
             Ok(subscription) => {
                 info!("Using WebSocket newHeads notifications");
-                Ok(Box::pin(subscription.into_stream().map(|_| Ok(()))))
+                Ok(Box::pin(subscription.into_stream().map(|_| ())))
             }
             Err(err)
                 if err
@@ -507,11 +505,9 @@ impl L1Subscriber {
                 info!("Pubsub unavailable, using HTTP block filter polling");
                 let mut watcher = provider.watch_blocks().await?;
                 watcher.set_poll_interval(HTTP_POLL_INTERVAL);
-                Ok(Box::pin(
-                    watcher.into_stream().filter_map(|hashes| async move {
-                        (!hashes.is_empty()).then_some(Ok::<(), eyre::Report>(()))
-                    }),
-                ))
+                Ok(Box::pin(watcher.into_stream().filter_map(
+                    |hashes| async move { (!hashes.is_empty()).then_some(()) },
+                )))
             }
             Err(err) => Err(err.into()),
         }
@@ -522,7 +518,7 @@ impl L1Subscriber {
     /// The zone's persisted Tempo checkpoint is the authoritative source for
     /// where ingestion resumes. A non-zero hash distinguishes an L1-anchored
     /// block-zero genesis from the unanchored template.
-    pub(crate) fn resolve_start_block(&self) -> L1SubscriberResult<u64> {
+    pub(crate) fn resolve_start_block(&self) -> Result<u64, L1SubscriberError> {
         let local_checkpoint = self.local_state.latest_tempo_checkpoint()?;
         if local_checkpoint.hash == B256::ZERO {
             return Err(eyre::eyre!("zone genesis is not anchored to an L1 block").into());
@@ -533,7 +529,7 @@ impl L1Subscriber {
     }
 
     /// Resolve the first L1 block that has not already been ingested.
-    pub(crate) fn next_block_to_sync(&self) -> L1SubscriberResult<u64> {
+    pub(crate) fn next_block_to_sync(&self) -> Result<u64, L1SubscriberError> {
         let resolved = self.resolve_start_block()?;
         let queued = self
             .deposit_queue
@@ -563,7 +559,7 @@ impl L1Subscriber {
     async fn finalized_block_number(
         &self,
         l1_provider: &impl Provider<TempoNetwork>,
-    ) -> L1SubscriberResult<u64> {
+    ) -> Result<u64, L1SubscriberError> {
         l1_provider
             .get_header_by_number(BlockNumberOrTag::Finalized)
             .await
@@ -580,7 +576,7 @@ impl L1Subscriber {
         &self,
         l1_provider: &impl Provider<TempoNetwork>,
         next_block: u64,
-    ) -> L1SubscriberResult<u64> {
+    ) -> Result<u64, L1SubscriberError> {
         let finalized = self.finalized_block_number(l1_provider).await?;
         if next_block > finalized {
             self.record_seen_block(finalized, 0);
@@ -612,20 +608,19 @@ impl L1Subscriber {
     pub(crate) async fn follow_finalized<S>(
         &self,
         l1_provider: &impl Provider<TempoNetwork>,
-        triggers: S,
-    ) -> L1SubscriberResult<()>
+        header_stream: S,
+    ) -> Result<(), L1SubscriberError>
     where
-        S: Stream<Item = eyre::Result<()>> + Send,
+        S: Stream<Item = ()> + Send,
     {
-        let mut triggers = Box::pin(triggers);
+        let mut header_stream = Box::pin(header_stream);
         let mut next_block = self.next_block_to_sync()?;
 
         // Subscribe before the initial sync so a head published while catching
-        // up remains queued as another trigger.
+        // up remains queued in the header stream.
         next_block = self.sync_finalized_once(l1_provider, next_block).await?;
 
-        while let Some(trigger) = triggers.next().await {
-            trigger?;
+        while header_stream.next().await.is_some() {
             next_block = self.sync_finalized_once(l1_provider, next_block).await?;
         }
 
@@ -644,7 +639,7 @@ impl L1Subscriber {
         l1_provider: &impl Provider<TempoNetwork>,
         from: u64,
         to: u64,
-    ) -> L1SubscriberResult<()> {
+    ) -> Result<(), L1SubscriberError> {
         use futures::stream;
 
         let concurrency = self.config.l1_fetch_concurrency.max(1);
@@ -820,16 +815,17 @@ impl L1Subscriber {
         loop {
             let result = async {
                 let provider = self.connect().await?;
-                let triggers = self.head_triggers(&provider).await?;
+                let header_stream = self.subscribe_block_headers(&provider).await?;
                 info!(
                     portal = %self.config.portal_address,
                     "Following finalized L1 blocks"
                 );
-                self.follow_finalized(&provider, triggers).await
+                self.follow_finalized(&provider, header_stream).await
             }
             .await;
 
             if let Err(error) = result {
+                // Retry ordinary errors; finalized event decoding and application errors are fatal.
                 if error.should_retry() {
                     let retry_interval = self.config.retry_connection_interval;
                     self.subscriber_metrics.reconnects.increment(1);
@@ -966,7 +962,7 @@ async fn fetch_and_verify_receipts_for_header(
     block: NumHash,
     expected_receipts_root: B256,
     expected_logs_bloom: Bloom,
-) -> L1SubscriberResult<Vec<tempo_alloy::rpc::TempoTransactionReceipt>> {
+) -> Result<Vec<tempo_alloy::rpc::TempoTransactionReceipt>, L1SubscriberError> {
     let block_number = block.number;
     let block_hash = block.hash;
     let receipts = provider

--- a/crates/l1/src/subscriber.rs
+++ b/crates/l1/src/subscriber.rs
@@ -462,55 +462,23 @@ pub(crate) fn is_fenced_ingestion_error(error: &eyre::Report) -> bool {
 }
 
 impl L1Subscriber {
-    /// Create and spawn the L1 subscriber as a critical background task.
-    ///
-    /// Transient failures reconnect after the configured retry interval. Deterministic failures
-    /// while applying a receipt-verified finalized block fail the critical task instead.
-    pub fn spawn<P>(
+    /// Create an L1 subscriber.
+    pub fn new<P>(
         config: L1SubscriberConfig,
         local_state_provider: P,
         deposit_queue: DepositQueue,
-        task_executor: reth_tasks::Runtime,
-    ) where
+    ) -> Self
+    where
         P: StateProviderFactory + Clone + Send + Sync + 'static,
     {
-        let subscriber = Self {
+        Self {
             config,
             local_state: Arc::new(ProviderLocalTempoCheckpointReader {
                 provider: local_state_provider,
             }),
             deposit_queue,
             subscriber_metrics: Default::default(),
-        };
-
-        task_executor.spawn_critical_task(
-            "l1-block-subscriber",
-            Box::pin(async move {
-                loop {
-                    if let Err(e) = subscriber.run().await {
-                        if let Some(fenced) = fenced_ingestion_error(&e) {
-                            error!(
-                                block_number = fenced.block_number,
-                                stage = fenced.stage,
-                                error = %e,
-                                "Fatal L1 ingestion fence; refusing to retry an immutable finalized block"
-                            );
-                            // This is a critical task: panicking notifies the task manager and
-                            // shuts the node down instead of leaving it alive with frozen L1 state.
-                            panic!("{fenced}");
-                        }
-                        let retry_interval = subscriber.config.retry_connection_interval;
-                        subscriber.subscriber_metrics.reconnects.increment(1);
-                        error!(
-                            error = %e,
-                            retry_secs = retry_interval.as_secs_f32(),
-                            "L1 subscriber failed, reconnecting after retry interval"
-                        );
-                        tokio::time::sleep(retry_interval).await;
-                    }
-                }
-            }),
-        );
+        }
     }
 
     /// Connect to the L1 node.
@@ -862,22 +830,47 @@ impl L1Subscriber {
         Ok(())
     }
 
-    /// Run the L1 subscriber until an RPC operation fails.
+    /// Run the L1 subscriber, reconnecting after transient RPC failures.
     ///
     /// The subscriber follows only the L1 `finalized` tag. WebSocket
     /// `newHeads` or HTTP block-filter updates are used as wakeups; each
     /// notification ingests the missing finalized range in order.
     ///
-    /// [`Self::spawn`] retries transient errors and treats deterministic finalized-block
-    /// ingestion failures as fatal.
-    pub async fn run(&self) -> eyre::Result<()> {
-        let provider = self.connect().await?;
-        let triggers = self.head_triggers(&provider).await?;
-        info!(
-            portal = %self.config.portal_address,
-            "Following finalized L1 blocks"
-        );
-        self.follow_finalized(&provider, triggers).await
+    /// Transient failures reconnect after the configured retry interval. Deterministic failures
+    /// while applying a receipt-verified finalized block are fatal.
+    pub async fn run(self) {
+        loop {
+            let result = async {
+                let provider = self.connect().await?;
+                let triggers = self.head_triggers(&provider).await?;
+                info!(
+                    portal = %self.config.portal_address,
+                    "Following finalized L1 blocks"
+                );
+                self.follow_finalized(&provider, triggers).await
+            }
+            .await;
+
+            if let Err(e) = result {
+                if let Some(fenced) = fenced_ingestion_error(&e) {
+                    error!(
+                        block_number = fenced.block_number,
+                        stage = fenced.stage,
+                        error = %e,
+                        "Fatal L1 ingestion fence; refusing to retry an immutable finalized block"
+                    );
+                    panic!("{fenced}");
+                }
+                let retry_interval = self.config.retry_connection_interval;
+                self.subscriber_metrics.reconnects.increment(1);
+                error!(
+                    error = %e,
+                    retry_secs = retry_interval.as_secs_f32(),
+                    "L1 subscriber failed, reconnecting after retry interval"
+                );
+                tokio::time::sleep(retry_interval).await;
+            }
+        }
     }
 
     /// Extract portal events and raw-cache mutation barriers from fetched receipts.

--- a/crates/l1/src/subscriber.rs
+++ b/crates/l1/src/subscriber.rs
@@ -430,6 +430,14 @@ pub enum L1SubscriberError {
 }
 
 impl L1SubscriberError {
+    fn fatal_from_err(block_number: u64, stage: &'static str) -> impl FnOnce(eyre::Report) -> Self {
+        move |source| Self::Fatal {
+            block_number,
+            stage,
+            source,
+        }
+    }
+
     pub(crate) fn should_retry(&self) -> bool {
         !matches!(self, Self::Fatal { .. })
     }
@@ -701,14 +709,13 @@ impl L1Subscriber {
             // block before anything is enqueued or any cache advances.
             let processed_events = self
                 .extract_events(block_number, &receipts)
-                .map_err(|err| {
+                .inspect_err(|_| {
                     self.subscriber_metrics.decode_fence_failures.increment(1);
-                    L1SubscriberError::Fatal {
-                        block_number,
-                        stage: "portal event decoding",
-                        source: err,
-                    }
-                })?;
+                })
+                .map_err(L1SubscriberError::fatal_from_err(
+                    block_number,
+                    "portal event decoding",
+                ))?;
             let (events, invalidated, portal_logs) = processed_events;
             self.record_seen_block(block_number, to.saturating_sub(block_number));
 
@@ -721,11 +728,10 @@ impl L1Subscriber {
                 let transition =
                     events
                         .final_leader_transition()
-                        .map_err(|err| L1SubscriberError::Fatal {
+                        .map_err(L1SubscriberError::fatal_from_err(
                             block_number,
-                            stage: "leadership event validation",
-                            source: err,
-                        })?;
+                            "leadership event validation",
+                        ))?;
                 if let Some(transition) = transition {
                     sink.apply_leader_transition(transition)
                         .wrap_err_with(|| {
@@ -733,21 +739,19 @@ impl L1Subscriber {
                                 "cannot apply the leadership transition from block {block_number}"
                             )
                         })
-                        .map_err(|source| L1SubscriberError::Fatal {
+                        .map_err(L1SubscriberError::fatal_from_err(
                             block_number,
-                            stage: "leadership transition application",
-                            source,
-                        })?;
+                            "leadership transition application",
+                        ))?;
                 }
             }
             if let Some(keys) = &self.config.encryption_keys {
                 for rotation in &events.encryption_key_rotations {
                     keys.apply_rotation(rotation)
-                        .map_err(|source| L1SubscriberError::Fatal {
+                        .map_err(L1SubscriberError::fatal_from_err(
                             block_number,
-                            stage: "encryption key rotation application",
-                            source,
-                        })?;
+                            "encryption key rotation application",
+                        ))?;
                 }
             }
             let appended = self

--- a/crates/l1/src/subscriber.rs
+++ b/crates/l1/src/subscriber.rs
@@ -351,7 +351,7 @@ fn portal_event_cache_invalidation_address(topic0: Option<&B256>) -> Option<Addr
 /// Implemented by the node over its `LeadershipSchedule`. The subscriber applies every
 /// transition **before** enqueueing the block that recorded it — enqueueing notifies the
 /// engine internally, so append-after-enqueue could race a producer waking on that notify.
-/// An error fences ingestion of the whole L1 block.
+/// An error makes ingestion of the finalized L1 block fail.
 pub trait LeadershipSink: Send + Sync + std::fmt::Debug {
     /// Apply one decoded leadership transition.
     fn apply_leader_transition(&self, transition: &crate::LeaderTransition) -> eyre::Result<()>;
@@ -414,52 +414,28 @@ pub struct L1Subscriber {
     pub(crate) subscriber_metrics: crate::metrics::L1SubscriberMetrics,
 }
 
-/// A deterministic failure while applying an already receipt-verified finalized block.
-///
-/// Reconnecting cannot change these inputs, so retrying would loop forever on the same block.
-#[derive(Debug)]
-struct FencedIngestionError {
-    block_number: u64,
-    stage: &'static str,
-    source: eyre::Report,
+#[derive(Debug, thiserror::Error)]
+pub enum L1SubscriberError {
+    #[error(transparent)]
+    TransportError(#[from] alloy_transport::TransportError),
+    #[error(transparent)]
+    Other(#[from] eyre::Report),
+    #[error("fatal L1 ingestion error at block {block_number} during {stage}: {source}")]
+    Fatal {
+        block_number: u64,
+        stage: &'static str,
+        #[source]
+        source: eyre::Report,
+    },
 }
 
-impl FencedIngestionError {
-    const fn new(block_number: u64, stage: &'static str, source: eyre::Report) -> Self {
-        Self {
-            block_number,
-            stage,
-            source,
-        }
+impl L1SubscriberError {
+    pub(crate) fn should_retry(&self) -> bool {
+        !matches!(self, Self::Fatal { .. })
     }
 }
 
-impl std::fmt::Display for FencedIngestionError {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        write!(
-            f,
-            "L1 ingestion fenced at block {} during {}: {}",
-            self.block_number, self.stage, self.source
-        )
-    }
-}
-
-impl std::error::Error for FencedIngestionError {
-    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
-        Some(self.source.as_ref())
-    }
-}
-
-fn fenced_ingestion_error(error: &eyre::Report) -> Option<&FencedIngestionError> {
-    error
-        .chain()
-        .find_map(|cause| cause.downcast_ref::<FencedIngestionError>())
-}
-
-#[cfg(test)]
-pub(crate) fn is_fenced_ingestion_error(error: &eyre::Report) -> bool {
-    fenced_ingestion_error(error).is_some()
-}
+type L1SubscriberResult<T> = Result<T, L1SubscriberError>;
 
 impl L1Subscriber {
     /// Create an L1 subscriber.
@@ -485,10 +461,10 @@ impl L1Subscriber {
     ///
     /// The transport (HTTP or WebSocket) is auto-detected from the URL scheme.
     #[instrument(skip(self), fields(l1_rpc_url = %self.config.l1_rpc_url))]
-    async fn connect(&self) -> eyre::Result<DynProvider<TempoNetwork>> {
+    async fn connect(&self) -> L1SubscriberResult<DynProvider<TempoNetwork>> {
         info!(url = %self.config.l1_rpc_url, "Connecting to L1 node");
 
-        let url: url::Url = self.config.l1_rpc_url.parse()?;
+        let url: url::Url = self.config.l1_rpc_url.parse().map_err(eyre::Report::from)?;
         let mut conn_config =
             crate::rpc::rpc_connection_config(self.config.retry_connection_interval);
 
@@ -517,7 +493,7 @@ impl L1Subscriber {
     pub(crate) async fn head_triggers<'a>(
         &self,
         provider: &'a DynProvider<TempoNetwork>,
-    ) -> eyre::Result<Pin<Box<dyn Stream<Item = eyre::Result<()>> + Send + 'a>>> {
+    ) -> L1SubscriberResult<Pin<Box<dyn Stream<Item = eyre::Result<()>> + Send + 'a>>> {
         match provider.subscribe_blocks().await {
             Ok(subscription) => {
                 info!("Using WebSocket newHeads notifications");
@@ -546,19 +522,18 @@ impl L1Subscriber {
     /// The zone's persisted Tempo checkpoint is the authoritative source for
     /// where ingestion resumes. A non-zero hash distinguishes an L1-anchored
     /// block-zero genesis from the unanchored template.
-    pub(crate) fn resolve_start_block(&self) -> eyre::Result<u64> {
+    pub(crate) fn resolve_start_block(&self) -> L1SubscriberResult<u64> {
         let local_checkpoint = self.local_state.latest_tempo_checkpoint()?;
-        eyre::ensure!(
-            local_checkpoint.hash != B256::ZERO,
-            "zone genesis is not anchored to an L1 block"
-        );
+        if local_checkpoint.hash == B256::ZERO {
+            return Err(eyre::eyre!("zone genesis is not anchored to an L1 block").into());
+        }
         let local_tempo_block_number = local_checkpoint.number;
         info!(local_tempo_block_number, "Resuming from local zone state");
         Ok(local_tempo_block_number + 1)
     }
 
     /// Resolve the first L1 block that has not already been ingested.
-    pub(crate) fn next_block_to_sync(&self) -> eyre::Result<u64> {
+    pub(crate) fn next_block_to_sync(&self) -> L1SubscriberResult<u64> {
         let resolved = self.resolve_start_block()?;
         let queued = self
             .deposit_queue
@@ -588,13 +563,13 @@ impl L1Subscriber {
     async fn finalized_block_number(
         &self,
         l1_provider: &impl Provider<TempoNetwork>,
-    ) -> eyre::Result<u64> {
+    ) -> L1SubscriberResult<u64> {
         l1_provider
             .get_header_by_number(BlockNumberOrTag::Finalized)
             .await
             .inspect_err(|_| self.subscriber_metrics.fetch_failures.increment(1))?
             .map(|header| header.number())
-            .ok_or_else(|| eyre::eyre!("L1 finalized block is not available"))
+            .ok_or_else(|| eyre::eyre!("L1 finalized block is not available").into())
     }
 
     /// Synchronize all missing blocks through the current finalized L1 head.
@@ -605,7 +580,7 @@ impl L1Subscriber {
         &self,
         l1_provider: &impl Provider<TempoNetwork>,
         next_block: u64,
-    ) -> eyre::Result<u64> {
+    ) -> L1SubscriberResult<u64> {
         let finalized = self.finalized_block_number(l1_provider).await?;
         if next_block > finalized {
             self.record_seen_block(finalized, 0);
@@ -638,7 +613,7 @@ impl L1Subscriber {
         &self,
         l1_provider: &impl Provider<TempoNetwork>,
         triggers: S,
-    ) -> eyre::Result<()>
+    ) -> L1SubscriberResult<()>
     where
         S: Stream<Item = eyre::Result<()>> + Send,
     {
@@ -654,7 +629,7 @@ impl L1Subscriber {
             next_block = self.sync_finalized_once(l1_provider, next_block).await?;
         }
 
-        Err(eyre::eyre!("L1 head notification stream ended"))
+        Err(eyre::eyre!("L1 head notification stream ended").into())
     }
 
     /// Backfill L1 blocks from `from..=to` with pipelined RPC fetching.
@@ -669,7 +644,7 @@ impl L1Subscriber {
         l1_provider: &impl Provider<TempoNetwork>,
         from: u64,
         to: u64,
-    ) -> eyre::Result<()> {
+    ) -> L1SubscriberResult<()> {
         use futures::stream;
 
         let concurrency = self.config.l1_fetch_concurrency.max(1);
@@ -686,12 +661,10 @@ impl L1Subscriber {
                     let start = std::time::Instant::now();
                     let fetch_failures = &subscriber_metrics.fetch_failures;
                     let header_resp = async {
-                        provider
-                            .get_header_by_number(block_number.into())
-                            .await?
-                            .ok_or_else(|| {
-                                eyre::eyre!("L1 header not found for block {block_number}")
-                            })
+                        let header = provider.get_header_by_number(block_number.into()).await?;
+                        Ok::<_, L1SubscriberError>(header.ok_or_else(|| {
+                            eyre::eyre!("L1 header not found for block {block_number}")
+                        })?)
                     }
                     .await
                     .inspect_err(|_| {
@@ -720,7 +693,7 @@ impl L1Subscriber {
                         "Fetched and validated L1 block data"
                     );
                     let header = header_resp.inner.inner;
-                    Ok::<_, eyre::Report>((header, receipts))
+                    Ok::<_, L1SubscriberError>((header, receipts))
                 }
             })
             .buffered(concurrency);
@@ -731,13 +704,16 @@ impl L1Subscriber {
         while let Some((header, receipts)) = fetched.try_next().await? {
             let block_number = header.number();
             // Decoding fails closed: a decode failure of a recognized portal log aborts this
-            // block before anything is enqueued or any cache advances. Ingestion halts here (fenced)
-            // instead of continuing under a partial event view.
+            // block before anything is enqueued or any cache advances.
             let processed_events = self
                 .extract_events(block_number, &receipts)
                 .map_err(|err| {
                     self.subscriber_metrics.decode_fence_failures.increment(1);
-                    FencedIngestionError::new(block_number, "portal event decoding", err)
+                    L1SubscriberError::Fatal {
+                        block_number,
+                        stage: "portal event decoding",
+                        source: err,
+                    }
                 })?;
             let (events, invalidated, portal_logs) = processed_events;
             self.record_seen_block(block_number, to.saturating_sub(block_number));
@@ -748,9 +724,14 @@ impl L1Subscriber {
             // Publish the leadership transition _before_ the activation block becomes
             // consumable.
             if let Some(sink) = &self.config.leadership_sink {
-                let transition = events.final_leader_transition().map_err(|err| {
-                    FencedIngestionError::new(block_number, "leadership event validation", err)
-                })?;
+                let transition =
+                    events
+                        .final_leader_transition()
+                        .map_err(|err| L1SubscriberError::Fatal {
+                            block_number,
+                            stage: "leadership event validation",
+                            source: err,
+                        })?;
                 if let Some(transition) = transition {
                     sink.apply_leader_transition(transition)
                         .wrap_err_with(|| {
@@ -758,24 +739,21 @@ impl L1Subscriber {
                                 "cannot apply the leadership transition from block {block_number}"
                             )
                         })
-                        .map_err(|err| {
-                            FencedIngestionError::new(
-                                block_number,
-                                "leadership transition application",
-                                err,
-                            )
+                        .map_err(|source| L1SubscriberError::Fatal {
+                            block_number,
+                            stage: "leadership transition application",
+                            source,
                         })?;
                 }
             }
             if let Some(keys) = &self.config.encryption_keys {
                 for rotation in &events.encryption_key_rotations {
-                    keys.apply_rotation(rotation).map_err(|err| {
-                        FencedIngestionError::new(
+                    keys.apply_rotation(rotation)
+                        .map_err(|source| L1SubscriberError::Fatal {
                             block_number,
-                            "encryption key rotation application",
-                            err,
-                        )
-                    })?;
+                            stage: "encryption key rotation application",
+                            source,
+                        })?;
                 }
             }
             let appended = self
@@ -836,8 +814,8 @@ impl L1Subscriber {
     /// `newHeads` or HTTP block-filter updates are used as wakeups; each
     /// notification ingests the missing finalized range in order.
     ///
-    /// Transient failures reconnect after the configured retry interval. Deterministic failures
-    /// while applying a receipt-verified finalized block are fatal.
+    /// Transport and ordinary failures reconnect after the configured retry interval.
+    /// Deterministic failures while applying a receipt-verified finalized block are fatal.
     pub async fn run(self) {
         loop {
             let result = async {
@@ -851,24 +829,19 @@ impl L1Subscriber {
             }
             .await;
 
-            if let Err(e) = result {
-                if let Some(fenced) = fenced_ingestion_error(&e) {
+            if let Err(error) = result {
+                if error.should_retry() {
+                    let retry_interval = self.config.retry_connection_interval;
+                    self.subscriber_metrics.reconnects.increment(1);
                     error!(
-                        block_number = fenced.block_number,
-                        stage = fenced.stage,
-                        error = %e,
-                        "Fatal L1 ingestion fence; refusing to retry an immutable finalized block"
+                        error = %error,
+                        retry_secs = retry_interval.as_secs_f32(),
+                        "L1 subscriber failed, reconnecting after retry interval"
                     );
-                    panic!("{fenced}");
+                    tokio::time::sleep(retry_interval).await;
+                } else {
+                    panic!("{error}");
                 }
-                let retry_interval = self.config.retry_connection_interval;
-                self.subscriber_metrics.reconnects.increment(1);
-                error!(
-                    error = %e,
-                    retry_secs = retry_interval.as_secs_f32(),
-                    "L1 subscriber failed, reconnecting after retry interval"
-                );
-                tokio::time::sleep(retry_interval).await;
             }
         }
     }
@@ -993,7 +966,7 @@ async fn fetch_and_verify_receipts_for_header(
     block: NumHash,
     expected_receipts_root: B256,
     expected_logs_bloom: Bloom,
-) -> eyre::Result<Vec<tempo_alloy::rpc::TempoTransactionReceipt>> {
+) -> L1SubscriberResult<Vec<tempo_alloy::rpc::TempoTransactionReceipt>> {
     let block_number = block.number;
     let block_hash = block.hash;
     let receipts = provider

--- a/crates/l1/src/subscriber.rs
+++ b/crates/l1/src/subscriber.rs
@@ -435,6 +435,8 @@ impl L1SubscriberError {
     }
 }
 
+type HeaderStream = Pin<Box<dyn Stream<Item = ()> + Send>>;
+
 impl L1Subscriber {
     /// Create an L1 subscriber.
     pub fn new<P>(
@@ -488,10 +490,10 @@ impl L1Subscriber {
     /// connections fall back to `eth_newBlockFilter` / `eth_getFilterChanges`.
     /// Header payloads are ignored because block selection always comes from
     /// the L1 `finalized` tag.
-    pub(crate) async fn subscribe_block_headers<'a>(
+    pub(crate) async fn subscribe_block_headers(
         &self,
-        provider: &'a DynProvider<TempoNetwork>,
-    ) -> Result<Pin<Box<dyn Stream<Item = ()> + Send + 'a>>, L1SubscriberError> {
+        provider: &DynProvider<TempoNetwork>,
+    ) -> Result<HeaderStream, L1SubscriberError> {
         match provider.subscribe_blocks().await {
             Ok(subscription) => {
                 info!("Using WebSocket newHeads notifications");
@@ -605,22 +607,18 @@ impl L1Subscriber {
     ///
     /// Header contents are intentionally ignored. Canonical block selection is
     /// always based on the `finalized` tag read by [`Self::sync_finalized_once`].
-    pub(crate) async fn follow_finalized<S>(
+    pub(crate) async fn follow_finalized(
         &self,
         l1_provider: &impl Provider<TempoNetwork>,
-        header_stream: S,
-    ) -> Result<(), L1SubscriberError>
-    where
-        S: Stream<Item = ()> + Send,
-    {
-        let mut header_stream = Box::pin(header_stream);
+        mut stream: HeaderStream,
+    ) -> Result<(), L1SubscriberError> {
         let mut next_block = self.next_block_to_sync()?;
 
         // Subscribe before the initial sync so a head published while catching
-        // up remains queued in the header stream.
+        // up remains queued in the stream.
         next_block = self.sync_finalized_once(l1_provider, next_block).await?;
 
-        while header_stream.next().await.is_some() {
+        while stream.next().await.is_some() {
             next_block = self.sync_finalized_once(l1_provider, next_block).await?;
         }
 

--- a/crates/l1/src/tests.rs
+++ b/crates/l1/src/tests.rs
@@ -783,7 +783,7 @@ async fn test_follow_finalized_uses_new_heads_to_sync_missing_finalized_range() 
     push_header_and_empty_receipts(&asserter, header_12);
 
     let err = subscriber
-        .follow_finalized(&l1_provider, futures::stream::iter([()]))
+        .follow_finalized(&l1_provider, Box::pin(futures::stream::iter([()])))
         .await
         .expect_err("finite header stream should end the subscriber");
     assert!(err.to_string().contains("head notification stream ended"));

--- a/crates/l1/src/tests.rs
+++ b/crates/l1/src/tests.rs
@@ -783,12 +783,9 @@ async fn test_follow_finalized_uses_new_heads_to_sync_missing_finalized_range() 
     push_header_and_empty_receipts(&asserter, header_12);
 
     let err = subscriber
-        .follow_finalized(
-            &l1_provider,
-            futures::stream::iter([Ok::<_, eyre::Report>(())]),
-        )
+        .follow_finalized(&l1_provider, futures::stream::iter([()]))
         .await
-        .expect_err("finite trigger stream should end the subscriber");
+        .expect_err("finite header stream should end the subscriber");
     assert!(err.to_string().contains("head notification stream ended"));
 
     let blocks = subscriber.deposit_queue.drain();
@@ -808,7 +805,7 @@ async fn test_follow_finalized_uses_new_heads_to_sync_missing_finalized_range() 
 }
 
 #[tokio::test]
-async fn test_head_triggers_falls_back_to_http_block_filter() {
+async fn test_subscribe_block_headers_falls_back_to_http_block_filter() {
     let subscriber = test_subscriber(Arc::new(SequenceLocalTempoCheckpointReader::new([10])));
     let asserter = Asserter::new();
     let l1_provider = ProviderBuilder::new_with_network::<TempoNetwork>()
@@ -818,13 +815,15 @@ async fn test_head_triggers_falls_back_to_http_block_filter() {
     asserter.push_success(&U256::from(1));
     asserter.push_success(&vec![B256::with_last_byte(1)]);
 
-    let mut triggers = subscriber.head_triggers(&l1_provider).await.unwrap();
-    let trigger = tokio::time::timeout(Duration::from_secs(2), triggers.next())
+    let mut header_stream = subscriber
+        .subscribe_block_headers(&l1_provider)
         .await
-        .expect("HTTP block filter should emit a trigger")
+        .unwrap();
+    tokio::time::timeout(Duration::from_secs(2), header_stream.next())
+        .await
+        .expect("HTTP block filter should emit a header notification")
         .expect("HTTP block filter stream should remain open");
 
-    trigger.expect("HTTP block filter request should succeed");
     assert!(asserter.read_q().is_empty());
 }
 

--- a/crates/l1/src/tests.rs
+++ b/crates/l1/src/tests.rs
@@ -1,5 +1,5 @@
 use super::*;
-use crate::{abi::DepositType, subscriber::is_fenced_ingestion_error};
+use crate::{abi::DepositType, subscriber::L1SubscriberError};
 use alloy_consensus::{Header, ReceiptWithBloom};
 use alloy_primitives::{Bloom, Bytes, address};
 use alloy_rpc_types_eth::{Header as RpcHeader, TransactionReceipt};
@@ -1658,7 +1658,7 @@ fn extract_events_fails_closed_on_corrupt_recognized_portal_log() {
     subscriber.config.retain_portal_evidence = true;
     let portal = subscriber.config.portal_address;
 
-    // A recognized topic0 with garbage payload must fence the whole block, never be skipped.
+    // A recognized topic0 with garbage payload must reject the whole block, never be skipped.
     let corrupt = corrupt_recognized_portal_log(portal);
     let receipt = make_receipt_with_logs(10, B256::with_last_byte(0x10), vec![corrupt]);
 
@@ -1668,7 +1668,7 @@ fn extract_events_fails_closed_on_corrupt_recognized_portal_log() {
             .contains("failed to decode a portal event in L1 block 10")
     );
 
-    // Unknown signatures are still skipped: a pre-upgrade contract event cannot fence us.
+    // Unknown signatures are still skipped: a pre-upgrade contract event cannot reject the block.
     let unknown = Log {
         inner: alloy_primitives::Log {
             address: portal,
@@ -1732,7 +1732,7 @@ fn pause_events_invalidate_cached_portal_storage() {
 }
 
 #[tokio::test]
-async fn sync_classifies_corrupt_recognized_portal_log_as_fenced() {
+async fn sync_classifies_corrupt_recognized_portal_log_as_fatal() {
     let subscriber = test_subscriber(Arc::new(SequenceLocalTempoCheckpointReader::new([9])));
     let portal = subscriber.config.portal_address;
     let queue = subscriber.deposit_queue.clone();
@@ -1754,16 +1754,22 @@ async fn sync_classifies_corrupt_recognized_portal_log_as_fenced() {
         .sync_finalized_once(&l1_provider, 10)
         .await
         .unwrap_err();
-    assert!(is_fenced_ingestion_error(&err));
+    assert!(matches!(
+        err,
+        L1SubscriberError::Fatal {
+            block_number: 10,
+            stage: "portal event decoding",
+            ..
+        }
+    ));
     assert_eq!(queue.last_enqueued(), None);
     assert_eq!(subscriber.config.block_tracker.latest(), None);
 }
 
 #[test]
 fn ordinary_subscriber_errors_remain_retryable() {
-    assert!(!is_fenced_ingestion_error(&eyre::eyre!(
-        "transient L1 RPC failure"
-    )));
+    let error = L1SubscriberError::Other(eyre::eyre!("transient L1 RPC failure"));
+    assert!(error.should_retry());
 }
 
 #[derive(Debug)]
@@ -1833,7 +1839,7 @@ async fn sync_applies_leadership_transition_before_enqueueing_the_activation_blo
 }
 
 #[tokio::test]
-async fn sync_fences_the_block_when_the_leadership_sink_rejects_the_transition() {
+async fn sync_fails_fatally_when_the_leadership_sink_rejects_the_transition() {
     let mut subscriber = test_subscriber(Arc::new(SequenceLocalTempoCheckpointReader::new([9])));
     let portal = subscriber.config.portal_address;
     let queue = subscriber.deposit_queue.clone();
@@ -1861,10 +1867,16 @@ async fn sync_fences_the_block_when_the_leadership_sink_rejects_the_transition()
         .sync_finalized_once(&l1_provider, 10)
         .await
         .unwrap_err();
-    assert!(err.to_string().contains("leadership transition"));
-    assert!(is_fenced_ingestion_error(&err));
+    assert!(matches!(
+        err,
+        L1SubscriberError::Fatal {
+            block_number: 10,
+            stage: "leadership transition application",
+            ..
+        }
+    ));
 
-    // Nothing was enqueued and no observation advanced: the block is fenced, not half-applied.
+    // Nothing was enqueued and no observation advanced: the block was not half-applied.
     assert_eq!(queue.last_enqueued(), None);
     assert_eq!(subscriber.config.block_tracker.latest(), None);
 }

--- a/crates/node/src/node.rs
+++ b/crates/node/src/node.rs
@@ -637,15 +637,15 @@ where
             }));
         }
 
-        L1Subscriber::spawn(
+        let l1_subscriber = L1Subscriber::new(
             self.l1_config.clone(),
             ctx.node.provider().clone(),
             self.deposit_queue.clone(),
-            ctx.node.task_executor().clone(),
         );
+        let task_executor = ctx.node.task_executor().clone();
+        task_executor.spawn_critical_task("l1-block-subscriber", Box::pin(l1_subscriber.run()));
         info!(target: "reth::cli", "L1 subscriber started with deposit enqueueing");
 
-        let task_executor = ctx.node.task_executor().clone();
         // Start the Commonware network and the long-lived event router
         let sequencer_rpc_slot = Arc::new(std::sync::OnceLock::new());
         let p2p_runtime = if let Some(config) = self.p2p_config.take() {


### PR DESCRIPTION
This PR simplifies the L1 subscriber lifecycle and makes its retry behavior easier to follow.

Previously, the subscriber registered its own task, split execution across `spawn`, `run`, and `run_once`, and detected fatal ingestion failures by searching an erased error chain. This made ownership and failure handling harder to understand. The node now owns task registration, while `L1Subscriber::run` owns connection, subscription, retry, and fatal handling.

```rust
let l1_subscriber = L1Subscriber::new(...);
task_executor.spawn_critical_task("l1-block-subscriber", Box::pin(l1_subscriber.run()));
```

The subscriber now uses one explicit error type. Transport and ordinary errors retry; deterministic failures while applying a finalized block remain fatal.

```rust
    pub async fn run(self) {
        loop {
          // --snip--
            if let Err(error) = result {
                // Retry ordinary errors, finalized event decoding and application errors are fatal.
                if error.should_retry() {
                   // --snip--
                    tokio::time::sleep(retry_interval).await;
                } else {
                    panic!("{error}");
                }
            }
        }
    }

```

Block notifications are also updated to be represented by a small `HeaderStream`. Finalized block selection and ingestion behavior are unchanged.