### PR TITLE
refactor(ci): build prover EIF inputs in parallel

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -177,26 +177,19 @@ jobs:
           VERGEN_GIT_SHA: ${{ github.sha }}
           VERGEN_GIT_SHA_SHORT: ${{ steps.shortsha.outputs.shortsha }}
 
-      # Nitro CLI converts an image from the runner's local Docker image store.
-      - name: Load tempo-zone-prover enclave payload
+      # Nitro CLI converts images from the runner's local Docker image store.
+      # Bake both independent inputs together so BuildKit can build them in parallel.
+      - name: Load tempo-zone-prover EIF inputs
         uses: tempoxyz/gh-actions/vendor/depot/bake-action@6f436eb3a168279692739e8c0c9fdb52b94bfae7
         with:
           files: docker/docker-bake.hcl
-          targets: tempo-zone-prover-enclave
+          targets: |
+            tempo-zone-prover-enclave
+            tempo-zone-prover-eif-builder
           set: |
             tempo-zone-prover-enclave.tags=tempo-zone-prover-enclave:eif-source
             tempo-zone-prover-enclave.contexts.tempo-genesis=.tempo-genesis
-          project: 0c6tg19qsp
-          load: true
-          no-cache: ${{ github.event_name == 'schedule' }}
-          pull: ${{ github.event_name == 'schedule' }}
-
-      - name: Load tempo-zone-prover EIF builder
-        uses: tempoxyz/gh-actions/vendor/depot/bake-action@6f436eb3a168279692739e8c0c9fdb52b94bfae7
-        with:
-          files: docker/docker-bake.hcl
-          targets: tempo-zone-prover-eif-builder
-          set: tempo-zone-prover-eif-builder.tags=tempo-zone-prover-eif-builder:local
+            tempo-zone-prover-eif-builder.tags=tempo-zone-prover-eif-builder:local
           project: 0c6tg19qsp
           load: true
           no-cache: ${{ github.event_name == 'schedule' }}

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -114,7 +114,7 @@ jobs:
 
       - name: Docker metadata for tempo-zone-prover-utils
         id: meta-tempo-zone-prover-utils
-        uses: docker/metadata-action@80c7e94dd9b9319bd5eb7a0e0fe9291e23a2a2e9 # v6.1.0
+        uses: tempoxyz/gh-actions/vendor/docker/metadata-action@6f436eb3a168279692739e8c0c9fdb52b94bfae7
         with:
           images: ${{ env.REGISTRY }}/tempo-zone-prover-utils
           bake-target: tempo-zone-prover-utils


### PR DESCRIPTION
## Summary

- load the prover enclave payload and EIF builder in one Depot Bake invocation
- let BuildKit execute the independent target graphs concurrently while loading both images into the runner Docker store
- temporarily carry #1375’s vendored metadata-action fix so branch builds can start from the current `main`

## Validation

- [branch Docker build](https://github.com/tempoxyz/zones/actions/runs/33770098728) completed successfully
- parsed `.github/workflows/docker.yml` with PyYAML
- verified the vendored Depot action accepts multiline `targets` input
- ran `git diff --check`

Prompted by: @shekhirin