### PR TITLE
refactor(l1): simplify subscriber state ownership

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -13832,7 +13832,6 @@ dependencies = [
  "reth-primitives-traits",
  "reth-provider",
  "reth-storage-api",
- "reth-tasks",
  "schnellru",
  "serde",
  "serde_json",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -13839,6 +13839,7 @@ dependencies = [
  "tempo-contracts",
  "tempo-primitives",
  "tempo-zone-contracts",
+ "thiserror 2.0.18",
  "tokio",
  "tracing",
  "url",

--- a/crates/l1/Cargo.toml
+++ b/crates/l1/Cargo.toml
@@ -47,6 +47,7 @@ metrics.workspace = true
 parking_lot.workspace = true
 schnellru.workspace = true
 serde = { workspace = true, features = ["derive"] }
+thiserror.workspace = true
 tokio.workspace = true
 tracing.workspace = true
 url = "2"

--- a/crates/l1/Cargo.toml
+++ b/crates/l1/Cargo.toml
@@ -55,4 +55,5 @@ url = "2"
 [dev-dependencies]
 alloy-rlp.workspace = true
 const-hex.workspace = true
+reth-provider = { workspace = true, features = ["test-utils"] }
 serde_json.workspace = true

--- a/crates/l1/Cargo.toml
+++ b/crates/l1/Cargo.toml
@@ -25,7 +25,6 @@ reth-metrics.workspace = true
 reth-primitives-traits.workspace = true
 reth-provider.workspace = true
 reth-storage-api.workspace = true
-reth-tasks.workspace = true
 
 # alloy
 alloy-consensus.workspace = true

--- a/crates/l1/src/lib.rs
+++ b/crates/l1/src/lib.rs
@@ -102,5 +102,3 @@ pub use subscriber::{
 
 #[cfg(test)]
 pub(crate) use queue::PendingDeposits;
-#[cfg(test)]
-pub(crate) use subscriber::LocalTempoCheckpointReader;

--- a/crates/l1/src/lib.rs
+++ b/crates/l1/src/lib.rs
@@ -96,8 +96,8 @@ pub use ext::{ChainTempoStateExt, TempoStateExt};
 pub use queue::DepositQueue;
 pub use state::L1StateCache;
 pub use subscriber::{
-    AuthenticatedPortalLogs, L1BlockTracker, L1Subscriber, L1SubscriberConfig, LeadershipSink,
-    MAX_L1_LOOKAHEAD_BLOCKS, verify_receipts_against_header,
+    AuthenticatedPortalLogs, L1BlockTracker, L1Subscriber, L1SubscriberConfig, L1SubscriberError,
+    LeadershipSink, MAX_L1_LOOKAHEAD_BLOCKS, verify_receipts_against_header,
 };
 
 #[cfg(test)]

--- a/crates/l1/src/subscriber.rs
+++ b/crates/l1/src/subscriber.rs
@@ -1,5 +1,5 @@
 use super::*;
-use eyre::WrapErr as _;
+use eyre::{OptionExt as _, WrapErr as _};
 use std::collections::HashSet;
 use tempo_contracts::precompiles::{ITIP20::TransferPolicyUpdate, TIP403_REGISTRY_ADDRESS};
 use tempo_primitives::is_tip20_prefix;
@@ -562,12 +562,12 @@ impl L1Subscriber {
         &self,
         l1_provider: &impl Provider<TempoNetwork>,
     ) -> Result<u64, L1SubscriberError> {
-        l1_provider
+        Ok(l1_provider
             .get_header_by_number(BlockNumberOrTag::Finalized)
             .await
             .inspect_err(|_| self.subscriber_metrics.fetch_failures.increment(1))?
             .map(|header| header.number())
-            .ok_or_else(|| eyre::eyre!("L1 finalized block is not available").into())
+            .ok_or_eyre("L1 finalized block is not available")?)
     }
 
     /// Synchronize all missing blocks through the current finalized L1 head.
@@ -653,16 +653,17 @@ impl L1Subscriber {
                     block_tracker.wait_for_capacity(block_number).await?;
                     let start = std::time::Instant::now();
                     let fetch_failures = &subscriber_metrics.fetch_failures;
-                    let header_resp = async {
-                        let header = provider.get_header_by_number(block_number.into()).await?;
-                        Ok::<_, L1SubscriberError>(header.ok_or_else(|| {
-                            eyre::eyre!("L1 header not found for block {block_number}")
-                        })?)
-                    }
-                    .await
-                    .inspect_err(|_| {
-                        fetch_failures.increment(1);
-                    })?;
+                    let header_resp =
+                        async {
+                            let header = provider.get_header_by_number(block_number.into()).await?;
+                            Ok::<_, L1SubscriberError>(header.ok_or_eyre(format!(
+                                "L1 header not found for block {block_number}"
+                            ))?)
+                        }
+                        .await
+                        .inspect_err(|_| {
+                            fetch_failures.increment(1);
+                        })?;
                     let block_hash = header_resp.hash();
                     let block = NumHash::new(block_number, block_hash);
                     let expected_receipts_root = header_resp.receipts_root();
@@ -966,7 +967,9 @@ async fn fetch_and_verify_receipts_for_header(
     let receipts = provider
         .get_block_receipts(BlockId::hash(block_hash))
         .await?
-        .ok_or_else(|| eyre::eyre!("no receipts for block {block_number} ({block_hash})"))?;
+        .ok_or_eyre(format!(
+            "no receipts for block {block_number} ({block_hash})"
+        ))?;
     verify_receipts_against_header(
         block,
         expected_receipts_root,

--- a/crates/l1/src/subscriber.rs
+++ b/crates/l1/src/subscriber.rs
@@ -435,8 +435,6 @@ impl L1SubscriberError {
     }
 }
 
-type L1SubscriberResult<T> = Result<T, L1SubscriberError>;
-
 impl L1Subscriber {
     /// Create an L1 subscriber.
     pub fn new<P>(
@@ -461,7 +459,7 @@ impl L1Subscriber {
     ///
     /// The transport (HTTP or WebSocket) is auto-detected from the URL scheme.
     #[instrument(skip(self), fields(l1_rpc_url = %self.config.l1_rpc_url))]
-    async fn connect(&self) -> L1SubscriberResult<DynProvider<TempoNetwork>> {
+    async fn connect(&self) -> Result<DynProvider<TempoNetwork>, L1SubscriberError> {
         info!(url = %self.config.l1_rpc_url, "Connecting to L1 node");
 
         let url: url::Url = self.config.l1_rpc_url.parse().map_err(eyre::Report::from)?;
@@ -484,20 +482,20 @@ impl L1Subscriber {
         Ok(provider)
     }
 
-    /// Return transport-appropriate L1 head notifications as unit triggers.
+    /// Subscribe to transport-appropriate L1 head notifications.
     ///
     /// WebSocket connections use `newHeads`. When pubsub is unavailable, HTTP
     /// connections fall back to `eth_newBlockFilter` / `eth_getFilterChanges`.
-    /// Trigger payloads are ignored because block selection always comes from
+    /// Header payloads are ignored because block selection always comes from
     /// the L1 `finalized` tag.
-    pub(crate) async fn head_triggers<'a>(
+    pub(crate) async fn subscribe_block_headers<'a>(
         &self,
         provider: &'a DynProvider<TempoNetwork>,
-    ) -> L1SubscriberResult<Pin<Box<dyn Stream<Item = eyre::Result<()>> + Send + 'a>>> {
+    ) -> Result<Pin<Box<dyn Stream<Item = ()> + Send + 'a>>, L1SubscriberError> {
         match provider.subscribe_blocks().await {
             Ok(subscription) => {
                 info!("Using WebSocket newHeads notifications");
-                Ok(Box::pin(subscription.into_stream().map(|_| Ok(()))))
+                Ok(Box::pin(subscription.into_stream().map(|_| ())))
             }
             Err(err)
                 if err
@@ -507,11 +505,9 @@ impl L1Subscriber {
                 info!("Pubsub unavailable, using HTTP block filter polling");
                 let mut watcher = provider.watch_blocks().await?;
                 watcher.set_poll_interval(HTTP_POLL_INTERVAL);
-                Ok(Box::pin(
-                    watcher.into_stream().filter_map(|hashes| async move {
-                        (!hashes.is_empty()).then_some(Ok::<(), eyre::Report>(()))
-                    }),
-                ))
+                Ok(Box::pin(watcher.into_stream().filter_map(
+                    |hashes| async move { (!hashes.is_empty()).then_some(()) },
+                )))
             }
             Err(err) => Err(err.into()),
         }
@@ -522,7 +518,7 @@ impl L1Subscriber {
     /// The zone's persisted Tempo checkpoint is the authoritative source for
     /// where ingestion resumes. A non-zero hash distinguishes an L1-anchored
     /// block-zero genesis from the unanchored template.
-    pub(crate) fn resolve_start_block(&self) -> L1SubscriberResult<u64> {
+    pub(crate) fn resolve_start_block(&self) -> Result<u64, L1SubscriberError> {
         let local_checkpoint = self.local_state.latest_tempo_checkpoint()?;
         if local_checkpoint.hash == B256::ZERO {
             return Err(eyre::eyre!("zone genesis is not anchored to an L1 block").into());
@@ -533,7 +529,7 @@ impl L1Subscriber {
     }
 
     /// Resolve the first L1 block that has not already been ingested.
-    pub(crate) fn next_block_to_sync(&self) -> L1SubscriberResult<u64> {
+    pub(crate) fn next_block_to_sync(&self) -> Result<u64, L1SubscriberError> {
         let resolved = self.resolve_start_block()?;
         let queued = self
             .deposit_queue
@@ -563,7 +559,7 @@ impl L1Subscriber {
     async fn finalized_block_number(
         &self,
         l1_provider: &impl Provider<TempoNetwork>,
-    ) -> L1SubscriberResult<u64> {
+    ) -> Result<u64, L1SubscriberError> {
         l1_provider
             .get_header_by_number(BlockNumberOrTag::Finalized)
             .await
@@ -580,7 +576,7 @@ impl L1Subscriber {
         &self,
         l1_provider: &impl Provider<TempoNetwork>,
         next_block: u64,
-    ) -> L1SubscriberResult<u64> {
+    ) -> Result<u64, L1SubscriberError> {
         let finalized = self.finalized_block_number(l1_provider).await?;
         if next_block > finalized {
             self.record_seen_block(finalized, 0);
@@ -612,20 +608,19 @@ impl L1Subscriber {
     pub(crate) async fn follow_finalized<S>(
         &self,
         l1_provider: &impl Provider<TempoNetwork>,
-        triggers: S,
-    ) -> L1SubscriberResult<()>
+        header_stream: S,
+    ) -> Result<(), L1SubscriberError>
     where
-        S: Stream<Item = eyre::Result<()>> + Send,
+        S: Stream<Item = ()> + Send,
     {
-        let mut triggers = Box::pin(triggers);
+        let mut header_stream = Box::pin(header_stream);
         let mut next_block = self.next_block_to_sync()?;
 
         // Subscribe before the initial sync so a head published while catching
-        // up remains queued as another trigger.
+        // up remains queued in the header stream.
         next_block = self.sync_finalized_once(l1_provider, next_block).await?;
 
-        while let Some(trigger) = triggers.next().await {
-            trigger?;
+        while header_stream.next().await.is_some() {
             next_block = self.sync_finalized_once(l1_provider, next_block).await?;
         }
 
@@ -644,7 +639,7 @@ impl L1Subscriber {
         l1_provider: &impl Provider<TempoNetwork>,
         from: u64,
         to: u64,
-    ) -> L1SubscriberResult<()> {
+    ) -> Result<(), L1SubscriberError> {
         use futures::stream;
 
         let concurrency = self.config.l1_fetch_concurrency.max(1);
@@ -820,16 +815,17 @@ impl L1Subscriber {
         loop {
             let result = async {
                 let provider = self.connect().await?;
-                let triggers = self.head_triggers(&provider).await?;
+                let header_stream = self.subscribe_block_headers(&provider).await?;
                 info!(
                     portal = %self.config.portal_address,
                     "Following finalized L1 blocks"
                 );
-                self.follow_finalized(&provider, triggers).await
+                self.follow_finalized(&provider, header_stream).await
             }
             .await;
 
             if let Err(error) = result {
+                // Retry ordinary errors; finalized event decoding and application errors are fatal.
                 if error.should_retry() {
                     let retry_interval = self.config.retry_connection_interval;
                     self.subscriber_metrics.reconnects.increment(1);
@@ -966,7 +962,7 @@ async fn fetch_and_verify_receipts_for_header(
     block: NumHash,
     expected_receipts_root: B256,
     expected_logs_bloom: Bloom,
-) -> L1SubscriberResult<Vec<tempo_alloy::rpc::TempoTransactionReceipt>> {
+) -> Result<Vec<tempo_alloy::rpc::TempoTransactionReceipt>, L1SubscriberError> {
     let block_number = block.number;
     let block_hash = block.hash;
     let receipts = provider

--- a/crates/l1/src/subscriber.rs
+++ b/crates/l1/src/subscriber.rs
@@ -462,55 +462,23 @@ pub(crate) fn is_fenced_ingestion_error(error: &eyre::Report) -> bool {
 }
 
 impl L1Subscriber {
-    /// Create and spawn the L1 subscriber as a critical background task.
-    ///
-    /// Transient failures reconnect after the configured retry interval. Deterministic failures
-    /// while applying a receipt-verified finalized block fail the critical task instead.
-    pub fn spawn<P>(
+    /// Create an L1 subscriber.
+    pub fn new<P>(
         config: L1SubscriberConfig,
         local_state_provider: P,
         deposit_queue: DepositQueue,
-        task_executor: reth_tasks::Runtime,
-    ) where
+    ) -> Self
+    where
         P: StateProviderFactory + Clone + Send + Sync + 'static,
     {
-        let subscriber = Self {
+        Self {
             config,
             local_state: Arc::new(ProviderLocalTempoCheckpointReader {
                 provider: local_state_provider,
             }),
             deposit_queue,
             subscriber_metrics: Default::default(),
-        };
-
-        task_executor.spawn_critical_task(
-            "l1-block-subscriber",
-            Box::pin(async move {
-                loop {
-                    if let Err(e) = subscriber.run().await {
-                        if let Some(fenced) = fenced_ingestion_error(&e) {
-                            error!(
-                                block_number = fenced.block_number,
-                                stage = fenced.stage,
-                                error = %e,
-                                "Fatal L1 ingestion fence; refusing to retry an immutable finalized block"
-                            );
-                            // This is a critical task: panicking notifies the task manager and
-                            // shuts the node down instead of leaving it alive with frozen L1 state.
-                            panic!("{fenced}");
-                        }
-                        let retry_interval = subscriber.config.retry_connection_interval;
-                        subscriber.subscriber_metrics.reconnects.increment(1);
-                        error!(
-                            error = %e,
-                            retry_secs = retry_interval.as_secs_f32(),
-                            "L1 subscriber failed, reconnecting after retry interval"
-                        );
-                        tokio::time::sleep(retry_interval).await;
-                    }
-                }
-            }),
-        );
+        }
     }
 
     /// Connect to the L1 node.
@@ -862,22 +830,47 @@ impl L1Subscriber {
         Ok(())
     }
 
-    /// Run the L1 subscriber until an RPC operation fails.
+    /// Run the L1 subscriber, reconnecting after transient RPC failures.
     ///
     /// The subscriber follows only the L1 `finalized` tag. WebSocket
     /// `newHeads` or HTTP block-filter updates are used as wakeups; each
     /// notification ingests the missing finalized range in order.
     ///
-    /// [`Self::spawn`] retries transient errors and treats deterministic finalized-block
-    /// ingestion failures as fatal.
-    pub async fn run(&self) -> eyre::Result<()> {
-        let provider = self.connect().await?;
-        let triggers = self.head_triggers(&provider).await?;
-        info!(
-            portal = %self.config.portal_address,
-            "Following finalized L1 blocks"
-        );
-        self.follow_finalized(&provider, triggers).await
+    /// Transient failures reconnect after the configured retry interval. Deterministic failures
+    /// while applying a receipt-verified finalized block are fatal.
+    pub async fn run(self) {
+        loop {
+            let result = async {
+                let provider = self.connect().await?;
+                let triggers = self.head_triggers(&provider).await?;
+                info!(
+                    portal = %self.config.portal_address,
+                    "Following finalized L1 blocks"
+                );
+                self.follow_finalized(&provider, triggers).await
+            }
+            .await;
+
+            if let Err(e) = result {
+                if let Some(fenced) = fenced_ingestion_error(&e) {
+                    error!(
+                        block_number = fenced.block_number,
+                        stage = fenced.stage,
+                        error = %e,
+                        "Fatal L1 ingestion fence; refusing to retry an immutable finalized block"
+                    );
+                    panic!("{fenced}");
+                }
+                let retry_interval = self.config.retry_connection_interval;
+                self.subscriber_metrics.reconnects.increment(1);
+                error!(
+                    error = %e,
+                    retry_secs = retry_interval.as_secs_f32(),
+                    "L1 subscriber failed, reconnecting after retry interval"
+                );
+                tokio::time::sleep(retry_interval).await;
+            }
+        }
     }
 
     /// Extract portal events and raw-cache mutation barriers from fetched receipts.

--- a/crates/l1/src/subscriber.rs
+++ b/crates/l1/src/subscriber.rs
@@ -1,4 +1,7 @@
 use super::*;
+use crate::{
+    EncryptionKeyRing, L1StateCache, metrics::L1SubscriberMetrics, state::EnabledTokenRegistry,
+};
 use eyre::{OptionExt as _, WrapErr as _};
 use std::collections::HashSet;
 use tempo_contracts::precompiles::{ITIP20::TransferPolicyUpdate, TIP403_REGISTRY_ADDRESS};
@@ -364,23 +367,11 @@ pub struct L1SubscriberConfig {
     pub l1_rpc_url: String,
     /// ZonePortal contract address on L1.
     pub portal_address: Address,
-    /// Shared registry of tokens enabled for this zone.
-    pub enabled_tokens: crate::state::EnabledTokenRegistry,
-    /// Shared L1 state cache. The subscriber updates the cache anchor on each
-    /// finalized block.
-    pub l1_state_cache: crate::state::cache::L1StateCache,
-    /// Validated and applied L1 anchors shared with follower block import.
-    pub block_tracker: L1BlockTracker,
     /// Maximum number of concurrent header and receipt fetches while syncing a
     /// finalized L1 range.
     pub l1_fetch_concurrency: usize,
     /// Interval between L1 connection attempts.
     pub retry_connection_interval: std::time::Duration,
-    /// Optional sink that receives leadership transitions before the block that
-    /// recorded them is enqueued.
-    pub leadership_sink: Option<Arc<dyn LeadershipSink>>,
-    /// Private encryption keys bound by finalized Portal rotation events.
-    pub encryption_keys: Option<crate::EncryptionKeyRing>,
     /// Whether to retain authenticated Portal logs for external observers.
     pub retain_portal_evidence: bool,
 }
@@ -392,8 +383,18 @@ pub struct L1Subscriber<P> {
     pub(crate) provider: P,
     /// Finalized L1 blocks retained until a Zone consumer processes them.
     pub(crate) deposit_queue: DepositQueue,
+    /// Shared registry of tokens enabled for this zone.
+    pub(crate) enabled_tokens: EnabledTokenRegistry,
+    /// Shared L1 state cache updated after each finalized block.
+    pub(crate) l1_state_cache: L1StateCache,
+    /// Validated and applied L1 anchors shared with follower block import.
+    pub(crate) block_tracker: L1BlockTracker,
+    /// Optional sink for leadership transitions.
+    pub(crate) leadership_sink: Option<Arc<dyn LeadershipSink>>,
+    /// Private encryption keys bound by finalized Portal rotation events.
+    pub(crate) encryption_keys: Option<EncryptionKeyRing>,
     /// L1 subscriber metrics for connection health, backfill, and event ingestion.
-    pub(crate) subscriber_metrics: crate::metrics::L1SubscriberMetrics,
+    pub(crate) subscriber_metrics: L1SubscriberMetrics,
 }
 
 #[derive(Debug, thiserror::Error)]
@@ -432,11 +433,25 @@ where
     P: StateProviderFactory + Sync,
 {
     /// Create an L1 subscriber.
-    pub fn new(config: L1SubscriberConfig, provider: P, deposit_queue: DepositQueue) -> Self {
+    pub fn new(
+        config: L1SubscriberConfig,
+        provider: P,
+        deposit_queue: DepositQueue,
+        enabled_tokens: EnabledTokenRegistry,
+        l1_state_cache: L1StateCache,
+        block_tracker: L1BlockTracker,
+        leadership_sink: Option<Arc<dyn LeadershipSink>>,
+        encryption_keys: Option<EncryptionKeyRing>,
+    ) -> Self {
         Self {
             config,
             provider,
             deposit_queue,
+            enabled_tokens,
+            l1_state_cache,
+            block_tracker,
+            leadership_sink,
+            encryption_keys,
             subscriber_metrics: Default::default(),
         }
     }
@@ -523,7 +538,6 @@ where
             .last_enqueued()
             .map(|last| last.number.saturating_add(1));
         let observed = self
-            .config
             .block_tracker
             .latest()
             .map(|last| last.number.saturating_add(1));
@@ -536,8 +550,7 @@ where
 
         // Only the persisted zone checkpoint proves consumption.
         // Queue and observation cursors are fetch high-water marks.
-        self.config
-            .block_tracker
+        self.block_tracker
             .initialize_consumed_through(resolved.saturating_sub(1));
         Ok(next)
     }
@@ -627,7 +640,7 @@ where
 
         let concurrency = self.config.l1_fetch_concurrency.max(1);
         let subscriber_metrics = self.subscriber_metrics.clone();
-        let block_tracker = self.config.block_tracker.clone();
+        let block_tracker = self.block_tracker.clone();
 
         let mut fetched = stream::iter(from..=to)
             .map(move |block_number| {
@@ -701,7 +714,7 @@ where
             let portal_evidence = portal_logs.map(|logs| (sealed.parent_hash(), logs));
             // Publish the leadership transition _before_ the activation block becomes
             // consumable.
-            if let Some(sink) = &self.config.leadership_sink {
+            if let Some(sink) = &self.leadership_sink {
                 let transition =
                     events
                         .final_leader_transition()
@@ -722,7 +735,7 @@ where
                         ))?;
                 }
             }
-            if let Some(keys) = &self.config.encryption_keys {
+            if let Some(keys) = &self.encryption_keys {
                 for rotation in &events.encryption_key_rotations {
                     keys.apply_rotation(rotation)
                         .map_err(L1SubscriberError::fatal_from_err(
@@ -738,15 +751,14 @@ where
                     format!("unexpected discontinuity while enqueueing L1 block {block_number}")
                 })?;
             if let Some((parent_hash, logs)) = portal_evidence {
-                self.config.block_tracker.record_with_portal_evidence(
+                self.block_tracker.record_with_portal_evidence(
                     anchor,
                     parent_hash,
                     events.clone(),
                     logs,
                 )?;
             } else {
-                self.config
-                    .block_tracker
+                self.block_tracker
                     .record_with_portal_events(anchor, events.clone())?;
             }
             // Publish derived L1 state only after the header has been admitted to every
@@ -914,7 +926,7 @@ where
             return;
         }
 
-        let mut enabled_tokens = self.config.enabled_tokens.write();
+        let mut enabled_tokens = self.enabled_tokens.write();
         for enabled in &portal_events.enabled_tokens {
             if enabled_tokens.insert(enabled.token) {
                 info!(token = %enabled.token, "New token enabled");
@@ -928,8 +940,7 @@ where
         number: u64,
         invalidated_accounts: &HashSet<Address>,
     ) {
-        self.config
-            .l1_state_cache
+        self.l1_state_cache
             .lock()
             .invalidate_and_set_anchor(number, invalidated_accounts.iter().copied());
     }

--- a/crates/l1/src/subscriber.rs
+++ b/crates/l1/src/subscriber.rs
@@ -430,6 +430,14 @@ pub enum L1SubscriberError {
 }
 
 impl L1SubscriberError {
+    fn fatal_from_err(block_number: u64, stage: &'static str) -> impl FnOnce(eyre::Report) -> Self {
+        move |source| Self::Fatal {
+            block_number,
+            stage,
+            source,
+        }
+    }
+
     pub(crate) fn should_retry(&self) -> bool {
         !matches!(self, Self::Fatal { .. })
     }
@@ -701,14 +709,13 @@ impl L1Subscriber {
             // block before anything is enqueued or any cache advances.
             let processed_events = self
                 .extract_events(block_number, &receipts)
-                .map_err(|err| {
+                .inspect_err(|_| {
                     self.subscriber_metrics.decode_fence_failures.increment(1);
-                    L1SubscriberError::Fatal {
-                        block_number,
-                        stage: "portal event decoding",
-                        source: err,
-                    }
-                })?;
+                })
+                .map_err(L1SubscriberError::fatal_from_err(
+                    block_number,
+                    "portal event decoding",
+                ))?;
             let (events, invalidated, portal_logs) = processed_events;
             self.record_seen_block(block_number, to.saturating_sub(block_number));
 
@@ -721,11 +728,10 @@ impl L1Subscriber {
                 let transition =
                     events
                         .final_leader_transition()
-                        .map_err(|err| L1SubscriberError::Fatal {
+                        .map_err(L1SubscriberError::fatal_from_err(
                             block_number,
-                            stage: "leadership event validation",
-                            source: err,
-                        })?;
+                            "leadership event validation",
+                        ))?;
                 if let Some(transition) = transition {
                     sink.apply_leader_transition(transition)
                         .wrap_err_with(|| {
@@ -733,21 +739,19 @@ impl L1Subscriber {
                                 "cannot apply the leadership transition from block {block_number}"
                             )
                         })
-                        .map_err(|source| L1SubscriberError::Fatal {
+                        .map_err(L1SubscriberError::fatal_from_err(
                             block_number,
-                            stage: "leadership transition application",
-                            source,
-                        })?;
+                            "leadership transition application",
+                        ))?;
                 }
             }
             if let Some(keys) = &self.config.encryption_keys {
                 for rotation in &events.encryption_key_rotations {
                     keys.apply_rotation(rotation)
-                        .map_err(|source| L1SubscriberError::Fatal {
+                        .map_err(L1SubscriberError::fatal_from_err(
                             block_number,
-                            stage: "encryption key rotation application",
-                            source,
-                        })?;
+                            "encryption key rotation application",
+                        ))?;
                 }
             }
             let appended = self

--- a/crates/l1/src/subscriber.rs
+++ b/crates/l1/src/subscriber.rs
@@ -818,7 +818,7 @@ where
             .await;
 
             if let Err(error) = result {
-                // Retry ordinary errors; finalized event decoding and application errors are fatal.
+                // Retry connection and sync errors, finalized event errors are fatal.
                 if error.should_retry() {
                     let retry_interval = self.config.retry_connection_interval;
                     self.subscriber_metrics.reconnects.increment(1);

--- a/crates/l1/src/subscriber.rs
+++ b/crates/l1/src/subscriber.rs
@@ -351,7 +351,7 @@ fn portal_event_cache_invalidation_address(topic0: Option<&B256>) -> Option<Addr
 /// Implemented by the node over its `LeadershipSchedule`. The subscriber applies every
 /// transition **before** enqueueing the block that recorded it — enqueueing notifies the
 /// engine internally, so append-after-enqueue could race a producer waking on that notify.
-/// An error fences ingestion of the whole L1 block.
+/// An error makes ingestion of the finalized L1 block fail.
 pub trait LeadershipSink: Send + Sync + std::fmt::Debug {
     /// Apply one decoded leadership transition.
     fn apply_leader_transition(&self, transition: &crate::LeaderTransition) -> eyre::Result<()>;
@@ -414,52 +414,28 @@ pub struct L1Subscriber {
     pub(crate) subscriber_metrics: crate::metrics::L1SubscriberMetrics,
 }
 
-/// A deterministic failure while applying an already receipt-verified finalized block.
-///
-/// Reconnecting cannot change these inputs, so retrying would loop forever on the same block.
-#[derive(Debug)]
-struct FencedIngestionError {
-    block_number: u64,
-    stage: &'static str,
-    source: eyre::Report,
+#[derive(Debug, thiserror::Error)]
+pub enum L1SubscriberError {
+    #[error(transparent)]
+    TransportError(#[from] alloy_transport::TransportError),
+    #[error(transparent)]
+    Other(#[from] eyre::Report),
+    #[error("fatal L1 ingestion error at block {block_number} during {stage}: {source}")]
+    Fatal {
+        block_number: u64,
+        stage: &'static str,
+        #[source]
+        source: eyre::Report,
+    },
 }
 
-impl FencedIngestionError {
-    const fn new(block_number: u64, stage: &'static str, source: eyre::Report) -> Self {
-        Self {
-            block_number,
-            stage,
-            source,
-        }
+impl L1SubscriberError {
+    pub(crate) fn should_retry(&self) -> bool {
+        !matches!(self, Self::Fatal { .. })
     }
 }
 
-impl std::fmt::Display for FencedIngestionError {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        write!(
-            f,
-            "L1 ingestion fenced at block {} during {}: {}",
-            self.block_number, self.stage, self.source
-        )
-    }
-}
-
-impl std::error::Error for FencedIngestionError {
-    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
-        Some(self.source.as_ref())
-    }
-}
-
-fn fenced_ingestion_error(error: &eyre::Report) -> Option<&FencedIngestionError> {
-    error
-        .chain()
-        .find_map(|cause| cause.downcast_ref::<FencedIngestionError>())
-}
-
-#[cfg(test)]
-pub(crate) fn is_fenced_ingestion_error(error: &eyre::Report) -> bool {
-    fenced_ingestion_error(error).is_some()
-}
+type L1SubscriberResult<T> = Result<T, L1SubscriberError>;
 
 impl L1Subscriber {
     /// Create an L1 subscriber.
@@ -485,10 +461,10 @@ impl L1Subscriber {
     ///
     /// The transport (HTTP or WebSocket) is auto-detected from the URL scheme.
     #[instrument(skip(self), fields(l1_rpc_url = %self.config.l1_rpc_url))]
-    async fn connect(&self) -> eyre::Result<DynProvider<TempoNetwork>> {
+    async fn connect(&self) -> L1SubscriberResult<DynProvider<TempoNetwork>> {
         info!(url = %self.config.l1_rpc_url, "Connecting to L1 node");
 
-        let url: url::Url = self.config.l1_rpc_url.parse()?;
+        let url: url::Url = self.config.l1_rpc_url.parse().map_err(eyre::Report::from)?;
         let mut conn_config =
             crate::rpc::rpc_connection_config(self.config.retry_connection_interval);
 
@@ -517,7 +493,7 @@ impl L1Subscriber {
     pub(crate) async fn head_triggers<'a>(
         &self,
         provider: &'a DynProvider<TempoNetwork>,
-    ) -> eyre::Result<Pin<Box<dyn Stream<Item = eyre::Result<()>> + Send + 'a>>> {
+    ) -> L1SubscriberResult<Pin<Box<dyn Stream<Item = eyre::Result<()>> + Send + 'a>>> {
         match provider.subscribe_blocks().await {
             Ok(subscription) => {
                 info!("Using WebSocket newHeads notifications");
@@ -546,19 +522,18 @@ impl L1Subscriber {
     /// The zone's persisted Tempo checkpoint is the authoritative source for
     /// where ingestion resumes. A non-zero hash distinguishes an L1-anchored
     /// block-zero genesis from the unanchored template.
-    pub(crate) fn resolve_start_block(&self) -> eyre::Result<u64> {
+    pub(crate) fn resolve_start_block(&self) -> L1SubscriberResult<u64> {
         let local_checkpoint = self.local_state.latest_tempo_checkpoint()?;
-        eyre::ensure!(
-            local_checkpoint.hash != B256::ZERO,
-            "zone genesis is not anchored to an L1 block"
-        );
+        if local_checkpoint.hash == B256::ZERO {
+            return Err(eyre::eyre!("zone genesis is not anchored to an L1 block").into());
+        }
         let local_tempo_block_number = local_checkpoint.number;
         info!(local_tempo_block_number, "Resuming from local zone state");
         Ok(local_tempo_block_number + 1)
     }
 
     /// Resolve the first L1 block that has not already been ingested.
-    pub(crate) fn next_block_to_sync(&self) -> eyre::Result<u64> {
+    pub(crate) fn next_block_to_sync(&self) -> L1SubscriberResult<u64> {
         let resolved = self.resolve_start_block()?;
         let queued = self
             .deposit_queue
@@ -588,13 +563,13 @@ impl L1Subscriber {
     async fn finalized_block_number(
         &self,
         l1_provider: &impl Provider<TempoNetwork>,
-    ) -> eyre::Result<u64> {
+    ) -> L1SubscriberResult<u64> {
         l1_provider
             .get_header_by_number(BlockNumberOrTag::Finalized)
             .await
             .inspect_err(|_| self.subscriber_metrics.fetch_failures.increment(1))?
             .map(|header| header.number())
-            .ok_or_else(|| eyre::eyre!("L1 finalized block is not available"))
+            .ok_or_else(|| eyre::eyre!("L1 finalized block is not available").into())
     }
 
     /// Synchronize all missing blocks through the current finalized L1 head.
@@ -605,7 +580,7 @@ impl L1Subscriber {
         &self,
         l1_provider: &impl Provider<TempoNetwork>,
         next_block: u64,
-    ) -> eyre::Result<u64> {
+    ) -> L1SubscriberResult<u64> {
         let finalized = self.finalized_block_number(l1_provider).await?;
         if next_block > finalized {
             self.record_seen_block(finalized, 0);
@@ -638,7 +613,7 @@ impl L1Subscriber {
         &self,
         l1_provider: &impl Provider<TempoNetwork>,
         triggers: S,
-    ) -> eyre::Result<()>
+    ) -> L1SubscriberResult<()>
     where
         S: Stream<Item = eyre::Result<()>> + Send,
     {
@@ -654,7 +629,7 @@ impl L1Subscriber {
             next_block = self.sync_finalized_once(l1_provider, next_block).await?;
         }
 
-        Err(eyre::eyre!("L1 head notification stream ended"))
+        Err(eyre::eyre!("L1 head notification stream ended").into())
     }
 
     /// Backfill L1 blocks from `from..=to` with pipelined RPC fetching.
@@ -669,7 +644,7 @@ impl L1Subscriber {
         l1_provider: &impl Provider<TempoNetwork>,
         from: u64,
         to: u64,
-    ) -> eyre::Result<()> {
+    ) -> L1SubscriberResult<()> {
         use futures::stream;
 
         let concurrency = self.config.l1_fetch_concurrency.max(1);
@@ -686,12 +661,10 @@ impl L1Subscriber {
                     let start = std::time::Instant::now();
                     let fetch_failures = &subscriber_metrics.fetch_failures;
                     let header_resp = async {
-                        provider
-                            .get_header_by_number(block_number.into())
-                            .await?
-                            .ok_or_else(|| {
-                                eyre::eyre!("L1 header not found for block {block_number}")
-                            })
+                        let header = provider.get_header_by_number(block_number.into()).await?;
+                        Ok::<_, L1SubscriberError>(header.ok_or_else(|| {
+                            eyre::eyre!("L1 header not found for block {block_number}")
+                        })?)
                     }
                     .await
                     .inspect_err(|_| {
@@ -720,7 +693,7 @@ impl L1Subscriber {
                         "Fetched and validated L1 block data"
                     );
                     let header = header_resp.inner.inner;
-                    Ok::<_, eyre::Report>((header, receipts))
+                    Ok::<_, L1SubscriberError>((header, receipts))
                 }
             })
             .buffered(concurrency);
@@ -731,13 +704,16 @@ impl L1Subscriber {
         while let Some((header, receipts)) = fetched.try_next().await? {
             let block_number = header.number();
             // Decoding fails closed: a decode failure of a recognized portal log aborts this
-            // block before anything is enqueued or any cache advances. Ingestion halts here (fenced)
-            // instead of continuing under a partial event view.
+            // block before anything is enqueued or any cache advances.
             let processed_events = self
                 .extract_events(block_number, &receipts)
                 .map_err(|err| {
                     self.subscriber_metrics.decode_fence_failures.increment(1);
-                    FencedIngestionError::new(block_number, "portal event decoding", err)
+                    L1SubscriberError::Fatal {
+                        block_number,
+                        stage: "portal event decoding",
+                        source: err,
+                    }
                 })?;
             let (events, invalidated, portal_logs) = processed_events;
             self.record_seen_block(block_number, to.saturating_sub(block_number));
@@ -748,9 +724,14 @@ impl L1Subscriber {
             // Publish the leadership transition _before_ the activation block becomes
             // consumable.
             if let Some(sink) = &self.config.leadership_sink {
-                let transition = events.final_leader_transition().map_err(|err| {
-                    FencedIngestionError::new(block_number, "leadership event validation", err)
-                })?;
+                let transition =
+                    events
+                        .final_leader_transition()
+                        .map_err(|err| L1SubscriberError::Fatal {
+                            block_number,
+                            stage: "leadership event validation",
+                            source: err,
+                        })?;
                 if let Some(transition) = transition {
                     sink.apply_leader_transition(transition)
                         .wrap_err_with(|| {
@@ -758,24 +739,21 @@ impl L1Subscriber {
                                 "cannot apply the leadership transition from block {block_number}"
                             )
                         })
-                        .map_err(|err| {
-                            FencedIngestionError::new(
-                                block_number,
-                                "leadership transition application",
-                                err,
-                            )
+                        .map_err(|source| L1SubscriberError::Fatal {
+                            block_number,
+                            stage: "leadership transition application",
+                            source,
                         })?;
                 }
             }
             if let Some(keys) = &self.config.encryption_keys {
                 for rotation in &events.encryption_key_rotations {
-                    keys.apply_rotation(rotation).map_err(|err| {
-                        FencedIngestionError::new(
+                    keys.apply_rotation(rotation)
+                        .map_err(|source| L1SubscriberError::Fatal {
                             block_number,
-                            "encryption key rotation application",
-                            err,
-                        )
-                    })?;
+                            stage: "encryption key rotation application",
+                            source,
+                        })?;
                 }
             }
             let appended = self
@@ -836,8 +814,8 @@ impl L1Subscriber {
     /// `newHeads` or HTTP block-filter updates are used as wakeups; each
     /// notification ingests the missing finalized range in order.
     ///
-    /// Transient failures reconnect after the configured retry interval. Deterministic failures
-    /// while applying a receipt-verified finalized block are fatal.
+    /// Transport and ordinary failures reconnect after the configured retry interval.
+    /// Deterministic failures while applying a receipt-verified finalized block are fatal.
     pub async fn run(self) {
         loop {
             let result = async {
@@ -851,24 +829,19 @@ impl L1Subscriber {
             }
             .await;
 
-            if let Err(e) = result {
-                if let Some(fenced) = fenced_ingestion_error(&e) {
+            if let Err(error) = result {
+                if error.should_retry() {
+                    let retry_interval = self.config.retry_connection_interval;
+                    self.subscriber_metrics.reconnects.increment(1);
                     error!(
-                        block_number = fenced.block_number,
-                        stage = fenced.stage,
-                        error = %e,
-                        "Fatal L1 ingestion fence; refusing to retry an immutable finalized block"
+                        error = %error,
+                        retry_secs = retry_interval.as_secs_f32(),
+                        "L1 subscriber failed, reconnecting after retry interval"
                     );
-                    panic!("{fenced}");
+                    tokio::time::sleep(retry_interval).await;
+                } else {
+                    panic!("{error}");
                 }
-                let retry_interval = self.config.retry_connection_interval;
-                self.subscriber_metrics.reconnects.increment(1);
-                error!(
-                    error = %e,
-                    retry_secs = retry_interval.as_secs_f32(),
-                    "L1 subscriber failed, reconnecting after retry interval"
-                );
-                tokio::time::sleep(retry_interval).await;
             }
         }
     }
@@ -993,7 +966,7 @@ async fn fetch_and_verify_receipts_for_header(
     block: NumHash,
     expected_receipts_root: B256,
     expected_logs_bloom: Bloom,
-) -> eyre::Result<Vec<tempo_alloy::rpc::TempoTransactionReceipt>> {
+) -> L1SubscriberResult<Vec<tempo_alloy::rpc::TempoTransactionReceipt>> {
     let block_number = block.number;
     let block_hash = block.hash;
     let receipts = provider

--- a/crates/l1/src/subscriber.rs
+++ b/crates/l1/src/subscriber.rs
@@ -380,7 +380,7 @@ pub struct L1SubscriberConfig {
 #[derive(Clone)]
 pub struct L1Subscriber<P> {
     pub(crate) config: L1SubscriberConfig,
-    pub(crate) provider: P,
+    pub(crate) zone_provider: P,
     /// Finalized L1 blocks retained until a Zone consumer processes them.
     pub(crate) deposit_queue: DepositQueue,
     /// Shared registry of tokens enabled for this zone.
@@ -436,7 +436,7 @@ where
     #[expect(clippy::too_many_arguments)]
     pub fn new(
         config: L1SubscriberConfig,
-        provider: P,
+        zone_provider: P,
         deposit_queue: DepositQueue,
         enabled_tokens: EnabledTokenRegistry,
         l1_state_cache: L1StateCache,
@@ -446,7 +446,7 @@ where
     ) -> Self {
         Self {
             config,
-            provider,
+            zone_provider,
             deposit_queue,
             enabled_tokens,
             l1_state_cache,
@@ -521,7 +521,7 @@ where
     /// where ingestion resumes. A non-zero hash distinguishes an L1-anchored
     /// block-zero genesis from the unanchored template.
     pub(crate) fn resolve_start_block(&self) -> Result<u64, L1SubscriberError> {
-        let state = self.provider.latest().map_err(eyre::Report::from)?;
+        let state = self.zone_provider.latest().map_err(eyre::Report::from)?;
         let local_checkpoint = state.tempo_num_hash().map_err(eyre::Report::from)?;
         if local_checkpoint.hash == B256::ZERO {
             return Err(eyre::eyre!("zone genesis is not anchored to an L1 block").into());

--- a/crates/l1/src/subscriber.rs
+++ b/crates/l1/src/subscriber.rs
@@ -435,6 +435,8 @@ impl L1SubscriberError {
     }
 }
 
+type HeaderStream = Pin<Box<dyn Stream<Item = ()> + Send>>;
+
 impl L1Subscriber {
     /// Create an L1 subscriber.
     pub fn new<P>(
@@ -488,10 +490,10 @@ impl L1Subscriber {
     /// connections fall back to `eth_newBlockFilter` / `eth_getFilterChanges`.
     /// Header payloads are ignored because block selection always comes from
     /// the L1 `finalized` tag.
-    pub(crate) async fn subscribe_block_headers<'a>(
+    pub(crate) async fn subscribe_block_headers(
         &self,
-        provider: &'a DynProvider<TempoNetwork>,
-    ) -> Result<Pin<Box<dyn Stream<Item = ()> + Send + 'a>>, L1SubscriberError> {
+        provider: &DynProvider<TempoNetwork>,
+    ) -> Result<HeaderStream, L1SubscriberError> {
         match provider.subscribe_blocks().await {
             Ok(subscription) => {
                 info!("Using WebSocket newHeads notifications");
@@ -605,22 +607,18 @@ impl L1Subscriber {
     ///
     /// Header contents are intentionally ignored. Canonical block selection is
     /// always based on the `finalized` tag read by [`Self::sync_finalized_once`].
-    pub(crate) async fn follow_finalized<S>(
+    pub(crate) async fn follow_finalized(
         &self,
         l1_provider: &impl Provider<TempoNetwork>,
-        header_stream: S,
-    ) -> Result<(), L1SubscriberError>
-    where
-        S: Stream<Item = ()> + Send,
-    {
-        let mut header_stream = Box::pin(header_stream);
+        mut stream: HeaderStream,
+    ) -> Result<(), L1SubscriberError> {
         let mut next_block = self.next_block_to_sync()?;
 
         // Subscribe before the initial sync so a head published while catching
-        // up remains queued in the header stream.
+        // up remains queued in the stream.
         next_block = self.sync_finalized_once(l1_provider, next_block).await?;
 
-        while header_stream.next().await.is_some() {
+        while stream.next().await.is_some() {
             next_block = self.sync_finalized_once(l1_provider, next_block).await?;
         }
 

--- a/crates/l1/src/subscriber.rs
+++ b/crates/l1/src/subscriber.rs
@@ -385,29 +385,11 @@ pub struct L1SubscriberConfig {
     pub retain_portal_evidence: bool,
 }
 
-pub(crate) trait LocalTempoCheckpointReader: Send + Sync {
-    fn latest_tempo_checkpoint(&self) -> eyre::Result<NumHash>;
-}
-
-struct ProviderLocalTempoCheckpointReader<P> {
-    provider: P,
-}
-
-impl<P> LocalTempoCheckpointReader for ProviderLocalTempoCheckpointReader<P>
-where
-    P: StateProviderFactory + Clone + Send + Sync + 'static,
-{
-    fn latest_tempo_checkpoint(&self) -> eyre::Result<NumHash> {
-        let state = self.provider.latest()?;
-        Ok(state.tempo_num_hash()?)
-    }
-}
-
 /// L1 chain subscriber that listens for new blocks and extracts deposit events.
 #[derive(Clone)]
-pub struct L1Subscriber {
+pub struct L1Subscriber<P> {
     pub(crate) config: L1SubscriberConfig,
-    pub(crate) local_state: Arc<dyn LocalTempoCheckpointReader>,
+    pub(crate) provider: P,
     /// Finalized L1 blocks retained until a Zone consumer processes them.
     pub(crate) deposit_queue: DepositQueue,
     /// L1 subscriber metrics for connection health, backfill, and event ingestion.
@@ -445,21 +427,15 @@ impl L1SubscriberError {
 
 type HeaderStream = Pin<Box<dyn Stream<Item = ()> + Send>>;
 
-impl L1Subscriber {
+impl<P> L1Subscriber<P>
+where
+    P: StateProviderFactory + Sync,
+{
     /// Create an L1 subscriber.
-    pub fn new<P>(
-        config: L1SubscriberConfig,
-        local_state_provider: P,
-        deposit_queue: DepositQueue,
-    ) -> Self
-    where
-        P: StateProviderFactory + Clone + Send + Sync + 'static,
-    {
+    pub fn new(config: L1SubscriberConfig, provider: P, deposit_queue: DepositQueue) -> Self {
         Self {
             config,
-            local_state: Arc::new(ProviderLocalTempoCheckpointReader {
-                provider: local_state_provider,
-            }),
+            provider,
             deposit_queue,
             subscriber_metrics: Default::default(),
         }
@@ -529,7 +505,8 @@ impl L1Subscriber {
     /// where ingestion resumes. A non-zero hash distinguishes an L1-anchored
     /// block-zero genesis from the unanchored template.
     pub(crate) fn resolve_start_block(&self) -> Result<u64, L1SubscriberError> {
-        let local_checkpoint = self.local_state.latest_tempo_checkpoint()?;
+        let state = self.provider.latest().map_err(eyre::Report::from)?;
+        let local_checkpoint = state.tempo_num_hash().map_err(eyre::Report::from)?;
         if local_checkpoint.hash == B256::ZERO {
             return Err(eyre::eyre!("zone genesis is not anchored to an L1 block").into());
         }

--- a/crates/l1/src/tests.rs
+++ b/crates/l1/src/tests.rs
@@ -148,17 +148,17 @@ fn test_subscriber_with_checkpoint(checkpoint: NumHash) -> L1Subscriber<MockEthP
         config: L1SubscriberConfig {
             l1_rpc_url: "http://127.0.0.1:8545".to_owned(),
             portal_address,
-            enabled_tokens: crate::state::EnabledTokenRegistry::default(),
-            l1_state_cache: crate::L1StateCache::new(),
-            block_tracker: L1BlockTracker::default(),
             l1_fetch_concurrency: 1,
             retry_connection_interval: Duration::from_secs(1),
-            leadership_sink: None,
-            encryption_keys: None,
             retain_portal_evidence: false,
         },
         provider,
         deposit_queue: DepositQueue::default(),
+        enabled_tokens: crate::state::EnabledTokenRegistry::default(),
+        l1_state_cache: crate::L1StateCache::new(),
+        block_tracker: L1BlockTracker::default(),
+        leadership_sink: None,
+        encryption_keys: None,
         subscriber_metrics: Default::default(),
     }
 }
@@ -389,23 +389,22 @@ fn subscriber_applies_state_and_records_observation() {
     let cached_value = B256::with_last_byte(2);
 
     {
-        let mut cache = subscriber.config.l1_state_cache.lock();
+        let mut cache = subscriber.l1_state_cache.lock();
         cache.invalidate_and_set_anchor(9, []);
         cache.set(cached_address, cached_slot, 9, cached_value);
     }
     subscriber.update_l1_state_anchor(10, &HashSet::new());
-    subscriber.config.block_tracker.record(anchor).unwrap();
+    subscriber.block_tracker.record(anchor).unwrap();
 
     assert_eq!(
         subscriber
-            .config
             .l1_state_cache
             .lock()
             .get(cached_address, cached_slot, 10),
         Some(cached_value)
     );
     assert_eq!(
-        subscriber.config.block_tracker.observed_hash(10),
+        subscriber.block_tracker.observed_hash(10),
         Some(anchor.hash)
     );
 }
@@ -675,17 +674,14 @@ fn update_l1_state_anchor_applies_raw_mutations_before_publishing_coverage() {
     let stable_slot = B256::with_last_byte(3);
     let stable_value = B256::with_last_byte(4);
     subscriber
-        .config
         .l1_state_cache
         .lock()
         .invalidate_and_set_anchor(9, []);
     subscriber
-        .config
         .l1_state_cache
         .lock()
         .set(TIP403_REGISTRY_ADDRESS, slot, 10, value);
     subscriber
-        .config
         .l1_state_cache
         .lock()
         .set(stable_account, stable_slot, 10, stable_value);
@@ -693,7 +689,6 @@ fn update_l1_state_anchor_applies_raw_mutations_before_publishing_coverage() {
     subscriber.update_l1_state_anchor(10, &HashSet::new());
     assert_eq!(
         subscriber
-            .config
             .l1_state_cache
             .lock()
             .get(TIP403_REGISTRY_ADDRESS, slot, 10),
@@ -701,7 +696,7 @@ fn update_l1_state_anchor_applies_raw_mutations_before_publishing_coverage() {
     );
 
     subscriber.update_l1_state_anchor(11, &HashSet::from([TIP403_REGISTRY_ADDRESS]));
-    let mut cache = subscriber.config.l1_state_cache.lock();
+    let mut cache = subscriber.l1_state_cache.lock();
     assert_eq!(
         cache.get(stable_account, stable_slot, 11),
         Some(stable_value)
@@ -787,7 +782,7 @@ async fn test_follow_finalized_uses_new_heads_to_sync_missing_finalized_range() 
         vec![10, 11, 12]
     );
     assert_eq!(
-        subscriber.config.block_tracker.observed_hash(12),
+        subscriber.block_tracker.observed_hash(12),
         Some(anchor_12.hash),
         "a queue-backed subscriber must retain observations until its consumer prunes them"
     );
@@ -893,7 +888,7 @@ fn confirmed_token_enabled_event_updates_registry() {
 
     subscriber.apply_enabled_token_events(&events);
 
-    assert!(subscriber.config.enabled_tokens.read().contains(&token));
+    assert!(subscriber.enabled_tokens.read().contains(&token));
 }
 
 #[test]
@@ -1682,7 +1677,7 @@ fn pause_events_invalidate_cached_portal_storage() {
     let account = address!("0x0000000000000000000000000000000000000123");
     let pause_slot = B256::with_last_byte(25);
     {
-        let mut cache = subscriber.config.l1_state_cache.lock();
+        let mut cache = subscriber.l1_state_cache.lock();
         cache.set(portal, pause_slot, 0, B256::with_last_byte(0x42));
     }
     let logs = vec![
@@ -1711,11 +1706,7 @@ fn pause_events_invalidate_cached_portal_storage() {
     assert!(invalidated.contains(&portal));
     subscriber.update_l1_state_anchor(1, &invalidated);
     assert_eq!(
-        subscriber
-            .config
-            .l1_state_cache
-            .lock()
-            .get(portal, pause_slot, 1),
+        subscriber.l1_state_cache.lock().get(portal, pause_slot, 1),
         None
     );
 }
@@ -1752,7 +1743,7 @@ async fn sync_classifies_corrupt_recognized_portal_log_as_fatal() {
         }
     ));
     assert_eq!(queue.last_enqueued(), None);
-    assert_eq!(subscriber.config.block_tracker.latest(), None);
+    assert_eq!(subscriber.block_tracker.latest(), None);
 }
 
 #[test]
@@ -1790,7 +1781,7 @@ async fn sync_applies_leadership_transition_before_enqueueing_the_activation_blo
         seen: parking_lot::Mutex::new(Vec::new()),
         fail: false,
     });
-    subscriber.config.leadership_sink = Some(sink.clone());
+    subscriber.leadership_sink = Some(sink.clone());
 
     let new_leader = address!("0x0000000000000000000000000000000000002222");
     let log = leader_updated_log(portal, Address::ZERO, new_leader, 2, 10);
@@ -1832,7 +1823,7 @@ async fn sync_fails_fatally_when_the_leadership_sink_rejects_the_transition() {
     let mut subscriber = test_subscriber(9);
     let portal = subscriber.config.portal_address;
     let queue = subscriber.deposit_queue.clone();
-    subscriber.config.leadership_sink = Some(Arc::new(RecordingLeadershipSink {
+    subscriber.leadership_sink = Some(Arc::new(RecordingLeadershipSink {
         queue: queue.clone(),
         seen: parking_lot::Mutex::new(Vec::new()),
         fail: true,
@@ -1867,5 +1858,5 @@ async fn sync_fails_fatally_when_the_leadership_sink_rejects_the_transition() {
 
     // Nothing was enqueued and no observation advanced: the block was not half-applied.
     assert_eq!(queue.last_enqueued(), None);
-    assert_eq!(subscriber.config.block_tracker.latest(), None);
+    assert_eq!(subscriber.block_tracker.latest(), None);
 }

--- a/crates/l1/src/tests.rs
+++ b/crates/l1/src/tests.rs
@@ -783,7 +783,7 @@ async fn test_follow_finalized_uses_new_heads_to_sync_missing_finalized_range() 
     push_header_and_empty_receipts(&asserter, header_12);
 
     let err = subscriber
-        .follow_finalized(&l1_provider, futures::stream::iter([()]))
+        .follow_finalized(&l1_provider, Box::pin(futures::stream::iter([()])))
         .await
         .expect_err("finite header stream should end the subscriber");
     assert!(err.to_string().contains("head notification stream ended"));

--- a/crates/l1/src/tests.rs
+++ b/crates/l1/src/tests.rs
@@ -5,11 +5,9 @@ use alloy_primitives::{Bloom, Bytes, address};
 use alloy_rpc_types_eth::{Header as RpcHeader, TransactionReceipt};
 use alloy_sol_types::SolEvent;
 use alloy_transport::mock::Asserter;
+use reth_provider::test_utils::{ExtendedAccount, MockEthProvider};
 use serde::Deserialize;
-use std::{
-    collections::{HashSet, VecDeque},
-    time::Duration,
-};
+use std::{collections::HashSet, time::Duration};
 use tempo_alloy::rpc::{TempoHeaderResponse, TempoTransactionReceipt};
 use tempo_contracts::precompiles::TIP403_REGISTRY_ADDRESS;
 use tempo_primitives::{TempoReceipt, TempoTxType};
@@ -123,42 +121,28 @@ fn make_withdrawal_bounce_back(amount: u128) -> L1Deposit {
     })
 }
 
-struct SequenceLocalTempoCheckpointReader {
-    values: Mutex<VecDeque<NumHash>>,
-    last_value: NumHash,
+fn set_tempo_checkpoint(provider: &MockEthProvider, checkpoint: NumHash) {
+    provider.add_account(
+        crate::abi::TEMPO_STATE_ADDRESS,
+        ExtendedAccount::new(0, U256::ZERO).extend_storage([
+            (
+                B256::from(
+                    crate::precompiles::tempo_state::slots::TEMPO_BLOCK_NUMBER.to_be_bytes(),
+                ),
+                U256::from(checkpoint.number),
+            ),
+            (
+                B256::from(crate::precompiles::tempo_state::slots::TEMPO_BLOCK_HASH.to_be_bytes()),
+                U256::from_be_slice(checkpoint.hash.as_slice()),
+            ),
+        ]),
+    );
 }
 
-impl SequenceLocalTempoCheckpointReader {
-    fn new(values: impl Into<VecDeque<u64>>) -> Self {
-        let values = values
-            .into()
-            .into_iter()
-            .map(|number| NumHash::new(number, B256::with_last_byte(1)))
-            .collect::<VecDeque<_>>();
-        let last_value = values.back().copied().unwrap_or_default();
-        Self {
-            values: Mutex::new(values),
-            last_value,
-        }
-    }
-
-    fn unanchored() -> Self {
-        Self {
-            values: Mutex::new(VecDeque::from([NumHash::default()])),
-            last_value: NumHash::default(),
-        }
-    }
-}
-
-impl LocalTempoCheckpointReader for SequenceLocalTempoCheckpointReader {
-    fn latest_tempo_checkpoint(&self) -> eyre::Result<NumHash> {
-        let mut values = self.values.lock();
-        Ok(values.pop_front().unwrap_or(self.last_value))
-    }
-}
-
-fn test_subscriber(local_state: Arc<dyn LocalTempoCheckpointReader>) -> L1Subscriber {
+fn test_subscriber_with_checkpoint(checkpoint: NumHash) -> L1Subscriber<MockEthProvider> {
     let portal_address = address!("0x0000000000000000000000000000000000000ABC");
+    let provider = MockEthProvider::new();
+    set_tempo_checkpoint(&provider, checkpoint);
 
     L1Subscriber {
         config: L1SubscriberConfig {
@@ -173,10 +157,14 @@ fn test_subscriber(local_state: Arc<dyn LocalTempoCheckpointReader>) -> L1Subscr
             encryption_keys: None,
             retain_portal_evidence: false,
         },
-        local_state,
+        provider,
         deposit_queue: DepositQueue::default(),
         subscriber_metrics: Default::default(),
     }
+}
+
+fn test_subscriber(block_number: u64) -> L1Subscriber<MockEthProvider> {
+    test_subscriber_with_checkpoint(NumHash::new(block_number, B256::with_last_byte(1)))
 }
 
 #[tokio::test]
@@ -392,7 +380,7 @@ fn l1_block_tracker_rejects_first_observation_above_persisted_successor() {
 
 #[test]
 fn subscriber_applies_state_and_records_observation() {
-    let subscriber = test_subscriber(Arc::new(SequenceLocalTempoCheckpointReader::new([9])));
+    let subscriber = test_subscriber(9);
     let header = make_test_header(10);
     let sealed = seal(header);
     let anchor = sealed.num_hash();
@@ -680,7 +668,7 @@ fn assert_tempo_header_rejected(input: &[u8]) {
 
 #[test]
 fn update_l1_state_anchor_applies_raw_mutations_before_publishing_coverage() {
-    let subscriber = test_subscriber(Arc::new(SequenceLocalTempoCheckpointReader::new([0])));
+    let subscriber = test_subscriber(0);
     let slot = B256::with_last_byte(1);
     let value = B256::with_last_byte(2);
     let stable_account = address!("0x0000000000000000000000000000000000000ABC");
@@ -735,22 +723,24 @@ fn deposit_hash_chain(previous_hash: B256, deposits: &[L1Deposit]) -> B256 {
 
 #[test]
 fn test_resolve_start_block_reads_live_local_state_each_time() {
-    let subscriber = test_subscriber(Arc::new(SequenceLocalTempoCheckpointReader::new(
-        VecDeque::from([10, 11]),
-    )));
+    let subscriber = test_subscriber(10);
     assert_eq!(subscriber.resolve_start_block().unwrap(), 11);
+    set_tempo_checkpoint(
+        &subscriber.provider,
+        NumHash::new(11, B256::with_last_byte(1)),
+    );
     assert_eq!(subscriber.resolve_start_block().unwrap(), 12);
 }
 
 #[test]
 fn test_resolve_start_block_accepts_block_zero_with_nonzero_hash() {
-    let subscriber = test_subscriber(Arc::new(SequenceLocalTempoCheckpointReader::new([0])));
+    let subscriber = test_subscriber(0);
     assert_eq!(subscriber.resolve_start_block().unwrap(), 1);
 }
 
 #[test]
 fn test_resolve_start_block_rejects_unanchored_genesis() {
-    let subscriber = test_subscriber(Arc::new(SequenceLocalTempoCheckpointReader::unanchored()));
+    let subscriber = test_subscriber_with_checkpoint(NumHash::default());
     assert!(
         subscriber
             .resolve_start_block()
@@ -762,7 +752,7 @@ fn test_resolve_start_block_rejects_unanchored_genesis() {
 
 #[tokio::test]
 async fn test_follow_finalized_uses_new_heads_to_sync_missing_finalized_range() {
-    let subscriber = test_subscriber(Arc::new(SequenceLocalTempoCheckpointReader::new([9])));
+    let subscriber = test_subscriber(9);
     let asserter = Asserter::new();
     let l1_provider =
         ProviderBuilder::new_with_network::<TempoNetwork>().connect_mocked_client(asserter.clone());
@@ -806,7 +796,7 @@ async fn test_follow_finalized_uses_new_heads_to_sync_missing_finalized_range() 
 
 #[tokio::test]
 async fn test_subscribe_block_headers_falls_back_to_http_block_filter() {
-    let subscriber = test_subscriber(Arc::new(SequenceLocalTempoCheckpointReader::new([10])));
+    let subscriber = test_subscriber(10);
     let asserter = Asserter::new();
     let l1_provider = ProviderBuilder::new_with_network::<TempoNetwork>()
         .connect_mocked_client(asserter.clone())
@@ -829,7 +819,7 @@ async fn test_subscribe_block_headers_falls_back_to_http_block_filter() {
 
 #[tokio::test]
 async fn test_sync_finalized_once_does_not_refetch_current_cursor() {
-    let subscriber = test_subscriber(Arc::new(SequenceLocalTempoCheckpointReader::new([10])));
+    let subscriber = test_subscriber(10);
     let asserter = Asserter::new();
     let l1_provider =
         ProviderBuilder::new_with_network::<TempoNetwork>().connect_mocked_client(asserter.clone());
@@ -889,7 +879,7 @@ fn test_push_log_decodes_withdrawal_bounce_back() {
 
 #[test]
 fn confirmed_token_enabled_event_updates_registry() {
-    let subscriber = test_subscriber(Arc::new(SequenceLocalTempoCheckpointReader::new([0])));
+    let subscriber = test_subscriber(0);
     let token = address!("0x20c0000000000000000000000000000000000001");
     let events = L1PortalEvents {
         enabled_tokens: vec![EnabledToken {
@@ -1653,7 +1643,7 @@ fn corrupt_recognized_portal_log(portal: Address) -> Log {
 
 #[test]
 fn extract_events_fails_closed_on_corrupt_recognized_portal_log() {
-    let mut subscriber = test_subscriber(Arc::new(SequenceLocalTempoCheckpointReader::new([9])));
+    let mut subscriber = test_subscriber(9);
     subscriber.config.retain_portal_evidence = true;
     let portal = subscriber.config.portal_address;
 
@@ -1687,7 +1677,7 @@ fn extract_events_fails_closed_on_corrupt_recognized_portal_log() {
 
 #[test]
 fn pause_events_invalidate_cached_portal_storage() {
-    let subscriber = test_subscriber(Arc::new(SequenceLocalTempoCheckpointReader::new([9])));
+    let subscriber = test_subscriber(9);
     let portal = subscriber.config.portal_address;
     let account = address!("0x0000000000000000000000000000000000000123");
     let pause_slot = B256::with_last_byte(25);
@@ -1732,7 +1722,7 @@ fn pause_events_invalidate_cached_portal_storage() {
 
 #[tokio::test]
 async fn sync_classifies_corrupt_recognized_portal_log_as_fatal() {
-    let subscriber = test_subscriber(Arc::new(SequenceLocalTempoCheckpointReader::new([9])));
+    let subscriber = test_subscriber(9);
     let portal = subscriber.config.portal_address;
     let queue = subscriber.deposit_queue.clone();
 
@@ -1792,7 +1782,7 @@ impl LeadershipSink for RecordingLeadershipSink {
 
 #[tokio::test]
 async fn sync_applies_leadership_transition_before_enqueueing_the_activation_block() {
-    let mut subscriber = test_subscriber(Arc::new(SequenceLocalTempoCheckpointReader::new([9])));
+    let mut subscriber = test_subscriber(9);
     let portal = subscriber.config.portal_address;
     let queue = subscriber.deposit_queue.clone();
     let sink = Arc::new(RecordingLeadershipSink {
@@ -1839,7 +1829,7 @@ async fn sync_applies_leadership_transition_before_enqueueing_the_activation_blo
 
 #[tokio::test]
 async fn sync_fails_fatally_when_the_leadership_sink_rejects_the_transition() {
-    let mut subscriber = test_subscriber(Arc::new(SequenceLocalTempoCheckpointReader::new([9])));
+    let mut subscriber = test_subscriber(9);
     let portal = subscriber.config.portal_address;
     let queue = subscriber.deposit_queue.clone();
     subscriber.config.leadership_sink = Some(Arc::new(RecordingLeadershipSink {

--- a/crates/l1/src/tests.rs
+++ b/crates/l1/src/tests.rs
@@ -783,12 +783,9 @@ async fn test_follow_finalized_uses_new_heads_to_sync_missing_finalized_range() 
     push_header_and_empty_receipts(&asserter, header_12);
 
     let err = subscriber
-        .follow_finalized(
-            &l1_provider,
-            futures::stream::iter([Ok::<_, eyre::Report>(())]),
-        )
+        .follow_finalized(&l1_provider, futures::stream::iter([()]))
         .await
-        .expect_err("finite trigger stream should end the subscriber");
+        .expect_err("finite header stream should end the subscriber");
     assert!(err.to_string().contains("head notification stream ended"));
 
     let blocks = subscriber.deposit_queue.drain();
@@ -808,7 +805,7 @@ async fn test_follow_finalized_uses_new_heads_to_sync_missing_finalized_range() 
 }
 
 #[tokio::test]
-async fn test_head_triggers_falls_back_to_http_block_filter() {
+async fn test_subscribe_block_headers_falls_back_to_http_block_filter() {
     let subscriber = test_subscriber(Arc::new(SequenceLocalTempoCheckpointReader::new([10])));
     let asserter = Asserter::new();
     let l1_provider = ProviderBuilder::new_with_network::<TempoNetwork>()
@@ -818,13 +815,15 @@ async fn test_head_triggers_falls_back_to_http_block_filter() {
     asserter.push_success(&U256::from(1));
     asserter.push_success(&vec![B256::with_last_byte(1)]);
 
-    let mut triggers = subscriber.head_triggers(&l1_provider).await.unwrap();
-    let trigger = tokio::time::timeout(Duration::from_secs(2), triggers.next())
+    let mut header_stream = subscriber
+        .subscribe_block_headers(&l1_provider)
         .await
-        .expect("HTTP block filter should emit a trigger")
+        .unwrap();
+    tokio::time::timeout(Duration::from_secs(2), header_stream.next())
+        .await
+        .expect("HTTP block filter should emit a header notification")
         .expect("HTTP block filter stream should remain open");
 
-    trigger.expect("HTTP block filter request should succeed");
     assert!(asserter.read_q().is_empty());
 }
 

--- a/crates/l1/src/tests.rs
+++ b/crates/l1/src/tests.rs
@@ -141,8 +141,8 @@ fn set_tempo_checkpoint(provider: &MockEthProvider, checkpoint: NumHash) {
 
 fn test_subscriber_with_checkpoint(checkpoint: NumHash) -> L1Subscriber<MockEthProvider> {
     let portal_address = address!("0x0000000000000000000000000000000000000ABC");
-    let provider = MockEthProvider::new();
-    set_tempo_checkpoint(&provider, checkpoint);
+    let zone_provider = MockEthProvider::new();
+    set_tempo_checkpoint(&zone_provider, checkpoint);
 
     L1Subscriber {
         config: L1SubscriberConfig {
@@ -152,7 +152,7 @@ fn test_subscriber_with_checkpoint(checkpoint: NumHash) -> L1Subscriber<MockEthP
             retry_connection_interval: Duration::from_secs(1),
             retain_portal_evidence: false,
         },
-        provider,
+        zone_provider,
         deposit_queue: DepositQueue::default(),
         enabled_tokens: crate::state::EnabledTokenRegistry::default(),
         l1_state_cache: crate::L1StateCache::new(),
@@ -721,7 +721,7 @@ fn test_resolve_start_block_reads_live_local_state_each_time() {
     let subscriber = test_subscriber(10);
     assert_eq!(subscriber.resolve_start_block().unwrap(), 11);
     set_tempo_checkpoint(
-        &subscriber.provider,
+        &subscriber.zone_provider,
         NumHash::new(11, B256::with_last_byte(1)),
     );
     assert_eq!(subscriber.resolve_start_block().unwrap(), 12);

--- a/crates/l1/src/tests.rs
+++ b/crates/l1/src/tests.rs
@@ -1,5 +1,5 @@
 use super::*;
-use crate::{abi::DepositType, subscriber::is_fenced_ingestion_error};
+use crate::{abi::DepositType, subscriber::L1SubscriberError};
 use alloy_consensus::{Header, ReceiptWithBloom};
 use alloy_primitives::{Bloom, Bytes, address};
 use alloy_rpc_types_eth::{Header as RpcHeader, TransactionReceipt};
@@ -1658,7 +1658,7 @@ fn extract_events_fails_closed_on_corrupt_recognized_portal_log() {
     subscriber.config.retain_portal_evidence = true;
     let portal = subscriber.config.portal_address;
 
-    // A recognized topic0 with garbage payload must fence the whole block, never be skipped.
+    // A recognized topic0 with garbage payload must reject the whole block, never be skipped.
     let corrupt = corrupt_recognized_portal_log(portal);
     let receipt = make_receipt_with_logs(10, B256::with_last_byte(0x10), vec![corrupt]);
 
@@ -1668,7 +1668,7 @@ fn extract_events_fails_closed_on_corrupt_recognized_portal_log() {
             .contains("failed to decode a portal event in L1 block 10")
     );
 
-    // Unknown signatures are still skipped: a pre-upgrade contract event cannot fence us.
+    // Unknown signatures are still skipped: a pre-upgrade contract event cannot reject the block.
     let unknown = Log {
         inner: alloy_primitives::Log {
             address: portal,
@@ -1732,7 +1732,7 @@ fn pause_events_invalidate_cached_portal_storage() {
 }
 
 #[tokio::test]
-async fn sync_classifies_corrupt_recognized_portal_log_as_fenced() {
+async fn sync_classifies_corrupt_recognized_portal_log_as_fatal() {
     let subscriber = test_subscriber(Arc::new(SequenceLocalTempoCheckpointReader::new([9])));
     let portal = subscriber.config.portal_address;
     let queue = subscriber.deposit_queue.clone();
@@ -1754,16 +1754,22 @@ async fn sync_classifies_corrupt_recognized_portal_log_as_fenced() {
         .sync_finalized_once(&l1_provider, 10)
         .await
         .unwrap_err();
-    assert!(is_fenced_ingestion_error(&err));
+    assert!(matches!(
+        err,
+        L1SubscriberError::Fatal {
+            block_number: 10,
+            stage: "portal event decoding",
+            ..
+        }
+    ));
     assert_eq!(queue.last_enqueued(), None);
     assert_eq!(subscriber.config.block_tracker.latest(), None);
 }
 
 #[test]
 fn ordinary_subscriber_errors_remain_retryable() {
-    assert!(!is_fenced_ingestion_error(&eyre::eyre!(
-        "transient L1 RPC failure"
-    )));
+    let error = L1SubscriberError::Other(eyre::eyre!("transient L1 RPC failure"));
+    assert!(error.should_retry());
 }
 
 #[derive(Debug)]
@@ -1833,7 +1839,7 @@ async fn sync_applies_leadership_transition_before_enqueueing_the_activation_blo
 }
 
 #[tokio::test]
-async fn sync_fences_the_block_when_the_leadership_sink_rejects_the_transition() {
+async fn sync_fails_fatally_when_the_leadership_sink_rejects_the_transition() {
     let mut subscriber = test_subscriber(Arc::new(SequenceLocalTempoCheckpointReader::new([9])));
     let portal = subscriber.config.portal_address;
     let queue = subscriber.deposit_queue.clone();
@@ -1861,10 +1867,16 @@ async fn sync_fences_the_block_when_the_leadership_sink_rejects_the_transition()
         .sync_finalized_once(&l1_provider, 10)
         .await
         .unwrap_err();
-    assert!(err.to_string().contains("leadership transition"));
-    assert!(is_fenced_ingestion_error(&err));
+    assert!(matches!(
+        err,
+        L1SubscriberError::Fatal {
+            block_number: 10,
+            stage: "leadership transition application",
+            ..
+        }
+    ));
 
-    // Nothing was enqueued and no observation advanced: the block is fenced, not half-applied.
+    // Nothing was enqueued and no observation advanced: the block was not half-applied.
     assert_eq!(queue.last_enqueued(), None);
     assert_eq!(subscriber.config.block_tracker.latest(), None);
 }

--- a/crates/node/src/node.rs
+++ b/crates/node/src/node.rs
@@ -605,51 +605,53 @@ where
         // snapshot at the local Tempo anchor, and install the transition sink before
         // the subscriber starts so no block is ever consumed ahead of its
         // leadership transition.
-        let mut leadership_sink: Option<Arc<dyn LeadershipSink>> = None;
-        if let Some(p2p) = self.p2p_config.as_ref() {
-            let schedule = p2p.leadership();
-            let snapshot_anchor = tempo_block_number;
-            // Freeze the replay/live boundary before the subscriber starts. Historical identities
-            // may authenticate transitions that were already finalized when this process began,
-            // but must never authorize a leader selected later.
-            let finalized_replay_boundary = async {
-                l1_provider
-                    .get_header_by_number(BlockNumberOrTag::Finalized)
-                    .await
-                    .map_err(|err| {
-                        eyre::eyre!("failed reading finalized L1 replay boundary: {err}")
-                    })?
-                    .map(|header| header.number())
-                    .ok_or_else(|| eyre::eyre!("L1 finalized block is not available"))
-            };
-            let (historical_replay_through, ()) = tokio::try_join!(
-                finalized_replay_boundary,
-                seed_leadership_schedule(
+        let leadership_sink: Option<Arc<dyn LeadershipSink>> =
+            if let Some(p2p) = self.p2p_config.as_ref() {
+                let schedule = p2p.leadership();
+                let snapshot_anchor = tempo_block_number;
+                // Freeze the replay/live boundary before the subscriber starts. Historical identities
+                // may authenticate transitions that were already finalized when this process began,
+                // but must never authorize a leader selected later.
+                let finalized_replay_boundary = async {
+                    l1_provider
+                        .get_header_by_number(BlockNumberOrTag::Finalized)
+                        .await
+                        .map_err(|err| {
+                            eyre::eyre!("failed reading finalized L1 replay boundary: {err}")
+                        })?
+                        .map(|header| header.number())
+                        .ok_or_else(|| eyre::eyre!("L1 finalized block is not available"))
+                };
+                let (historical_replay_through, ()) = tokio::try_join!(
+                    finalized_replay_boundary,
+                    seed_leadership_schedule(
+                        &l1_provider,
+                        self.portal_address,
+                        snapshot_anchor,
+                        p2p.manifest(),
+                        &schedule,
+                    ),
+                )?;
+                // Seed the applied anchor from the persisted checkpoint so it targets the leader
+                // of the next anchor from the very start (and not after the first post-restart block)
+                schedule.record_applied_anchor(snapshot_anchor);
+                install_manifest_forced_recovery(
+                    ctx.node.provider(),
                     &l1_provider,
                     self.portal_address,
                     snapshot_anchor,
                     p2p.manifest(),
                     &schedule,
-                ),
-            )?;
-            // Seed the applied anchor from the persisted checkpoint so it targets the leader
-            // of the next anchor from the very start (and not after the first post-restart block)
-            schedule.record_applied_anchor(snapshot_anchor);
-            install_manifest_forced_recovery(
-                ctx.node.provider(),
-                &l1_provider,
-                self.portal_address,
-                snapshot_anchor,
-                p2p.manifest(),
-                &schedule,
-            )
-            .await?;
-            leadership_sink = Some(Arc::new(ScheduleLeadershipSink {
-                schedule,
-                manifest: p2p.manifest().clone(),
-                historical_replay_through,
-            }));
-        }
+                )
+                .await?;
+                Some(Arc::new(ScheduleLeadershipSink {
+                    schedule,
+                    manifest: p2p.manifest().clone(),
+                    historical_replay_through,
+                }))
+            } else {
+                None
+            };
 
         let l1_subscriber = L1Subscriber::new(
             self.l1_config.clone(),

--- a/crates/node/src/node.rs
+++ b/crates/node/src/node.rs
@@ -637,15 +637,15 @@ where
             }));
         }
 
-        L1Subscriber::spawn(
+        let l1_subscriber = L1Subscriber::new(
             self.l1_config.clone(),
             ctx.node.provider().clone(),
             self.deposit_queue.clone(),
-            ctx.node.task_executor().clone(),
         );
+        let task_executor = ctx.node.task_executor().clone();
+        task_executor.spawn_critical_task("l1-block-subscriber", Box::pin(l1_subscriber.run()));
         info!(target: "reth::cli", "L1 subscriber started with deposit enqueueing");
 
-        let task_executor = ctx.node.task_executor().clone();
         // Start the Commonware network and the long-lived event router
         let sequencer_rpc_slot = Arc::new(std::sync::OnceLock::new());
         let p2p_runtime = if let Some(config) = self.p2p_config.take() {

--- a/crates/node/src/node.rs
+++ b/crates/node/src/node.rs
@@ -225,6 +225,8 @@ pub struct ZoneNode {
     enabled_tokens: EnabledTokenRegistry,
     /// L1 anchors independently observed and applied by the subscriber.
     l1_block_tracker: L1BlockTracker,
+    /// Private encryption keys bound by finalized Portal rotation events.
+    encryption_keys: Option<EncryptionKeyRing>,
     /// Address of the L1 deposit portal contract.
     portal_address: Address,
     /// Number of zone blocks between withdrawal batch boundaries.
@@ -257,13 +259,8 @@ impl ZoneNode {
         let l1_config = L1SubscriberConfig {
             l1_rpc_url: l1_rpc_url.clone(),
             portal_address,
-            enabled_tokens: enabled_tokens.clone(),
-            l1_state_cache: l1_state_cache.clone(),
-            block_tracker: l1_block_tracker.clone(),
             l1_fetch_concurrency,
             retry_connection_interval,
-            leadership_sink: None,
-            encryption_keys: None,
             retain_portal_evidence: false,
         };
 
@@ -281,6 +278,7 @@ impl ZoneNode {
             l1_state_cache,
             enabled_tokens,
             l1_block_tracker,
+            encryption_keys: None,
             portal_address,
             withdrawal_batch_interval_blocks: DEFAULT_WITHDRAWAL_BATCH_INTERVAL_BLOCKS,
             withdrawal_reveal_encryptor: None,
@@ -322,7 +320,6 @@ impl ZoneNode {
         keys: impl IntoIterator<Item = SecretKey>,
     ) -> Self {
         let ring = self
-            .l1_config
             .encryption_keys
             .get_or_insert_with(EncryptionKeyRing::default);
         for key in keys {
@@ -401,7 +398,7 @@ impl ZoneNode {
 
     /// Returns the shared encrypted-deposit key ring, when configured.
     pub fn deposit_decryption_keys(&self) -> Option<EncryptionKeyRing> {
-        self.l1_config.encryption_keys.clone()
+        self.encryption_keys.clone()
     }
 }
 
@@ -430,6 +427,14 @@ where
     deposit_queue: DepositQueue,
     /// Configuration for the L1 event subscriber
     l1_config: L1SubscriberConfig,
+    /// Shared L1 state cache updated by the subscriber.
+    l1_state_cache: L1StateCache,
+    /// Shared registry of tokens enabled for this zone.
+    enabled_tokens: EnabledTokenRegistry,
+    /// L1 anchors independently observed and applied by the subscriber.
+    l1_block_tracker: L1BlockTracker,
+    /// Private encryption keys bound by finalized Portal rotation events.
+    encryption_keys: Option<EncryptionKeyRing>,
     /// ZonePortal address on L1.
     portal_address: Address,
     /// Redacted RPC configuration.
@@ -460,6 +465,10 @@ where
     pub fn new(
         deposit_queue: DepositQueue,
         l1_config: L1SubscriberConfig,
+        l1_state_cache: L1StateCache,
+        enabled_tokens: EnabledTokenRegistry,
+        l1_block_tracker: L1BlockTracker,
+        encryption_keys: Option<EncryptionKeyRing>,
         portal_address: Address,
         redacted_rpc_config: ZoneRedactedRpcConfig,
         sequencer_config: Option<ZoneSequencerAddOnsConfig>,
@@ -477,6 +486,10 @@ where
             ),
             deposit_queue,
             l1_config,
+            l1_state_cache,
+            enabled_tokens,
+            l1_block_tracker,
+            encryption_keys,
             portal_address,
             redacted_rpc_config,
             sequencer_config,
@@ -583,7 +596,7 @@ where
 
         self.resolve_and_seed_tokens(&l1_provider, tempo_block_number)
             .await?;
-        if let Some(keys) = self.l1_config.encryption_keys.clone() {
+        if let Some(keys) = self.encryption_keys.clone() {
             self.resolve_and_seed_encryption_keys(&l1_provider, tempo_block_number, &keys)
                 .await?;
         }
@@ -592,6 +605,7 @@ where
         // snapshot at the local Tempo anchor, and install the transition sink before
         // the subscriber starts so no block is ever consumed ahead of its
         // leadership transition.
+        let mut leadership_sink: Option<Arc<dyn LeadershipSink>> = None;
         if let Some(p2p) = self.p2p_config.as_ref() {
             let schedule = p2p.leadership();
             let snapshot_anchor = tempo_block_number;
@@ -630,7 +644,7 @@ where
                 &schedule,
             )
             .await?;
-            self.l1_config.leadership_sink = Some(Arc::new(ScheduleLeadershipSink {
+            leadership_sink = Some(Arc::new(ScheduleLeadershipSink {
                 schedule,
                 manifest: p2p.manifest().clone(),
                 historical_replay_through,
@@ -641,6 +655,11 @@ where
             self.l1_config.clone(),
             ctx.node.provider().clone(),
             self.deposit_queue.clone(),
+            self.enabled_tokens.clone(),
+            self.l1_state_cache.clone(),
+            self.l1_block_tracker.clone(),
+            leadership_sink,
+            self.encryption_keys.clone(),
         );
         let task_executor = ctx.node.task_executor().clone();
         task_executor.spawn_critical_task("l1-block-subscriber", Box::pin(l1_subscriber.run()));
@@ -662,7 +681,7 @@ where
                         .unwrap_or_default(),
                     self.l1_config.l1_rpc_url.clone(),
                     self.l1_config.retry_connection_interval,
-                    self.l1_config.encryption_keys.clone().unwrap_or_default(),
+                    self.encryption_keys.clone().unwrap_or_default(),
                     &task_executor,
                     &sequencer_rpc_slot,
                 )
@@ -740,7 +759,7 @@ where
             self.l1_config.l1_rpc_url.clone(),
             self.l1_config.retry_connection_interval,
             self.l1_config.portal_address,
-            self.l1_config.enabled_tokens.clone(),
+            self.enabled_tokens.clone(),
             chain_id,
             max_response_size,
         )
@@ -789,9 +808,9 @@ where
                 payload_builder,
                 chain_spec: provider.chain_spec(),
                 deposit_queue: self.deposit_queue.clone(),
-                l1_block_tracker: self.l1_config.block_tracker.clone(),
+                l1_block_tracker: self.l1_block_tracker.clone(),
                 // Follower-only nodes have no private keys and never construct an engine.
-                encryption_keys: self.l1_config.encryption_keys.clone().unwrap_or_default(),
+                encryption_keys: self.encryption_keys.clone().unwrap_or_default(),
                 commands,
                 backfill_commands,
                 attestation,
@@ -1310,7 +1329,7 @@ where
             "Discovered enabled tokens from L1"
         );
 
-        let mut registry = self.l1_config.enabled_tokens.write();
+        let mut registry = self.enabled_tokens.write();
         registry.clear();
         registry.extend(enabled_tokens);
         Ok(())
@@ -1392,11 +1411,10 @@ where
             ctx.beacon_engine_handle.clone(),
             ctx.node.payload_builder_handle().clone(),
             self.deposit_queue.clone(),
-            self.l1_config.block_tracker.clone(),
+            self.l1_block_tracker.clone(),
             last_header,
             fee_recipient,
-            self.l1_config
-                .encryption_keys
+            self.encryption_keys
                 .clone()
                 .expect("sequencer mode configures deposit decryption keys"),
             self.portal_address,
@@ -1593,6 +1611,10 @@ where
         ZoneAddOns::new(
             self.deposit_queue.clone(),
             self.l1_config.clone(),
+            self.l1_state_cache.clone(),
+            self.enabled_tokens.clone(),
+            self.l1_block_tracker.clone(),
+            self.encryption_keys.clone(),
             self.portal_address,
             self.redacted_rpc_config.clone(),
             self.sequencer_config.clone(),


### PR DESCRIPTION
This PR simplifies the L1 subscriber's state ownership and makes the ingestion path easier to follow.

Previously, `L1SubscriberConfig` mixed durable settings with runtime objects such as caches, key state, and the block tracker. The subscriber also erased its local state provider behind a custom checkpoint-reader trait. This obscured where the persisted Zone checkpoint came from and made configuration responsible for mutable runtime state.

The subscriber is now generic over the existing `StateProviderFactory` and reads the latest persisted checkpoint directly from that provider.

```rust
pub struct L1Subscriber<P> {
    config: L1SubscriberConfig,
    provider: P,
    // --snip--
}
```

Runtime dependencies are now explicit subscriber fields, while `L1SubscriberConfig` contains only actual settings.

```rust
pub struct L1SubscriberConfig {
    pub l1_rpc_url: String,
    pub portal_address: Address,
    pub l1_fetch_concurrency: usize,
    pub retry_connection_interval: Duration,
    pub retain_portal_evidence: bool,
}
```

