### PR TITLE
chore(ci): add Cargo dependency cooldown

### DIFF
--- a/.github/workflows/cargo-cooldown.yml
+++ b/.github/workflows/cargo-cooldown.yml
@@ -1,0 +1,25 @@
+name: Cargo dependency cooldown
+
+on:
+  workflow_call:
+
+permissions:
+  contents: read
+
+jobs:
+  check:
+    name: Reject newly published crates
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
+
+      - name: Install Rust toolchain
+        uses: tempoxyz/gh-actions/vendor/dtolnay/rust-toolchain@3151fd5acf3a3a6158b550d2644d5a8fd51f0ba4 # gh-actions#98
+        with:
+          toolchain: stable
+
+      - name: Enforce Cargo dependency cooldown
+        uses: tempoxyz/gh-actions/actions/cargo-cooldown@3151fd5acf3a3a6158b550d2644d5a8fd51f0ba4 # gh-actions#98

--- a/.github/workflows/contracts.yml
+++ b/.github/workflows/contracts.yml
@@ -30,8 +30,14 @@ env:
   FOUNDRY_REF: 6902a96211da7bcc3d9c4d8e97910ac5c9d5d2c6
 
 jobs:
+  cargo-cooldown:
+    permissions:
+      contents: read
+    uses: ./.github/workflows/cargo-cooldown.yml
+
   conformance:
     name: ABI and storage conformance
+    needs: cargo-cooldown
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -37,6 +37,11 @@ env:
   TEMPO_DEVNET_GENESIS_URL: ${{ inputs.tempo_genesis_url || 'https://devnet-assets.tempoxyz.dev/tempo-devnet-nextfork.json' }}
 
 jobs:
+  cargo-cooldown:
+    permissions:
+      contents: read
+    uses: ./.github/workflows/cargo-cooldown.yml
+
   build-and-push:
     name: Build and Push Docker Images
     # Private copies retain PR image builds, but must not publish shared images
@@ -44,6 +49,7 @@ jobs:
     if: >-
       github.repository == 'tempoxyz/zones' ||
       (github.event_name != 'schedule' && github.event_name != 'push')
+    needs: cargo-cooldown
     runs-on: depot-ubuntu-latest-16
     permissions:
       contents: read

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -13,9 +13,15 @@ concurrency:
   cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 jobs:
+  cargo-cooldown:
+    permissions:
+      contents: read
+    uses: ./.github/workflows/cargo-cooldown.yml
+
   rust:
     permissions:
       contents: read
+    needs: cargo-cooldown
     uses: tempoxyz/gh-actions/.github/workflows/rust-lint.yml@98b1081dcf34361b576aca2ab3041772708582ef
     with:
       rust-toolchain: nightly-2026-02-21

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -18,11 +18,17 @@ env:
   RUSTC_WRAPPER: "sccache"
 
 jobs:
+  cargo-cooldown:
+    permissions:
+      contents: read
+    uses: ./.github/workflows/cargo-cooldown.yml
+
   build-test-artifacts:
     name: build test artifacts
     # Keep private-copy PR validation while avoiding a full test run for every
     # hourly mirror update to its main branch.
     if: github.repository == 'tempoxyz/zones' || github.event_name != 'push'
+    needs: cargo-cooldown
     runs-on: depot-ubuntu-latest-16
     timeout-minutes: 30
     permissions:


### PR DESCRIPTION
## Summary

- add a reusable seven-day Cargo dependency cooldown gate
- pin the trial to `tempoxyz/gh-actions#98` commit `3151fd5acf3a3a6158b550d2644d5a8fd51f0ba4`
- require the gate before Rust lint, test artifact, Docker, and contract conformance builds

## Validation

- parsed all workflow YAML files
- `git diff --check`
- `zizmor --pedantic` (no high-severity findings)
- local live index validation attempted; the sandbox could not reach `index.crates.io`, so draft PR CI is the runtime validation

Prompted by: @grandizzy