### PR TITLE
feat(ci): publish Zone prover utils image

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -112,6 +112,24 @@ jobs:
             type=sha,prefix=sha-
             type=ref,event=pr
 
+      - name: Docker metadata for tempo-zone-prover-utils
+        id: meta-tempo-zone-prover-utils
+        uses: docker/metadata-action@80c7e94dd9b9319bd5eb7a0e0fe9291e23a2a2e9 # v6.1.0
+        with:
+          images: ${{ env.REGISTRY }}/tempo-zone-prover-utils
+          bake-target: tempo-zone-prover-utils
+          tags: |
+            type=schedule,pattern=nightly
+            type=raw,value=nightly,enable=${{ github.event.inputs.nightly == 'true' }}
+            type=semver,pattern={{version}}
+            type=semver,pattern={{major}}.{{minor}}
+            type=semver,pattern={{major}}
+            type=raw,value=stable,enable=${{ github.ref_type == 'tag' }}
+            type=raw,value=latest,enable={{is_default_branch}}
+            type=edge,branch=main
+            type=sha,prefix=sha-
+            type=ref,event=pr
+
       - name: Log in to Container Registry
         if: github.repository == 'tempoxyz/zones'
         uses: docker/login-action@650006c6eb7dba73a995cc03b0b2d7f5ca915bee # v4.2.0
@@ -146,6 +164,7 @@ jobs:
             docker/docker-bake.hcl
             ${{ steps.meta-tempo-zone.outputs.bake-file }}
             ${{ steps.meta-tempo-zone-xtask.outputs.bake-file }}
+            ${{ steps.meta-tempo-zone-prover-utils.outputs.bake-file }}
           targets: default
           project: 0c6tg19qsp
           push: ${{ github.repository == 'tempoxyz/zones' && github.event_name != 'pull_request' }}

--- a/docker/Dockerfile.prover-utils
+++ b/docker/Dockerfile.prover-utils
@@ -1,0 +1,27 @@
+# syntax=docker/dockerfile:1.7
+
+ARG CHEF_IMAGE=chef
+
+FROM ${CHEF_IMAGE} AS builder
+
+ARG RUST_PROFILE=release
+
+COPY . .
+
+RUN --mount=type=cache,target=/usr/local/cargo/registry,sharing=locked,id=cargo-registry \
+    --mount=type=cache,target=/usr/local/cargo/git,sharing=locked,id=cargo-git \
+    --mount=type=cache,target=$SCCACHE_DIR,sharing=locked,id=sccache \
+    RUSTFLAGS="-C link-arg=-fuse-ld=mold" \
+    cargo build --locked --profile ${RUST_PROFILE} --bin tempo-zone-prover-utils \
+    && /app/target/${RUST_PROFILE}/tempo-zone-prover-utils --help >/dev/null
+
+FROM debian:bookworm-slim@sha256:4724b8cc51e33e398f0e2e15e18d5ec2851ff0c2280647e1310bc1642182655d
+
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    ca-certificates \
+    && rm -rf /var/lib/apt/lists/*
+
+COPY --from=builder /app/target/release/tempo-zone-prover-utils /usr/local/bin/tempo-zone-prover-utils
+
+USER 65532:65532
+ENTRYPOINT ["/usr/local/bin/tempo-zone-prover-utils"]

--- a/docker/docker-bake.hcl
+++ b/docker/docker-bake.hcl
@@ -11,7 +11,7 @@ variable "PROVER_EIF_CONTEXT" {
 }
 
 group "default" {
-  targets = ["tempo-zone", "tempo-zone-xtask"]
+  targets = ["tempo-zone", "tempo-zone-xtask", "tempo-zone-prover-utils"]
 }
 
 target "docker-metadata" {}
@@ -59,6 +59,20 @@ target "tempo-zone" {
 
 target "tempo-zone-prover-enclave" {
   dockerfile = "docker/Dockerfile.prover-enclave"
+  context = "."
+  contexts = {
+    chef = "target:prover-chef"
+  }
+  args = {
+    CHEF_IMAGE = "chef"
+    RUST_PROFILE = "release"
+  }
+  platforms = ["linux/amd64"]
+}
+
+target "tempo-zone-prover-utils" {
+  inherits = ["docker-metadata"]
+  dockerfile = "docker/Dockerfile.prover-utils"
   context = "."
   contexts = {
     chef = "target:prover-chef"


### PR DESCRIPTION
## Summary

- add a release image for `tempo-zone-prover-utils`
- build it through the release-profile prover dependency cache
- publish it with the same nightly, semver, SHA, edge, latest, and PR tags as the other Zone images

## Validation

- `cargo check --locked -p tempo-zone-prover-utils`
- `git diff --check`

Prompted by: @rkrasiuk
