### PR TITLE
fix(ci): use vendored prover utils metadata action

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -114,7 +114,7 @@ jobs:
 
       - name: Docker metadata for tempo-zone-prover-utils
         id: meta-tempo-zone-prover-utils
-        uses: docker/metadata-action@80c7e94dd9b9319bd5eb7a0e0fe9291e23a2a2e9 # v6.1.0
+        uses: tempoxyz/gh-actions/vendor/docker/metadata-action@6f436eb3a168279692739e8c0c9fdb52b94bfae7
         with:
           images: ${{ env.REGISTRY }}/tempo-zone-prover-utils
           bake-target: tempo-zone-prover-utils


### PR DESCRIPTION
## Summary

- use the enterprise-owned vendored Docker metadata action for `tempo-zone-prover-utils`
- align the new image metadata step with every other third-party action in the Docker workflow
- unblock Docker workflow startup after the failed post-merge run for #1371

## Validation

- verified all third-party references in `.github/workflows/docker.yml` resolve through `tempoxyz/gh-actions`
- `git diff --check`

Prompted by: @rkrasiuk
