### PR TITLE
feat(prover): support multiple embedded genesis files

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -14,17 +14,20 @@ on:
         description: "Tag nightly"
         type: boolean
         default: false
-      tempo_genesis_url:
-        description: "Tempo genesis JSON URL to embed in the prover image"
+      tempo_genesis_urls:
+        description: "Newline-separated Tempo genesis JSON URLs to embed in the prover image"
         type: string
         default: "https://devnet-assets.tempoxyz.dev/tempo-devnet-nextfork.json"
   workflow_call:
     inputs:
-      tempo_genesis_url:
-        description: "Tempo genesis JSON URL to embed in the prover image"
+      tempo_genesis_urls:
+        description: "Newline-separated Tempo genesis JSON URLs to embed in the prover image"
         required: false
         type: string
-        default: "https://devnet-assets.tempoxyz.dev/tempo-devnet-nextfork.json"
+      tempo_genesis_url:
+        description: "Deprecated single Tempo genesis JSON URL to embed in the prover image"
+        required: false
+        type: string
   schedule:
     - cron: "5 9 * * *"
     - cron: "30 20 * * *"
@@ -34,7 +37,7 @@ permissions:
 
 env:
   REGISTRY: ghcr.io/tempoxyz
-  TEMPO_DEVNET_GENESIS_URL: ${{ inputs.tempo_genesis_url || 'https://devnet-assets.tempoxyz.dev/tempo-devnet-nextfork.json' }}
+  TEMPO_DEVNET_GENESIS_URLS: ${{ inputs.tempo_genesis_urls || inputs.tempo_genesis_url || 'https://devnet-assets.tempoxyz.dev/tempo-devnet-nextfork.json' }}
 
 jobs:
   build-and-push:
@@ -128,16 +131,28 @@ jobs:
         run: |
           set -euo pipefail
 
+          rm -rf .tempo-genesis
           mkdir -p .tempo-genesis
-          curl --proto '=https' --tlsv1.2 \
-            --fail-with-body --location \
-            --output .tempo-genesis/genesis.json \
-            "$TEMPO_DEVNET_GENESIS_URL"
-          jq -e '.config.chainId | type == "number"' \
-            .tempo-genesis/genesis.json >/dev/null
 
-          genesis_sha=$(sha256sum .tempo-genesis/genesis.json | cut -d' ' -f1)
-          echo "Embedding Tempo devnet genesis sha256:${genesis_sha}"
+          mapfile -t genesis_urls < <(
+            printf '%s\n' "$TEMPO_DEVNET_GENESIS_URLS" |
+              sed 's/^[[:space:]]*//; s/[[:space:]]*$//; /^[[:space:]]*$/d'
+          )
+          ((${#genesis_urls[@]} > 0)) || {
+            echo "At least one Tempo genesis URL is required" >&2
+            exit 1
+          }
+
+          for index in "${!genesis_urls[@]}"; do
+            genesis_file=".tempo-genesis/genesis-${index}.json"
+            curl --proto '=https' --tlsv1.2 \
+              --fail-with-body --location \
+              --output "$genesis_file" \
+              "${genesis_urls[$index]}"
+            chain_id=$(jq -er '.config.chainId | numbers' "$genesis_file")
+            genesis_sha=$(sha256sum "$genesis_file" | cut -d' ' -f1)
+            echo "Embedding Tempo genesis for chain ${chain_id} sha256:${genesis_sha}"
+          done
 
       - name: Build and push Docker images
         uses: depot/bake-action@1d58c2668346981089b088b7ef36755b206b20e9 # v1.13.0

--- a/bin/prover/enclave/README.md
+++ b/bin/prover/enclave/README.md
@@ -50,8 +50,9 @@ docker buildx bake \
   tempo-zone-prover-enclave
 ```
 
-CI supplies the downloaded devnet genesis as a named build context. The enclave payload stores it
-in `/etc/tempo/genesis/` and passes that directory to the prover explicitly through the image
+CI accepts one Tempo genesis URL per line through the `tempo_genesis_urls` workflow input and
+supplies the downloaded files as a named build context. The enclave payload stores them in
+`/etc/tempo/genesis/` and passes that directory to the prover explicitly through the image
 entrypoint.
 
 Convert the payload to an EIF with the repository's pinned Nitro CLI builder image, then build the


### PR DESCRIPTION
## Summary

- accept one Tempo genesis URL per line in the prover Docker workflow
- download, validate, and embed every configured genesis with deterministic filenames
- preserve the previous single-URL reusable-workflow input for compatibility

## Validation

- parsed `.github/workflows/docker.yml` with PyYAML
- checked the download script with `bash -n`
- ran the download script against a two-genesis mock and verified both outputs
- ran `git diff --check`

Prompted by: @rkrasiuk