### PR TITLE
feat(evm): align Zones with Tempo T11 precompile decoding

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -88,9 +88,9 @@ checksum = "683d7910e743518b0e34f1186f92494becacb047c7b6bf616c96772180fef923"
 
 [[package]]
 name = "alloy"
-version = "2.3.0"
+version = "2.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6c8d8a7d7e896331d13d94cd50779a843d3fb3d8b0389826e43638f6276bc4b3"
+checksum = "9867f85f660948ddbef071ae484027654c04b62c7decd5b61464a7ed1f8931a0"
 dependencies = [
  "alloy-consensus",
  "alloy-contract",
@@ -128,9 +128,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-consensus"
-version = "2.3.0"
+version = "2.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "51b9eb70841f76b69b1205bb57b551b7d7afd8407ad57cbda02e833877507c16"
+checksum = "12a542fe1e6a48cfd010a9e8eba1235436de58ee0f1415e588c27d5d556e98df"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -156,9 +156,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-consensus-any"
-version = "2.3.0"
+version = "2.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f89486e1bd2c5c56522cf18e73460c3fe7b54d50f5e80131466e62b7632edfcb"
+checksum = "05ac1559726a5e71d6dbab59cbd8ad0988c762105d2ae41ae4f3241a3166262d"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -171,9 +171,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-contract"
-version = "2.3.0"
+version = "2.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b4c0dadb2468adc8aaaaad4c9a6cfa6bd055fe6596c40017067b37671f2c45f5"
+checksum = "b86722084d6d07822a6c67e39ae794d437fb9de12fa4127d4f9fd93f89651121"
 dependencies = [
  "alloy-consensus",
  "alloy-dyn-abi",
@@ -190,7 +190,9 @@ dependencies = [
  "futures-util",
  "serde_json",
  "thiserror 2.0.18",
+ "tokio",
  "tracing",
+ "wasmtimer",
 ]
 
 [[package]]
@@ -208,9 +210,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-dyn-abi"
-version = "1.6.1"
+version = "1.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9a04eb4abc2b5074a18e687ee63918f407cc7990083cba9b999445f839796060"
+checksum = "201b9e973fe90b2effd9ab356d4f2a46ab56046ba9d46f163367553e72c045b0"
 dependencies = [
  "alloy-json-abi",
  "alloy-primitives",
@@ -271,9 +273,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-eip7928"
-version = "0.4.5"
+version = "0.4.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b3b12337f74cbfa451cb04dac173974814a6ff463079e1793aa09600ba8813ab"
+checksum = "3fb59cca9e58f5c624becc3cffb32772dc278f31eeae4606844a88592e8d2672"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -286,9 +288,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-eips"
-version = "2.3.0"
+version = "2.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fddc9c1868d6331b56926de8ab4c4a80d8dcb7bc4f8f7bebc6a89d0548f79af2"
+checksum = "d40246adf7468b430fce87945ece8a54ef27fa760dd9f670f5162a412007bdb2"
 dependencies = [
  "alloy-eip2124",
  "alloy-eip2930",
@@ -312,9 +314,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-ens"
-version = "2.3.0"
+version = "2.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3fe3f812d024acd2a612aea20629130cd59595064f1420953e6e20c84165def9"
+checksum = "be9aa797694e7c55b007aa8f172daef76a83272cbedb8800bdc7038eed3bdb1a"
 dependencies = [
  "alloy-contract",
  "alloy-primitives",
@@ -346,9 +348,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-genesis"
-version = "2.3.0"
+version = "2.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "921b3dccecc4e9dd571c9f9a728d913c2fc7a8ecdfce6005ed99751817523d0d"
+checksum = "4951473e6ff25cdf82eb87b6a1a5fbb4af9c97528398a4a62fbf516198ec5028"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -361,9 +363,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-hardforks"
-version = "0.4.7"
+version = "0.4.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "83ba208044232d14d4adbfa77e57d6329f51bc1acc21f5667bb7db72d88a0831"
+checksum = "865371fb677c005f7cb0ea9c2847a1ba4fdb042caf6428b1769fee20368bbfc7"
 dependencies = [
  "alloy-chains",
  "alloy-eip2124",
@@ -375,9 +377,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-json-abi"
-version = "1.6.1"
+version = "1.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6cee30dd4c2f4b23f434fdf675e7bf9681b86768141277266c6f548ef25cba0a"
+checksum = "1dba4e59c3581a39e03e0b0b4a46ee9c41315b5d843b1e903271952b32bedb7c"
 dependencies = [
  "alloy-primitives",
  "alloy-sol-type-parser",
@@ -387,9 +389,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-json-rpc"
-version = "2.3.0"
+version = "2.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "989d701ece9bccec3294991ce4b4a39dd1cecd0979ea58e86b9878679591b4f5"
+checksum = "7e5722ea29a9a85ecdba2516c58f50d71e77cd25f8ce7e9f4ee8570ddeee6df1"
 dependencies = [
  "alloy-primitives",
  "alloy-sol-types",
@@ -402,9 +404,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-network"
-version = "2.3.0"
+version = "2.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "acfca49fbbe3b30de8114b9cfd89029f87cb33ca7e8a5f5f48a809caaf085126"
+checksum = "e2e4d278913f00ab611f5367448a3a800fed173ab791c3cc67b7a1b0d7afd305"
 dependencies = [
  "alloy-consensus",
  "alloy-consensus-any",
@@ -428,9 +430,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-network-primitives"
-version = "2.3.0"
+version = "2.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2af7b76520abc91b9e0f1aa987d42df55a66494f94a1881cdadd9b8f67e0b924"
+checksum = "e4e52ae56d1acaa6b46e9d7015b8ae6c10f3d1c213a32ae70b17426a03ae6729"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -441,9 +443,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-primitives"
-version = "1.6.1"
+version = "1.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f007e257069855bdf21d27762fd3f3705a613f805c9a08309bf353503f081d71"
+checksum = "ce7b00f0cb42c66ec353076ded1dff1fbf818f6e0e26c40c8a8456c04483fca4"
 dependencies = [
  "alloy-rlp",
  "arbitrary",
@@ -473,9 +475,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-provider"
-version = "2.3.0"
+version = "2.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3a3fb53b31526b0f97cdbfaf9d8bb72b3e4a9ac7965148d79ecec4c733c8558e"
+checksum = "386124639a5c386329b9f2ef2b42969badbf7bba40422b513e3e5739c516dc34"
 dependencies = [
  "alloy-chains",
  "alloy-consensus",
@@ -504,7 +506,7 @@ dependencies = [
  "either",
  "futures",
  "futures-utils-wasm",
- "lru 0.16.4",
+ "lru",
  "parking_lot",
  "pin-project",
  "reqwest",
@@ -519,9 +521,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-pubsub"
-version = "2.3.0"
+version = "2.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "197325ef17fcdf5dfa21999a2a33877b82bb5009d5cc9b5c7f5ddb840fa3b6bb"
+checksum = "ca2c32b323d8001b6e883444b7433804be0e6d55e4dbfd64e3bd2ba025282b77"
 dependencies = [
  "alloy-json-rpc",
  "alloy-primitives",
@@ -563,9 +565,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-rpc-client"
-version = "2.3.0"
+version = "2.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f5274f9ada7f558d2feaba16fadcb96022512566cf424147f9cfa2000bc2e458"
+checksum = "3dfd3ebc1756426a6a9e17979d4467632aff01f359136c50e5320ac6e32d6b8d"
 dependencies = [
  "alloy-json-rpc",
  "alloy-primitives",
@@ -589,9 +591,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-rpc-types"
-version = "2.3.0"
+version = "2.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "12a456d697d4f639d20ac242981de13b94f911c99199e4175e85eaf52b8f785c"
+checksum = "417dc664965e36fc43a4f9c8eb8b2d14067a29c430e23470d2c923c1c977bac7"
 dependencies = [
  "alloy-primitives",
  "alloy-rpc-types-anvil",
@@ -606,9 +608,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-rpc-types-admin"
-version = "2.3.0"
+version = "2.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f36ee47a0f4e901b95180fbe86c92fec3ea73f12c88c5ec70d1cb41abb8d911"
+checksum = "8bfdc2a2cde178ad3a79594b4fabbc0f2f11be5a98a3363083e91575fc95335c"
 dependencies = [
  "alloy-genesis",
  "alloy-primitives",
@@ -618,9 +620,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-rpc-types-anvil"
-version = "2.3.0"
+version = "2.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7d7e911c628067c406effef5137d0e253d98e117cdb81d47aacfe2816199297e"
+checksum = "5a07bb602ee07767e393b5862f719a1d061deca15e617fbb1f7af49cd49576e4"
 dependencies = [
  "alloy-primitives",
  "alloy-rpc-types-eth",
@@ -630,9 +632,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-rpc-types-any"
-version = "2.3.0"
+version = "2.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5493c88bfdd02271de47f28d69481191a2af6b2907901a3a8c7aff79a6b574eb"
+checksum = "cd0a6cce3f97e5d9c0048081b5d173e0e406c2056c52c012e578a1d451ff0cdc"
 dependencies = [
  "alloy-consensus-any",
  "alloy-network-primitives",
@@ -645,9 +647,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-rpc-types-beacon"
-version = "2.3.0"
+version = "2.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b8573342cde98a4d40120b7bc0063fbda42cfd87fb305ab834704177b60d8691"
+checksum = "905e705ef91d2ed6cf08afbec0f9d79318175785eb146656441e8c644786ee5f"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -665,9 +667,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-rpc-types-debug"
-version = "2.3.0"
+version = "2.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bddf06191e2b12eaaeb3a50ef29a8f3416fb74c61421b80f9d7554c4c1d59a56"
+checksum = "32f6d7c9462a3cf3bb046d0b870b86f1ce8c6892157491abebba62913e6f53cb"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -678,9 +680,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-rpc-types-engine"
-version = "2.3.0"
+version = "2.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "866fa880cfd95681c979bf3f8385964c2317ef7423c31c0de53159f01112fedf"
+checksum = "b6e23b5864b3ed3479285ae9af1924266d60cac839dc559d50da868a0734c1d3"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -698,9 +700,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-rpc-types-eth"
-version = "2.3.0"
+version = "2.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9d3b805bb9cafaf1362c28b377e2035e49fc5ae0a5ee3ea61bafd9a5d33959e1"
+checksum = "1eb4c87dfdde83cd97e03a8c0c5e986b52e14075e02266e322ac6c7eb02e7399"
 dependencies = [
  "alloy-consensus",
  "alloy-consensus-any",
@@ -720,9 +722,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-rpc-types-mev"
-version = "2.3.0"
+version = "2.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2b973745b97a364c0215f681b2fb3cb6f0bbeda4dcdba5f56c50f999719ec96f"
+checksum = "e97bfdac1ec57f53ab2a0dacfedf382aeba1245ecb4ad7ecd8aeb4438a6c3b9b"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -735,9 +737,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-rpc-types-trace"
-version = "2.3.0"
+version = "2.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2a6fae28f1bda2586b117a5754b49366160770e63e09ac93fc3d872015a5a993"
+checksum = "7d45ae3eadb97bf7933086205b4be0fef82c208bfc3007759e9afdcb6efa74c5"
 dependencies = [
  "alloy-primitives",
  "alloy-rpc-types-eth",
@@ -749,9 +751,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-rpc-types-txpool"
-version = "2.3.0"
+version = "2.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4962825b8819e54028cbdaadeba128a613afa55c91b9a88e0b0dc257772a14d7"
+checksum = "ce0d7a9ab748d011daac12902ab9aedf8232d9b070bec6344cadd8509d8a6798"
 dependencies = [
  "alloy-primitives",
  "alloy-rpc-types-eth",
@@ -761,9 +763,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-serde"
-version = "2.3.0"
+version = "2.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3ad7efdd5e8fe92f5bab87956d6d3f717d1614c4ab6ad0d1f869b16e83b0dff9"
+checksum = "2ff89f75b8a9d00f659750e9220c31b42d67c69ffc43b2ac8911dfd0506eb4a6"
 dependencies = [
  "alloy-primitives",
  "arbitrary",
@@ -773,9 +775,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-signer"
-version = "2.3.0"
+version = "2.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "afa150cd076471ef21aa7b181d8186cb86c3239518859a2e5d80fbec74f0ec38"
+checksum = "69e1f6fae3ade809daa4c32bee35a30a439bb307209d7b42f3995988b5cc74b8"
 dependencies = [
  "alloy-primitives",
  "async-trait",
@@ -788,9 +790,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-signer-local"
-version = "2.3.0"
+version = "2.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f125bb730d4772538835d4a31e8e5ed5068e2a991619ba32711fd53ad8c93032"
+checksum = "621cc39c34b85875858ef149598f3d5f9797dff9a3247f3606fcc06f9b20acc8"
 dependencies = [
  "alloy-consensus",
  "alloy-network",
@@ -807,9 +809,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-sol-macro"
-version = "1.6.1"
+version = "1.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b5655c38d5f84955bf727b2eeb62fddd91ebb98fd1d7ae6eb77f73ea88f9b9cf"
+checksum = "c64558980fb038cd34b4285ec2b36a2a8bd8d4ddd13b3f6e42d97cb5ee29938e"
 dependencies = [
  "alloy-sol-macro-expander",
  "alloy-sol-macro-input",
@@ -821,9 +823,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-sol-macro-expander"
-version = "1.6.1"
+version = "1.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6277c780e07b76951e09a59788dde230d1582612324177d11a43a61e21a6bb83"
+checksum = "1ffb0e793abdbaea9d01259493c8272c3af295d03389e70a2acdf53b57ad1edf"
 dependencies = [
  "alloy-json-abi",
  "alloy-sol-macro-input",
@@ -840,9 +842,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-sol-macro-input"
-version = "1.6.1"
+version = "1.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9762b2ad3e5a0c09886de54fe549ab0056681df843cb082e2df7e1c0eb270d30"
+checksum = "32c2c0ec8425d9663dac939ba75750f17d2933d2f020814b4f8fde4a60da6d26"
 dependencies = [
  "alloy-json-abi",
  "const-hex",
@@ -858,9 +860,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-sol-type-parser"
-version = "1.6.1"
+version = "1.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "da4c7130f0f01f4719678bda3db3bc7267fc2f7f9d0565e3bd964cd2bb45050d"
+checksum = "96b37db6a7ad8170596345f864522f789cc7af093f516d6cdf34bbdcfba8adab"
 dependencies = [
  "serde",
  "winnow 1.0.4",
@@ -868,9 +870,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-sol-types"
-version = "1.6.1"
+version = "1.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d96e74d6213180f78dbdccddce8af02a639c160c94b0a543fa35c77c58b8a7fc"
+checksum = "1f40e33a0f588dde548c3b6767a71e61b593421a8c1b253b9cf1441dc7cf7ab5"
 dependencies = [
  "alloy-json-abi",
  "alloy-primitives",
@@ -880,9 +882,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-transport"
-version = "2.3.0"
+version = "2.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3cd5dbd32cae5d1bc3afaf455064ebd9bcce70b57de220468908717c225225dd"
+checksum = "06f4ca8484d6295d5165f67de8fdb00ae630ba585efb606f003171286b56441c"
 dependencies = [
  "alloy-json-rpc",
  "auto_impl",
@@ -903,9 +905,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-transport-http"
-version = "2.3.0"
+version = "2.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f0b7b1f0e528ae788d05937f5b351afae3b4c1e08f17a061d868bd28e56aa9e3"
+checksum = "8342aa5a7f8dee6d606307eebbc847d9799a823c7e4f37b9c1e32b08715f73c8"
 dependencies = [
  "alloy-json-rpc",
  "alloy-transport",
@@ -919,9 +921,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-transport-ipc"
-version = "2.3.0"
+version = "2.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b964b4c048eea647a701a6af07307c64995c4abd42d46ba0b3be9593ae3c333c"
+checksum = "184e03e1845edd5534f309d3169d93969a819ad1609108d9378fd33059de7547"
 dependencies = [
  "alloy-json-rpc",
  "alloy-pubsub",
@@ -939,9 +941,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-transport-ws"
-version = "2.3.0"
+version = "2.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "efecf9efc5d56276e115b13b36ff27311b8cd6f72affc9788a10ff46b55b2616"
+checksum = "ee146fb5859e612e95570642a29def87c060c7ce47d14a0caa5ab7ee8570ec2c"
 dependencies = [
  "alloy-pubsub",
  "alloy-transport",
@@ -978,9 +980,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-tx-macros"
-version = "2.3.0"
+version = "2.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b3e2386593cef5b12c7d439dbcf62d7d51c3a50dc943909b42ae34b48f1b69dc"
+checksum = "1d0626c4f3b2028f7e8db32f53c22d9ecd5939f772317b7c4b6fe5219cb0589a"
 dependencies = [
  "darling",
  "proc-macro2",
@@ -1039,7 +1041,7 @@ version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -1050,7 +1052,7 @@ checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
 dependencies = [
  "anstyle",
  "once_cell_polyfill",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -2322,8 +2324,9 @@ dependencies = [
 
 [[package]]
 name = "commonware-actor"
-version = "2026.7.0"
-source = "git+https://github.com/commonwarexyz/monorepo?rev=5950bf7179bb0650a57ed58b9e0478822944b335#5950bf7179bb0650a57ed58b9e0478822944b335"
+version = "2026.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c51f1d2adda7330ae87c9ac815d707a2a41bb91a11dc1a588e5a81fe2a5a2b1b"
 dependencies = [
  "cfg-if",
  "commonware-macros",
@@ -2335,8 +2338,9 @@ dependencies = [
 
 [[package]]
 name = "commonware-broadcast"
-version = "2026.7.0"
-source = "git+https://github.com/commonwarexyz/monorepo?rev=5950bf7179bb0650a57ed58b9e0478822944b335#5950bf7179bb0650a57ed58b9e0478822944b335"
+version = "2026.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0f0e4a50ee1fa3ed2db220da0b0b85546556edc20cc5b71acc90af3d50a94821"
 dependencies = [
  "commonware-actor",
  "commonware-codec",
@@ -2351,8 +2355,9 @@ dependencies = [
 
 [[package]]
 name = "commonware-codec"
-version = "2026.7.0"
-source = "git+https://github.com/commonwarexyz/monorepo?rev=5950bf7179bb0650a57ed58b9e0478822944b335#5950bf7179bb0650a57ed58b9e0478822944b335"
+version = "2026.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "785ff1148d798363638d83a1dfcca9db8ac6001a27292a23dc10a8595e1ee480"
 dependencies = [
  "bytes",
  "cfg-if",
@@ -2365,8 +2370,9 @@ dependencies = [
 
 [[package]]
 name = "commonware-codec-macros"
-version = "2026.7.0"
-source = "git+https://github.com/commonwarexyz/monorepo?rev=5950bf7179bb0650a57ed58b9e0478822944b335#5950bf7179bb0650a57ed58b9e0478822944b335"
+version = "2026.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3e308eca99c0be5ae7d8c19ecb5c2c85b7484b3b7e24f6e36eaed46a9a7cad0c"
 dependencies = [
  "proc-macro-crate",
  "proc-macro2",
@@ -2376,8 +2382,9 @@ dependencies = [
 
 [[package]]
 name = "commonware-coding"
-version = "2026.7.0"
-source = "git+https://github.com/commonwarexyz/monorepo?rev=5950bf7179bb0650a57ed58b9e0478822944b335#5950bf7179bb0650a57ed58b9e0478822944b335"
+version = "2026.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d561336cf1562aca4ac8df2c51035fdab8bd9d8a6f23764ba3c7ad9b87f574c9"
 dependencies = [
  "bytes",
  "commonware-codec",
@@ -2394,8 +2401,9 @@ dependencies = [
 
 [[package]]
 name = "commonware-consensus"
-version = "2026.7.0"
-source = "git+https://github.com/commonwarexyz/monorepo?rev=5950bf7179bb0650a57ed58b9e0478822944b335#5950bf7179bb0650a57ed58b9e0478822944b335"
+version = "2026.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8c854f77e510cf97cffcf02723737bca035ee77b1aa9fc7d6dd88694d3c8f0d"
 dependencies = [
  "bytes",
  "cfg-if",
@@ -2424,8 +2432,9 @@ dependencies = [
 
 [[package]]
 name = "commonware-cryptography"
-version = "2026.7.0"
-source = "git+https://github.com/commonwarexyz/monorepo?rev=5950bf7179bb0650a57ed58b9e0478822944b335#5950bf7179bb0650a57ed58b9e0478822944b335"
+version = "2026.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "57bb1a88685e18438cea8258ae5073c89175dcd7c1f8711f5b60ef0be17c80ff"
 dependencies = [
  "ahash",
  "anyhow",
@@ -2465,8 +2474,9 @@ dependencies = [
 
 [[package]]
 name = "commonware-formatting"
-version = "2026.7.0"
-source = "git+https://github.com/commonwarexyz/monorepo?rev=5950bf7179bb0650a57ed58b9e0478822944b335#5950bf7179bb0650a57ed58b9e0478822944b335"
+version = "2026.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "15d388a79f0fad7ad9fad6b5f4a594c1e6675935221224aaa4d7e376b362c203"
 dependencies = [
  "commonware-macros",
  "const-hex",
@@ -2474,8 +2484,9 @@ dependencies = [
 
 [[package]]
 name = "commonware-macros"
-version = "2026.7.0"
-source = "git+https://github.com/commonwarexyz/monorepo?rev=5950bf7179bb0650a57ed58b9e0478822944b335#5950bf7179bb0650a57ed58b9e0478822944b335"
+version = "2026.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b49853beaa75a447c448eaf6a48a38ba247a85792807956bc4487565a35fa35b"
 dependencies = [
  "commonware-macros-impl",
  "tokio",
@@ -2483,8 +2494,9 @@ dependencies = [
 
 [[package]]
 name = "commonware-macros-impl"
-version = "2026.7.0"
-source = "git+https://github.com/commonwarexyz/monorepo?rev=5950bf7179bb0650a57ed58b9e0478822944b335#5950bf7179bb0650a57ed58b9e0478822944b335"
+version = "2026.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b4b099d6d10014a6ab1ae0b112c8329570adacc1fdbf6b27c9aebb38195f4eee"
 dependencies = [
  "proc-macro-crate",
  "proc-macro2",
@@ -2495,8 +2507,9 @@ dependencies = [
 
 [[package]]
 name = "commonware-math"
-version = "2026.7.0"
-source = "git+https://github.com/commonwarexyz/monorepo?rev=5950bf7179bb0650a57ed58b9e0478822944b335#5950bf7179bb0650a57ed58b9e0478822944b335"
+version = "2026.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4fd414779c4ebd26d9806cf012ad4f490555844aedafafa64cc26428e2f854f1"
 dependencies = [
  "bytes",
  "commonware-codec",
@@ -2508,8 +2521,9 @@ dependencies = [
 
 [[package]]
 name = "commonware-p2p"
-version = "2026.7.0"
-source = "git+https://github.com/commonwarexyz/monorepo?rev=5950bf7179bb0650a57ed58b9e0478822944b335#5950bf7179bb0650a57ed58b9e0478822944b335"
+version = "2026.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3775a5d3bb4dcb20d654ff64b5504234822995dc16cb4417ea65b03225944ed7"
 dependencies = [
  "commonware-actor",
  "commonware-codec",
@@ -2534,8 +2548,9 @@ dependencies = [
 
 [[package]]
 name = "commonware-parallel"
-version = "2026.7.0"
-source = "git+https://github.com/commonwarexyz/monorepo?rev=5950bf7179bb0650a57ed58b9e0478822944b335#5950bf7179bb0650a57ed58b9e0478822944b335"
+version = "2026.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7a1b76ed5be614064839d20ec70f0177f92ba7da04dea0f5b0411c7e10a9ad6"
 dependencies = [
  "cfg-if",
  "commonware-macros",
@@ -2546,8 +2561,9 @@ dependencies = [
 
 [[package]]
 name = "commonware-resolver"
-version = "2026.7.0"
-source = "git+https://github.com/commonwarexyz/monorepo?rev=5950bf7179bb0650a57ed58b9e0478822944b335#5950bf7179bb0650a57ed58b9e0478822944b335"
+version = "2026.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5958d4f162dc81cecf87cda2c00fdca00a750c994149f776d0b1ed39e0bb921c"
 dependencies = [
  "bytes",
  "commonware-actor",
@@ -2567,8 +2583,9 @@ dependencies = [
 
 [[package]]
 name = "commonware-runtime"
-version = "2026.7.0"
-source = "git+https://github.com/commonwarexyz/monorepo?rev=5950bf7179bb0650a57ed58b9e0478822944b335#5950bf7179bb0650a57ed58b9e0478822944b335"
+version = "2026.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "082c8a0fc3962c3aceddf9f5532322b15564369a7b9bf846220ff750051ce9cb"
 dependencies = [
  "ahash",
  "axum",
@@ -2607,8 +2624,9 @@ dependencies = [
 
 [[package]]
 name = "commonware-runtime-macros"
-version = "2026.7.0"
-source = "git+https://github.com/commonwarexyz/monorepo?rev=5950bf7179bb0650a57ed58b9e0478822944b335#5950bf7179bb0650a57ed58b9e0478822944b335"
+version = "2026.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e4982c0997b8a5d2039234a55fff383e443cc72f0c7b2a52b8ab93075c3edeae"
 dependencies = [
  "proc-macro-crate",
  "proc-macro2",
@@ -2618,8 +2636,9 @@ dependencies = [
 
 [[package]]
 name = "commonware-storage"
-version = "2026.7.0"
-source = "git+https://github.com/commonwarexyz/monorepo?rev=5950bf7179bb0650a57ed58b9e0478822944b335#5950bf7179bb0650a57ed58b9e0478822944b335"
+version = "2026.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "627b4a7d67ab75bf4d8115fd883d74b9839b36a1405f5b23a874827a62dfceb1"
 dependencies = [
  "ahash",
  "anyhow",
@@ -2642,8 +2661,9 @@ dependencies = [
 
 [[package]]
 name = "commonware-stream"
-version = "2026.7.0"
-source = "git+https://github.com/commonwarexyz/monorepo?rev=5950bf7179bb0650a57ed58b9e0478822944b335#5950bf7179bb0650a57ed58b9e0478822944b335"
+version = "2026.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0ce2d3acfc869e78d33577c1284d9cf2a0a67f98fcf09ab5d6e43efeed2d2bf4"
 dependencies = [
  "chacha20poly1305",
  "commonware-codec",
@@ -2661,8 +2681,9 @@ dependencies = [
 
 [[package]]
 name = "commonware-utils"
-version = "2026.7.0"
-source = "git+https://github.com/commonwarexyz/monorepo?rev=5950bf7179bb0650a57ed58b9e0478822944b335#5950bf7179bb0650a57ed58b9e0478822944b335"
+version = "2026.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "54c7b4991ff7135416985adf3bf39f16f77cd2066fbbe2e3854e99379d90c6e5"
 dependencies = [
  "ahash",
  "bytes",
@@ -3632,7 +3653,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -4022,8 +4043,8 @@ dependencies = [
  "libc",
  "log",
  "rustversion",
- "windows-link 0.2.1",
- "windows-result 0.4.1",
+ "windows-link 0.1.3",
+ "windows-result 0.3.4",
 ]
 
 [[package]]
@@ -4605,7 +4626,7 @@ dependencies = [
  "js-sys",
  "log",
  "wasm-bindgen",
- "windows-core 0.62.2",
+ "windows-core 0.61.2",
 ]
 
 [[package]]
@@ -5549,18 +5570,9 @@ dependencies = [
 
 [[package]]
 name = "lru"
-version = "0.16.4"
+version = "0.18.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f66e8d5d03f609abc3a39e6f08e4164ebf1447a732906d39eb9b99b7919ef39"
-dependencies = [
- "hashbrown 0.16.1",
-]
-
-[[package]]
-name = "lru"
-version = "0.18.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b6180140927ee907000b0aa540091f6ea512ead4447c92b8fc35bc72788a5a6"
+checksum = "ff9840bcc50b71349309900da0ce7279aa336ae71d73250b07998932c7d97c25"
 dependencies = [
  "hashbrown 0.17.1",
 ]
@@ -5956,7 +5968,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -6938,7 +6950,7 @@ dependencies = [
  "once_cell",
  "socket2",
  "tracing",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -7128,7 +7140,7 @@ dependencies = [
  "hashbrown 0.17.1",
  "itertools 0.14.0",
  "kasuari",
- "lru 0.18.1",
+ "lru",
  "palette",
  "serde",
  "strum 0.28.0",
@@ -7324,8 +7336,8 @@ checksum = "1e061d1b48cb8d38042de4ae0a7a6401009d6143dc80d2e2d6f31f0bdd6470c7"
 
 [[package]]
 name = "reth-basic-payload-builder"
-version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=10aa6a512ba7c4f5f01ff489b1f513da0745821f#10aa6a512ba7c4f5f01ff489b1f513da0745821f"
+version = "2.5.1"
+source = "git+https://github.com/paradigmxyz/reth?rev=9812056#98120568b6f1c133fbffefd0371e1af6413271ee"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -7351,8 +7363,8 @@ dependencies = [
 
 [[package]]
 name = "reth-chain-state"
-version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=10aa6a512ba7c4f5f01ff489b1f513da0745821f#10aa6a512ba7c4f5f01ff489b1f513da0745821f"
+version = "2.5.1"
+source = "git+https://github.com/paradigmxyz/reth?rev=9812056#98120568b6f1c133fbffefd0371e1af6413271ee"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -7382,8 +7394,8 @@ dependencies = [
 
 [[package]]
 name = "reth-chainspec"
-version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=10aa6a512ba7c4f5f01ff489b1f513da0745821f#10aa6a512ba7c4f5f01ff489b1f513da0745821f"
+version = "2.5.1"
+source = "git+https://github.com/paradigmxyz/reth?rev=9812056#98120568b6f1c133fbffefd0371e1af6413271ee"
 dependencies = [
  "alloy-chains",
  "alloy-consensus",
@@ -7402,8 +7414,8 @@ dependencies = [
 
 [[package]]
 name = "reth-cli"
-version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=10aa6a512ba7c4f5f01ff489b1f513da0745821f#10aa6a512ba7c4f5f01ff489b1f513da0745821f"
+version = "2.5.1"
+source = "git+https://github.com/paradigmxyz/reth?rev=9812056#98120568b6f1c133fbffefd0371e1af6413271ee"
 dependencies = [
  "alloy-genesis",
  "clap",
@@ -7415,11 +7427,12 @@ dependencies = [
 
 [[package]]
 name = "reth-cli-commands"
-version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=10aa6a512ba7c4f5f01ff489b1f513da0745821f#10aa6a512ba7c4f5f01ff489b1f513da0745821f"
+version = "2.5.1"
+source = "git+https://github.com/paradigmxyz/reth?rev=9812056#98120568b6f1c133fbffefd0371e1af6413271ee"
 dependencies = [
  "alloy-chains",
  "alloy-consensus",
+ "alloy-eip7928",
  "alloy-eips",
  "alloy-primitives",
  "alloy-rlp",
@@ -7499,8 +7512,8 @@ dependencies = [
 
 [[package]]
 name = "reth-cli-runner"
-version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=10aa6a512ba7c4f5f01ff489b1f513da0745821f#10aa6a512ba7c4f5f01ff489b1f513da0745821f"
+version = "2.5.1"
+source = "git+https://github.com/paradigmxyz/reth?rev=9812056#98120568b6f1c133fbffefd0371e1af6413271ee"
 dependencies = [
  "reth-tasks",
  "tokio",
@@ -7509,8 +7522,8 @@ dependencies = [
 
 [[package]]
 name = "reth-cli-util"
-version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=10aa6a512ba7c4f5f01ff489b1f513da0745821f#10aa6a512ba7c4f5f01ff489b1f513da0745821f"
+version = "2.5.1"
+source = "git+https://github.com/paradigmxyz/reth?rev=9812056#98120568b6f1c133fbffefd0371e1af6413271ee"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -7560,11 +7573,12 @@ dependencies = [
 
 [[package]]
 name = "reth-config"
-version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=10aa6a512ba7c4f5f01ff489b1f513da0745821f#10aa6a512ba7c4f5f01ff489b1f513da0745821f"
+version = "2.5.1"
+source = "git+https://github.com/paradigmxyz/reth?rev=9812056#98120568b6f1c133fbffefd0371e1af6413271ee"
 dependencies = [
  "eyre",
  "humantime-serde",
+ "reth-network-peers",
  "reth-network-types",
  "reth-prune-types",
  "reth-stages-types",
@@ -7576,8 +7590,8 @@ dependencies = [
 
 [[package]]
 name = "reth-consensus"
-version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=10aa6a512ba7c4f5f01ff489b1f513da0745821f#10aa6a512ba7c4f5f01ff489b1f513da0745821f"
+version = "2.5.1"
+source = "git+https://github.com/paradigmxyz/reth?rev=9812056#98120568b6f1c133fbffefd0371e1af6413271ee"
 dependencies = [
  "alloy-consensus",
  "alloy-eip7928",
@@ -7590,8 +7604,8 @@ dependencies = [
 
 [[package]]
 name = "reth-consensus-common"
-version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=10aa6a512ba7c4f5f01ff489b1f513da0745821f#10aa6a512ba7c4f5f01ff489b1f513da0745821f"
+version = "2.5.1"
+source = "git+https://github.com/paradigmxyz/reth?rev=9812056#98120568b6f1c133fbffefd0371e1af6413271ee"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -7603,8 +7617,8 @@ dependencies = [
 
 [[package]]
 name = "reth-consensus-debug-client"
-version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=10aa6a512ba7c4f5f01ff489b1f513da0745821f#10aa6a512ba7c4f5f01ff489b1f513da0745821f"
+version = "2.5.1"
+source = "git+https://github.com/paradigmxyz/reth?rev=9812056#98120568b6f1c133fbffefd0371e1af6413271ee"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -7628,8 +7642,8 @@ dependencies = [
 
 [[package]]
 name = "reth-db"
-version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=10aa6a512ba7c4f5f01ff489b1f513da0745821f#10aa6a512ba7c4f5f01ff489b1f513da0745821f"
+version = "2.5.1"
+source = "git+https://github.com/paradigmxyz/reth?rev=9812056#98120568b6f1c133fbffefd0371e1af6413271ee"
 dependencies = [
  "alloy-primitives",
  "derive_more",
@@ -7657,8 +7671,8 @@ dependencies = [
 
 [[package]]
 name = "reth-db-api"
-version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=10aa6a512ba7c4f5f01ff489b1f513da0745821f#10aa6a512ba7c4f5f01ff489b1f513da0745821f"
+version = "2.5.1"
+source = "git+https://github.com/paradigmxyz/reth?rev=9812056#98120568b6f1c133fbffefd0371e1af6413271ee"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -7683,8 +7697,8 @@ dependencies = [
 
 [[package]]
 name = "reth-db-common"
-version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=10aa6a512ba7c4f5f01ff489b1f513da0745821f#10aa6a512ba7c4f5f01ff489b1f513da0745821f"
+version = "2.5.1"
+source = "git+https://github.com/paradigmxyz/reth?rev=9812056#98120568b6f1c133fbffefd0371e1af6413271ee"
 dependencies = [
  "alloy-consensus",
  "alloy-genesis",
@@ -7713,8 +7727,8 @@ dependencies = [
 
 [[package]]
 name = "reth-db-models"
-version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=10aa6a512ba7c4f5f01ff489b1f513da0745821f#10aa6a512ba7c4f5f01ff489b1f513da0745821f"
+version = "2.5.1"
+source = "git+https://github.com/paradigmxyz/reth?rev=9812056#98120568b6f1c133fbffefd0371e1af6413271ee"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -7728,8 +7742,8 @@ dependencies = [
 
 [[package]]
 name = "reth-discv4"
-version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=10aa6a512ba7c4f5f01ff489b1f513da0745821f#10aa6a512ba7c4f5f01ff489b1f513da0745821f"
+version = "2.5.1"
+source = "git+https://github.com/paradigmxyz/reth?rev=9812056#98120568b6f1c133fbffefd0371e1af6413271ee"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -7753,8 +7767,8 @@ dependencies = [
 
 [[package]]
 name = "reth-discv5"
-version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=10aa6a512ba7c4f5f01ff489b1f513da0745821f#10aa6a512ba7c4f5f01ff489b1f513da0745821f"
+version = "2.5.1"
+source = "git+https://github.com/paradigmxyz/reth?rev=9812056#98120568b6f1c133fbffefd0371e1af6413271ee"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -7777,8 +7791,8 @@ dependencies = [
 
 [[package]]
 name = "reth-dns-discovery"
-version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=10aa6a512ba7c4f5f01ff489b1f513da0745821f#10aa6a512ba7c4f5f01ff489b1f513da0745821f"
+version = "2.5.1"
+source = "git+https://github.com/paradigmxyz/reth?rev=9812056#98120568b6f1c133fbffefd0371e1af6413271ee"
 dependencies = [
  "alloy-primitives",
  "dashmap",
@@ -7801,8 +7815,8 @@ dependencies = [
 
 [[package]]
 name = "reth-downloaders"
-version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=10aa6a512ba7c4f5f01ff489b1f513da0745821f#10aa6a512ba7c4f5f01ff489b1f513da0745821f"
+version = "2.5.1"
+source = "git+https://github.com/paradigmxyz/reth?rev=9812056#98120568b6f1c133fbffefd0371e1af6413271ee"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -7817,6 +7831,7 @@ dependencies = [
  "rayon",
  "reth-config",
  "reth-consensus",
+ "reth-eth-wire-types",
  "reth-ethereum-primitives",
  "reth-metrics",
  "reth-network-p2p",
@@ -7826,6 +7841,7 @@ dependencies = [
  "reth-storage-api",
  "reth-tasks",
  "reth-testing-utils",
+ "reth-trie-common",
  "tempfile",
  "thiserror 2.0.18",
  "tokio",
@@ -7836,8 +7852,8 @@ dependencies = [
 
 [[package]]
 name = "reth-ecies"
-version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=10aa6a512ba7c4f5f01ff489b1f513da0745821f#10aa6a512ba7c4f5f01ff489b1f513da0745821f"
+version = "2.5.1"
+source = "git+https://github.com/paradigmxyz/reth?rev=9812056#98120568b6f1c133fbffefd0371e1af6413271ee"
 dependencies = [
  "aes",
  "alloy-primitives",
@@ -7863,8 +7879,8 @@ dependencies = [
 
 [[package]]
 name = "reth-engine-local"
-version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=10aa6a512ba7c4f5f01ff489b1f513da0745821f#10aa6a512ba7c4f5f01ff489b1f513da0745821f"
+version = "2.5.1"
+source = "git+https://github.com/paradigmxyz/reth?rev=9812056#98120568b6f1c133fbffefd0371e1af6413271ee"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -7886,8 +7902,8 @@ dependencies = [
 
 [[package]]
 name = "reth-engine-primitives"
-version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=10aa6a512ba7c4f5f01ff489b1f513da0745821f#10aa6a512ba7c4f5f01ff489b1f513da0745821f"
+version = "2.5.1"
+source = "git+https://github.com/paradigmxyz/reth?rev=9812056#98120568b6f1c133fbffefd0371e1af6413271ee"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -7913,8 +7929,8 @@ dependencies = [
 
 [[package]]
 name = "reth-engine-tree"
-version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=10aa6a512ba7c4f5f01ff489b1f513da0745821f#10aa6a512ba7c4f5f01ff489b1f513da0745821f"
+version = "2.5.1"
+source = "git+https://github.com/paradigmxyz/reth?rev=9812056#98120568b6f1c133fbffefd0371e1af6413271ee"
 dependencies = [
  "alloy-consensus",
  "alloy-eip7928",
@@ -7969,8 +7985,8 @@ dependencies = [
 
 [[package]]
 name = "reth-engine-util"
-version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=10aa6a512ba7c4f5f01ff489b1f513da0745821f#10aa6a512ba7c4f5f01ff489b1f513da0745821f"
+version = "2.5.1"
+source = "git+https://github.com/paradigmxyz/reth?rev=9812056#98120568b6f1c133fbffefd0371e1af6413271ee"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -7999,8 +8015,8 @@ dependencies = [
 
 [[package]]
 name = "reth-era"
-version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=10aa6a512ba7c4f5f01ff489b1f513da0745821f#10aa6a512ba7c4f5f01ff489b1f513da0745821f"
+version = "2.5.1"
+source = "git+https://github.com/paradigmxyz/reth?rev=9812056#98120568b6f1c133fbffefd0371e1af6413271ee"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -8017,8 +8033,8 @@ dependencies = [
 
 [[package]]
 name = "reth-era-downloader"
-version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=10aa6a512ba7c4f5f01ff489b1f513da0745821f#10aa6a512ba7c4f5f01ff489b1f513da0745821f"
+version = "2.5.1"
+source = "git+https://github.com/paradigmxyz/reth?rev=9812056#98120568b6f1c133fbffefd0371e1af6413271ee"
 dependencies = [
  "alloy-primitives",
  "bytes",
@@ -8033,8 +8049,8 @@ dependencies = [
 
 [[package]]
 name = "reth-era-utils"
-version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=10aa6a512ba7c4f5f01ff489b1f513da0745821f#10aa6a512ba7c4f5f01ff489b1f513da0745821f"
+version = "2.5.1"
+source = "git+https://github.com/paradigmxyz/reth?rev=9812056#98120568b6f1c133fbffefd0371e1af6413271ee"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -8057,8 +8073,8 @@ dependencies = [
 
 [[package]]
 name = "reth-errors"
-version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=10aa6a512ba7c4f5f01ff489b1f513da0745821f#10aa6a512ba7c4f5f01ff489b1f513da0745821f"
+version = "2.5.1"
+source = "git+https://github.com/paradigmxyz/reth?rev=9812056#98120568b6f1c133fbffefd0371e1af6413271ee"
 dependencies = [
  "reth-consensus",
  "reth-execution-errors",
@@ -8068,8 +8084,8 @@ dependencies = [
 
 [[package]]
 name = "reth-eth-wire"
-version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=10aa6a512ba7c4f5f01ff489b1f513da0745821f#10aa6a512ba7c4f5f01ff489b1f513da0745821f"
+version = "2.5.1"
+source = "git+https://github.com/paradigmxyz/reth?rev=9812056#98120568b6f1c133fbffefd0371e1af6413271ee"
 dependencies = [
  "alloy-chains",
  "alloy-primitives",
@@ -8096,8 +8112,8 @@ dependencies = [
 
 [[package]]
 name = "reth-eth-wire-types"
-version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=10aa6a512ba7c4f5f01ff489b1f513da0745821f#10aa6a512ba7c4f5f01ff489b1f513da0745821f"
+version = "2.5.1"
+source = "git+https://github.com/paradigmxyz/reth?rev=9812056#98120568b6f1c133fbffefd0371e1af6413271ee"
 dependencies = [
  "alloy-chains",
  "alloy-consensus",
@@ -8106,6 +8122,7 @@ dependencies = [
  "alloy-hardforks",
  "alloy-primitives",
  "alloy-rlp",
+ "alloy-trie",
  "bytes",
  "derive_more",
  "reth-chainspec",
@@ -8118,8 +8135,8 @@ dependencies = [
 
 [[package]]
 name = "reth-ethereum"
-version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=10aa6a512ba7c4f5f01ff489b1f513da0745821f#10aa6a512ba7c4f5f01ff489b1f513da0745821f"
+version = "2.5.1"
+source = "git+https://github.com/paradigmxyz/reth?rev=9812056#98120568b6f1c133fbffefd0371e1af6413271ee"
 dependencies = [
  "alloy-rpc-types-engine",
  "alloy-rpc-types-eth",
@@ -8158,8 +8175,8 @@ dependencies = [
 
 [[package]]
 name = "reth-ethereum-cli"
-version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=10aa6a512ba7c4f5f01ff489b1f513da0745821f#10aa6a512ba7c4f5f01ff489b1f513da0745821f"
+version = "2.5.1"
+source = "git+https://github.com/paradigmxyz/reth?rev=9812056#98120568b6f1c133fbffefd0371e1af6413271ee"
 dependencies = [
  "clap",
  "eyre",
@@ -8181,8 +8198,8 @@ dependencies = [
 
 [[package]]
 name = "reth-ethereum-consensus"
-version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=10aa6a512ba7c4f5f01ff489b1f513da0745821f#10aa6a512ba7c4f5f01ff489b1f513da0745821f"
+version = "2.5.1"
+source = "git+https://github.com/paradigmxyz/reth?rev=9812056#98120568b6f1c133fbffefd0371e1af6413271ee"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -8197,8 +8214,8 @@ dependencies = [
 
 [[package]]
 name = "reth-ethereum-engine-primitives"
-version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=10aa6a512ba7c4f5f01ff489b1f513da0745821f#10aa6a512ba7c4f5f01ff489b1f513da0745821f"
+version = "2.5.1"
+source = "git+https://github.com/paradigmxyz/reth?rev=9812056#98120568b6f1c133fbffefd0371e1af6413271ee"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -8213,8 +8230,8 @@ dependencies = [
 
 [[package]]
 name = "reth-ethereum-forks"
-version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=10aa6a512ba7c4f5f01ff489b1f513da0745821f#10aa6a512ba7c4f5f01ff489b1f513da0745821f"
+version = "2.5.1"
+source = "git+https://github.com/paradigmxyz/reth?rev=9812056#98120568b6f1c133fbffefd0371e1af6413271ee"
 dependencies = [
  "alloy-eip2124",
  "alloy-hardforks",
@@ -8226,8 +8243,8 @@ dependencies = [
 
 [[package]]
 name = "reth-ethereum-payload-builder"
-version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=10aa6a512ba7c4f5f01ff489b1f513da0745821f#10aa6a512ba7c4f5f01ff489b1f513da0745821f"
+version = "2.5.1"
+source = "git+https://github.com/paradigmxyz/reth?rev=9812056#98120568b6f1c133fbffefd0371e1af6413271ee"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -8256,8 +8273,8 @@ dependencies = [
 
 [[package]]
 name = "reth-ethereum-primitives"
-version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=10aa6a512ba7c4f5f01ff489b1f513da0745821f#10aa6a512ba7c4f5f01ff489b1f513da0745821f"
+version = "2.5.1"
+source = "git+https://github.com/paradigmxyz/reth?rev=9812056#98120568b6f1c133fbffefd0371e1af6413271ee"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -8270,8 +8287,8 @@ dependencies = [
 
 [[package]]
 name = "reth-etl"
-version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=10aa6a512ba7c4f5f01ff489b1f513da0745821f#10aa6a512ba7c4f5f01ff489b1f513da0745821f"
+version = "2.5.1"
+source = "git+https://github.com/paradigmxyz/reth?rev=9812056#98120568b6f1c133fbffefd0371e1af6413271ee"
 dependencies = [
  "rayon",
  "reth-db-api",
@@ -8280,8 +8297,8 @@ dependencies = [
 
 [[package]]
 name = "reth-evm"
-version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=10aa6a512ba7c4f5f01ff489b1f513da0745821f#10aa6a512ba7c4f5f01ff489b1f513da0745821f"
+version = "2.5.1"
+source = "git+https://github.com/paradigmxyz/reth?rev=9812056#98120568b6f1c133fbffefd0371e1af6413271ee"
 dependencies = [
  "alloy-consensus",
  "alloy-eip7928",
@@ -8306,8 +8323,8 @@ dependencies = [
 
 [[package]]
 name = "reth-evm-ethereum"
-version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=10aa6a512ba7c4f5f01ff489b1f513da0745821f#10aa6a512ba7c4f5f01ff489b1f513da0745821f"
+version = "2.5.1"
+source = "git+https://github.com/paradigmxyz/reth?rev=9812056#98120568b6f1c133fbffefd0371e1af6413271ee"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -8326,8 +8343,8 @@ dependencies = [
 
 [[package]]
 name = "reth-execution-cache"
-version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=10aa6a512ba7c4f5f01ff489b1f513da0745821f#10aa6a512ba7c4f5f01ff489b1f513da0745821f"
+version = "2.5.1"
+source = "git+https://github.com/paradigmxyz/reth?rev=9812056#98120568b6f1c133fbffefd0371e1af6413271ee"
 dependencies = [
  "alloy-primitives",
  "fixed-cache",
@@ -8344,8 +8361,8 @@ dependencies = [
 
 [[package]]
 name = "reth-execution-errors"
-version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=10aa6a512ba7c4f5f01ff489b1f513da0745821f#10aa6a512ba7c4f5f01ff489b1f513da0745821f"
+version = "2.5.1"
+source = "git+https://github.com/paradigmxyz/reth?rev=9812056#98120568b6f1c133fbffefd0371e1af6413271ee"
 dependencies = [
  "alloy-evm",
  "alloy-primitives",
@@ -8357,8 +8374,8 @@ dependencies = [
 
 [[package]]
 name = "reth-execution-types"
-version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=10aa6a512ba7c4f5f01ff489b1f513da0745821f#10aa6a512ba7c4f5f01ff489b1f513da0745821f"
+version = "2.5.1"
+source = "git+https://github.com/paradigmxyz/reth?rev=9812056#98120568b6f1c133fbffefd0371e1af6413271ee"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -8376,8 +8393,8 @@ dependencies = [
 
 [[package]]
 name = "reth-exex"
-version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=10aa6a512ba7c4f5f01ff489b1f513da0745821f#10aa6a512ba7c4f5f01ff489b1f513da0745821f"
+version = "2.5.1"
+source = "git+https://github.com/paradigmxyz/reth?rev=9812056#98120568b6f1c133fbffefd0371e1af6413271ee"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -8414,8 +8431,8 @@ dependencies = [
 
 [[package]]
 name = "reth-exex-types"
-version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=10aa6a512ba7c4f5f01ff489b1f513da0745821f#10aa6a512ba7c4f5f01ff489b1f513da0745821f"
+version = "2.5.1"
+source = "git+https://github.com/paradigmxyz/reth?rev=9812056#98120568b6f1c133fbffefd0371e1af6413271ee"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -8428,8 +8445,8 @@ dependencies = [
 
 [[package]]
 name = "reth-fs-util"
-version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=10aa6a512ba7c4f5f01ff489b1f513da0745821f#10aa6a512ba7c4f5f01ff489b1f513da0745821f"
+version = "2.5.1"
+source = "git+https://github.com/paradigmxyz/reth?rev=9812056#98120568b6f1c133fbffefd0371e1af6413271ee"
 dependencies = [
  "serde",
  "serde_json",
@@ -8438,8 +8455,8 @@ dependencies = [
 
 [[package]]
 name = "reth-invalid-block-hooks"
-version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=10aa6a512ba7c4f5f01ff489b1f513da0745821f#10aa6a512ba7c4f5f01ff489b1f513da0745821f"
+version = "2.5.1"
+source = "git+https://github.com/paradigmxyz/reth?rev=9812056#98120568b6f1c133fbffefd0371e1af6413271ee"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -8464,8 +8481,8 @@ dependencies = [
 
 [[package]]
 name = "reth-ipc"
-version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=10aa6a512ba7c4f5f01ff489b1f513da0745821f#10aa6a512ba7c4f5f01ff489b1f513da0745821f"
+version = "2.5.1"
+source = "git+https://github.com/paradigmxyz/reth?rev=9812056#98120568b6f1c133fbffefd0371e1af6413271ee"
 dependencies = [
  "bytes",
  "futures",
@@ -8484,8 +8501,8 @@ dependencies = [
 
 [[package]]
 name = "reth-libmdbx"
-version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=10aa6a512ba7c4f5f01ff489b1f513da0745821f#10aa6a512ba7c4f5f01ff489b1f513da0745821f"
+version = "2.5.1"
+source = "git+https://github.com/paradigmxyz/reth?rev=9812056#98120568b6f1c133fbffefd0371e1af6413271ee"
 dependencies = [
  "bitflags 2.13.0",
  "byteorder",
@@ -8501,8 +8518,8 @@ dependencies = [
 
 [[package]]
 name = "reth-mdbx-sys"
-version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=10aa6a512ba7c4f5f01ff489b1f513da0745821f#10aa6a512ba7c4f5f01ff489b1f513da0745821f"
+version = "2.5.1"
+source = "git+https://github.com/paradigmxyz/reth?rev=9812056#98120568b6f1c133fbffefd0371e1af6413271ee"
 dependencies = [
  "bindgen",
  "cc",
@@ -8510,8 +8527,8 @@ dependencies = [
 
 [[package]]
 name = "reth-metrics"
-version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=10aa6a512ba7c4f5f01ff489b1f513da0745821f#10aa6a512ba7c4f5f01ff489b1f513da0745821f"
+version = "2.5.1"
+source = "git+https://github.com/paradigmxyz/reth?rev=9812056#98120568b6f1c133fbffefd0371e1af6413271ee"
 dependencies = [
  "futures",
  "libc",
@@ -8524,8 +8541,8 @@ dependencies = [
 
 [[package]]
 name = "reth-net-banlist"
-version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=10aa6a512ba7c4f5f01ff489b1f513da0745821f#10aa6a512ba7c4f5f01ff489b1f513da0745821f"
+version = "2.5.1"
+source = "git+https://github.com/paradigmxyz/reth?rev=9812056#98120568b6f1c133fbffefd0371e1af6413271ee"
 dependencies = [
  "alloy-primitives",
  "ipnet",
@@ -8533,8 +8550,8 @@ dependencies = [
 
 [[package]]
 name = "reth-net-nat"
-version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=10aa6a512ba7c4f5f01ff489b1f513da0745821f#10aa6a512ba7c4f5f01ff489b1f513da0745821f"
+version = "2.5.1"
+source = "git+https://github.com/paradigmxyz/reth?rev=9812056#98120568b6f1c133fbffefd0371e1af6413271ee"
 dependencies = [
  "futures-util",
  "if-addrs",
@@ -8547,8 +8564,8 @@ dependencies = [
 
 [[package]]
 name = "reth-network"
-version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=10aa6a512ba7c4f5f01ff489b1f513da0745821f#10aa6a512ba7c4f5f01ff489b1f513da0745821f"
+version = "2.5.1"
+source = "git+https://github.com/paradigmxyz/reth?rev=9812056#98120568b6f1c133fbffefd0371e1af6413271ee"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -8606,8 +8623,8 @@ dependencies = [
 
 [[package]]
 name = "reth-network-api"
-version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=10aa6a512ba7c4f5f01ff489b1f513da0745821f#10aa6a512ba7c4f5f01ff489b1f513da0745821f"
+version = "2.5.1"
+source = "git+https://github.com/paradigmxyz/reth?rev=9812056#98120568b6f1c133fbffefd0371e1af6413271ee"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -8631,8 +8648,8 @@ dependencies = [
 
 [[package]]
 name = "reth-network-p2p"
-version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=10aa6a512ba7c4f5f01ff489b1f513da0745821f#10aa6a512ba7c4f5f01ff489b1f513da0745821f"
+version = "2.5.1"
+source = "git+https://github.com/paradigmxyz/reth?rev=9812056#98120568b6f1c133fbffefd0371e1af6413271ee"
 dependencies = [
  "alloy-consensus",
  "alloy-eip7928",
@@ -8655,8 +8672,8 @@ dependencies = [
 
 [[package]]
 name = "reth-network-peers"
-version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=10aa6a512ba7c4f5f01ff489b1f513da0745821f#10aa6a512ba7c4f5f01ff489b1f513da0745821f"
+version = "2.5.1"
+source = "git+https://github.com/paradigmxyz/reth?rev=9812056#98120568b6f1c133fbffefd0371e1af6413271ee"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -8670,8 +8687,8 @@ dependencies = [
 
 [[package]]
 name = "reth-network-types"
-version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=10aa6a512ba7c4f5f01ff489b1f513da0745821f#10aa6a512ba7c4f5f01ff489b1f513da0745821f"
+version = "2.5.1"
+source = "git+https://github.com/paradigmxyz/reth?rev=9812056#98120568b6f1c133fbffefd0371e1af6413271ee"
 dependencies = [
  "alloy-eip2124",
  "humantime-serde",
@@ -8684,8 +8701,8 @@ dependencies = [
 
 [[package]]
 name = "reth-nippy-jar"
-version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=10aa6a512ba7c4f5f01ff489b1f513da0745821f#10aa6a512ba7c4f5f01ff489b1f513da0745821f"
+version = "2.5.1"
+source = "git+https://github.com/paradigmxyz/reth?rev=9812056#98120568b6f1c133fbffefd0371e1af6413271ee"
 dependencies = [
  "anyhow",
  "bincode",
@@ -8701,8 +8718,8 @@ dependencies = [
 
 [[package]]
 name = "reth-node-api"
-version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=10aa6a512ba7c4f5f01ff489b1f513da0745821f#10aa6a512ba7c4f5f01ff489b1f513da0745821f"
+version = "2.5.1"
+source = "git+https://github.com/paradigmxyz/reth?rev=9812056#98120568b6f1c133fbffefd0371e1af6413271ee"
 dependencies = [
  "alloy-rpc-types-engine",
  "eyre",
@@ -8725,8 +8742,8 @@ dependencies = [
 
 [[package]]
 name = "reth-node-builder"
-version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=10aa6a512ba7c4f5f01ff489b1f513da0745821f#10aa6a512ba7c4f5f01ff489b1f513da0745821f"
+version = "2.5.1"
+source = "git+https://github.com/paradigmxyz/reth?rev=9812056#98120568b6f1c133fbffefd0371e1af6413271ee"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -8793,8 +8810,8 @@ dependencies = [
 
 [[package]]
 name = "reth-node-core"
-version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=10aa6a512ba7c4f5f01ff489b1f513da0745821f#10aa6a512ba7c4f5f01ff489b1f513da0745821f"
+version = "2.5.1"
+source = "git+https://github.com/paradigmxyz/reth?rev=9812056#98120568b6f1c133fbffefd0371e1af6413271ee"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -8848,8 +8865,8 @@ dependencies = [
 
 [[package]]
 name = "reth-node-ethereum"
-version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=10aa6a512ba7c4f5f01ff489b1f513da0745821f#10aa6a512ba7c4f5f01ff489b1f513da0745821f"
+version = "2.5.1"
+source = "git+https://github.com/paradigmxyz/reth?rev=9812056#98120568b6f1c133fbffefd0371e1af6413271ee"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -8897,8 +8914,8 @@ dependencies = [
 
 [[package]]
 name = "reth-node-ethstats"
-version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=10aa6a512ba7c4f5f01ff489b1f513da0745821f#10aa6a512ba7c4f5f01ff489b1f513da0745821f"
+version = "2.5.1"
+source = "git+https://github.com/paradigmxyz/reth?rev=9812056#98120568b6f1c133fbffefd0371e1af6413271ee"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -8921,8 +8938,8 @@ dependencies = [
 
 [[package]]
 name = "reth-node-events"
-version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=10aa6a512ba7c4f5f01ff489b1f513da0745821f#10aa6a512ba7c4f5f01ff489b1f513da0745821f"
+version = "2.5.1"
+source = "git+https://github.com/paradigmxyz/reth?rev=9812056#98120568b6f1c133fbffefd0371e1af6413271ee"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -8945,8 +8962,8 @@ dependencies = [
 
 [[package]]
 name = "reth-node-metrics"
-version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=10aa6a512ba7c4f5f01ff489b1f513da0745821f#10aa6a512ba7c4f5f01ff489b1f513da0745821f"
+version = "2.5.1"
+source = "git+https://github.com/paradigmxyz/reth?rev=9812056#98120568b6f1c133fbffefd0371e1af6413271ee"
 dependencies = [
  "bytes",
  "eyre",
@@ -8969,8 +8986,8 @@ dependencies = [
 
 [[package]]
 name = "reth-node-types"
-version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=10aa6a512ba7c4f5f01ff489b1f513da0745821f#10aa6a512ba7c4f5f01ff489b1f513da0745821f"
+version = "2.5.1"
+source = "git+https://github.com/paradigmxyz/reth?rev=9812056#98120568b6f1c133fbffefd0371e1af6413271ee"
 dependencies = [
  "reth-chainspec",
  "reth-db-api",
@@ -8981,8 +8998,8 @@ dependencies = [
 
 [[package]]
 name = "reth-payload-builder"
-version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=10aa6a512ba7c4f5f01ff489b1f513da0745821f#10aa6a512ba7c4f5f01ff489b1f513da0745821f"
+version = "2.5.1"
+source = "git+https://github.com/paradigmxyz/reth?rev=9812056#98120568b6f1c133fbffefd0371e1af6413271ee"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -9005,8 +9022,8 @@ dependencies = [
 
 [[package]]
 name = "reth-payload-builder-primitives"
-version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=10aa6a512ba7c4f5f01ff489b1f513da0745821f#10aa6a512ba7c4f5f01ff489b1f513da0745821f"
+version = "2.5.1"
+source = "git+https://github.com/paradigmxyz/reth?rev=9812056#98120568b6f1c133fbffefd0371e1af6413271ee"
 dependencies = [
  "pin-project",
  "reth-payload-primitives",
@@ -9017,8 +9034,8 @@ dependencies = [
 
 [[package]]
 name = "reth-payload-primitives"
-version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=10aa6a512ba7c4f5f01ff489b1f513da0745821f#10aa6a512ba7c4f5f01ff489b1f513da0745821f"
+version = "2.5.1"
+source = "git+https://github.com/paradigmxyz/reth?rev=9812056#98120568b6f1c133fbffefd0371e1af6413271ee"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9040,8 +9057,8 @@ dependencies = [
 
 [[package]]
 name = "reth-payload-validator"
-version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=10aa6a512ba7c4f5f01ff489b1f513da0745821f#10aa6a512ba7c4f5f01ff489b1f513da0745821f"
+version = "2.5.1"
+source = "git+https://github.com/paradigmxyz/reth?rev=9812056#98120568b6f1c133fbffefd0371e1af6413271ee"
 dependencies = [
  "alloy-consensus",
  "alloy-rpc-types-engine",
@@ -9083,8 +9100,8 @@ dependencies = [
 
 [[package]]
 name = "reth-provider"
-version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=10aa6a512ba7c4f5f01ff489b1f513da0745821f#10aa6a512ba7c4f5f01ff489b1f513da0745821f"
+version = "2.5.1"
+source = "git+https://github.com/paradigmxyz/reth?rev=9812056#98120568b6f1c133fbffefd0371e1af6413271ee"
 dependencies = [
  "alloy-consensus",
  "alloy-eip7928",
@@ -9094,6 +9111,7 @@ dependencies = [
  "alloy-rpc-types-engine",
  "eyre",
  "itertools 0.14.0",
+ "libc",
  "metrics",
  "notify",
  "parking_lot",
@@ -9132,8 +9150,8 @@ dependencies = [
 
 [[package]]
 name = "reth-prune"
-version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=10aa6a512ba7c4f5f01ff489b1f513da0745821f#10aa6a512ba7c4f5f01ff489b1f513da0745821f"
+version = "2.5.1"
+source = "git+https://github.com/paradigmxyz/reth?rev=9812056#98120568b6f1c133fbffefd0371e1af6413271ee"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -9159,8 +9177,8 @@ dependencies = [
 
 [[package]]
 name = "reth-prune-types"
-version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=10aa6a512ba7c4f5f01ff489b1f513da0745821f#10aa6a512ba7c4f5f01ff489b1f513da0745821f"
+version = "2.5.1"
+source = "git+https://github.com/paradigmxyz/reth?rev=9812056#98120568b6f1c133fbffefd0371e1af6413271ee"
 dependencies = [
  "alloy-primitives",
  "arbitrary",
@@ -9175,8 +9193,8 @@ dependencies = [
 
 [[package]]
 name = "reth-revm"
-version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=10aa6a512ba7c4f5f01ff489b1f513da0745821f#10aa6a512ba7c4f5f01ff489b1f513da0745821f"
+version = "2.5.1"
+source = "git+https://github.com/paradigmxyz/reth?rev=9812056#98120568b6f1c133fbffefd0371e1af6413271ee"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -9190,8 +9208,8 @@ dependencies = [
 
 [[package]]
 name = "reth-rpc"
-version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=10aa6a512ba7c4f5f01ff489b1f513da0745821f#10aa6a512ba7c4f5f01ff489b1f513da0745821f"
+version = "2.5.1"
+source = "git+https://github.com/paradigmxyz/reth?rev=9812056#98120568b6f1c133fbffefd0371e1af6413271ee"
 dependencies = [
  "alloy-consensus",
  "alloy-dyn-abi",
@@ -9231,7 +9249,6 @@ dependencies = [
  "reth-engine-primitives",
  "reth-errors",
  "reth-ethereum-engine-primitives",
- "reth-ethereum-primitives",
  "reth-evm",
  "reth-evm-ethereum",
  "reth-execution-types",
@@ -9267,8 +9284,8 @@ dependencies = [
 
 [[package]]
 name = "reth-rpc-api"
-version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=10aa6a512ba7c4f5f01ff489b1f513da0745821f#10aa6a512ba7c4f5f01ff489b1f513da0745821f"
+version = "2.5.1"
+source = "git+https://github.com/paradigmxyz/reth?rev=9812056#98120568b6f1c133fbffefd0371e1af6413271ee"
 dependencies = [
  "alloy-eips",
  "alloy-genesis",
@@ -9297,8 +9314,8 @@ dependencies = [
 
 [[package]]
 name = "reth-rpc-builder"
-version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=10aa6a512ba7c4f5f01ff489b1f513da0745821f#10aa6a512ba7c4f5f01ff489b1f513da0745821f"
+version = "2.5.1"
+source = "git+https://github.com/paradigmxyz/reth?rev=9812056#98120568b6f1c133fbffefd0371e1af6413271ee"
 dependencies = [
  "alloy-network",
  "alloy-provider",
@@ -9340,8 +9357,8 @@ dependencies = [
 
 [[package]]
 name = "reth-rpc-convert"
-version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=10aa6a512ba7c4f5f01ff489b1f513da0745821f#10aa6a512ba7c4f5f01ff489b1f513da0745821f"
+version = "2.5.1"
+source = "git+https://github.com/paradigmxyz/reth?rev=9812056#98120568b6f1c133fbffefd0371e1af6413271ee"
 dependencies = [
  "alloy-consensus",
  "alloy-evm",
@@ -9360,8 +9377,8 @@ dependencies = [
 
 [[package]]
 name = "reth-rpc-engine-api"
-version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=10aa6a512ba7c4f5f01ff489b1f513da0745821f#10aa6a512ba7c4f5f01ff489b1f513da0745821f"
+version = "2.5.1"
+source = "git+https://github.com/paradigmxyz/reth?rev=9812056#98120568b6f1c133fbffefd0371e1af6413271ee"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -9391,8 +9408,8 @@ dependencies = [
 
 [[package]]
 name = "reth-rpc-eth-api"
-version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=10aa6a512ba7c4f5f01ff489b1f513da0745821f#10aa6a512ba7c4f5f01ff489b1f513da0745821f"
+version = "2.5.1"
+source = "git+https://github.com/paradigmxyz/reth?rev=9812056#98120568b6f1c133fbffefd0371e1af6413271ee"
 dependencies = [
  "alloy-consensus",
  "alloy-dyn-abi",
@@ -9438,8 +9455,8 @@ dependencies = [
 
 [[package]]
 name = "reth-rpc-eth-types"
-version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=10aa6a512ba7c4f5f01ff489b1f513da0745821f#10aa6a512ba7c4f5f01ff489b1f513da0745821f"
+version = "2.5.1"
+source = "git+https://github.com/paradigmxyz/reth?rev=9812056#98120568b6f1c133fbffefd0371e1af6413271ee"
 dependencies = [
  "alloy-chains",
  "alloy-consensus",
@@ -9475,7 +9492,6 @@ dependencies = [
  "reth-storage-api",
  "reth-tasks",
  "reth-transaction-pool",
- "reth-trie",
  "revm",
  "revm-inspectors",
  "schnellru",
@@ -9489,13 +9505,15 @@ dependencies = [
 
 [[package]]
 name = "reth-rpc-layer"
-version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=10aa6a512ba7c4f5f01ff489b1f513da0745821f#10aa6a512ba7c4f5f01ff489b1f513da0745821f"
+version = "2.5.1"
+source = "git+https://github.com/paradigmxyz/reth?rev=9812056#98120568b6f1c133fbffefd0371e1af6413271ee"
 dependencies = [
  "alloy-rpc-types-engine",
  "http",
+ "http-body-util",
  "jsonrpsee-http-client",
  "pin-project",
+ "tokio",
  "tower",
  "tower-http",
  "tracing",
@@ -9503,8 +9521,8 @@ dependencies = [
 
 [[package]]
 name = "reth-rpc-server-types"
-version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=10aa6a512ba7c4f5f01ff489b1f513da0745821f#10aa6a512ba7c4f5f01ff489b1f513da0745821f"
+version = "2.5.1"
+source = "git+https://github.com/paradigmxyz/reth?rev=9812056#98120568b6f1c133fbffefd0371e1af6413271ee"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -9534,10 +9552,11 @@ dependencies = [
 
 [[package]]
 name = "reth-stages"
-version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=10aa6a512ba7c4f5f01ff489b1f513da0745821f#10aa6a512ba7c4f5f01ff489b1f513da0745821f"
+version = "2.5.1"
+source = "git+https://github.com/paradigmxyz/reth?rev=9812056#98120568b6f1c133fbffefd0371e1af6413271ee"
 dependencies = [
  "alloy-consensus",
+ "alloy-eip7928",
  "alloy-primitives",
  "alloy-rlp",
  "eyre",
@@ -9585,8 +9604,8 @@ dependencies = [
 
 [[package]]
 name = "reth-stages-api"
-version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=10aa6a512ba7c4f5f01ff489b1f513da0745821f#10aa6a512ba7c4f5f01ff489b1f513da0745821f"
+version = "2.5.1"
+source = "git+https://github.com/paradigmxyz/reth?rev=9812056#98120568b6f1c133fbffefd0371e1af6413271ee"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -9613,8 +9632,8 @@ dependencies = [
 
 [[package]]
 name = "reth-stages-types"
-version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=10aa6a512ba7c4f5f01ff489b1f513da0745821f#10aa6a512ba7c4f5f01ff489b1f513da0745821f"
+version = "2.5.1"
+source = "git+https://github.com/paradigmxyz/reth?rev=9812056#98120568b6f1c133fbffefd0371e1af6413271ee"
 dependencies = [
  "alloy-primitives",
  "arbitrary",
@@ -9627,8 +9646,8 @@ dependencies = [
 
 [[package]]
 name = "reth-static-file"
-version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=10aa6a512ba7c4f5f01ff489b1f513da0745821f#10aa6a512ba7c4f5f01ff489b1f513da0745821f"
+version = "2.5.1"
+source = "git+https://github.com/paradigmxyz/reth?rev=9812056#98120568b6f1c133fbffefd0371e1af6413271ee"
 dependencies = [
  "alloy-primitives",
  "parking_lot",
@@ -9647,8 +9666,8 @@ dependencies = [
 
 [[package]]
 name = "reth-static-file-types"
-version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=10aa6a512ba7c4f5f01ff489b1f513da0745821f#10aa6a512ba7c4f5f01ff489b1f513da0745821f"
+version = "2.5.1"
+source = "git+https://github.com/paradigmxyz/reth?rev=9812056#98120568b6f1c133fbffefd0371e1af6413271ee"
 dependencies = [
  "alloy-primitives",
  "clap",
@@ -9662,8 +9681,8 @@ dependencies = [
 
 [[package]]
 name = "reth-storage-api"
-version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=10aa6a512ba7c4f5f01ff489b1f513da0745821f#10aa6a512ba7c4f5f01ff489b1f513da0745821f"
+version = "2.5.1"
+source = "git+https://github.com/paradigmxyz/reth?rev=9812056#98120568b6f1c133fbffefd0371e1af6413271ee"
 dependencies = [
  "alloy-consensus",
  "alloy-eip7928",
@@ -9688,8 +9707,8 @@ dependencies = [
 
 [[package]]
 name = "reth-storage-errors"
-version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=10aa6a512ba7c4f5f01ff489b1f513da0745821f#10aa6a512ba7c4f5f01ff489b1f513da0745821f"
+version = "2.5.1"
+source = "git+https://github.com/paradigmxyz/reth?rev=9812056#98120568b6f1c133fbffefd0371e1af6413271ee"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -9705,8 +9724,8 @@ dependencies = [
 
 [[package]]
 name = "reth-storage-overlay"
-version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=10aa6a512ba7c4f5f01ff489b1f513da0745821f#10aa6a512ba7c4f5f01ff489b1f513da0745821f"
+version = "2.5.1"
+source = "git+https://github.com/paradigmxyz/reth?rev=9812056#98120568b6f1c133fbffefd0371e1af6413271ee"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -9714,6 +9733,7 @@ dependencies = [
  "parking_lot",
  "rayon",
  "reth-chain-state",
+ "reth-db-api",
  "reth-errors",
  "reth-ethereum-primitives",
  "reth-metrics",
@@ -9726,13 +9746,14 @@ dependencies = [
  "reth-trie",
  "reth-trie-common",
  "reth-trie-db",
+ "revm",
  "tracing",
 ]
 
 [[package]]
 name = "reth-tasks"
-version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=10aa6a512ba7c4f5f01ff489b1f513da0745821f#10aa6a512ba7c4f5f01ff489b1f513da0745821f"
+version = "2.5.1"
+source = "git+https://github.com/paradigmxyz/reth?rev=9812056#98120568b6f1c133fbffefd0371e1af6413271ee"
 dependencies = [
  "crossbeam-utils",
  "dashmap",
@@ -9752,8 +9773,8 @@ dependencies = [
 
 [[package]]
 name = "reth-testing-utils"
-version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=10aa6a512ba7c4f5f01ff489b1f513da0745821f#10aa6a512ba7c4f5f01ff489b1f513da0745821f"
+version = "2.5.1"
+source = "git+https://github.com/paradigmxyz/reth?rev=9812056#98120568b6f1c133fbffefd0371e1af6413271ee"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9768,8 +9789,8 @@ dependencies = [
 
 [[package]]
 name = "reth-tokio-util"
-version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=10aa6a512ba7c4f5f01ff489b1f513da0745821f#10aa6a512ba7c4f5f01ff489b1f513da0745821f"
+version = "2.5.1"
+source = "git+https://github.com/paradigmxyz/reth?rev=9812056#98120568b6f1c133fbffefd0371e1af6413271ee"
 dependencies = [
  "tokio",
  "tokio-stream",
@@ -9778,8 +9799,8 @@ dependencies = [
 
 [[package]]
 name = "reth-tracing"
-version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=10aa6a512ba7c4f5f01ff489b1f513da0745821f#10aa6a512ba7c4f5f01ff489b1f513da0745821f"
+version = "2.5.1"
+source = "git+https://github.com/paradigmxyz/reth?rev=9812056#98120568b6f1c133fbffefd0371e1af6413271ee"
 dependencies = [
  "clap",
  "eyre",
@@ -9796,8 +9817,8 @@ dependencies = [
 
 [[package]]
 name = "reth-tracing-otlp"
-version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=10aa6a512ba7c4f5f01ff489b1f513da0745821f#10aa6a512ba7c4f5f01ff489b1f513da0745821f"
+version = "2.5.1"
+source = "git+https://github.com/paradigmxyz/reth?rev=9812056#98120568b6f1c133fbffefd0371e1af6413271ee"
 dependencies = [
  "base64 0.22.1",
  "clap",
@@ -9814,8 +9835,8 @@ dependencies = [
 
 [[package]]
 name = "reth-transaction-pool"
-version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=10aa6a512ba7c4f5f01ff489b1f513da0745821f#10aa6a512ba7c4f5f01ff489b1f513da0745821f"
+version = "2.5.1"
+source = "git+https://github.com/paradigmxyz/reth?rev=9812056#98120568b6f1c133fbffefd0371e1af6413271ee"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9857,8 +9878,8 @@ dependencies = [
 
 [[package]]
 name = "reth-trie"
-version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=10aa6a512ba7c4f5f01ff489b1f513da0745821f#10aa6a512ba7c4f5f01ff489b1f513da0745821f"
+version = "2.5.1"
+source = "git+https://github.com/paradigmxyz/reth?rev=9812056#98120568b6f1c133fbffefd0371e1af6413271ee"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9883,8 +9904,8 @@ dependencies = [
 
 [[package]]
 name = "reth-trie-common"
-version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=10aa6a512ba7c4f5f01ff489b1f513da0745821f#10aa6a512ba7c4f5f01ff489b1f513da0745821f"
+version = "2.5.1"
+source = "git+https://github.com/paradigmxyz/reth?rev=9812056#98120568b6f1c133fbffefd0371e1af6413271ee"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -9906,12 +9927,13 @@ dependencies = [
  "revm",
  "serde",
  "serde_with",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
 name = "reth-trie-db"
-version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=10aa6a512ba7c4f5f01ff489b1f513da0745821f#10aa6a512ba7c4f5f01ff489b1f513da0745821f"
+version = "2.5.1"
+source = "git+https://github.com/paradigmxyz/reth?rev=9812056#98120568b6f1c133fbffefd0371e1af6413271ee"
 dependencies = [
  "alloy-primitives",
  "reth-db-api",
@@ -9926,8 +9948,8 @@ dependencies = [
 
 [[package]]
 name = "reth-trie-parallel"
-version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=10aa6a512ba7c4f5f01ff489b1f513da0745821f#10aa6a512ba7c4f5f01ff489b1f513da0745821f"
+version = "2.5.1"
+source = "git+https://github.com/paradigmxyz/reth?rev=9812056#98120568b6f1c133fbffefd0371e1af6413271ee"
 dependencies = [
  "alloy-evm",
  "alloy-primitives",
@@ -9950,8 +9972,8 @@ dependencies = [
 
 [[package]]
 name = "reth-trie-sparse"
-version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=10aa6a512ba7c4f5f01ff489b1f513da0745821f#10aa6a512ba7c4f5f01ff489b1f513da0745821f"
+version = "2.5.1"
+source = "git+https://github.com/paradigmxyz/reth?rev=9812056#98120568b6f1c133fbffefd0371e1af6413271ee"
 dependencies = [
  "alloy-primitives",
  "alloy-trie",
@@ -10112,9 +10134,9 @@ dependencies = [
 
 [[package]]
 name = "revm-inspectors"
-version = "0.42.0"
+version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3958b5de5c2c08c6a49b8d94f6ead3e9cd7980c43d6ed240aa3d6485d53269b5"
+checksum = "90c136a072540987ee442e9824631835520b13e5756f20780a637ba2e11f9c28"
 dependencies = [
  "alloy-primitives",
  "alloy-rpc-types-eth",
@@ -10402,7 +10424,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -10482,7 +10504,7 @@ dependencies = [
  "security-framework",
  "security-framework-sys",
  "webpki-root-certs 1.0.8",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -11084,7 +11106,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c3d1e2c7f27f8d4cb10542a02c49005dbd6e93095799d6f3be745fae9f8fedd4"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -11234,9 +11256,9 @@ dependencies = [
 
 [[package]]
 name = "syn-solidity"
-version = "1.6.1"
+version = "1.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "083be3061e64d362cbe6ef12cfe1307ba3884326d8856448fe8a120fa2c44ebf"
+checksum = "4c6415502cd1e9ed58b3ceb415164b812d5572757b1a6f0e280ae806723c1fab"
 dependencies = [
  "paste",
  "proc-macro2",
@@ -11346,13 +11368,13 @@ dependencies = [
  "getrandom 0.4.3",
  "once_cell",
  "rustix",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
 name = "tempo-alloy"
-version = "1.10.1"
-source = "git+https://github.com/tempoxyz/tempo?rev=9f7fc9295ea3fa3b49ec2b0a9e524a8b2cb202b1#9f7fc9295ea3fa3b49ec2b0a9e524a8b2cb202b1"
+version = "1.11.0"
+source = "git+https://github.com/tempoxyz/tempo?rev=734f823071db06238142cab7dd4d599a1552be40#734f823071db06238142cab7dd4d599a1552be40"
 dependencies = [
  "alloy-consensus",
  "alloy-contract",
@@ -11397,8 +11419,8 @@ dependencies = [
 
 [[package]]
 name = "tempo-chainspec"
-version = "1.10.1"
-source = "git+https://github.com/tempoxyz/tempo?rev=9f7fc9295ea3fa3b49ec2b0a9e524a8b2cb202b1#9f7fc9295ea3fa3b49ec2b0a9e524a8b2cb202b1"
+version = "1.11.0"
+source = "git+https://github.com/tempoxyz/tempo?rev=734f823071db06238142cab7dd4d599a1552be40#734f823071db06238142cab7dd4d599a1552be40"
 dependencies = [
  "alloy-eips",
  "alloy-evm",
@@ -11420,8 +11442,8 @@ dependencies = [
 
 [[package]]
 name = "tempo-contracts"
-version = "1.10.1"
-source = "git+https://github.com/tempoxyz/tempo?rev=9f7fc9295ea3fa3b49ec2b0a9e524a8b2cb202b1#9f7fc9295ea3fa3b49ec2b0a9e524a8b2cb202b1"
+version = "1.11.0"
+source = "git+https://github.com/tempoxyz/tempo?rev=734f823071db06238142cab7dd4d599a1552be40#734f823071db06238142cab7dd4d599a1552be40"
 dependencies = [
  "alloy-contract",
  "alloy-primitives",
@@ -11432,8 +11454,8 @@ dependencies = [
 
 [[package]]
 name = "tempo-dkg-onchain-artifacts"
-version = "1.11.0"
-source = "git+https://github.com/tempoxyz/tempo?rev=9f7fc9295ea3fa3b49ec2b0a9e524a8b2cb202b1#9f7fc9295ea3fa3b49ec2b0a9e524a8b2cb202b1"
+version = "1.13.2"
+source = "git+https://github.com/tempoxyz/tempo?rev=734f823071db06238142cab7dd4d599a1552be40#734f823071db06238142cab7dd4d599a1552be40"
 dependencies = [
  "bytes",
  "commonware-codec",
@@ -11444,8 +11466,8 @@ dependencies = [
 
 [[package]]
 name = "tempo-evm"
-version = "1.11.0"
-source = "git+https://github.com/tempoxyz/tempo?rev=9f7fc9295ea3fa3b49ec2b0a9e524a8b2cb202b1#9f7fc9295ea3fa3b49ec2b0a9e524a8b2cb202b1"
+version = "1.13.2"
+source = "git+https://github.com/tempoxyz/tempo?rev=734f823071db06238142cab7dd4d599a1552be40#734f823071db06238142cab7dd4d599a1552be40"
 dependencies = [
  "alloy-consensus",
  "alloy-evm",
@@ -11479,8 +11501,8 @@ dependencies = [
 
 [[package]]
 name = "tempo-hardfork"
-version = "1.10.1"
-source = "git+https://github.com/tempoxyz/tempo?rev=9f7fc9295ea3fa3b49ec2b0a9e524a8b2cb202b1#9f7fc9295ea3fa3b49ec2b0a9e524a8b2cb202b1"
+version = "1.11.0"
+source = "git+https://github.com/tempoxyz/tempo?rev=734f823071db06238142cab7dd4d599a1552be40#734f823071db06238142cab7dd4d599a1552be40"
 dependencies = [
  "alloy-eips",
  "alloy-evm",
@@ -11491,8 +11513,8 @@ dependencies = [
 
 [[package]]
 name = "tempo-node"
-version = "1.11.0"
-source = "git+https://github.com/tempoxyz/tempo?rev=9f7fc9295ea3fa3b49ec2b0a9e524a8b2cb202b1#9f7fc9295ea3fa3b49ec2b0a9e524a8b2cb202b1"
+version = "1.13.2"
+source = "git+https://github.com/tempoxyz/tempo?rev=734f823071db06238142cab7dd4d599a1552be40#734f823071db06238142cab7dd4d599a1552be40"
 dependencies = [
  "alloy",
  "alloy-eips",
@@ -11503,9 +11525,13 @@ dependencies = [
  "alloy-serde",
  "async-trait",
  "clap",
+ "commonware-codec",
+ "commonware-consensus",
+ "commonware-cryptography",
  "commonware-runtime",
  "eyre",
  "futures",
+ "governor",
  "jiff",
  "jsonrpsee",
  "metrics",
@@ -11514,6 +11540,7 @@ dependencies = [
  "reth-errors",
  "reth-ethereum",
  "reth-evm",
+ "reth-metrics",
  "reth-network-api",
  "reth-node-api",
  "reth-node-builder",
@@ -11544,6 +11571,7 @@ dependencies = [
  "tempo-transaction-pool",
  "thiserror 2.0.18",
  "tokio",
+ "tokio-stream",
  "url",
  "vergen",
  "vergen-git2",
@@ -11551,8 +11579,8 @@ dependencies = [
 
 [[package]]
 name = "tempo-payload-builder"
-version = "1.11.0"
-source = "git+https://github.com/tempoxyz/tempo?rev=9f7fc9295ea3fa3b49ec2b0a9e524a8b2cb202b1#9f7fc9295ea3fa3b49ec2b0a9e524a8b2cb202b1"
+version = "1.13.2"
+source = "git+https://github.com/tempoxyz/tempo?rev=734f823071db06238142cab7dd4d599a1552be40#734f823071db06238142cab7dd4d599a1552be40"
 dependencies = [
  "alloy-consensus",
  "alloy-eip7928",
@@ -11589,8 +11617,8 @@ dependencies = [
 
 [[package]]
 name = "tempo-payload-types"
-version = "1.11.0"
-source = "git+https://github.com/tempoxyz/tempo?rev=9f7fc9295ea3fa3b49ec2b0a9e524a8b2cb202b1#9f7fc9295ea3fa3b49ec2b0a9e524a8b2cb202b1"
+version = "1.13.2"
+source = "git+https://github.com/tempoxyz/tempo?rev=734f823071db06238142cab7dd4d599a1552be40#734f823071db06238142cab7dd4d599a1552be40"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -11609,8 +11637,8 @@ dependencies = [
 
 [[package]]
 name = "tempo-precompiles"
-version = "1.11.0"
-source = "git+https://github.com/tempoxyz/tempo?rev=9f7fc9295ea3fa3b49ec2b0a9e524a8b2cb202b1#9f7fc9295ea3fa3b49ec2b0a9e524a8b2cb202b1"
+version = "1.13.2"
+source = "git+https://github.com/tempoxyz/tempo?rev=734f823071db06238142cab7dd4d599a1552be40#734f823071db06238142cab7dd4d599a1552be40"
 dependencies = [
  "alloy",
  "alloy-evm",
@@ -11636,8 +11664,8 @@ dependencies = [
 
 [[package]]
 name = "tempo-precompiles-macros"
-version = "1.11.0"
-source = "git+https://github.com/tempoxyz/tempo?rev=9f7fc9295ea3fa3b49ec2b0a9e524a8b2cb202b1#9f7fc9295ea3fa3b49ec2b0a9e524a8b2cb202b1"
+version = "1.13.2"
+source = "git+https://github.com/tempoxyz/tempo?rev=734f823071db06238142cab7dd4d599a1552be40#734f823071db06238142cab7dd4d599a1552be40"
 dependencies = [
  "alloy",
  "proc-macro2",
@@ -11647,8 +11675,8 @@ dependencies = [
 
 [[package]]
 name = "tempo-primitives"
-version = "1.10.1"
-source = "git+https://github.com/tempoxyz/tempo?rev=9f7fc9295ea3fa3b49ec2b0a9e524a8b2cb202b1#9f7fc9295ea3fa3b49ec2b0a9e524a8b2cb202b1"
+version = "1.11.0"
+source = "git+https://github.com/tempoxyz/tempo?rev=734f823071db06238142cab7dd4d599a1552be40#734f823071db06238142cab7dd4d599a1552be40"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -11679,8 +11707,8 @@ dependencies = [
 
 [[package]]
 name = "tempo-revm"
-version = "1.11.0"
-source = "git+https://github.com/tempoxyz/tempo?rev=9f7fc9295ea3fa3b49ec2b0a9e524a8b2cb202b1#9f7fc9295ea3fa3b49ec2b0a9e524a8b2cb202b1"
+version = "1.13.2"
+source = "git+https://github.com/tempoxyz/tempo?rev=734f823071db06238142cab7dd4d599a1552be40#734f823071db06238142cab7dd4d599a1552be40"
 dependencies = [
  "alloy-consensus",
  "alloy-evm",
@@ -11702,8 +11730,8 @@ dependencies = [
 
 [[package]]
 name = "tempo-transaction-pool"
-version = "1.11.0"
-source = "git+https://github.com/tempoxyz/tempo?rev=9f7fc9295ea3fa3b49ec2b0a9e524a8b2cb202b1#9f7fc9295ea3fa3b49ec2b0a9e524a8b2cb202b1"
+version = "1.13.2"
+source = "git+https://github.com/tempoxyz/tempo?rev=734f823071db06238142cab7dd4d599a1552be40#734f823071db06238142cab7dd4d599a1552be40"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -13030,7 +13058,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -101,26 +101,26 @@ incremental = false
 
 [workspace.dependencies]
 # tempo (from upstream)
-tempo-alloy = { git = "https://github.com/tempoxyz/tempo", rev = "9f7fc9295ea3fa3b49ec2b0a9e524a8b2cb202b1" }
-tempo-chainspec = { git = "https://github.com/tempoxyz/tempo", rev = "9f7fc9295ea3fa3b49ec2b0a9e524a8b2cb202b1", default-features = false }
-tempo-consensus = { git = "https://github.com/tempoxyz/tempo", rev = "9f7fc9295ea3fa3b49ec2b0a9e524a8b2cb202b1", default-features = false }
-tempo-contracts = { git = "https://github.com/tempoxyz/tempo", rev = "9f7fc9295ea3fa3b49ec2b0a9e524a8b2cb202b1", default-features = false, features = [
+tempo-alloy = { git = "https://github.com/tempoxyz/tempo", rev = "734f823071db06238142cab7dd4d599a1552be40" }
+tempo-chainspec = { git = "https://github.com/tempoxyz/tempo", rev = "734f823071db06238142cab7dd4d599a1552be40", default-features = false }
+tempo-consensus = { git = "https://github.com/tempoxyz/tempo", rev = "734f823071db06238142cab7dd4d599a1552be40", default-features = false }
+tempo-contracts = { git = "https://github.com/tempoxyz/tempo", rev = "734f823071db06238142cab7dd4d599a1552be40", default-features = false, features = [
   "serde",
 ] }
-tempo-evm = { git = "https://github.com/tempoxyz/tempo", rev = "9f7fc9295ea3fa3b49ec2b0a9e524a8b2cb202b1", default-features = false }
-tempo-hardfork = { git = "https://github.com/tempoxyz/tempo", rev = "9f7fc9295ea3fa3b49ec2b0a9e524a8b2cb202b1", default-features = false }
-tempo-node = { git = "https://github.com/tempoxyz/tempo", rev = "9f7fc9295ea3fa3b49ec2b0a9e524a8b2cb202b1" }
-tempo-payload-types = { git = "https://github.com/tempoxyz/tempo", rev = "9f7fc9295ea3fa3b49ec2b0a9e524a8b2cb202b1", default-features = false }
-tempo-precompiles = { git = "https://github.com/tempoxyz/tempo", rev = "9f7fc9295ea3fa3b49ec2b0a9e524a8b2cb202b1", default-features = false }
-tempo-precompiles-macros = { git = "https://github.com/tempoxyz/tempo", rev = "9f7fc9295ea3fa3b49ec2b0a9e524a8b2cb202b1" }
-tempo-primitives = { git = "https://github.com/tempoxyz/tempo", rev = "9f7fc9295ea3fa3b49ec2b0a9e524a8b2cb202b1", default-features = false, features = [
+tempo-evm = { git = "https://github.com/tempoxyz/tempo", rev = "734f823071db06238142cab7dd4d599a1552be40", default-features = false }
+tempo-hardfork = { git = "https://github.com/tempoxyz/tempo", rev = "734f823071db06238142cab7dd4d599a1552be40", default-features = false }
+tempo-node = { git = "https://github.com/tempoxyz/tempo", rev = "734f823071db06238142cab7dd4d599a1552be40" }
+tempo-payload-types = { git = "https://github.com/tempoxyz/tempo", rev = "734f823071db06238142cab7dd4d599a1552be40", default-features = false }
+tempo-precompiles = { git = "https://github.com/tempoxyz/tempo", rev = "734f823071db06238142cab7dd4d599a1552be40", default-features = false }
+tempo-precompiles-macros = { git = "https://github.com/tempoxyz/tempo", rev = "734f823071db06238142cab7dd4d599a1552be40" }
+tempo-primitives = { git = "https://github.com/tempoxyz/tempo", rev = "734f823071db06238142cab7dd4d599a1552be40", default-features = false, features = [
   "reth",
   "serde",
   "serde-bincode-compat",
   "reth-codec",
 ] }
-tempo-revm = { git = "https://github.com/tempoxyz/tempo", rev = "9f7fc9295ea3fa3b49ec2b0a9e524a8b2cb202b1", default-features = false }
-tempo-transaction-pool = { git = "https://github.com/tempoxyz/tempo", rev = "9f7fc9295ea3fa3b49ec2b0a9e524a8b2cb202b1", default-features = false }
+tempo-revm = { git = "https://github.com/tempoxyz/tempo", rev = "734f823071db06238142cab7dd4d599a1552be40", default-features = false }
+tempo-transaction-pool = { git = "https://github.com/tempoxyz/tempo", rev = "734f823071db06238142cab7dd4d599a1552be40", default-features = false }
 
 # zones
 tempo-zone-contracts = { path = "crates/contracts", default-features = false }
@@ -140,48 +140,48 @@ zone-spf = { path = "crates/spf" }
 zone-checker = { path = "crates/checker" }
 
 # reth
-reth-basic-payload-builder = { git = "https://github.com/paradigmxyz/reth", rev = "10aa6a512ba7c4f5f01ff489b1f513da0745821f" }
-reth-chain-state = { git = "https://github.com/paradigmxyz/reth", rev = "10aa6a512ba7c4f5f01ff489b1f513da0745821f" }
-reth-chainspec = { git = "https://github.com/paradigmxyz/reth", rev = "10aa6a512ba7c4f5f01ff489b1f513da0745821f" }
-reth-cli = { git = "https://github.com/paradigmxyz/reth", rev = "10aa6a512ba7c4f5f01ff489b1f513da0745821f" }
-reth-cli-util = { git = "https://github.com/paradigmxyz/reth", rev = "10aa6a512ba7c4f5f01ff489b1f513da0745821f" }
-reth-consensus = { git = "https://github.com/paradigmxyz/reth", rev = "10aa6a512ba7c4f5f01ff489b1f513da0745821f" }
+reth-basic-payload-builder = { git = "https://github.com/paradigmxyz/reth", rev = "9812056" }
+reth-chain-state = { git = "https://github.com/paradigmxyz/reth", rev = "9812056" }
+reth-chainspec = { git = "https://github.com/paradigmxyz/reth", rev = "9812056" }
+reth-cli = { git = "https://github.com/paradigmxyz/reth", rev = "9812056" }
+reth-cli-util = { git = "https://github.com/paradigmxyz/reth", rev = "9812056" }
+reth-consensus = { git = "https://github.com/paradigmxyz/reth", rev = "9812056" }
 reth-codecs = { version = "0.6.0", default-features = false }
-reth-db = { git = "https://github.com/paradigmxyz/reth", rev = "10aa6a512ba7c4f5f01ff489b1f513da0745821f" }
-reth-engine-local = { git = "https://github.com/paradigmxyz/reth", rev = "10aa6a512ba7c4f5f01ff489b1f513da0745821f" }
-reth-errors = { git = "https://github.com/paradigmxyz/reth", rev = "10aa6a512ba7c4f5f01ff489b1f513da0745821f" }
-reth-eth-wire-types = { git = "https://github.com/paradigmxyz/reth", rev = "10aa6a512ba7c4f5f01ff489b1f513da0745821f" }
-reth-ethereum = { git = "https://github.com/paradigmxyz/reth", rev = "10aa6a512ba7c4f5f01ff489b1f513da0745821f" }
-reth-ethereum-primitives = { git = "https://github.com/paradigmxyz/reth", rev = "10aa6a512ba7c4f5f01ff489b1f513da0745821f" }
-reth-evm = { git = "https://github.com/paradigmxyz/reth", rev = "10aa6a512ba7c4f5f01ff489b1f513da0745821f" }
-reth-exex = { git = "https://github.com/paradigmxyz/reth", rev = "10aa6a512ba7c4f5f01ff489b1f513da0745821f" }
-reth-execution-types = { git = "https://github.com/paradigmxyz/reth", rev = "10aa6a512ba7c4f5f01ff489b1f513da0745821f" }
-reth-metrics = { git = "https://github.com/paradigmxyz/reth", rev = "10aa6a512ba7c4f5f01ff489b1f513da0745821f" }
-reth-network-peers = { git = "https://github.com/paradigmxyz/reth", rev = "10aa6a512ba7c4f5f01ff489b1f513da0745821f" }
-reth-node-api = { git = "https://github.com/paradigmxyz/reth", rev = "10aa6a512ba7c4f5f01ff489b1f513da0745821f" }
-reth-node-builder = { git = "https://github.com/paradigmxyz/reth", rev = "10aa6a512ba7c4f5f01ff489b1f513da0745821f" }
-reth-node-core = { git = "https://github.com/paradigmxyz/reth", rev = "10aa6a512ba7c4f5f01ff489b1f513da0745821f" }
-reth-payload-builder = { git = "https://github.com/paradigmxyz/reth", rev = "10aa6a512ba7c4f5f01ff489b1f513da0745821f" }
-reth-payload-primitives = { git = "https://github.com/paradigmxyz/reth", rev = "10aa6a512ba7c4f5f01ff489b1f513da0745821f" }
+reth-db = { git = "https://github.com/paradigmxyz/reth", rev = "9812056" }
+reth-engine-local = { git = "https://github.com/paradigmxyz/reth", rev = "9812056" }
+reth-errors = { git = "https://github.com/paradigmxyz/reth", rev = "9812056" }
+reth-eth-wire-types = { git = "https://github.com/paradigmxyz/reth", rev = "9812056" }
+reth-ethereum = { git = "https://github.com/paradigmxyz/reth", rev = "9812056" }
+reth-ethereum-primitives = { git = "https://github.com/paradigmxyz/reth", rev = "9812056" }
+reth-evm = { git = "https://github.com/paradigmxyz/reth", rev = "9812056" }
+reth-exex = { git = "https://github.com/paradigmxyz/reth", rev = "9812056" }
+reth-execution-types = { git = "https://github.com/paradigmxyz/reth", rev = "9812056" }
+reth-metrics = { git = "https://github.com/paradigmxyz/reth", rev = "9812056" }
+reth-network-peers = { git = "https://github.com/paradigmxyz/reth", rev = "9812056" }
+reth-node-api = { git = "https://github.com/paradigmxyz/reth", rev = "9812056" }
+reth-node-builder = { git = "https://github.com/paradigmxyz/reth", rev = "9812056" }
+reth-node-core = { git = "https://github.com/paradigmxyz/reth", rev = "9812056" }
+reth-payload-builder = { git = "https://github.com/paradigmxyz/reth", rev = "9812056" }
+reth-payload-primitives = { git = "https://github.com/paradigmxyz/reth", rev = "9812056" }
 reth-primitives-traits = { version = "0.6.0", default-features = false }
-reth-provider = { git = "https://github.com/paradigmxyz/reth", rev = "10aa6a512ba7c4f5f01ff489b1f513da0745821f" }
-reth-revm = { git = "https://github.com/paradigmxyz/reth", rev = "10aa6a512ba7c4f5f01ff489b1f513da0745821f", features = [
+reth-provider = { git = "https://github.com/paradigmxyz/reth", rev = "9812056" }
+reth-revm = { git = "https://github.com/paradigmxyz/reth", rev = "9812056", features = [
   "std",
   "optional-checks",
 ] }
-reth-rpc = { git = "https://github.com/paradigmxyz/reth", rev = "10aa6a512ba7c4f5f01ff489b1f513da0745821f" }
-reth-rpc-api = { git = "https://github.com/paradigmxyz/reth", rev = "10aa6a512ba7c4f5f01ff489b1f513da0745821f" }
-reth-rpc-builder = { git = "https://github.com/paradigmxyz/reth", rev = "10aa6a512ba7c4f5f01ff489b1f513da0745821f" }
-reth-rpc-eth-api = { git = "https://github.com/paradigmxyz/reth", rev = "10aa6a512ba7c4f5f01ff489b1f513da0745821f" }
-reth-rpc-eth-types = { git = "https://github.com/paradigmxyz/reth", rev = "10aa6a512ba7c4f5f01ff489b1f513da0745821f" }
-reth-storage-api = { git = "https://github.com/paradigmxyz/reth", rev = "10aa6a512ba7c4f5f01ff489b1f513da0745821f" }
-reth-tasks = { git = "https://github.com/paradigmxyz/reth", rev = "10aa6a512ba7c4f5f01ff489b1f513da0745821f" }
-reth-tracing = { git = "https://github.com/paradigmxyz/reth", rev = "10aa6a512ba7c4f5f01ff489b1f513da0745821f" }
-reth-transaction-pool = { git = "https://github.com/paradigmxyz/reth", rev = "10aa6a512ba7c4f5f01ff489b1f513da0745821f" }
-reth-trie-common = { git = "https://github.com/paradigmxyz/reth", rev = "10aa6a512ba7c4f5f01ff489b1f513da0745821f", default-features = false, features = [
+reth-rpc = { git = "https://github.com/paradigmxyz/reth", rev = "9812056" }
+reth-rpc-api = { git = "https://github.com/paradigmxyz/reth", rev = "9812056" }
+reth-rpc-builder = { git = "https://github.com/paradigmxyz/reth", rev = "9812056" }
+reth-rpc-eth-api = { git = "https://github.com/paradigmxyz/reth", rev = "9812056" }
+reth-rpc-eth-types = { git = "https://github.com/paradigmxyz/reth", rev = "9812056" }
+reth-storage-api = { git = "https://github.com/paradigmxyz/reth", rev = "9812056" }
+reth-tasks = { git = "https://github.com/paradigmxyz/reth", rev = "9812056" }
+reth-tracing = { git = "https://github.com/paradigmxyz/reth", rev = "9812056" }
+reth-transaction-pool = { git = "https://github.com/paradigmxyz/reth", rev = "9812056" }
+reth-trie-common = { git = "https://github.com/paradigmxyz/reth", rev = "9812056", default-features = false, features = [
   "std",
 ] }
-reth-trie-sparse = { git = "https://github.com/paradigmxyz/reth", rev = "10aa6a512ba7c4f5f01ff489b1f513da0745821f", default-features = false, features = [
+reth-trie-sparse = { git = "https://github.com/paradigmxyz/reth", rev = "9812056", default-features = false, features = [
   "std",
 ] }
 revm = { version = "42.0.1", features = [
@@ -189,37 +189,37 @@ revm = { version = "42.0.1", features = [
 ], default-features = false }
 
 # alloy
-alloy = { version = "2.3.0", default-features = false }
+alloy = { version = "2.4.1", default-features = false }
 alloy-chains = "0.2.36"
 alloy-hardforks = { version = "0.4.7", default-features = false }
-alloy-consensus = { version = "2.3.0", default-features = false }
-alloy-contract = { version = "2.3.0", default-features = false }
-alloy-eips = { version = "2.3.0", default-features = false }
+alloy-consensus = { version = "2.4.1", default-features = false }
+alloy-contract = { version = "2.4.1", default-features = false }
+alloy-eips = { version = "2.4.1", default-features = false }
 alloy-evm = { version = "0.38.0", default-features = false }
-alloy-genesis = { version = "2.3.0", default-features = false }
-alloy-json-abi = "1.6.1"
-alloy-network = { version = "2.3.0", default-features = false }
-alloy-primitives = { version = "1.6.1", default-features = false }
-alloy-provider = { version = "2.3.0", default-features = false }
+alloy-genesis = { version = "2.4.1", default-features = false }
+alloy-json-abi = "1.7.2"
+alloy-network = { version = "2.4.1", default-features = false }
+alloy-primitives = { version = "1.7.2", default-features = false }
+alloy-provider = { version = "2.4.1", default-features = false }
 alloy-rlp = { version = "0.3.16", default-features = false }
-alloy-rpc-client = "2.3.0"
-alloy-rpc-types-debug = "2.3.0"
-alloy-rpc-types-engine = "2.3.0"
-alloy-rpc-types-eth = { version = "2.3.0" }
-alloy-signer = "2.3.0"
-alloy-signer-local = "2.3.0"
-alloy-sol-types = { version = "1.6.1", default-features = false }
-alloy-transport = "2.3.0"
+alloy-rpc-client = "2.4.1"
+alloy-rpc-types-debug = "2.4.1"
+alloy-rpc-types-engine = "2.4.1"
+alloy-rpc-types-eth = { version = "2.4.1" }
+alloy-signer = "2.4.1"
+alloy-signer-local = "2.4.1"
+alloy-sol-types = { version = "1.7.2", default-features = false }
+alloy-transport = "2.4.1"
 
 # commonware
-commonware-actor = "=2026.7.0"
-commonware-codec = "=2026.7.0"
-commonware-consensus = "=2026.7.0"
-commonware-cryptography = "=2026.7.0"
-commonware-math = "=2026.7.0"
-commonware-p2p = "=2026.7.0"
-commonware-runtime = "=2026.7.0"
-commonware-utils = "=2026.7.0"
+commonware-actor = "=2026.7.1"
+commonware-codec = "=2026.7.1"
+commonware-consensus = "=2026.7.1"
+commonware-cryptography = "=2026.7.1"
+commonware-math = "=2026.7.1"
+commonware-p2p = "=2026.7.1"
+commonware-runtime = "=2026.7.1"
+commonware-utils = "=2026.7.1"
 
 # misc
 bincode = "1.3.3"
@@ -270,21 +270,3 @@ tracing-subscriber = { version = "0.3.23", features = ["env-filter"] }
 vergen = { version = "10.0.1", features = ["build", "cargo", "emit_and_set"] }
 vergen-git2 = "10.0.1"
 zeroize = "1.9.0"
-
-# Keep Commonware aligned with the revision used by upstream Tempo. Cargo does
-# not inherit a git dependency's `[patch]` section into this workspace.
-[patch.crates-io]
-commonware-actor = { git = "https://github.com/commonwarexyz/monorepo", rev = "5950bf7179bb0650a57ed58b9e0478822944b335" }
-commonware-broadcast = { git = "https://github.com/commonwarexyz/monorepo", rev = "5950bf7179bb0650a57ed58b9e0478822944b335" }
-commonware-codec = { git = "https://github.com/commonwarexyz/monorepo", rev = "5950bf7179bb0650a57ed58b9e0478822944b335" }
-commonware-consensus = { git = "https://github.com/commonwarexyz/monorepo", rev = "5950bf7179bb0650a57ed58b9e0478822944b335" }
-commonware-cryptography = { git = "https://github.com/commonwarexyz/monorepo", rev = "5950bf7179bb0650a57ed58b9e0478822944b335" }
-commonware-macros = { git = "https://github.com/commonwarexyz/monorepo", rev = "5950bf7179bb0650a57ed58b9e0478822944b335" }
-commonware-math = { git = "https://github.com/commonwarexyz/monorepo", rev = "5950bf7179bb0650a57ed58b9e0478822944b335" }
-commonware-p2p = { git = "https://github.com/commonwarexyz/monorepo", rev = "5950bf7179bb0650a57ed58b9e0478822944b335" }
-commonware-parallel = { git = "https://github.com/commonwarexyz/monorepo", rev = "5950bf7179bb0650a57ed58b9e0478822944b335" }
-commonware-resolver = { git = "https://github.com/commonwarexyz/monorepo", rev = "5950bf7179bb0650a57ed58b9e0478822944b335" }
-commonware-runtime = { git = "https://github.com/commonwarexyz/monorepo", rev = "5950bf7179bb0650a57ed58b9e0478822944b335" }
-commonware-storage = { git = "https://github.com/commonwarexyz/monorepo", rev = "5950bf7179bb0650a57ed58b9e0478822944b335" }
-commonware-stream = { git = "https://github.com/commonwarexyz/monorepo", rev = "5950bf7179bb0650a57ed58b9e0478822944b335" }
-commonware-utils = { git = "https://github.com/commonwarexyz/monorepo", rev = "5950bf7179bb0650a57ed58b9e0478822944b335" }

--- a/crates/evm/src/executor.rs
+++ b/crates/evm/src/executor.rs
@@ -13,7 +13,7 @@ use alloy_evm::{
     },
     eth::{EthBlockExecutor, EthTxResult},
 };
-use alloy_sol_types::SolEvent as _;
+use alloy_sol_types::{SolCall as _, SolEvent as _};
 use reth_evm::block::StateDB;
 use reth_revm::{Inspector, context::result::ResultAndState};
 use tempo_evm::{TempoBlockExecutionCtx, TempoReceiptBuilder};
@@ -22,9 +22,7 @@ use tempo_revm::evm::TempoContext;
 use tempo_zone_contracts::IZoneOutbox;
 use zone_chainspec::ZoneChainSpec;
 use zone_l1::state::L1StateProvider;
-use zone_precompiles::{
-    ADVANCE_TEMPO_SELECTOR, L1StorageReader, is_finalize_withdrawal_batch_calldata,
-};
+use zone_precompiles::{ADVANCE_TEMPO_SELECTOR, L1StorageReader};
 use zone_primitives::constants::{ZONE_INBOX_ADDRESS, ZONE_OUTBOX_ADDRESS};
 
 use crate::{L1OverlayDB, ZoneEvm};
@@ -106,7 +104,8 @@ impl ZoneTransactionKind {
         }
 
         if tx.calls().any(|(kind, input)| {
-            kind.to() == Some(&ZONE_OUTBOX_ADDRESS) && is_finalize_withdrawal_batch_calldata(input)
+            kind.to() == Some(&ZONE_OUTBOX_ADDRESS)
+                && input.starts_with(&IZoneOutbox::finalizeWithdrawalBatchCall::SELECTOR)
         }) {
             return Self::FinalizeWithdrawalBatch;
         }
@@ -285,7 +284,7 @@ mod tests {
     use reth_chainspec::EthChainSpec as _;
     use reth_primitives_traits::Recovered;
     use revm::database::{CacheDB, EmptyDB};
-    use tempo_chainspec::spec::DEV;
+    use tempo_chainspec::{hardfork::TempoHardfork, spec::DEV};
     use tempo_evm::TempoBlockExecutionCtx;
     use tempo_precompiles::{
         DEFAULT_FEE_TOKEN, TIP_FEE_MANAGER_ADDRESS,
@@ -461,14 +460,74 @@ mod tests {
             ZONE_OUTBOX_ADDRESS,
             Bytes::copy_from_slice(&IZoneOutbox::finalizeWithdrawalBatchCall::SELECTOR),
         );
-        let error = ZoneBlockPhase::Executing
-            .validate_transaction(&malformed_finalize)
-            .unwrap_err();
         assert_eq!(
-            error.to_string(),
-            "system transactions after advanceTempo must call \
-             ZoneOutbox.finalizeWithdrawalBatch"
+            ZoneBlockPhase::Executing
+                .validate_transaction(&malformed_finalize)
+                .unwrap(),
+            ZoneBlockPhase::WithdrawalsFinalized
         );
+
+        let mut trailing_calldata = IZoneOutbox::finalizeWithdrawalBatchCall {
+            count: U256::ZERO,
+            blockNumber: 1,
+            encryptedSenders: vec![],
+        }
+        .abi_encode();
+        trailing_calldata.extend_from_slice(&[0; 32]);
+        let trailing_finalize = system_tx(ZONE_OUTBOX_ADDRESS, trailing_calldata.into());
+        assert_eq!(
+            ZoneBlockPhase::Executing
+                .validate_transaction(&trailing_finalize)
+                .unwrap(),
+            ZoneBlockPhase::WithdrawalsFinalized
+        );
+    }
+
+    #[test]
+    fn malformed_t11_finalization_does_not_advance_block_phase() {
+        let mut zone_genesis = DEV.genesis().clone();
+        zone_genesis.config.chain_id = zone_chain_id(DEV.chain().id(), 2).unwrap();
+        let chain_spec = std::sync::Arc::new(ZoneChainSpec::from_genesis(zone_genesis).unwrap());
+        let factory =
+            ZoneEvmFactory::new(chain_spec.clone(), MockL1Reader::default(), Address::ZERO);
+        let mut env = EvmEnv::default();
+        env.cfg_env.spec = TempoHardfork::T11;
+        let evm = factory.create_evm(CacheDB::new(EmptyDB::default()), env);
+        let ctx = TempoBlockExecutionCtx {
+            inner: EthBlockExecutionCtx {
+                parent_hash: B256::ZERO,
+                parent_beacon_block_root: None,
+                ommers: &[],
+                withdrawals: None,
+                extra_data: Bytes::new(),
+                tx_count_hint: Some(1),
+                slot_number: None,
+            },
+            general_gas_limit: 0,
+            shared_gas_limit: 0,
+            validator_set: None,
+            consensus_context: None,
+            subblock_fee_recipients: Default::default(),
+        };
+        let mut executor = ZoneBlockExecutor::new(evm, ctx, &chain_spec);
+        executor.phase = ZoneBlockPhase::Executing;
+
+        let tx = Recovered::new_unchecked(
+            system_tx(
+                ZONE_OUTBOX_ADDRESS,
+                Bytes::copy_from_slice(&IZoneOutbox::finalizeWithdrawalBatchCall::SELECTOR),
+            ),
+            TEMPO_SYSTEM_TX_SENDER,
+        );
+        let error = executor.execute_transaction_without_commit(tx).unwrap_err();
+
+        assert!(
+            error
+                .to_string()
+                .contains("system transaction execution failed"),
+            "unexpected error: {error}"
+        );
+        assert_eq!(executor.phase, ZoneBlockPhase::Executing);
     }
 
     #[test]

--- a/crates/node/src/replication.rs
+++ b/crates/node/src/replication.rs
@@ -18,6 +18,8 @@ use std::{
     time::Duration,
 };
 use tempo_alloy::TempoNetwork;
+use tempo_chainspec::hardfork::TempoHardfork;
+use tempo_precompiles::dispatch::abi_decoder_config_for_spec;
 use tempo_primitives::{Block, TempoHeader, TempoTxEnvelope};
 use tokio::sync::{mpsc, oneshot};
 use tokio_util::sync;
@@ -1375,8 +1377,11 @@ fn decode_advance_tempo(
     if signed.tx().to != ZONE_INBOX_ADDRESS.into() {
         eyre::bail!("first Tempo system transaction is not sent to IZoneInbox")
     }
-    let call = IZoneInbox::advanceTempoCall::abi_decode(signed.tx().input.as_ref())
-        .map_err(|err| eyre::eyre!("first transaction does not decode as advanceTempo: {err}"))?;
+    let call = IZoneInbox::advanceTempoCall::abi_decode_with_config(
+        signed.tx().input.as_ref(),
+        abi_decoder_config_for_spec(TempoHardfork::latest()),
+    )
+    .map_err(|err| eyre::eyre!("first transaction does not decode as advanceTempo: {err}"))?;
 
     // 3. the system tx is valid.
     let mut header_rlp = call.header.as_ref();

--- a/crates/node/src/rpc.rs
+++ b/crates/node/src/rpc.rs
@@ -11,7 +11,7 @@ use std::{
     time::Duration,
 };
 
-use alloy_consensus::BlockHeader;
+use alloy_consensus::{BlockHeader, transaction::TxHashRef};
 use alloy_eips::eip2935::{HISTORY_SERVE_WINDOW, HISTORY_STORAGE_ADDRESS};
 use alloy_network::{ReceiptResponse, TransactionBuilder, TransactionResponse};
 use alloy_primitives::{Address, B256, Bloom, Bytes, U64, U256, keccak256};
@@ -37,7 +37,7 @@ use reth_rpc_eth_api::{
 };
 use reth_rpc_eth_types::{EthApiError, logs_utils};
 use reth_storage_api::{BlockNumReader, StateProviderFactory};
-use reth_trie_common::{ExecutionWitnessMode, HashedStorage};
+use reth_trie_common::{ExecutionWitnessMode, HashedPostState};
 use tempo_alloy::{
     TempoNetwork,
     provider::ext::TempoProviderExt as _,
@@ -286,17 +286,27 @@ where
                 let (evm_config, recorder) = eth_api.evm_config().with_l1_storage_recorder();
                 let block_executor = evm_config.executor(&mut db);
                 let mode = ExecutionWitnessMode::default();
-                let mut witness_record = ExecutionWitnessRecord::default();
+                let mut witness = None;
 
                 let _ = block_executor
                     .execute_with_state_closure(&block, |statedb: &State<_>| {
-                        witness_record.record_executed_state(statedb, mode);
-                        record_block_hash_storage_proofs(&mut witness_record, statedb);
+                        let mut additional_state = HashedPostState::default();
+                        record_block_hash_storage_proofs(&mut additional_state, statedb);
+                        witness = Some(
+                            ExecutionWitnessRecord::new(statedb)
+                                .with_additional_state(additional_state)
+                                .into_execution_witness(
+                                    &statedb.database.database.0,
+                                    eth_api.provider(),
+                                    block_number,
+                                    mode,
+                                ),
+                        );
                     })
                     .map_err(|error| EthApiError::Internal(error.into()))?;
 
-                let witness = witness_record
-                    .into_execution_witness(&db.database.0, eth_api.provider(), block_number, mode)
+                let witness = witness
+                    .expect("state closure is called after successful execution")
                     .map_err(EthApiError::from)?;
                 Ok(ZoneExecutionWitness {
                     execution_witness: witness,
@@ -320,17 +330,16 @@ where
 /// Reth records these reads in REVM's block-hash cache and normally proves them with ancestor
 /// headers. Zones already commit the EIP-2935 history contract in state, so adding the matching
 /// storage targets lets the SPF authenticate the same values against the parent state root.
-fn record_block_hash_storage_proofs<DB>(witness: &mut ExecutionWitnessRecord, state: &State<DB>) {
+fn record_block_hash_storage_proofs<DB>(additional_state: &mut HashedPostState, state: &State<DB>) {
     let block_hashes = state.block_hashes.iter().collect::<Vec<_>>();
     if block_hashes.is_empty() {
         return;
     }
 
-    let history_storage = witness
-        .hashed_state
+    let history_storage = additional_state
         .storages
         .entry(keccak256(HISTORY_STORAGE_ADDRESS))
-        .or_insert_with(|| HashedStorage::new(false));
+        .or_default();
     for (number, hash) in block_hashes {
         let slot = U256::from(number % HISTORY_SERVE_WINDOW as u64);
         history_storage.storage.insert(
@@ -1187,6 +1196,7 @@ where
     fn ws_subscribe_logs(&self, mut filter: Filter, auth: AuthContext) -> BoxWsSubscriptionFut<'_> {
         Box::pin(async move {
             let provider = self.eth.api.provider().clone();
+            let api = self.eth.api.clone();
             let caller = auth.caller;
 
             let zone_tokens = self.zone_tokens();
@@ -1195,18 +1205,36 @@ where
 
             let stream = provider
                 .canonical_state_stream()
-                .flat_map(|canon_state| futures::stream::iter(canon_state.block_receipts()))
-                .flat_map(move |(block_receipts, removed)| {
-                    let all_logs = logs_utils::matching_block_logs_with_tx_hashes(
-                        &filter,
-                        block_receipts.block,
-                        block_receipts.timestamp,
-                        block_receipts
-                            .tx_receipts
-                            .iter()
-                            .map(|(tx, receipt)| (*tx, receipt)),
-                        removed,
-                    );
+                .flat_map(move |canon_state| {
+                    let reverted_chains = canon_state.reverted();
+                    let committed_chain = canon_state.committed();
+                    let reverted = reverted_chains.iter().flat_map(|chain| {
+                        chain
+                            .blocks_and_receipts()
+                            .map(|(block, receipts)| (block, receipts, true))
+                    });
+                    let committed = committed_chain
+                        .blocks_and_receipts()
+                        .map(|(block, receipts)| (block, receipts, false));
+                    let mut all_logs = Vec::new();
+
+                    for (block, receipts, removed) in reverted.chain(committed) {
+                        match logs_utils::matching_block_logs_with_tx_hashes(
+                            api.converter(),
+                            &filter,
+                            block.sealed_header(),
+                            block
+                                .transactions_recovered()
+                                .zip(receipts.iter())
+                                .map(|(tx, receipt)| (*tx.tx_hash(), receipt)),
+                            removed,
+                        ) {
+                            Ok(logs) => all_logs.extend(logs),
+                            Err(error) => {
+                                tracing::error!(target: "rpc", %error, "Failed to convert logs");
+                            }
+                        }
+                    }
                     futures::stream::iter(all_logs)
                 });
 
@@ -1484,12 +1512,11 @@ mod tests {
             .with_database(revm::database::EmptyDB::default())
             .build();
         state.block_hashes.insert(number, hash);
-        let mut witness = ExecutionWitnessRecord::default();
+        let mut additional_state = HashedPostState::default();
 
-        record_block_hash_storage_proofs(&mut witness, &state);
+        record_block_hash_storage_proofs(&mut additional_state, &state);
 
-        let storage = witness
-            .hashed_state
+        let storage = additional_state
             .storages
             .get(&keccak256(HISTORY_STORAGE_ADDRESS))
             .unwrap();

--- a/crates/node/tests/it/network_chaos_p2p_e2e.rs
+++ b/crates/node/tests/it/network_chaos_p2p_e2e.rs
@@ -333,14 +333,15 @@ async fn resume_leadership_case(
     Ok(())
 }
 
-async fn assert_handoff_stalls_without_incoming_leader(
+async fn assert_handoff_stalls_without_incoming_quorum(
     cluster: &RealP2pCluster,
+    portal: &ZonePortal::ZonePortalInstance<alloy::providers::DynProvider>,
 ) -> eyre::Result<()> {
     let a_fenced_height = cluster.nodes[OUTGOING_LEADER]
         .provider()
         .get_block_number()
         .await?;
-    let b_height_before_fence = cluster.nodes[INCOMING_LEADER]
+    let follower_fenced_height = cluster.nodes[FOLLOWER]
         .provider()
         .get_block_number()
         .await?;
@@ -354,22 +355,27 @@ async fn assert_handoff_stalls_without_incoming_leader(
         "outgoing leader A continued producing after finalized leadership moved to disconnected B"
     );
 
-    let b_height_after_fence = cluster.nodes[INCOMING_LEADER]
-        .provider()
-        .get_block_number()
-        .await?;
-    let b_producer = cluster.attestation_signers[INCOMING_LEADER].address();
-    for height in b_height_before_fence + 1..=b_height_after_fence {
-        let block = cluster.nodes[INCOMING_LEADER]
+    eyre::ensure!(
+        cluster.nodes[FOLLOWER]
             .provider()
-            .get_block_by_number(BlockNumberOrTag::Number(height))
+            .get_block_number()
             .await?
-            .ok_or_else(|| eyre::eyre!("B is missing block {height} from its local chain"))?;
-        eyre::ensure!(
-            block.header.beneficiary() != b_producer,
-            "incoming leader B produced block {height} before its requested links were restored"
-        );
-    }
+            == follower_fenced_height,
+        "healthy follower C advanced without a quorum connection to incoming leader B"
+    );
+
+    // Commonware may let B build local proposals while it is isolated. Those blocks are safe as
+    // long as the connected A/C side does not advance and L1 cannot settle beyond its fenced tip.
+    let settled_height: u64 = portal
+        .zoneHeight()
+        .call()
+        .await?
+        .try_into()
+        .map_err(|_| eyre::eyre!("settled zone height does not fit in u64"))?;
+    eyre::ensure!(
+        settled_height <= a_fenced_height.max(follower_fenced_height),
+        "L1 settled isolated B's private proposal at zone height {settled_height}"
+    );
     Ok(())
 }
 
@@ -559,7 +565,7 @@ async fn run_leadership_fault_case(case: LeadershipFaultCase) -> eyre::Result<()
 
     let settled_during_outage = match case.expected {
         ExpectedDuringFault::WaitForIncomingLeader => {
-            assert_handoff_stalls_without_incoming_leader(&cluster).await?;
+            assert_handoff_stalls_without_incoming_quorum(&cluster, &portal).await?;
             None
         }
         ExpectedDuringFault::ContinueIfActivated => {
@@ -740,10 +746,11 @@ async fn test_handoff_recovers_across_settlement_boundary() -> eyre::Result<()> 
     )
     .await?;
 
-    // The transaction remains only in B's local pool while every P2P path involving B is down.
-    // Its eventual inclusion under B creates the settlement boundary this test follows.
+    // The transaction remains private to B while every P2P path involving B is down. Commonware
+    // may include it in a local proposal, but that proposal must not reach A/C or settle on L1.
+    // Its canonical inclusion under B after reconnection creates the boundary this test follows.
     let a_fenced_height = cluster.nodes[0].provider().get_block_number().await?;
-    let b_fenced_height = cluster.nodes[1].provider().get_block_number().await?;
+    let c_fenced_height = cluster.nodes[2].provider().get_block_number().await?;
     let withdrawal_hash = account.submit_withdrawal(WITHDRAWAL_AMOUNT).await?;
     eyre::ensure!(
         cluster.nodes[0]
@@ -759,16 +766,26 @@ async fn test_handoff_recovers_across_settlement_boundary() -> eyre::Result<()> 
         "outgoing leader A produced while incoming leader B was P2P-isolated"
     );
     eyre::ensure!(
-        cluster.nodes[1].provider().get_block_number().await? == b_fenced_height,
-        "incoming leader B produced a private block while P2P-isolated"
+        cluster.nodes[2].provider().get_block_number().await? == c_fenced_height,
+        "healthy follower C advanced while incoming leader B was P2P-isolated"
     );
     eyre::ensure!(
-        cluster.nodes[1]
+        cluster.nodes[2]
             .provider()
             .get_transaction_receipt(withdrawal_hash)
             .await?
             .is_none(),
-        "B included the withdrawal before its P2P links were restored"
+        "C observed B's withdrawal while their P2P links were disconnected"
+    );
+    let settled_height: u64 = portal
+        .zoneHeight()
+        .call()
+        .await?
+        .try_into()
+        .map_err(|_| eyre::eyre!("settled zone height does not fit in u64"))?;
+    eyre::ensure!(
+        settled_height <= a_fenced_height.max(c_fenced_height),
+        "L1 settled isolated B's private proposal at zone height {settled_height}"
     );
     let batches_at_fence = batch_count(&portal).await?;
 

--- a/crates/node/tests/it/network_chaos_p2p_e2e.rs
+++ b/crates/node/tests/it/network_chaos_p2p_e2e.rs
@@ -6,7 +6,10 @@
 use std::{collections::HashSet, time::Duration};
 
 use alloy::{
-    consensus::BlockHeader as _, eips::BlockNumberOrTag, primitives::U256, providers::Provider as _,
+    consensus::BlockHeader as _,
+    eips::{BlockId, BlockNumberOrTag},
+    primitives::U256,
+    providers::Provider as _,
 };
 use alloy_network::ReceiptResponse as _;
 use tempo_zone_contracts::{ZONE_TOKEN_ADDRESS, ZonePortal};
@@ -54,7 +57,7 @@ impl FaultPlanes {
 #[derive(Clone, Copy, Debug)]
 enum ExpectedDuringFault {
     WaitForIncomingLeader,
-    WaitForOutgoingLeader,
+    ContinueIfActivated,
     ContinueAndSettle,
 }
 
@@ -258,16 +261,23 @@ async fn assert_batch_history_is_canonical(
         }
     }
 
+    // Read both Portal fields at the same L1 block. A new settlement can land while the Zone
+    // nodes are catching up; comparing a height captured before that settlement with the latest
+    // hash afterwards would report a false fork.
+    let l1_block = cluster.l1.provider().get_block_number().await?;
+    let block_id = BlockId::number(l1_block);
     let settled_height: u64 = portal
         .zoneHeight()
+        .block(block_id)
         .call()
         .await?
         .try_into()
         .map_err(|_| eyre::eyre!("settled zone height does not fit in u64"))?;
+    let settled_hash = portal.blockHash().block(block_id).call().await?;
     cluster.wait_all_at(settled_height, NETWORK_TIMEOUT).await?;
     let canonical = cluster.assert_same_block(settled_height).await?;
     eyre::ensure!(
-        portal.blockHash().call().await? == canonical.hash,
+        settled_hash == canonical.hash,
         "Portal settled hash is not canonical at zone height {settled_height}"
     );
     Ok(settled_height)
@@ -363,7 +373,11 @@ async fn assert_handoff_stalls_without_incoming_leader(
     Ok(())
 }
 
-async fn assert_handoff_waits_for_outgoing_leader(cluster: &RealP2pCluster) -> eyre::Result<()> {
+async fn handoff_activated_during_fault(cluster: &RealP2pCluster) -> eyre::Result<bool> {
+    let a_height_before_wait = cluster.nodes[OUTGOING_LEADER]
+        .provider()
+        .get_block_number()
+        .await?;
     let b_height_before_wait = cluster.nodes[INCOMING_LEADER]
         .provider()
         .get_block_number()
@@ -373,6 +387,14 @@ async fn assert_handoff_waits_for_outgoing_leader(cluster: &RealP2pCluster) -> e
         .provider()
         .get_block_number()
         .await?;
+    eyre::ensure!(
+        cluster.nodes[OUTGOING_LEADER]
+            .provider()
+            .get_block_number()
+            .await?
+            == a_height_before_wait,
+        "outgoing leader A continued producing while isolated from its quorum"
+    );
     let b_producer = cluster.attestation_signers[INCOMING_LEADER].address();
     for height in b_height_before_wait + 1..=b_height_after_wait {
         let block = cluster.nodes[INCOMING_LEADER]
@@ -380,12 +402,11 @@ async fn assert_handoff_waits_for_outgoing_leader(cluster: &RealP2pCluster) -> e
             .get_block_by_number(BlockNumberOrTag::Number(height))
             .await?
             .ok_or_else(|| eyre::eyre!("B is missing block {height} from its local chain"))?;
-        eyre::ensure!(
-            block.header.beneficiary() != b_producer,
-            "incoming leader B produced block {height} before outgoing A reached the activation boundary"
-        );
+        if block.header.beneficiary() == b_producer {
+            return Ok(true);
+        }
     }
-    Ok(())
+    Ok(false)
 }
 
 async fn assert_handoff_preserves_quorum(
@@ -541,9 +562,25 @@ async fn run_leadership_fault_case(case: LeadershipFaultCase) -> eyre::Result<()
             assert_handoff_stalls_without_incoming_leader(&cluster).await?;
             None
         }
-        ExpectedDuringFault::WaitForOutgoingLeader => {
-            assert_handoff_waits_for_outgoing_leader(&cluster).await?;
-            None
+        ExpectedDuringFault::ContinueIfActivated => {
+            if handoff_activated_during_fault(&cluster).await? {
+                Some(
+                    assert_handoff_preserves_quorum(
+                        &cluster,
+                        &portal,
+                        baseline,
+                        &healthy_nodes,
+                        if case.planes.disconnects_p2p() {
+                            case.disconnected_nodes
+                        } else {
+                            &[]
+                        },
+                    )
+                    .await?,
+                )
+            } else {
+                None
+            }
         }
         ExpectedDuringFault::ContinueAndSettle => Some(
             assert_handoff_preserves_quorum(
@@ -636,13 +673,14 @@ leadership_fault_tests! {
         timing: FaultTiming::BeforeHandoff,
         expected: ExpectedDuringFault::WaitForIncomingLeader,
     },
-    /// A loses both network planes before it can consume the handoff activation block. B and C
-    /// must wait for A's boundary tip, then recover and settle under B after A reconnects.
+    /// A loses both network planes before it can consume the handoff activation block. If B and C
+    /// have already crossed the activation boundary they continue with quorum; otherwise they
+    /// recover and settle under B after A reconnects.
     test_handoff_waits_when_outgoing_leader_disconnects_before_activation => LeadershipFaultCase {
         disconnected_nodes: &[OUTGOING_LEADER],
         planes: FaultPlanes::Both,
         timing: FaultTiming::OutgoingLeaderBeforeActivation,
-        expected: ExpectedDuringFault::WaitForOutgoingLeader,
+        expected: ExpectedDuringFault::ContinueIfActivated,
     },
 }
 

--- a/crates/precompiles/src/account_keychain.rs
+++ b/crates/precompiles/src/account_keychain.rs
@@ -1,7 +1,7 @@
 //! Zone read-privacy rules for the upstream Tempo AccountKeychain precompile.
 
 use alloy_primitives::Address;
-use alloy_sol_types::SolInterface;
+use alloy_sol_types::{SolCall, SolInterface};
 use tempo_contracts::precompiles::IAccountKeychain;
 use tempo_precompiles::dispatch::abi_decoder_config_for_spec;
 
@@ -15,11 +15,36 @@ use crate::{
 #[derive(Clone)]
 pub(crate) struct AccountKeychainRules;
 
+const UNRESTRICTED_SELECTORS: &[[u8; 4]] = &[
+    IAccountKeychain::authorizeKey_0Call::SELECTOR,
+    IAccountKeychain::authorizeKey_1Call::SELECTOR,
+    IAccountKeychain::authorizeKey_2Call::SELECTOR,
+    IAccountKeychain::authorizeAdminKeyCall::SELECTOR,
+    IAccountKeychain::burnKeyAuthorizationWitnessCall::SELECTOR,
+    IAccountKeychain::revokeKeyCall::SELECTOR,
+    IAccountKeychain::updateSpendingLimitCall::SELECTOR,
+    IAccountKeychain::setAllowedCallsCall::SELECTOR,
+    IAccountKeychain::removeAllowedCallsCall::SELECTOR,
+    IAccountKeychain::getTransactionKeyCall::SELECTOR,
+];
+
 impl CallRules for AccountKeychainRules {
     fn admit(&self, data: &[u8], caller: Address) -> CallCheck {
+        let spec = StorageCtx::default().spec();
+
+        // These calls have no Zone-specific privacy policy. Defer directly to the upstream
+        // dispatcher for selector scheduling and ABI decoding.
+        if data.get(..4).is_some_and(|selector| {
+            UNRESTRICTED_SELECTORS
+                .iter()
+                .any(|allowed| selector == allowed.as_slice())
+        }) {
+            return CallCheck::Continue;
+        }
+
         let Ok(call) = IAccountKeychain::IAccountKeychainCalls::abi_decode_with_config(
             data,
-            abi_decoder_config_for_spec(StorageCtx::default().spec()),
+            abi_decoder_config_for_spec(spec),
         ) else {
             // Preserve the upstream error and gas behavior for malformed or unknown calldata.
             return CallCheck::Continue;
@@ -228,5 +253,19 @@ mod tests {
             admit_at(&rules, &data, outsider, TempoHardfork::T11),
             CallCheck::Continue
         ));
+    }
+
+    #[test]
+    fn malformed_unrestricted_calls_remain_deferred_to_upstream() {
+        let rules = AccountKeychainRules;
+
+        for data in UNRESTRICTED_SELECTORS {
+            for spec in [TempoHardfork::T10, TempoHardfork::T11] {
+                assert!(matches!(
+                    admit_at(&rules, data, Address::ZERO, spec),
+                    CallCheck::Continue
+                ));
+            }
+        }
     }
 }

--- a/crates/precompiles/src/account_keychain.rs
+++ b/crates/precompiles/src/account_keychain.rs
@@ -2,7 +2,9 @@
 
 use alloy_primitives::Address;
 use alloy_sol_types::SolInterface;
+use tempo_chainspec::hardfork::TempoHardfork;
 use tempo_contracts::precompiles::IAccountKeychain;
+use tempo_precompiles::dispatch::abi_decoder_config_for_spec;
 
 use crate::{
     execution::{CallCheck, CallRules},
@@ -14,8 +16,11 @@ use crate::{
 pub(crate) struct AccountKeychainRules;
 
 impl CallRules for AccountKeychainRules {
-    fn admit(&self, data: &[u8], caller: Address) -> CallCheck {
-        let Ok(call) = IAccountKeychain::IAccountKeychainCalls::abi_decode(data) else {
+    fn admit(&self, data: &[u8], caller: Address, spec: TempoHardfork) -> CallCheck {
+        let Ok(call) = IAccountKeychain::IAccountKeychainCalls::abi_decode_with_config(
+            data,
+            abi_decoder_config_for_spec(spec),
+        ) else {
             // Preserve the upstream error and gas behavior for malformed or unknown calldata.
             return CallCheck::Continue;
         };
@@ -74,12 +79,12 @@ mod tests {
         outsider: Address,
     ) {
         assert!(matches!(
-            rules.admit(&call.abi_encode(), owner),
+            rules.admit(&call.abi_encode(), owner, TempoHardfork::T8),
             CallCheck::Continue
         ));
         for caller in [sequencer, outsider] {
             assert!(matches!(
-                rules.admit(&call.clone().abi_encode(), caller),
+                rules.admit(&call.clone().abi_encode(), caller, TempoHardfork::T8),
                 CallCheck::Revert(data) if data == Unauthorized {}.abi_encode()
             ));
         }
@@ -170,7 +175,8 @@ mod tests {
         assert!(matches!(
             rules.admit(
                 &IAccountKeychain::getTransactionKeyCall {}.abi_encode(),
-                caller
+                caller,
+                TempoHardfork::T8,
             ),
             CallCheck::Continue
         ));
@@ -180,8 +186,31 @@ mod tests {
                     keyId: Address::repeat_byte(0x22),
                 }
                 .abi_encode(),
-                caller
+                caller,
+                TempoHardfork::T8,
             ),
+            CallCheck::Continue
+        ));
+    }
+
+    #[test]
+    fn t11_defers_noncanonical_address_calldata_to_upstream() {
+        let owner = Address::repeat_byte(0x11);
+        let outsider = Address::repeat_byte(0x22);
+        let rules = AccountKeychainRules;
+        let mut data = IAccountKeychain::getKeyCall {
+            account: owner,
+            keyId: Address::repeat_byte(0x33),
+        }
+        .abi_encode();
+        data[4] = 1;
+
+        assert!(matches!(
+            rules.admit(&data, outsider, TempoHardfork::T8),
+            CallCheck::Revert(data) if data == Unauthorized {}.abi_encode()
+        ));
+        assert!(matches!(
+            rules.admit(&data, outsider, TempoHardfork::T11),
             CallCheck::Continue
         ));
     }

--- a/crates/precompiles/src/account_keychain.rs
+++ b/crates/precompiles/src/account_keychain.rs
@@ -2,13 +2,13 @@
 
 use alloy_primitives::Address;
 use alloy_sol_types::SolInterface;
-use tempo_chainspec::hardfork::TempoHardfork;
 use tempo_contracts::precompiles::IAccountKeychain;
 use tempo_precompiles::dispatch::abi_decoder_config_for_spec;
 
 use crate::{
     execution::{CallCheck, CallRules},
     privacy::check_caller,
+    storage::StorageCtx,
 };
 
 /// Zone-specific rules applied before forwarding to upstream `AccountKeychain`.
@@ -16,10 +16,10 @@ use crate::{
 pub(crate) struct AccountKeychainRules;
 
 impl CallRules for AccountKeychainRules {
-    fn admit(&self, data: &[u8], caller: Address, spec: TempoHardfork) -> CallCheck {
+    fn admit(&self, data: &[u8], caller: Address) -> CallCheck {
         let Ok(call) = IAccountKeychain::IAccountKeychainCalls::abi_decode_with_config(
             data,
-            abi_decoder_config_for_spec(spec),
+            abi_decoder_config_for_spec(StorageCtx::default().spec()),
         ) else {
             // Preserve the upstream error and gas behavior for malformed or unknown calldata.
             return CallCheck::Continue;
@@ -64,12 +64,25 @@ mod tests {
     use super::*;
     use alloy_primitives::{Address, B256};
     use alloy_sol_types::{SolCall, SolError};
+    use tempo_chainspec::hardfork::TempoHardfork;
     use tempo_zone_contracts::Unauthorized;
 
     use crate::{
         storage::StorageCtx,
         test_utils::{test_context, test_storage_provider},
     };
+
+    fn admit_at(
+        rules: &AccountKeychainRules,
+        data: &[u8],
+        caller: Address,
+        spec: TempoHardfork,
+    ) -> CallCheck {
+        let mut ctx = test_context();
+        ctx.cfg.spec = spec;
+        let mut storage = test_storage_provider(&mut ctx, u64::MAX, true);
+        StorageCtx::enter(&mut storage, || rules.admit(data, caller))
+    }
 
     fn assert_account_scoped<C: SolCall + Clone>(
         rules: &AccountKeychainRules,
@@ -79,12 +92,12 @@ mod tests {
         outsider: Address,
     ) {
         assert!(matches!(
-            rules.admit(&call.abi_encode(), owner, TempoHardfork::T8),
+            rules.admit(&call.abi_encode(), owner),
             CallCheck::Continue
         ));
         for caller in [sequencer, outsider] {
             assert!(matches!(
-                rules.admit(&call.clone().abi_encode(), caller, TempoHardfork::T8),
+                rules.admit(&call.clone().abi_encode(), caller),
                 CallCheck::Revert(data) if data == Unauthorized {}.abi_encode()
             ));
         }
@@ -172,25 +185,27 @@ mod tests {
         let caller = Address::repeat_byte(0x11);
         let rules = AccountKeychainRules;
 
-        assert!(matches!(
-            rules.admit(
-                &IAccountKeychain::getTransactionKeyCall {}.abi_encode(),
-                caller,
-                TempoHardfork::T8,
-            ),
-            CallCheck::Continue
-        ));
-        assert!(matches!(
-            rules.admit(
-                &IAccountKeychain::revokeKeyCall {
-                    keyId: Address::repeat_byte(0x22),
-                }
-                .abi_encode(),
-                caller,
-                TempoHardfork::T8,
-            ),
-            CallCheck::Continue
-        ));
+        let mut ctx = test_context();
+        let mut storage = test_storage_provider(&mut ctx, u64::MAX, true);
+        StorageCtx::enter(&mut storage, || {
+            assert!(matches!(
+                rules.admit(
+                    &IAccountKeychain::getTransactionKeyCall {}.abi_encode(),
+                    caller,
+                ),
+                CallCheck::Continue
+            ));
+            assert!(matches!(
+                rules.admit(
+                    &IAccountKeychain::revokeKeyCall {
+                        keyId: Address::repeat_byte(0x22),
+                    }
+                    .abi_encode(),
+                    caller,
+                ),
+                CallCheck::Continue
+            ));
+        });
     }
 
     #[test]
@@ -206,11 +221,11 @@ mod tests {
         data[4] = 1;
 
         assert!(matches!(
-            rules.admit(&data, outsider, TempoHardfork::T8),
+            admit_at(&rules, &data, outsider, TempoHardfork::T8),
             CallCheck::Revert(data) if data == Unauthorized {}.abi_encode()
         ));
         assert!(matches!(
-            rules.admit(&data, outsider, TempoHardfork::T11),
+            admit_at(&rules, &data, outsider, TempoHardfork::T11),
             CallCheck::Continue
         ));
     }

--- a/crates/precompiles/src/execution.rs
+++ b/crates/precompiles/src/execution.rs
@@ -88,8 +88,8 @@ pub(crate) trait CallRules: 'static {
         None
     }
 
-    /// Applies Zone-specific admission rules using the active Tempo hardfork.
-    fn admit(&self, _data: &[u8], _caller: Address, _spec: TempoHardfork) -> CallCheck {
+    /// Applies Zone-specific admission rules.
+    fn admit(&self, _data: &[u8], _caller: Address) -> CallCheck {
         CallCheck::Continue
     }
 }
@@ -153,19 +153,17 @@ pub(crate) fn create_precompile(
             storage.set_tip1060_storage_credits(false);
         }
 
-        let mut result = StorageCtx::enter(&mut storage, || {
-            match rules.admit(data, caller, env.cfg.spec) {
-                CallCheck::Continue => execute(data, caller),
-                CallCheck::Revert(output) => {
-                    let s = StorageCtx::default();
-                    let output = s.revert_output(output);
-                    add_input_cost(s, data, Ok(output))
-                }
-                CallCheck::Error(error) => {
-                    let s = StorageCtx::default();
-                    let result = s.error_result(error);
-                    add_input_cost(s, data, result)
-                }
+        let mut result = StorageCtx::enter(&mut storage, || match rules.admit(data, caller) {
+            CallCheck::Continue => execute(data, caller),
+            CallCheck::Revert(output) => {
+                let s = StorageCtx::default();
+                let output = s.revert_output(output);
+                add_input_cost(s, data, Ok(output))
+            }
+            CallCheck::Error(error) => {
+                let s = StorageCtx::default();
+                let result = s.error_result(error);
+                add_input_cost(s, data, result)
             }
         });
         if let (Ok(output), Some(gas)) = (&mut result, fixed_gas) {
@@ -215,7 +213,7 @@ mod tests {
             Some(FIXED_GAS)
         }
 
-        fn admit(&self, data: &[u8], caller: Address, _spec: TempoHardfork) -> CallCheck {
+        fn admit(&self, data: &[u8], caller: Address) -> CallCheck {
             *self.0.borrow_mut() = Some((
                 Bytes::copy_from_slice(data),
                 selector_from_calldata(data),
@@ -379,7 +377,7 @@ mod tests {
             Some(FIXED_GAS)
         }
 
-        fn admit(&self, _data: &[u8], _caller: Address, _spec: TempoHardfork) -> CallCheck {
+        fn admit(&self, _data: &[u8], _caller: Address) -> CallCheck {
             self.0.set(true);
             CallCheck::Revert(Bytes::from_static(b"denied"))
         }
@@ -463,7 +461,7 @@ mod tests {
     struct FatalRules;
 
     impl CallRules for FatalRules {
-        fn admit(&self, _data: &[u8], _caller: Address, _spec: TempoHardfork) -> CallCheck {
+        fn admit(&self, _data: &[u8], _caller: Address) -> CallCheck {
             StorageCtx::default().deduct_gas(10).unwrap();
             CallCheck::Error(TempoPrecompileError::Fatal("boom".into()))
         }

--- a/crates/precompiles/src/execution.rs
+++ b/crates/precompiles/src/execution.rs
@@ -88,8 +88,8 @@ pub(crate) trait CallRules: 'static {
         None
     }
 
-    /// Applies pure Zone-specific admission rules before storage setup.
-    fn admit(&self, _data: &[u8], _caller: Address) -> CallCheck {
+    /// Applies Zone-specific admission rules using the active Tempo hardfork.
+    fn admit(&self, _data: &[u8], _caller: Address, _spec: TempoHardfork) -> CallCheck {
         CallCheck::Continue
     }
 }
@@ -115,7 +115,13 @@ pub(crate) fn create_precompile(
         }
 
         let (data, caller) = (input.data, input.caller);
-        if input.gas < input_cost(data.len()) {
+        let Ok(input_gas) = input_cost(env.cfg.spec, data.len()) else {
+            return Ok(PrecompileOutput::halt(
+                PrecompileHalt::OutOfGas,
+                input.reservoir,
+            ));
+        };
+        if input.gas < input_gas {
             return Ok(PrecompileOutput::halt(
                 PrecompileHalt::OutOfGas,
                 input.reservoir,
@@ -147,17 +153,19 @@ pub(crate) fn create_precompile(
             storage.set_tip1060_storage_credits(false);
         }
 
-        let mut result = StorageCtx::enter(&mut storage, || match rules.admit(data, caller) {
-            CallCheck::Continue => execute(data, caller),
-            CallCheck::Revert(output) => {
-                let s = StorageCtx::default();
-                let output = s.revert_output(output);
-                add_input_cost(s, data, Ok(output))
-            }
-            CallCheck::Error(error) => {
-                let s = StorageCtx::default();
-                let result = s.error_result(error);
-                add_input_cost(s, data, result)
+        let mut result = StorageCtx::enter(&mut storage, || {
+            match rules.admit(data, caller, env.cfg.spec) {
+                CallCheck::Continue => execute(data, caller),
+                CallCheck::Revert(output) => {
+                    let s = StorageCtx::default();
+                    let output = s.revert_output(output);
+                    add_input_cost(s, data, Ok(output))
+                }
+                CallCheck::Error(error) => {
+                    let s = StorageCtx::default();
+                    let result = s.error_result(error);
+                    add_input_cost(s, data, result)
+                }
             }
         });
         if let (Ok(output), Some(gas)) = (&mut result, fixed_gas) {
@@ -207,7 +215,7 @@ mod tests {
             Some(FIXED_GAS)
         }
 
-        fn admit(&self, data: &[u8], caller: Address) -> CallCheck {
+        fn admit(&self, data: &[u8], caller: Address, _spec: TempoHardfork) -> CallCheck {
             *self.0.borrow_mut() = Some((
                 Bytes::copy_from_slice(data),
                 selector_from_calldata(data),
@@ -371,7 +379,7 @@ mod tests {
             Some(FIXED_GAS)
         }
 
-        fn admit(&self, _data: &[u8], _caller: Address) -> CallCheck {
+        fn admit(&self, _data: &[u8], _caller: Address, _spec: TempoHardfork) -> CallCheck {
             self.0.set(true);
             CallCheck::Revert(Bytes::from_static(b"denied"))
         }
@@ -418,10 +426,44 @@ mod tests {
         assert_eq!(rejected.bytes, Bytes::from_static(b"denied"));
     }
 
+    #[test]
+    fn input_gas_threshold_tracks_t11() {
+        let calldata = [0u8; 32];
+
+        for (spec, required_gas) in [(TempoHardfork::T10, 6), (TempoHardfork::T11, 30)] {
+            let mut cfg = revm::context::CfgEnv::<TempoHardfork>::default();
+            cfg.spec = spec;
+            let env = ZonePrecompileEnv::new(
+                &cfg,
+                zone_hardfork::ZoneHardfork::Z0,
+                StorageActions::disabled(),
+                Rc::new(RefCell::new(NonCreditableSlots::empty())),
+            );
+            let precompile = create_precompile("InputGasTest", &env, NoCallRules, |_, _| {
+                Ok(StorageCtx::default().success_output(Bytes::new()))
+            });
+            let mut ctx = test_context();
+
+            let insufficient = precompile
+                .call(input(&mut ctx, &calldata, Address::ZERO, required_gas - 1))
+                .unwrap();
+            assert_eq!(
+                insufficient.halt_reason(),
+                Some(&PrecompileHalt::OutOfGas),
+                "{spec:?} must require {required_gas} input gas"
+            );
+
+            let sufficient = precompile
+                .call(input(&mut ctx, &calldata, Address::ZERO, required_gas))
+                .unwrap();
+            assert!(!sufficient.is_halt(), "{spec:?} must accept its exact cost");
+        }
+    }
+
     struct FatalRules;
 
     impl CallRules for FatalRules {
-        fn admit(&self, _data: &[u8], _caller: Address) -> CallCheck {
+        fn admit(&self, _data: &[u8], _caller: Address, _spec: TempoHardfork) -> CallCheck {
             StorageCtx::default().deduct_gas(10).unwrap();
             CallCheck::Error(TempoPrecompileError::Fatal("boom".into()))
         }

--- a/crates/precompiles/src/inbox/mod.rs
+++ b/crates/precompiles/src/inbox/mod.rs
@@ -20,9 +20,11 @@ use alloc::vec::Vec;
 
 use alloy_evm::precompiles::DynPrecompile;
 use alloy_primitives::{Address, B256, U256};
-use alloy_sol_types::{SolCall, SolType, SolValue};
+use alloy_sol_types::{SolCall, SolValue};
+use tempo_chainspec::hardfork::TempoHardfork;
 use tempo_precompiles::{
     PATH_USD_ADDRESS,
+    dispatch::abi_decoder_config_for_spec,
     error::TempoPrecompileError,
     storage::{Handler, Mapping, Slot, StorageCtx},
     tip20::{ISSUER_ROLE, ITIP20, TIP20Error, TIP20Token},
@@ -378,25 +380,20 @@ impl TryFrom<QueuedDeposit> for DecodedQueuedDeposit {
     type Error = ZonePrecompileError;
 
     fn try_from(queued: QueuedDeposit) -> Result<Self, Self::Error> {
+        let config = abi_decoder_config_for_spec(TempoHardfork::latest());
+
         match queued.depositType {
             DepositType::WithdrawalBounceBack => {
-                decode_canonical(&queued.depositData).map(Self::WithdrawalBounceBack)
+                WithdrawalBounceBackDeposit::abi_decode_with_config(&queued.depositData, config)
+                    .map(Self::WithdrawalBounceBack)
             }
-            DepositType::Deposit => decode_canonical(&queued.depositData).map(Self::Deposit),
+            DepositType::Deposit => {
+                Deposit::abi_decode_with_config(&queued.depositData, config).map(Self::Deposit)
+            }
             _ => return Err(ZonePrecompileError::MalformedCalldata),
         }
         .map_err(|_| ZonePrecompileError::MalformedCalldata)
     }
-}
-
-fn decode_canonical<T>(encoded: &[u8]) -> alloy_sol_types::Result<T>
-where
-    T: SolValue + From<<T::SolType as SolType>::RustType>,
-{
-    let value = T::abi_decode(encoded)?;
-    (value.abi_encode().as_slice() == encoded)
-        .then_some(value)
-        .ok_or(alloy_sol_types::Error::ReserMismatch)
 }
 
 fn decode_deposits(deposits: Vec<QueuedDeposit>) -> ZoneResult<Vec<DecodedQueuedDeposit>> {

--- a/crates/precompiles/src/lib.rs
+++ b/crates/precompiles/src/lib.rs
@@ -84,7 +84,7 @@ pub mod ztip20;
 pub use aes_gcm::AesGcmDecrypt;
 pub use chaum_pedersen::ChaumPedersenVerify;
 pub use inbox::{ADVANCE_TEMPO_SELECTOR, ZoneInbox};
-pub use outbox::{ZoneOutbox, is_finalize_withdrawal_batch_calldata};
+pub use outbox::ZoneOutbox;
 pub use storage::{L1State, L1StateError, L1StorageReader};
 pub use tempo_contracts::precompiles::TIP403_REGISTRY_ADDRESS;
 pub use tempo_state::TempoState;

--- a/crates/precompiles/src/nonce.rs
+++ b/crates/precompiles/src/nonce.rs
@@ -2,13 +2,13 @@
 
 use alloy_primitives::Address;
 use alloy_sol_types::SolInterface;
-use tempo_chainspec::hardfork::TempoHardfork;
 use tempo_contracts::precompiles::INonce;
 use tempo_precompiles::dispatch::abi_decoder_config_for_spec;
 
 use crate::{
     execution::{CallCheck, CallRules},
     privacy::check_caller,
+    storage::StorageCtx,
 };
 
 /// Zone-specific rules applied before forwarding to upstream `NonceManager`.
@@ -16,10 +16,11 @@ use crate::{
 pub(crate) struct NonceRules;
 
 impl CallRules for NonceRules {
-    fn admit(&self, data: &[u8], caller: Address, spec: TempoHardfork) -> CallCheck {
-        let Ok(call) =
-            INonce::INonceCalls::abi_decode_with_config(data, abi_decoder_config_for_spec(spec))
-        else {
+    fn admit(&self, data: &[u8], caller: Address) -> CallCheck {
+        let Ok(call) = INonce::INonceCalls::abi_decode_with_config(
+            data,
+            abi_decoder_config_for_spec(StorageCtx::default().spec()),
+        ) else {
             // Preserve the upstream error and gas behavior for malformed or unknown calldata.
             return CallCheck::Continue;
         };
@@ -36,12 +37,20 @@ mod tests {
     use super::*;
     use alloy_primitives::{Address, U256};
     use alloy_sol_types::{SolCall, SolError};
+    use tempo_chainspec::hardfork::TempoHardfork;
     use tempo_zone_contracts::Unauthorized;
 
     use crate::{
         storage::StorageCtx,
         test_utils::{test_context, test_storage_provider},
     };
+
+    fn admit_at(data: &[u8], caller: Address, spec: TempoHardfork) -> CallCheck {
+        let mut ctx = test_context();
+        ctx.cfg.spec = spec;
+        let mut storage = test_storage_provider(&mut ctx, u64::MAX, true);
+        StorageCtx::enter(&mut storage, || NonceRules.admit(data, caller))
+    }
 
     #[test]
     fn nonce_reads_allow_only_owner() {
@@ -59,12 +68,12 @@ mod tests {
 
         StorageCtx::enter(&mut storage, || {
             assert!(matches!(
-                rules.admit(&call.abi_encode(), owner, TempoHardfork::T8),
+                rules.admit(&call.abi_encode(), owner),
                 CallCheck::Continue
             ));
             for caller in [sequencer, outsider, intermediary] {
                 assert!(matches!(
-                    rules.admit(&call.abi_encode(), caller, TempoHardfork::T8),
+                    rules.admit(&call.abi_encode(), caller),
                     CallCheck::Revert(data) if data == Unauthorized {}.abi_encode()
                 ));
             }
@@ -75,7 +84,6 @@ mod tests {
     fn t11_defers_noncanonical_address_calldata_to_upstream() {
         let owner = Address::repeat_byte(0x11);
         let outsider = Address::repeat_byte(0x22);
-        let rules = NonceRules;
         let mut data = INonce::getNonceCall {
             account: owner,
             nonceKey: U256::from(1),
@@ -84,11 +92,11 @@ mod tests {
         data[4] = 1;
 
         assert!(matches!(
-            rules.admit(&data, outsider, TempoHardfork::T8),
+            admit_at(&data, outsider, TempoHardfork::T8),
             CallCheck::Revert(data) if data == Unauthorized {}.abi_encode()
         ));
         assert!(matches!(
-            rules.admit(&data, outsider, TempoHardfork::T11),
+            admit_at(&data, outsider, TempoHardfork::T11),
             CallCheck::Continue
         ));
     }

--- a/crates/precompiles/src/nonce.rs
+++ b/crates/precompiles/src/nonce.rs
@@ -2,7 +2,9 @@
 
 use alloy_primitives::Address;
 use alloy_sol_types::SolInterface;
+use tempo_chainspec::hardfork::TempoHardfork;
 use tempo_contracts::precompiles::INonce;
+use tempo_precompiles::dispatch::abi_decoder_config_for_spec;
 
 use crate::{
     execution::{CallCheck, CallRules},
@@ -14,8 +16,10 @@ use crate::{
 pub(crate) struct NonceRules;
 
 impl CallRules for NonceRules {
-    fn admit(&self, data: &[u8], caller: Address) -> CallCheck {
-        let Ok(call) = INonce::INonceCalls::abi_decode(data) else {
+    fn admit(&self, data: &[u8], caller: Address, spec: TempoHardfork) -> CallCheck {
+        let Ok(call) =
+            INonce::INonceCalls::abi_decode_with_config(data, abi_decoder_config_for_spec(spec))
+        else {
             // Preserve the upstream error and gas behavior for malformed or unknown calldata.
             return CallCheck::Continue;
         };
@@ -55,15 +59,37 @@ mod tests {
 
         StorageCtx::enter(&mut storage, || {
             assert!(matches!(
-                rules.admit(&call.abi_encode(), owner),
+                rules.admit(&call.abi_encode(), owner, TempoHardfork::T8),
                 CallCheck::Continue
             ));
             for caller in [sequencer, outsider, intermediary] {
                 assert!(matches!(
-                    rules.admit(&call.abi_encode(), caller),
+                    rules.admit(&call.abi_encode(), caller, TempoHardfork::T8),
                     CallCheck::Revert(data) if data == Unauthorized {}.abi_encode()
                 ));
             }
         });
+    }
+
+    #[test]
+    fn t11_defers_noncanonical_address_calldata_to_upstream() {
+        let owner = Address::repeat_byte(0x11);
+        let outsider = Address::repeat_byte(0x22);
+        let rules = NonceRules;
+        let mut data = INonce::getNonceCall {
+            account: owner,
+            nonceKey: U256::from(1),
+        }
+        .abi_encode();
+        data[4] = 1;
+
+        assert!(matches!(
+            rules.admit(&data, outsider, TempoHardfork::T8),
+            CallCheck::Revert(data) if data == Unauthorized {}.abi_encode()
+        ));
+        assert!(matches!(
+            rules.admit(&data, outsider, TempoHardfork::T11),
+            CallCheck::Continue
+        ));
     }
 }

--- a/crates/precompiles/src/outbox/mod.rs
+++ b/crates/precompiles/src/outbox/mod.rs
@@ -7,7 +7,6 @@ mod tests;
 use alloc::vec::Vec;
 
 use alloy_primitives::{Address, B256, Bytes, U256};
-use alloy_sol_types::SolCall;
 use tempo_precompiles::{
     Result as TempoResult,
     error::TempoPrecompileError,
@@ -31,14 +30,6 @@ use crate::{
 /// Maximum callback payload accepted by the Zone Outbox.
 pub const MAX_CALLBACK_DATA_SIZE: usize = 1024;
 const WITHDRAWAL_BASE_GAS: u64 = 50_000;
-
-/// Returns whether `calldata` is a canonical `finalizeWithdrawalBatch` call.
-pub fn is_finalize_withdrawal_batch_calldata(calldata: &[u8]) -> bool {
-    let Ok(call) = IZoneOutbox::finalizeWithdrawalBatchCall::abi_decode(calldata) else {
-        return false;
-    };
-    call.abi_encode() == calldata
-}
 
 #[contract(addr = ZONE_OUTBOX_ADDRESS)]
 pub struct ZoneOutbox {

--- a/crates/precompiles/src/receive_policy_guard.rs
+++ b/crates/precompiles/src/receive_policy_guard.rs
@@ -10,8 +10,12 @@ use crate::{
 };
 use alloy_primitives::Address;
 use alloy_sol_types::{SolCall, SolError};
+use tempo_chainspec::hardfork::TempoHardfork;
 use tempo_contracts::precompiles::IReceivePolicyGuard;
-use tempo_precompiles::{address_registry::AddressRegistry, dispatch::selector_from_calldata};
+use tempo_precompiles::{
+    address_registry::AddressRegistry,
+    dispatch::{abi_decoder_config_for_spec, selector_from_calldata},
+};
 use tempo_zone_contracts::Unauthorized;
 
 /// Stakeholder-only admission for receipt balance lookups.
@@ -26,12 +30,15 @@ impl CallRules for ReceivePolicyGuardRules {
             .then_some(TIP20_FIXED_TRANSFER_GAS)
     }
 
-    fn admit(&self, data: &[u8], caller: Address) -> CallCheck {
+    fn admit(&self, data: &[u8], caller: Address, spec: TempoHardfork) -> CallCheck {
         if selector_from_calldata(data) != Some(IReceivePolicyGuard::balanceOfCall::SELECTOR) {
             return CallCheck::Continue;
         }
 
-        let Ok(call) = IReceivePolicyGuard::balanceOfCall::abi_decode_raw(&data[4..]) else {
+        let Ok(call) = IReceivePolicyGuard::balanceOfCall::abi_decode_raw_with_config(
+            &data[4..],
+            abi_decoder_config_for_spec(spec),
+        ) else {
             // Preserve the upstream ABI error for malformed calldata.
             return CallCheck::Continue;
         };
@@ -115,7 +122,7 @@ mod tests {
         caller: Address,
     ) {
         assert!(matches!(
-            rules.admit(&balance_call(receipt), caller),
+            rules.admit(&balance_call(receipt), caller, TempoHardfork::T8),
             CallCheck::Continue
         ));
     }
@@ -126,7 +133,7 @@ mod tests {
         caller: Address,
     ) {
         assert!(matches!(
-            rules.admit(&balance_call(receipt), caller),
+            rules.admit(&balance_call(receipt), caller, TempoHardfork::T8),
             CallCheck::Revert(data) if data == Unauthorized {}.abi_encode()
         ));
     }
@@ -181,7 +188,7 @@ mod tests {
 
         StorageCtx::enter(&mut storage, || {
             assert!(matches!(
-                rules.admit(&balance_call(&receipt), OUTSIDER),
+                rules.admit(&balance_call(&receipt), OUTSIDER, TempoHardfork::T8),
                 CallCheck::Error(tempo_precompiles::error::TempoPrecompileError::OutOfGas)
             ));
         });
@@ -201,11 +208,34 @@ mod tests {
         }
         .abi_encode();
 
-        assert!(matches!(rules.admit(&claim, OUTSIDER), CallCheck::Continue));
         assert!(matches!(
-            rules.admit(&malformed, OUTSIDER),
+            rules.admit(&claim, OUTSIDER, TempoHardfork::T8),
             CallCheck::Continue
         ));
+        assert!(matches!(
+            rules.admit(&malformed, OUTSIDER, TempoHardfork::T8),
+            CallCheck::Continue
+        ));
+    }
+
+    #[test]
+    fn t11_defers_noncanonical_balance_calldata_to_upstream() {
+        let rules = ReceivePolicyGuardRules;
+        let mut data = balance_call(&receipt(RECEIVER, RECOVERY)).to_vec();
+        data.extend([0; 32]);
+        let mut ctx = test_context();
+        let mut storage = test_storage_provider(&mut ctx, u64::MAX, true);
+
+        StorageCtx::enter(&mut storage, || {
+            assert!(matches!(
+                rules.admit(&data, OUTSIDER, TempoHardfork::T8),
+                CallCheck::Revert(data) if data == Unauthorized {}.abi_encode()
+            ));
+            assert!(matches!(
+                rules.admit(&data, OUTSIDER, TempoHardfork::T11),
+                CallCheck::Continue
+            ));
+        });
     }
 
     #[test]

--- a/crates/precompiles/src/receive_policy_guard.rs
+++ b/crates/precompiles/src/receive_policy_guard.rs
@@ -6,11 +6,11 @@
 
 use crate::{
     execution::{CallCheck, CallRules},
+    storage::StorageCtx,
     ztip20::TIP20_FIXED_TRANSFER_GAS,
 };
 use alloy_primitives::Address;
 use alloy_sol_types::{SolCall, SolError};
-use tempo_chainspec::hardfork::TempoHardfork;
 use tempo_contracts::precompiles::IReceivePolicyGuard;
 use tempo_precompiles::{
     address_registry::AddressRegistry,
@@ -30,14 +30,14 @@ impl CallRules for ReceivePolicyGuardRules {
             .then_some(TIP20_FIXED_TRANSFER_GAS)
     }
 
-    fn admit(&self, data: &[u8], caller: Address, spec: TempoHardfork) -> CallCheck {
+    fn admit(&self, data: &[u8], caller: Address) -> CallCheck {
         if selector_from_calldata(data) != Some(IReceivePolicyGuard::balanceOfCall::SELECTOR) {
             return CallCheck::Continue;
         }
 
         let Ok(call) = IReceivePolicyGuard::balanceOfCall::abi_decode_raw_with_config(
             &data[4..],
-            abi_decoder_config_for_spec(spec),
+            abi_decoder_config_for_spec(StorageCtx::default().spec()),
         ) else {
             // Preserve the upstream ABI error for malformed calldata.
             return CallCheck::Continue;
@@ -69,6 +69,7 @@ mod tests {
     use alloy_primitives::{B256, Bytes, U256, address};
     use alloy_sol_types::SolValue;
     use revm::precompile::{PrecompileOutput, PrecompileResult};
+    use tempo_chainspec::hardfork::TempoHardfork;
     use tempo_contracts::precompiles::{IReceivePolicyGuard::InboundKind, ITIP20, ITIP403Registry};
     use tempo_precompiles::{
         PATH_USD_ADDRESS, RECEIVE_POLICY_GUARD_ADDRESS,
@@ -122,7 +123,7 @@ mod tests {
         caller: Address,
     ) {
         assert!(matches!(
-            rules.admit(&balance_call(receipt), caller, TempoHardfork::T8),
+            rules.admit(&balance_call(receipt), caller),
             CallCheck::Continue
         ));
     }
@@ -133,7 +134,7 @@ mod tests {
         caller: Address,
     ) {
         assert!(matches!(
-            rules.admit(&balance_call(receipt), caller, TempoHardfork::T8),
+            rules.admit(&balance_call(receipt), caller),
             CallCheck::Revert(data) if data == Unauthorized {}.abi_encode()
         ));
     }
@@ -188,7 +189,7 @@ mod tests {
 
         StorageCtx::enter(&mut storage, || {
             assert!(matches!(
-                rules.admit(&balance_call(&receipt), OUTSIDER, TempoHardfork::T8),
+                rules.admit(&balance_call(&receipt), OUTSIDER),
                 CallCheck::Error(tempo_precompiles::error::TempoPrecompileError::OutOfGas)
             ));
         });
@@ -208,14 +209,15 @@ mod tests {
         }
         .abi_encode();
 
-        assert!(matches!(
-            rules.admit(&claim, OUTSIDER, TempoHardfork::T8),
-            CallCheck::Continue
-        ));
-        assert!(matches!(
-            rules.admit(&malformed, OUTSIDER, TempoHardfork::T8),
-            CallCheck::Continue
-        ));
+        let mut ctx = test_context();
+        let mut storage = test_storage_provider(&mut ctx, u64::MAX, true);
+        StorageCtx::enter(&mut storage, || {
+            assert!(matches!(rules.admit(&claim, OUTSIDER), CallCheck::Continue));
+            assert!(matches!(
+                rules.admit(&malformed, OUTSIDER),
+                CallCheck::Continue
+            ));
+        });
     }
 
     #[test]
@@ -223,19 +225,18 @@ mod tests {
         let rules = ReceivePolicyGuardRules;
         let mut data = balance_call(&receipt(RECEIVER, RECOVERY)).to_vec();
         data.extend([0; 32]);
-        let mut ctx = test_context();
-        let mut storage = test_storage_provider(&mut ctx, u64::MAX, true);
+        let admit_at = |spec| {
+            let mut ctx = test_context();
+            ctx.cfg.spec = spec;
+            let mut storage = test_storage_provider(&mut ctx, u64::MAX, true);
+            StorageCtx::enter(&mut storage, || rules.admit(&data, OUTSIDER))
+        };
 
-        StorageCtx::enter(&mut storage, || {
-            assert!(matches!(
-                rules.admit(&data, OUTSIDER, TempoHardfork::T8),
-                CallCheck::Revert(data) if data == Unauthorized {}.abi_encode()
-            ));
-            assert!(matches!(
-                rules.admit(&data, OUTSIDER, TempoHardfork::T11),
-                CallCheck::Continue
-            ));
-        });
+        assert!(matches!(
+            admit_at(TempoHardfork::T8),
+            CallCheck::Revert(data) if data == Unauthorized {}.abi_encode()
+        ));
+        assert!(matches!(admit_at(TempoHardfork::T11), CallCheck::Continue));
     }
 
     #[test]

--- a/crates/precompiles/src/storage_credits.rs
+++ b/crates/precompiles/src/storage_credits.rs
@@ -2,7 +2,9 @@
 
 use alloy_primitives::Address;
 use alloy_sol_types::SolInterface;
+use tempo_chainspec::hardfork::TempoHardfork;
 use tempo_contracts::precompiles::IStorageCredits;
+use tempo_precompiles::dispatch::abi_decoder_config_for_spec;
 
 use crate::{
     execution::{CallCheck, CallRules},
@@ -14,8 +16,11 @@ use crate::{
 pub(crate) struct StorageCreditsRules;
 
 impl CallRules for StorageCreditsRules {
-    fn admit(&self, data: &[u8], caller: Address) -> CallCheck {
-        let Ok(call) = IStorageCredits::IStorageCreditsCalls::abi_decode(data) else {
+    fn admit(&self, data: &[u8], caller: Address, spec: TempoHardfork) -> CallCheck {
+        let Ok(call) = IStorageCredits::IStorageCreditsCalls::abi_decode_with_config(
+            data,
+            abi_decoder_config_for_spec(spec),
+        ) else {
             return CallCheck::Continue;
         };
 
@@ -69,12 +74,12 @@ mod tests {
                 }),
             ] {
                 assert!(matches!(
-                    rules.admit(&call.abi_encode(), owner),
+                    rules.admit(&call.abi_encode(), owner, TempoHardfork::T8),
                     CallCheck::Continue
                 ));
                 for caller in [sequencer, outsider] {
                     assert!(matches!(
-                        rules.admit(&call.abi_encode(), caller),
+                        rules.admit(&call.abi_encode(), caller, TempoHardfork::T8),
                         CallCheck::Revert(data) if data == Unauthorized {}.abi_encode()
                     ));
                 }
@@ -90,12 +95,35 @@ mod tests {
         assert!(matches!(
             rules.admit(
                 &IStorageCredits::setBudgetCall { credits: 7 }.abi_encode(),
-                caller
+                caller,
+                TempoHardfork::T8,
             ),
             CallCheck::Continue
         ));
         assert!(matches!(
-            rules.admit(&IStorageCredits::balanceOfCall::SELECTOR, caller),
+            rules.admit(
+                &IStorageCredits::balanceOfCall::SELECTOR,
+                caller,
+                TempoHardfork::T8,
+            ),
+            CallCheck::Continue
+        ));
+    }
+
+    #[test]
+    fn t11_defers_noncanonical_address_calldata_to_upstream() {
+        let owner = Address::repeat_byte(0x11);
+        let outsider = Address::repeat_byte(0x22);
+        let rules = StorageCreditsRules;
+        let mut data = IStorageCredits::balanceOfCall { account: owner }.abi_encode();
+        data[4] = 1;
+
+        assert!(matches!(
+            rules.admit(&data, outsider, TempoHardfork::T8),
+            CallCheck::Revert(data) if data == Unauthorized {}.abi_encode()
+        ));
+        assert!(matches!(
+            rules.admit(&data, outsider, TempoHardfork::T11),
             CallCheck::Continue
         ));
     }

--- a/crates/precompiles/src/storage_credits.rs
+++ b/crates/precompiles/src/storage_credits.rs
@@ -2,13 +2,13 @@
 
 use alloy_primitives::Address;
 use alloy_sol_types::SolInterface;
-use tempo_chainspec::hardfork::TempoHardfork;
 use tempo_contracts::precompiles::IStorageCredits;
 use tempo_precompiles::dispatch::abi_decoder_config_for_spec;
 
 use crate::{
     execution::{CallCheck, CallRules},
     privacy::check_caller,
+    storage::StorageCtx,
 };
 
 /// Zone-specific rules applied before forwarding to upstream `StorageCredits`.
@@ -16,10 +16,10 @@ use crate::{
 pub(crate) struct StorageCreditsRules;
 
 impl CallRules for StorageCreditsRules {
-    fn admit(&self, data: &[u8], caller: Address, spec: TempoHardfork) -> CallCheck {
+    fn admit(&self, data: &[u8], caller: Address) -> CallCheck {
         let Ok(call) = IStorageCredits::IStorageCreditsCalls::abi_decode_with_config(
             data,
-            abi_decoder_config_for_spec(spec),
+            abi_decoder_config_for_spec(StorageCtx::default().spec()),
         ) else {
             return CallCheck::Continue;
         };
@@ -45,12 +45,20 @@ impl CallRules for StorageCreditsRules {
 mod tests {
     use super::*;
     use alloy_sol_types::{SolCall, SolError};
+    use tempo_chainspec::hardfork::TempoHardfork;
     use tempo_zone_contracts::Unauthorized;
 
     use crate::{
         storage::StorageCtx,
         test_utils::{test_context, test_storage_provider},
     };
+
+    fn admit_at(data: &[u8], caller: Address, spec: TempoHardfork) -> CallCheck {
+        let mut ctx = test_context();
+        ctx.cfg.spec = spec;
+        let mut storage = test_storage_provider(&mut ctx, u64::MAX, true);
+        StorageCtx::enter(&mut storage, || StorageCreditsRules.admit(data, caller))
+    }
 
     #[test]
     fn account_indexed_getters_allow_only_owner() {
@@ -74,12 +82,12 @@ mod tests {
                 }),
             ] {
                 assert!(matches!(
-                    rules.admit(&call.abi_encode(), owner, TempoHardfork::T8),
+                    rules.admit(&call.abi_encode(), owner),
                     CallCheck::Continue
                 ));
                 for caller in [sequencer, outsider] {
                     assert!(matches!(
-                        rules.admit(&call.abi_encode(), caller, TempoHardfork::T8),
+                        rules.admit(&call.abi_encode(), caller),
                         CallCheck::Revert(data) if data == Unauthorized {}.abi_encode()
                     ));
                 }
@@ -90,10 +98,8 @@ mod tests {
     #[test]
     fn mutations_and_malformed_calldata_remain_upstream_authorized() {
         let caller = Address::repeat_byte(0x11);
-        let rules = StorageCreditsRules;
-
         assert!(matches!(
-            rules.admit(
+            admit_at(
                 &IStorageCredits::setBudgetCall { credits: 7 }.abi_encode(),
                 caller,
                 TempoHardfork::T8,
@@ -101,7 +107,7 @@ mod tests {
             CallCheck::Continue
         ));
         assert!(matches!(
-            rules.admit(
+            admit_at(
                 &IStorageCredits::balanceOfCall::SELECTOR,
                 caller,
                 TempoHardfork::T8,
@@ -114,16 +120,15 @@ mod tests {
     fn t11_defers_noncanonical_address_calldata_to_upstream() {
         let owner = Address::repeat_byte(0x11);
         let outsider = Address::repeat_byte(0x22);
-        let rules = StorageCreditsRules;
         let mut data = IStorageCredits::balanceOfCall { account: owner }.abi_encode();
         data[4] = 1;
 
         assert!(matches!(
-            rules.admit(&data, outsider, TempoHardfork::T8),
+            admit_at(&data, outsider, TempoHardfork::T8),
             CallCheck::Revert(data) if data == Unauthorized {}.abi_encode()
         ));
         assert!(matches!(
-            rules.admit(&data, outsider, TempoHardfork::T11),
+            admit_at(&data, outsider, TempoHardfork::T11),
             CallCheck::Continue
         ));
     }

--- a/crates/precompiles/src/tip403_proxy/mod.rs
+++ b/crates/precompiles/src/tip403_proxy/mod.rs
@@ -25,7 +25,12 @@ alloy_sol_types::sol! {
 pub(crate) struct Tip403Rules;
 
 impl CallRules for Tip403Rules {
-    fn admit(&self, _data: &[u8], caller: Address) -> CallCheck {
+    fn admit(
+        &self,
+        _data: &[u8],
+        caller: Address,
+        _spec: tempo_chainspec::hardfork::TempoHardfork,
+    ) -> CallCheck {
         // Operator simulations use `address(0)`. Public RPC simulations cannot select this caller.
         if caller.is_zero() {
             return CallCheck::Continue;
@@ -109,12 +114,20 @@ mod tests {
     fn only_zero_address_is_admitted() {
         let data = ITIP403Registry::policyIdCounterCall {}.abi_encode();
         assert!(matches!(
-            Tip403Rules.admit(&data, Address::ZERO),
+            Tip403Rules.admit(
+                &data,
+                Address::ZERO,
+                tempo_chainspec::hardfork::TempoHardfork::T8,
+            ),
             CallCheck::Continue
         ));
         for caller in [CALLER, Address::repeat_byte(0x20)] {
             assert!(matches!(
-                Tip403Rules.admit(&data, caller),
+                Tip403Rules.admit(
+                    &data,
+                    caller,
+                    tempo_chainspec::hardfork::TempoHardfork::T8,
+                ),
                 CallCheck::Revert(data) if data == OnlyPrecompiles {}.abi_encode()
             ));
         }

--- a/crates/precompiles/src/tip403_proxy/mod.rs
+++ b/crates/precompiles/src/tip403_proxy/mod.rs
@@ -25,12 +25,7 @@ alloy_sol_types::sol! {
 pub(crate) struct Tip403Rules;
 
 impl CallRules for Tip403Rules {
-    fn admit(
-        &self,
-        _data: &[u8],
-        caller: Address,
-        _spec: tempo_chainspec::hardfork::TempoHardfork,
-    ) -> CallCheck {
+    fn admit(&self, _data: &[u8], caller: Address) -> CallCheck {
         // Operator simulations use `address(0)`. Public RPC simulations cannot select this caller.
         if caller.is_zero() {
             return CallCheck::Continue;
@@ -114,20 +109,12 @@ mod tests {
     fn only_zero_address_is_admitted() {
         let data = ITIP403Registry::policyIdCounterCall {}.abi_encode();
         assert!(matches!(
-            Tip403Rules.admit(
-                &data,
-                Address::ZERO,
-                tempo_chainspec::hardfork::TempoHardfork::T8,
-            ),
+            Tip403Rules.admit(&data, Address::ZERO),
             CallCheck::Continue
         ));
         for caller in [CALLER, Address::repeat_byte(0x20)] {
             assert!(matches!(
-                Tip403Rules.admit(
-                    &data,
-                    caller,
-                    tempo_chainspec::hardfork::TempoHardfork::T8,
-                ),
+                Tip403Rules.admit(&data, caller),
                 CallCheck::Revert(data) if data == OnlyPrecompiles {}.abi_encode()
             ));
         }

--- a/crates/precompiles/src/ztip20/mod.rs
+++ b/crates/precompiles/src/ztip20/mod.rs
@@ -10,7 +10,10 @@
 
 use alloy_primitives::Address;
 use alloy_sol_types::{SolCall, SolError, SolInterface};
-use tempo_precompiles::tip20::{IRolesAuth, ITIP20};
+use tempo_precompiles::{
+    dispatch::abi_decoder_config_for_spec,
+    tip20::{IRolesAuth, ITIP20},
+};
 use tempo_zone_contracts::Unauthorized;
 
 use crate::{
@@ -50,8 +53,14 @@ impl CallRules for TIP20Rules {
     }
 
     /// Apply zone privacy and selector restrictions before upstream execution.
-    fn admit(&self, data: &[u8], caller: Address) -> CallCheck {
-        if let Ok(call) = ITIP20::ITIP20Calls::abi_decode(data) {
+    fn admit(
+        &self,
+        data: &[u8],
+        caller: Address,
+        spec: tempo_chainspec::hardfork::TempoHardfork,
+    ) -> CallCheck {
+        let config = abi_decoder_config_for_spec(spec);
+        if let Ok(call) = ITIP20::ITIP20Calls::abi_decode_with_config(data, config) {
             return match call {
                 ITIP20::ITIP20Calls::balanceOf(call) => {
                     check_caller(caller, &[call.account])
@@ -115,7 +124,7 @@ impl CallRules for TIP20Rules {
             };
         }
 
-        let Ok(call) = IRolesAuth::IRolesAuthCalls::abi_decode(data) else {
+        let Ok(call) = IRolesAuth::IRolesAuthCalls::abi_decode_with_config(data, config) else {
             // Preserve the upstream error and gas behavior for malformed or unknown calldata.
             return CallCheck::Continue;
         };
@@ -142,6 +151,7 @@ mod tests {
     use alloy_evm::precompiles::DynPrecompile;
     use alloy_sol_types::{SolCall, SolError, SolInterface};
     use revm::precompile::PrecompileResult;
+    use tempo_chainspec::hardfork::TempoHardfork;
     use tempo_contracts::precompiles::TIP20Error;
     use tempo_precompiles::{
         PATH_USD_ADDRESS,
@@ -173,14 +183,14 @@ mod tests {
 
     fn assert_allowed(rules: &TIP20Rules, call: impl SolCall, caller: Address) {
         assert!(matches!(
-            rules.admit(&call.abi_encode(), caller),
+            rules.admit(&call.abi_encode(), caller, TempoHardfork::T8),
             CallCheck::Continue
         ));
     }
 
     fn assert_unauthorized(rules: &TIP20Rules, call: impl SolCall, caller: Address) {
         assert!(matches!(
-            rules.admit(&call.abi_encode(), caller),
+            rules.admit(&call.abi_encode(), caller, TempoHardfork::T8),
             CallCheck::Revert(data) if data == Unauthorized {}.abi_encode()
         ));
     }
@@ -198,6 +208,10 @@ mod tests {
 
     impl PrecompileHarness {
         fn new() -> eyre::Result<Self> {
+            Self::new_at(TempoHardfork::T8)
+        }
+
+        fn new_at(spec: TempoHardfork) -> eyre::Result<Self> {
             let token = PATH_USD_ADDRESS;
             let admin = address!("0x00000000000000000000000000000000000000a1");
             let alice = address!("0x00000000000000000000000000000000000000a2");
@@ -208,6 +222,7 @@ mod tests {
             let l1_reader = MockL1Reader::default();
             l1_reader.seed_active_sequencer(PORTAL_ADDRESS, TEMPO_BLOCK_NUMBER, sequencer);
             let mut ctx = test_context();
+            ctx.cfg.spec = spec;
 
             {
                 let mut storage = test_storage_provider(&mut ctx, u64::MAX, false);
@@ -366,7 +381,7 @@ mod tests {
 
         for call in calls {
             assert!(matches!(
-                rules.admit(&call, caller),
+                rules.admit(&call, caller, TempoHardfork::T8),
                 CallCheck::Revert(data) if data == Unauthorized {}.abi_encode()
             ));
         }
@@ -512,6 +527,24 @@ mod tests {
         let blocked = harness.call(harness.bob, calldata.into(), 100_000, true)?;
         assert!(blocked.is_revert());
         assert_eq!(blocked.bytes, Bytes::from(Unauthorized {}.abi_encode()));
+
+        Ok(())
+    }
+
+    #[test]
+    fn t11_strict_decoding_precedes_read_privacy() -> eyre::Result<()> {
+        let mut harness = PrecompileHarness::new_at(TempoHardfork::T11)?;
+        let mut calldata = ITIP20::balanceOfCall {
+            account: harness.alice,
+        }
+        .abi_encode();
+        calldata[4] = 1;
+
+        for caller in [harness.alice, harness.bob] {
+            let output = harness.call(caller, calldata.clone().into(), 100_000, true)?;
+            assert!(output.is_revert());
+            assert!(output.bytes.is_empty());
+        }
 
         Ok(())
     }

--- a/crates/precompiles/src/ztip20/mod.rs
+++ b/crates/precompiles/src/ztip20/mod.rs
@@ -19,6 +19,7 @@ use tempo_zone_contracts::Unauthorized;
 use crate::{
     execution::{CallCheck, CallRules},
     privacy::check_caller,
+    storage::StorageCtx,
 };
 
 alloy_sol_types::sol! {
@@ -53,13 +54,8 @@ impl CallRules for TIP20Rules {
     }
 
     /// Apply zone privacy and selector restrictions before upstream execution.
-    fn admit(
-        &self,
-        data: &[u8],
-        caller: Address,
-        spec: tempo_chainspec::hardfork::TempoHardfork,
-    ) -> CallCheck {
-        let config = abi_decoder_config_for_spec(spec);
+    fn admit(&self, data: &[u8], caller: Address) -> CallCheck {
+        let config = abi_decoder_config_for_spec(StorageCtx::default().spec());
         if let Ok(call) = ITIP20::ITIP20Calls::abi_decode_with_config(data, config) {
             return match call {
                 ITIP20::ITIP20Calls::balanceOf(call) => {
@@ -181,16 +177,28 @@ mod tests {
         TIP20Rules
     }
 
+    fn admit_at(
+        rules: &TIP20Rules,
+        data: &[u8],
+        caller: Address,
+        spec: TempoHardfork,
+    ) -> CallCheck {
+        let mut ctx = test_context();
+        ctx.cfg.spec = spec;
+        let mut storage = test_storage_provider(&mut ctx, u64::MAX, true);
+        StorageCtx::enter(&mut storage, || rules.admit(data, caller))
+    }
+
     fn assert_allowed(rules: &TIP20Rules, call: impl SolCall, caller: Address) {
         assert!(matches!(
-            rules.admit(&call.abi_encode(), caller, TempoHardfork::T8),
+            admit_at(rules, &call.abi_encode(), caller, TempoHardfork::T8),
             CallCheck::Continue
         ));
     }
 
     fn assert_unauthorized(rules: &TIP20Rules, call: impl SolCall, caller: Address) {
         assert!(matches!(
-            rules.admit(&call.abi_encode(), caller, TempoHardfork::T8),
+            admit_at(rules, &call.abi_encode(), caller, TempoHardfork::T8),
             CallCheck::Revert(data) if data == Unauthorized {}.abi_encode()
         ));
     }
@@ -301,27 +309,22 @@ mod tests {
         let sequencer = Address::repeat_byte(0x33);
         let outsider = Address::repeat_byte(0x44);
         let rules = TIP20Rules;
-        let mut ctx = test_context();
-        let mut storage = test_storage_provider(&mut ctx, u64::MAX, false);
+        let balance = ITIP20::balanceOfCall { account: owner };
+        assert_allowed(&rules, balance.clone(), owner);
+        assert_unauthorized(&rules, balance.clone(), sequencer);
+        assert_unauthorized(&rules, balance, outsider);
 
-        StorageCtx::enter(&mut storage, || {
-            let balance = ITIP20::balanceOfCall { account: owner };
-            assert_allowed(&rules, balance.clone(), owner);
-            assert_unauthorized(&rules, balance.clone(), sequencer);
-            assert_unauthorized(&rules, balance, outsider);
+        let allowance = ITIP20::allowanceCall { owner, spender };
+        for caller in [owner, spender] {
+            assert_allowed(&rules, allowance.clone(), caller);
+        }
+        assert_unauthorized(&rules, allowance.clone(), sequencer);
+        assert_unauthorized(&rules, allowance, outsider);
 
-            let allowance = ITIP20::allowanceCall { owner, spender };
-            for caller in [owner, spender] {
-                assert_allowed(&rules, allowance.clone(), caller);
-            }
-            assert_unauthorized(&rules, allowance.clone(), sequencer);
-            assert_unauthorized(&rules, allowance, outsider);
-
-            let nonce = ITIP20::noncesCall { owner };
-            assert_allowed(&rules, nonce.clone(), owner);
-            assert_unauthorized(&rules, nonce.clone(), sequencer);
-            assert_unauthorized(&rules, nonce, outsider);
-        });
+        let nonce = ITIP20::noncesCall { owner };
+        assert_allowed(&rules, nonce.clone(), owner);
+        assert_unauthorized(&rules, nonce.clone(), sequencer);
+        assert_unauthorized(&rules, nonce, outsider);
     }
 
     #[test]
@@ -381,7 +384,7 @@ mod tests {
 
         for call in calls {
             assert!(matches!(
-                rules.admit(&call, caller, TempoHardfork::T8),
+                admit_at(&rules, &call, caller, TempoHardfork::T8),
                 CallCheck::Revert(data) if data == Unauthorized {}.abi_encode()
             ));
         }

--- a/crates/spf/src/mpt.rs
+++ b/crates/spf/src/mpt.rs
@@ -130,10 +130,9 @@ impl StatelessSparseTrie {
             for (hashed_address, storage) in storage_updates {
                 let current_account = self.trie_account(hashed_address)?;
                 let has_revealed_storage = self.inner.storage_trie_ref(&hashed_address).is_some();
-                if !storage.wiped
-                    && current_account
-                        .as_ref()
-                        .is_some_and(|account| account.storage_root != EMPTY_ROOT_HASH)
+                if current_account
+                    .as_ref()
+                    .is_some_and(|account| account.storage_root != EMPTY_ROOT_HASH)
                     && !has_revealed_storage
                 {
                     return Err(StatelessSparseTrieError::IncompleteStateUpdate);
@@ -143,11 +142,6 @@ impl StatelessSparseTrie {
                     .inner
                     .take_storage_trie(&hashed_address)
                     .unwrap_or_else(RevealableSparseTrie::revealed_empty);
-                if storage.wiped {
-                    storage_trie
-                        .wipe()
-                        .map_err(|_| StatelessSparseTrieError::InvalidSparseTrie)?;
-                }
 
                 let mut updates = storage
                     .storage


### PR DESCRIPTION
## Summary

Updates the Zones EVM integration to Tempo PR [#7444](https://github.com/tempoxyz/tempo/pull/7444) and makes Zone precompile admission follow the active Tempo hardfork.

- aligns Tempo, Reth, Alloy, Commonware, and lockfile revisions
- passes the active TempoHardfork into precompile input-gas calculation
- uses the Tempo fork-aware ABI decoder configuration in every Zone admission wrapper
- retains permissive decoding before T11 and enables strict decoding at T11

## Why

Tempo precompile input cost and ABI decoding are now hardfork-dependent. Zones wraps Tempo precompiles with its own authorization layer, so decoding calldata with a different configuration before forwarding can produce caller-dependent results for malformed input.

Using the same Tempo configuration in both layers ensures historical pre-T11 blocks retain their old decoding and gas behavior, while T11 blocks use the increased input cost, strict ABI validation, and the allocation limit selected by Tempo.

Zone chain specs already inherit Tempo fork activation times, and ZoneEvmConfig selects the Tempo spec from each block timestamp. This change carries that selected spec through the wrapper admission paths.

## Reexecution

- pre-T11: 6 gas per calldata word and permissive ABI decoding
- T11+: 30 gas per calldata word and strict ABI decoding
- historical blocks derive behavior from their original block timestamp

## Validation

- cargo test -p zone-precompiles --lib --no-fail-fast: 152 passed, 1 existing ignored
- cargo check -p zone-evm
- T10/T11 input-gas boundary regression
- pre-T11 noncanonical-address privacy regression
- T11 owner/outsider malformed-calldata consistency regression
- existing timestamp-based Tempo fork-selection coverage

## Stack note

This is the base of a two-PR stack.

The dependency alignment includes a newer Reth revision that removed the old HashedStorage.wiped and sparse-trie wipe APIs. As a result, the full workspace check stops at the expected zone-spf compatibility errors on this PR alone. The stacked child adapts stateless proof execution and the node APIs to the new Reth revision, and restores the full workspace build.

This split keeps the Tempo/T11 behavior change independently reviewable.