### PR TITLE
refactor(node): batch portal reads with multicall

### DIFF
--- a/crates/node/src/node.rs
+++ b/crates/node/src/node.rs
@@ -1071,17 +1071,15 @@ async fn seed_leadership_schedule(
     }
 
     let portal = ZonePortal::new(portal_address, l1_provider);
-    // All three describe the same transition at the same block and have no data dependency
-    // on each other, so they go out as one batch rather than three serial round trips on the
-    // startup path.
-    let leader_call = portal.leader().block(block_id);
-    let epoch_call = portal.leaderEpoch().block(block_id);
-    let activation_call = portal.leaderActivationTempoBlock().block(block_id);
-    let (leader, epoch, activation) = tokio::try_join!(
-        leader_call.call(),
-        epoch_call.call(),
-        activation_call.call(),
-    )?;
+    // Read the complete transition atomically at the authenticated snapshot.
+    let (leader, epoch, activation) = l1_provider
+        .multicall()
+        .block(block_id)
+        .add(portal.leader())
+        .add(portal.leaderEpoch())
+        .add(portal.leaderActivationTempoBlock())
+        .aggregate()
+        .await?;
     eyre::ensure!(
         !leader.is_zero(),
         "portal {portal_address} has no leader at finalized L1 snapshot block {snapshot_anchor}"

--- a/crates/node/src/settlement_attestation.rs
+++ b/crates/node/src/settlement_attestation.rs
@@ -62,21 +62,22 @@ pub(crate) async fn validate_registered_sequencer_set(
     // harmless for a startup sanity check.
     let portal = ZonePortal::new(portal_address, l1_provider);
     let quorum: Vec<_> = manifest.quorum_nodes().collect();
-    let sequencer_set_version = portal
-        .sequencerSetVersion()
-        .call()
+    let (sequencer_set_version, threshold, registered_count) = l1_provider
+        .multicall()
+        .add(portal.sequencerSetVersion())
+        .add(portal.sequencerThreshold())
+        .add(portal.sequencerCount())
+        .aggregate()
         .await
-        .wrap_err("failed reading the ZonePortal sequencer-set version")?;
-    let threshold_call = portal.sequencerThreshold();
-    let count_call = portal.sequencerCount();
-    let registered = futures::future::try_join_all(quorum.iter().map(|(node, address)| {
-        let (name, address) = (node.name(), *address);
-        let call = portal.isSequencer(address);
-        async move { call.call().await.map(|ok| (name, address, ok)) }
-    }));
-    let (threshold, registered_count, registered) =
-        tokio::try_join!(threshold_call.call(), count_call.call(), registered)
-            .wrap_err("failed reading the registered sequencer set from ZonePortal")?;
+        .wrap_err("failed reading the registered sequencer set from ZonePortal")?;
+    let mut registration_calls = l1_provider.multicall().dynamic();
+    for (_, address) in &quorum {
+        registration_calls = registration_calls.add_dynamic(portal.isSequencer(*address));
+    }
+    let registered = registration_calls
+        .aggregate()
+        .await
+        .wrap_err("failed reading the registered sequencers from ZonePortal")?;
     let validated_version = portal
         .sequencerSetVersion()
         .call()
@@ -87,7 +88,8 @@ pub(crate) async fn validate_registered_sequencer_set(
         "ZonePortal sequencer set changed during startup validation ({sequencer_set_version} -> {validated_version})"
     );
 
-    for (name, address, is_registered) in registered {
+    for ((node, address), is_registered) in quorum.iter().zip(registered) {
+        let name = node.name();
         eyre::ensure!(
             is_registered,
             "manifest quorum node `{name}` ({address}) is not a registered ZonePortal sequencer"
@@ -218,16 +220,15 @@ where
         previous_batch(provider, number)?;
 
     let portal = ZonePortal::new(context.domain.portal_address, context.l1_provider.clone());
-    let set_version_call = portal.sequencerSetVersion();
-    let portal_batch_index_call = portal.withdrawalBatchIndex();
-    let verifier_call = portal.verifier();
-    let portal_tip_call = portal.blockHash();
-    let (set_version, portal_batch_index, verifier, portal_tip) = tokio::try_join!(
-        set_version_call.call(),
-        portal_batch_index_call.call(),
-        verifier_call.call(),
-        portal_tip_call.call(),
-    )?;
+    let (set_version, portal_batch_index, verifier, portal_tip) = context
+        .l1_provider
+        .multicall()
+        .add(portal.sequencerSetVersion())
+        .add(portal.withdrawalBatchIndex())
+        .add(portal.verifier())
+        .add(portal.blockHash())
+        .aggregate()
+        .await?;
     validate_sequencer_set_version(context.pinned_sequencer_set_version, set_version)?;
     eyre::ensure!(
         portal_tip == previous_tip,


### PR DESCRIPTION
Batch related ZonePortal reads through Alloy Multicall3. This makes settlement and leadership snapshots atomic while reducing startup and attestation RPC round trips.

Tests:
- `cargo +nightly fmt --all --check`
- `cargo check -p zone-node --tests`
- `cargo test -p zone-node settlement_attestation::tests`
- `cargo +nightly clippy -p zone-node --lib`

Prompted by: @shekhirin