### PR TITLE
feat(ci): embed prover PCR measurements in image

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -203,6 +203,20 @@ jobs:
             --output-file /output/tempo-zone-prover.eif \
             | tee "$EIF_OUTPUT_DIR/measurements.json"
 
+      - name: Read tempo-zone-prover PCR measurements
+        id: prover_measurements
+        shell: bash
+        run: |
+          set -Eeuo pipefail
+
+          measurements=target/tempo-zone-prover-eif/measurements.json
+          {
+            echo "hash_algorithm=$(jq -er '.Measurements.HashAlgorithm | strings | select(length > 0)' "$measurements")"
+            echo "pcr0=$(jq -er '.Measurements.PCR0 | strings | select(length > 0)' "$measurements")"
+            echo "pcr1=$(jq -er '.Measurements.PCR1 | strings | select(length > 0)' "$measurements")"
+            echo "pcr2=$(jq -er '.Measurements.PCR2 | strings | select(length > 0)' "$measurements")"
+          } >> "$GITHUB_OUTPUT"
+
       - name: Build and push tempo-zone-prover
         uses: tempoxyz/gh-actions/vendor/depot/bake-action@6f436eb3a168279692739e8c0c9fdb52b94bfae7
         with:
@@ -210,6 +224,11 @@ jobs:
             docker/docker-bake.hcl
             ${{ steps.meta-tempo-zone-prover.outputs.bake-file }}
           targets: tempo-zone-prover
+          set: |
+            tempo-zone-prover.args.NITRO_HASH_ALGORITHM=${{ steps.prover_measurements.outputs.hash_algorithm }}
+            tempo-zone-prover.args.NITRO_PCR0=${{ steps.prover_measurements.outputs.pcr0 }}
+            tempo-zone-prover.args.NITRO_PCR1=${{ steps.prover_measurements.outputs.pcr1 }}
+            tempo-zone-prover.args.NITRO_PCR2=${{ steps.prover_measurements.outputs.pcr2 }}
           project: 0c6tg19qsp
           push: >-
             ${{ github.repository == 'tempoxyz/zones' &&

--- a/docker/Dockerfile.prover-host
+++ b/docker/Dockerfile.prover-host
@@ -9,6 +9,15 @@ FROM public.ecr.aws/amazonlinux/amazonlinux:2023@sha256:6d8e068b91f351df5bf6acd4
 # Keep these IDs in sync with the Pod security context and the Talos udev rule.
 ARG PROVER_UID=10001
 ARG PROVER_GID=10001
+ARG NITRO_HASH_ALGORITHM
+ARG NITRO_PCR0
+ARG NITRO_PCR1
+ARG NITRO_PCR2
+
+LABEL xyz.tempo.zone-prover.nitro.hash-algorithm="${NITRO_HASH_ALGORITHM}" \
+      xyz.tempo.zone-prover.nitro.pcr0="${NITRO_PCR0}" \
+      xyz.tempo.zone-prover.nitro.pcr1="${NITRO_PCR1}" \
+      xyz.tempo.zone-prover.nitro.pcr2="${NITRO_PCR2}"
 
 # Create the fixed runtime identity
 RUN dnf install -y shadow-utils


### PR DESCRIPTION
## Summary

- parse Nitro PCR measurements after building the prover EIF
- pass the hash algorithm and PCR0/PCR1/PCR2 into the prover host build
- expose the measurements as digest-bound labels on the published prover image

## Validation

- validated extraction against the measurements artifact from successful Docker workflow run `33764450715`
- `git diff --check`

Prompted by: @rkrasiuk
