### PR TITLE
ci: install Foundry via gh-actions setup-foundry (attested releases)

### DIFF
--- a/.github/workflows/contracts.yml
+++ b/.github/workflows/contracts.yml
@@ -44,7 +44,7 @@ jobs:
           toolchain: stable
 
       - name: Install Foundry
-        uses: tempoxyz/gh-actions/actions/setup-foundry@84404f82f267db9b96abab32a50bf835a524d8c7
+        uses: tempoxyz/gh-actions/actions/setup-foundry@16356ec5155405ba5e33f5558e80b5bf77eb70ab
         with:
           version: nightly
 
@@ -68,7 +68,7 @@ jobs:
           persist-credentials: false
 
       - name: Install Foundry
-        uses: tempoxyz/gh-actions/actions/setup-foundry@84404f82f267db9b96abab32a50bf835a524d8c7
+        uses: tempoxyz/gh-actions/actions/setup-foundry@16356ec5155405ba5e33f5558e80b5bf77eb70ab
         with:
           version: nightly
 
@@ -103,7 +103,7 @@ jobs:
           persist-credentials: false
 
       - name: Install Foundry
-        uses: tempoxyz/gh-actions/actions/setup-foundry@84404f82f267db9b96abab32a50bf835a524d8c7
+        uses: tempoxyz/gh-actions/actions/setup-foundry@16356ec5155405ba5e33f5558e80b5bf77eb70ab
         with:
           version: nightly
 

--- a/.github/workflows/scan-github-actions.yml
+++ b/.github/workflows/scan-github-actions.yml
@@ -20,7 +20,7 @@ jobs:
     name: Scan GitHub Actions
     # Only the upstream repository runs the recurring organization-wide scan.
     if: github.event_name != 'schedule' || github.repository == 'tempoxyz/zones'
-    uses: tempoxyz/gh-actions/.github/workflows/scan-github-actions.yml@98b1081dcf34361b576aca2ab3041772708582ef
+    uses: tempoxyz/gh-actions/.github/workflows/scan-github-actions.yml@9974f654e85ffade8a813c84157047910079be4c
     permissions:
       actions: read
       contents: read

--- a/.github/workflows/storage-layout.yml
+++ b/.github/workflows/storage-layout.yml
@@ -24,7 +24,7 @@ jobs:
           persist-credentials: false
 
       - name: Install Foundry
-        uses: tempoxyz/gh-actions/actions/setup-foundry@84404f82f267db9b96abab32a50bf835a524d8c7
+        uses: tempoxyz/gh-actions/actions/setup-foundry@16356ec5155405ba5e33f5558e80b5bf77eb70ab
         with:
           version: nightly
 

--- a/.github/workflows/sync-tempo-zone-runtimes.yml
+++ b/.github/workflows/sync-tempo-zone-runtimes.yml
@@ -29,7 +29,7 @@ jobs:
           persist-credentials: false
 
       - name: Install Foundry
-        uses: tempoxyz/gh-actions/actions/setup-foundry@84404f82f267db9b96abab32a50bf835a524d8c7
+        uses: tempoxyz/gh-actions/actions/setup-foundry@16356ec5155405ba5e33f5558e80b5bf77eb70ab
         with:
           version: nightly
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -55,7 +55,7 @@ jobs:
         with:
           tool: nextest@0.9.124
       - name: Install Foundry
-        uses: tempoxyz/gh-actions/actions/setup-foundry@84404f82f267db9b96abab32a50bf835a524d8c7
+        uses: tempoxyz/gh-actions/actions/setup-foundry@16356ec5155405ba5e33f5558e80b5bf77eb70ab
         with:
           version: nightly
 

--- a/.github/workflows/zones-benchmark.yml
+++ b/.github/workflows/zones-benchmark.yml
@@ -568,7 +568,7 @@ jobs:
         with:
           toolchain: stable
 
-      - uses: tempoxyz/gh-actions/actions/setup-foundry@84404f82f267db9b96abab32a50bf835a524d8c7
+      - uses: tempoxyz/gh-actions/actions/setup-foundry@16356ec5155405ba5e33f5558e80b5bf77eb70ab
         with:
           version: nightly
 


### PR DESCRIPTION
## Why

`tempoxyz/gh-actions` now ships a first-party `setup-foundry` (tempoxyz/gh-actions#82) that installs Foundry directly from GitHub releases and verifies each tarball's SLSA provenance with `gh attestation verify` (built by `foundry-rs/foundry`'s release workflow at the resolved tag, or `master` for nightlies), on top of the `.sha256` check. `foundry-rs/foundry-toolchain` runs `foundryup` and verifies nothing it downloads. Switching also removes a third-party action ahead of the org-only actions policy.

## What changes at run time

- `version: nightly` resolves to the newest `nightly-<commit>` build, which is the same content the rolling `nightly` tag mirrors, but attested. `stable` resolves to the newest `vX.Y.Z` release. Explicit tags work as before.
- forge, cast, anvil and chisel are installed under `RUNNER_TEMP` and added to `PATH`; `foundryup` itself is not installed (nothing here referenced it).
- The RPC response cache (`~/.foundry/cache`) is kept with the same `cache`, `cache-key` and `cache-restore-keys` inputs and key scheme; the first run after merge is a cache miss because the key prefix changed from `linux-` to `Linux-`.
- Inputs are unchanged, so no `with:` blocks needed editing.

Pinned to gh-actions `main` at `16356ec5` (the commit that landed the verifying installer). `actionlint` and `zizmor` report the same results as before on the changed files.

This repo already used `setup-foundry`, pinned to an older gh-actions commit whose implementation still wrapped `foundry-toolchain`; this bumps the pin to the verifying implementation.

Files: .github/workflows/contracts.yml
.github/workflows/storage-layout.yml
.github/workflows/sync-tempo-zone-runtimes.yml
.github/workflows/test.yml
.github/workflows/zones-benchmark.yml