### PR TITLE
perf(node): serve redacted blocks from the sealed header

### DIFF
--- a/crates/node/src/rpc.rs
+++ b/crates/node/src/rpc.rs
@@ -33,10 +33,10 @@ use reth_rpc_api::Web3ApiServer;
 use reth_rpc_builder::EthHandlers;
 use reth_rpc_eth_api::{
     EthApiTypes, EthFilterApiServer, RpcConvert,
-    helpers::{EthApiSpec, EthBlocks, EthCall, EthFees, EthState, EthTransactions, FullEthApi},
+    helpers::{EthApiSpec, EthCall, EthFees, EthState, EthTransactions, FullEthApi},
 };
 use reth_rpc_eth_types::{EthApiError, logs_utils};
-use reth_storage_api::{BlockNumReader, StateProviderFactory};
+use reth_storage_api::{BlockNumReader, BlockReaderIdExt, StateProviderFactory};
 use reth_trie_common::{ExecutionWitnessMode, HashedStorage};
 use tempo_alloy::{
     TempoNetwork,
@@ -739,19 +739,40 @@ impl<Api> ZoneRpc<Api>
 where
     Api: FullEthApi + EthApiTypes<NetworkTypes = TempoNetwork> + Send + Sync + 'static,
 {
+    /// Serve the redacted block from the sealed header alone.
+    ///
+    /// Redaction drops the entire body, so loading the recovered block (and evicting the block
+    /// cache with it) only to hash every transaction and RLP-encode the body for `size` is wasted
+    /// work.
     fn block_by_id(&self, id: BlockId) -> BoxFut<'_> {
         Box::pin(async move {
-            let block = EthBlocks::rpc_block(&self.eth.api, id, false)
-                .await
-                .map_err(internal)?;
-
-            let Some(mut block) = block else {
+            let Some(header) = self
+                .eth
+                .api
+                .provider()
+                .sealed_header_by_id(id)
+                .map_err(internal)?
+            else {
                 return Ok(raw_null());
             };
 
-            redact_block(&mut block);
+            // A block carries withdrawals exactly when its header has a withdrawals root.
+            let withdrawals = header.withdrawals_root().map(|_| Default::default());
+            // `redact_header` zeroes `size`, so the block's RLP length is never observed.
+            let mut header = self
+                .eth
+                .api
+                .converter()
+                .convert_header(header, 0)
+                .map_err(internal)?;
+            redact_header(&mut header);
 
-            to_raw(&block)
+            to_raw(&RpcBlock {
+                header,
+                uncles: Vec::new(),
+                transactions: BlockTransactions::Hashes(Vec::new()),
+                withdrawals,
+            })
         })
     }
 }
@@ -819,8 +840,11 @@ where
 
     fn coinbase(&self) -> BoxFut<'_> {
         Box::pin(async move {
-            let header = EthBlocks::rpc_block_header(&self.eth.api, BlockId::latest())
-                .await
+            let header = self
+                .eth
+                .api
+                .provider()
+                .latest_header()
                 .map_err(internal)?
                 .ok_or_else(|| JsonRpcError::internal("latest block not found"))?;
             to_raw(&header.beneficiary())
@@ -1450,13 +1474,6 @@ fn apply_public_fee_policy(request: &mut TempoTransactionRequest) {
     if request.max_fee_per_gas().is_none() {
         request.set_max_fee_per_gas(u128::from(TEMPO_T0_BASE_FEE) + priority_fee);
     }
-}
-
-/// Strip privacy-sensitive fields from a block returned by the redacted RPC.
-fn redact_block(block: &mut RpcBlock) {
-    redact_header(&mut block.header);
-    block.transactions = BlockTransactions::Hashes(Vec::new());
-    block.withdrawals = block.withdrawals.take().map(|_| Default::default());
 }
 
 pub(crate) fn rpc_connection_config(retry_connection_interval: Duration) -> ConnectionConfig {

--- a/crates/node/src/rpc.rs
+++ b/crates/node/src/rpc.rs
@@ -26,8 +26,7 @@ use eyre::WrapErr;
 use futures::StreamExt;
 use jsonrpsee::{RpcModule, core::RpcResult, proc_macros::rpc, types::ErrorObjectOwned};
 use reth_evm::{ConfigureEvm as _, execute::Executor as _};
-use reth_primitives_traits::SealedHeader;
-use reth_provider::{CanonStateSubscriptions, HeaderProvider, ProviderError};
+use reth_provider::{CanonStateSubscriptions, HeaderProvider};
 use reth_revm::{db::State, witness::ExecutionWitnessRecord};
 use reth_rpc::{EthFilter, eth::filter::EthFilterError};
 use reth_rpc_api::Web3ApiServer;
@@ -753,23 +752,27 @@ where
     ///
     /// Redaction drops the entire body, so loading the recovered block (and evicting the block
     /// cache with it) only to hash every transaction and RLP-encode the body for `size` is wasted
-    /// work. The header is read through the eth state cache, which serves it from the cached
-    /// header or the cached full block and only loads it from the provider on a miss.
+    /// work. The requested block is usually cached, since clients poll `latest`, so the header
+    /// is taken from the cached block and only read from the provider on a miss.
     fn block_by_id(&self, id: BlockId) -> BoxFut<'_> {
         Box::pin(async move {
-            let Some(hash) = self
-                .eth
-                .api
-                .provider()
-                .block_hash_for_id(id)
-                .map_err(internal)?
-            else {
+            let provider = self.eth.api.provider();
+            let Some(hash) = provider.block_hash_for_id(id).map_err(internal)? else {
                 return Ok(raw_null());
             };
-            let header = match self.eth.api.cache().get_header(hash).await {
-                Ok(header) => SealedHeader::new(header, hash),
-                Err(ProviderError::HeaderNotFound(_)) => return Ok(raw_null()),
-                Err(err) => return Err(internal(err)),
+            let cached = self
+                .eth
+                .api
+                .cache()
+                .get_maybe_block(hash)
+                .await
+                .map_err(internal)?;
+            let header = match cached {
+                Some(block) => block.clone_sealed_header(),
+                None => match provider.sealed_header_by_hash(hash).map_err(internal)? {
+                    Some(header) => header,
+                    None => return Ok(raw_null()),
+                },
             };
 
             // A block carries withdrawals exactly when its header has a withdrawals root.

--- a/crates/node/src/rpc.rs
+++ b/crates/node/src/rpc.rs
@@ -26,7 +26,8 @@ use eyre::WrapErr;
 use futures::StreamExt;
 use jsonrpsee::{RpcModule, core::RpcResult, proc_macros::rpc, types::ErrorObjectOwned};
 use reth_evm::{ConfigureEvm as _, execute::Executor as _};
-use reth_provider::{CanonStateSubscriptions, HeaderProvider};
+use reth_primitives_traits::SealedHeader;
+use reth_provider::{CanonStateSubscriptions, HeaderProvider, ProviderError};
 use reth_revm::{db::State, witness::ExecutionWitnessRecord};
 use reth_rpc::{EthFilter, eth::filter::EthFilterError};
 use reth_rpc_api::Web3ApiServer;
@@ -36,7 +37,7 @@ use reth_rpc_eth_api::{
     helpers::{EthApiSpec, EthCall, EthFees, EthState, EthTransactions, FullEthApi},
 };
 use reth_rpc_eth_types::{EthApiError, logs_utils};
-use reth_storage_api::{BlockNumReader, BlockReaderIdExt, StateProviderFactory};
+use reth_storage_api::{BlockIdReader, BlockNumReader, BlockReaderIdExt, StateProviderFactory};
 use reth_trie_common::{ExecutionWitnessMode, HashedStorage};
 use tempo_alloy::{
     TempoNetwork,
@@ -743,17 +744,23 @@ where
     ///
     /// Redaction drops the entire body, so loading the recovered block (and evicting the block
     /// cache with it) only to hash every transaction and RLP-encode the body for `size` is wasted
-    /// work.
+    /// work. The header is read through the eth state cache, which serves it from the cached
+    /// header or the cached full block and only loads it from the provider on a miss.
     fn block_by_id(&self, id: BlockId) -> BoxFut<'_> {
         Box::pin(async move {
-            let Some(header) = self
+            let Some(hash) = self
                 .eth
                 .api
                 .provider()
-                .sealed_header_by_id(id)
+                .block_hash_for_id(id)
                 .map_err(internal)?
             else {
                 return Ok(raw_null());
+            };
+            let header = match self.eth.api.cache().get_header(hash).await {
+                Ok(header) => SealedHeader::new(header, hash),
+                Err(ProviderError::HeaderNotFound(_)) => return Ok(raw_null()),
+                Err(err) => return Err(internal(err)),
             };
 
             // A block carries withdrawals exactly when its header has a withdrawals root.


### PR DESCRIPTION
`eth_getBlockByNumber` and `eth_getBlockByHash` on the redacted RPC loaded the recovered block, collected every transaction hash and RLP-encoded the whole block for `size`, then discarded all of it: `redact_block` emptied the transaction list and `redact_header` zeroed `size`. Header-only requests for old blocks also evicted live traffic from the block cache.

The response is now built from the header alone: the block id is resolved to a hash, the header is taken from the cached block when the eth state cache holds it and otherwise read from the provider, then it is converted with the same `RpcConvert` as before with size 0, and paired with empty uncles, an empty transaction list and a withdrawals field derived from the header's withdrawals root. A block has withdrawals exactly when its header has that root, so the serialized JSON is unchanged for every block, including `latest`, hash lookups and unknown blocks. The one behaviour change is that a header whose body was pruned now returns the redacted header instead of null, which cannot occur on zone nodes since they retain bodies.

`eth_coinbase` took the same full-block path and now reads the beneficiary from `latest_header`.


