### PR TITLE
feat: expose latest prover batch metrics

### DIFF
--- a/crates/sequencer/src/metrics.rs
+++ b/crates/sequencer/src/metrics.rs
@@ -62,23 +62,44 @@ pub(crate) struct ProverMetrics {
     /// Encoded witness size for a successfully validated batch candidate.
     pub(crate) witness_bytes: Histogram,
 
+    /// Encoded witness size for the latest successfully validated batch candidate.
+    pub(crate) witness_bytes_last: Gauge,
+
     /// Number of Zone blocks in a successfully validated batch witness.
     pub(crate) batch_size_blocks: Histogram,
+
+    /// Number of Zone blocks in the latest successfully validated batch witness.
+    pub(crate) batch_size_blocks_last: Gauge,
 
     /// Number of deposits in a successfully validated batch witness.
     pub(crate) deposits_per_batch: Histogram,
 
+    /// Number of deposits in the latest successfully validated batch witness.
+    pub(crate) deposits_per_batch_last: Gauge,
+
     /// Number of withdrawals in a successfully validated batch witness.
     pub(crate) withdrawals_per_batch: Histogram,
+
+    /// Number of withdrawals in the latest successfully validated batch witness.
+    pub(crate) withdrawals_per_batch_last: Gauge,
 
     /// Number of user transactions in a successfully validated batch witness.
     pub(crate) transactions_per_batch: Histogram,
 
+    /// Number of user transactions in the latest successfully validated batch witness.
+    pub(crate) transactions_per_batch_last: Gauge,
+
     /// Number of Zone state trie nodes in a successfully validated batch witness.
     pub(crate) zone_state_nodes: Histogram,
 
+    /// Number of Zone state trie nodes in the latest successfully validated batch witness.
+    pub(crate) zone_state_nodes_last: Gauge,
+
     /// Number of Tempo state trie nodes in a successfully validated batch witness.
     pub(crate) tempo_state_nodes: Histogram,
+
+    /// Number of Tempo state trie nodes in the latest successfully validated batch witness.
+    pub(crate) tempo_state_nodes_last: Gauge,
 }
 
 /// Metrics emitted by the withdrawal processor.

--- a/crates/sequencer/src/prover.rs
+++ b/crates/sequencer/src/prover.rs
@@ -201,20 +201,35 @@ pub(crate) fn spawn_shadow_prover<P: ZoneSequencerProvider>(
                 Ok(stats) => {
                     metrics.validation_success_total.increment(1);
                     metrics.witness_bytes.record(stats.witness_bytes as f64);
+                    metrics.witness_bytes_last.set(stats.witness_bytes as f64);
                     metrics.batch_size_blocks.record(stats.blocks as f64);
+                    metrics.batch_size_blocks_last.set(stats.blocks as f64);
                     metrics.deposits_per_batch.record(stats.deposits as f64);
+                    metrics.deposits_per_batch_last.set(stats.deposits as f64);
                     metrics
                         .withdrawals_per_batch
                         .record(stats.withdrawals as f64);
                     metrics
+                        .withdrawals_per_batch_last
+                        .set(stats.withdrawals as f64);
+                    metrics
                         .transactions_per_batch
                         .record(stats.transactions as f64);
+                    metrics
+                        .transactions_per_batch_last
+                        .set(stats.transactions as f64);
                     metrics
                         .zone_state_nodes
                         .record(stats.zone_state_nodes as f64);
                     metrics
+                        .zone_state_nodes_last
+                        .set(stats.zone_state_nodes as f64);
+                    metrics
                         .tempo_state_nodes
                         .record(stats.tempo_state_nodes as f64);
+                    metrics
+                        .tempo_state_nodes_last
+                        .set(stats.tempo_state_nodes as f64);
                     info!(
                         target: "zone::sequencer::prover",
                         zone_from = job.from,


### PR DESCRIPTION
## Summary
- record gauges for the latest successfully validated prover batch alongside the existing histograms
- expose `_last` metrics for witness bytes, batch size, deposits, withdrawals, transactions, Zone state nodes, and Tempo state nodes
- unblock the dashboard update in https://github.com/tempoxyz/grafana-dashboards/pull/73

## Validation
- `cargo +nightly fmt --all -- --check`
- `cargo check -p zone-sequencer`

Prompted by: @shekhirin