### PR TITLE
ci: switch to first-party actions from tempoxyz/gh-actions

### DIFF
--- a/.github/workflows/contracts.yml
+++ b/.github/workflows/contracts.yml
@@ -257,6 +257,6 @@ jobs:
     timeout-minutes: 5
     steps:
       - name: Decide whether the needed jobs succeeded or failed
-        uses: re-actors/alls-green@05ac9388f0aebcb5727afa17fcccfecd6f8ec5fe # v1.2.2
+        uses: tempoxyz/gh-actions/actions/check-needs@ab45d76f6e7420a094281a22aee1973ecc0754f8
         with:
           jobs: ${{ toJSON(needs) }}

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -30,6 +30,6 @@ jobs:
     timeout-minutes: 30
     steps:
       - name: Decide whether the needed jobs succeeded or failed
-        uses: re-actors/alls-green@05ac9388f0aebcb5727afa17fcccfecd6f8ec5fe # v1.2.2
+        uses: tempoxyz/gh-actions/actions/check-needs@ab45d76f6e7420a094281a22aee1973ecc0754f8
         with:
           jobs: ${{ toJSON(needs) }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -155,6 +155,6 @@ jobs:
     timeout-minutes: 30
     steps:
       - name: Decide whether the needed jobs succeeded or failed
-        uses: re-actors/alls-green@05ac9388f0aebcb5727afa17fcccfecd6f8ec5fe # v1.2.2
+        uses: tempoxyz/gh-actions/actions/check-needs@ab45d76f6e7420a094281a22aee1973ecc0754f8
         with:
           jobs: ${{ toJSON(needs) }}


### PR DESCRIPTION
## Summary

Switches this repository's workflows from third-party actions to the equivalent first-party composites in [tempoxyz/gh-actions](https://github.com/tempoxyz/gh-actions), pinned to a full commit SHA. Inputs and outputs are unchanged unless noted below.

| Before | After |
| --- | --- |
| `re-actors/alls-green` | [`tempoxyz/gh-actions/actions/check-needs`](https://github.com/tempoxyz/gh-actions/tree/ab45d76f6e7420a094281a22aee1973ecc0754f8/actions/check-needs) |

## Verification

- `actionlint` and `zizmor` (regular persona, offline) report no new findings after the change (actionlint 0 -> 0, zizmor 15 -> 15).
