### PR TITLE
perf(p2p): pass received payloads as Bytes instead of copying into Vec

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -13868,6 +13868,7 @@ dependencies = [
  "alloy-signer-local",
  "alloy-sol-types",
  "base64 0.22.1",
+ "bytes",
  "clap",
  "commonware-codec",
  "commonware-cryptography",
@@ -13947,6 +13948,7 @@ version = "0.2.2"
 dependencies = [
  "alloy-primitives",
  "alloy-signer-local",
+ "bytes",
  "commonware-actor",
  "commonware-codec",
  "commonware-cryptography",

--- a/crates/node/Cargo.toml
+++ b/crates/node/Cargo.toml
@@ -76,6 +76,7 @@ alloy-signer-local.workspace = true
 alloy-sol-types.workspace = true
 
 # misc
+bytes.workspace = true
 clap = { workspace = true, optional = true }
 eyre.workspace = true
 tokio-util = { workspace = true, features = ["rt"] }

--- a/crates/node/src/replication.rs
+++ b/crates/node/src/replication.rs
@@ -39,6 +39,7 @@ use zone_sequencer::{
 };
 
 use alloy_signer_local::PrivateKeySigner;
+use bytes::Bytes;
 use eyre::{OptionExt as _, WrapErr as _};
 
 use crate::settlement_attestation::build_settlement_attestation;
@@ -419,7 +420,7 @@ impl BackfillProgress {
 /// backfilled blocks.
 #[derive(Debug, Clone)]
 pub(crate) struct PendingPeerBlock {
-    encoded: Vec<u8>,
+    encoded: Bytes,
     live_sender: Option<P2pPeerId>,
 }
 
@@ -954,7 +955,7 @@ async fn process_follower_block<P>(
     pending: &mut BTreeMap<u64, PendingPeerBlock>,
     backfill: &mut BackfillProgress,
     number: u64,
-    block: Vec<u8>,
+    block: Bytes,
     live_sender: Option<P2pPeerId>,
     stop: &sync::CancellationToken,
 ) -> bool
@@ -1103,7 +1104,7 @@ where
         + 'static,
 {
     // Check the received block
-    let mut input = peer_block.encoded.as_slice();
+    let mut input = peer_block.encoded.as_ref();
     let block = Block::decode(&mut input)
         .map_err(|err| eyre::eyre!("invalid RLP-encoded zone block: {err}"))?;
     if !input.is_empty() {
@@ -2070,7 +2071,7 @@ mod tests {
 
     fn pending_block(payload: u64) -> super::PendingPeerBlock {
         super::PendingPeerBlock {
-            encoded: vec![payload as u8],
+            encoded: vec![payload as u8].into(),
             live_sender: None,
         }
     }

--- a/crates/node/src/tx_forwarding.rs
+++ b/crates/node/src/tx_forwarding.rs
@@ -455,7 +455,7 @@ mod tests {
             events
                 .send(P2pEvent::TransactionReceived {
                     follower_ed25519_public_key: peer.clone(),
-                    transaction,
+                    transaction: transaction.into(),
                 })
                 .await
                 .unwrap();

--- a/crates/p2p/Cargo.toml
+++ b/crates/p2p/Cargo.toml
@@ -21,6 +21,7 @@ commonware-p2p.workspace = true
 commonware-runtime = { workspace = true, features = ["external"] }
 commonware-utils.workspace = true
 
+bytes.workspace = true
 const-hex.workspace = true
 derive_more.workspace = true
 eyre.workspace = true

--- a/crates/p2p/src/backfill.rs
+++ b/crates/p2p/src/backfill.rs
@@ -5,6 +5,7 @@ use std::{
     time::{Duration, Instant},
 };
 
+use bytes::Bytes;
 use commonware_cryptography::ed25519::PublicKey;
 use commonware_p2p::{Recipients, Sender as _, authenticated::lookup};
 use tokio::sync::mpsc;
@@ -58,7 +59,7 @@ pub struct BackfillRequest {
 /// A response accepted for the active follower generation.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum BackfillResponse {
-    Block { peer: P2pPeerId, block: Vec<u8> },
+    Block { peer: P2pPeerId, block: Bytes },
     Completed { peer: P2pPeerId, tip: PeerTip },
 }
 
@@ -258,7 +259,7 @@ where
                 }
                 result = self.response_receiver.recv() => {
                     let (peer, bytes) = result.map_err(|err| eyre::eyre!("backfill response receive failed: {err}"))?;
-                    self.handle_response(peer, bytes.as_ref()).await?;
+                    self.handle_response(peer, bytes.into()).await?;
                 }
             }
         }
@@ -279,7 +280,11 @@ where
                     warn!(target: "zone::p2p", %peer, "Ignoring backfill block addressed to an unknown peer");
                     return Ok(());
                 }
-                let frame = match (ResponseFrame::Block { request_id, block }).encode() {
+                let response = ResponseFrame::Block {
+                    request_id,
+                    block: block.into(),
+                };
+                let frame = match response.encode() {
                     Ok(frame) => frame,
                     Err(err) => {
                         error!(target: "zone::p2p", %peer, %err, "Backfill block exceeds the P2P response frame size limit");
@@ -408,11 +413,12 @@ where
             .map_err(|_| eyre::eyre!("backfill request event channel closed"))
     }
 
-    async fn handle_response(&mut self, peer: PublicKey, bytes: &[u8]) -> eyre::Result<()> {
+    async fn handle_response(&mut self, peer: PublicKey, bytes: Bytes) -> eyre::Result<()> {
+        let size = bytes.len();
         let frame = match ResponseFrame::decode(bytes) {
             Ok(frame) => frame,
             Err(err) => {
-                warn!(target: "zone::p2p", %peer, size = bytes.len(), %err, "Ignoring malformed backfill response");
+                warn!(target: "zone::p2p", %peer, size, %err, "Ignoring malformed backfill response");
                 return Ok(());
             }
         };
@@ -570,17 +576,18 @@ mod tests {
         let mut malformed = vec![1];
         malformed.extend_from_slice(&request_id.to_be_bytes());
         malformed.extend_from_slice(&[0; PeerTip::ENCODED_LEN - 1]);
-        assert!(ResponseFrame::decode(&malformed).is_err());
+        assert!(ResponseFrame::decode(malformed.into()).is_err());
         assert!(job.accepts(&peer, request_id, now));
         assert_eq!(job.complete(&peer, request_id, now), Some(7));
         assert_eq!(
             ResponseFrame::decode(
-                &ResponseFrame::Complete {
+                ResponseFrame::Complete {
                     request_id,
                     tip: tip()
                 }
                 .encode()
                 .unwrap()
+                .into()
             ),
             Ok(ResponseFrame::Complete {
                 request_id,

--- a/crates/p2p/src/protocol.rs
+++ b/crates/p2p/src/protocol.rs
@@ -1,4 +1,5 @@
 use alloy_primitives::B256;
+use bytes::Bytes;
 
 use crate::network::MAX_MESSAGE_SIZE;
 
@@ -74,7 +75,7 @@ impl RequestFrame {
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub(crate) enum ResponseFrame {
-    Block { request_id: u64, block: Vec<u8> },
+    Block { request_id: u64, block: Bytes },
     Complete { request_id: u64, tip: PeerTip },
 }
 
@@ -105,7 +106,8 @@ impl ResponseFrame {
         }
     }
 
-    pub(crate) fn decode(bytes: &[u8]) -> Result<Self, DecodeError> {
+    /// Decodes one response frame, keeping the block payload as a view into `bytes`.
+    pub(crate) fn decode(bytes: Bytes) -> Result<Self, DecodeError> {
         let Some((&tag, payload)) = bytes.split_first() else {
             return Err(DecodeError::EmptyResponse);
         };
@@ -131,7 +133,7 @@ impl ResponseFrame {
                 }
                 Ok(Self::Block {
                     request_id,
-                    block: payload.to_vec(),
+                    block: bytes.slice(RESPONSE_HEADER_LEN..),
                 })
             }
             COMPLETE_FRAME => Ok(Self::Complete {
@@ -168,6 +170,7 @@ pub(crate) enum EncodeError {
 #[cfg(test)]
 mod tests {
     use alloy_primitives::B256;
+    use bytes::Bytes;
 
     use super::{
         DecodeError, EncodeError, PeerTip, RESPONSE_HEADER_LEN, RequestFrame, ResponseFrame,
@@ -206,13 +209,16 @@ mod tests {
     fn response_golden_bytes_and_round_trips() {
         let block = ResponseFrame::Block {
             request_id: 7,
-            block: vec![0xaa, 0xbb],
+            block: Bytes::from_static(&[0xaa, 0xbb]),
         };
         assert_eq!(
             block.encode().unwrap(),
             vec![0, 0, 0, 0, 0, 0, 0, 0, 7, 0xaa, 0xbb]
         );
-        assert_eq!(ResponseFrame::decode(&block.encode().unwrap()), Ok(block));
+        assert_eq!(
+            ResponseFrame::decode(block.encode().unwrap().into()),
+            Ok(block)
+        );
 
         let complete = ResponseFrame::Complete {
             request_id: 7,
@@ -222,7 +228,7 @@ mod tests {
         assert_eq!(encoded[0], 1);
         assert_eq!(&encoded[1..9], &7_u64.to_be_bytes());
         assert_eq!(encoded.len(), RESPONSE_HEADER_LEN + PeerTip::ENCODED_LEN);
-        assert_eq!(ResponseFrame::decode(&encoded), Ok(complete));
+        assert_eq!(ResponseFrame::decode(encoded.into()), Ok(complete));
     }
 
     #[test]
@@ -231,23 +237,26 @@ mod tests {
             RequestFrame::decode(&[]),
             Err(DecodeError::IncorrectRequestLength { .. })
         ));
-        assert_eq!(ResponseFrame::decode(&[]), Err(DecodeError::EmptyResponse));
         assert_eq!(
-            ResponseFrame::decode(&[0]),
+            ResponseFrame::decode(Bytes::new()),
+            Err(DecodeError::EmptyResponse)
+        );
+        assert_eq!(
+            ResponseFrame::decode(Bytes::from_static(&[0])),
             Err(DecodeError::MissingRequestId)
         );
         assert_eq!(
-            ResponseFrame::decode(&[9]),
+            ResponseFrame::decode(Bytes::from_static(&[9])),
             Err(DecodeError::UnknownResponseTag(9))
         );
         assert!(matches!(
-            ResponseFrame::decode(&[1, 0, 0, 0, 0, 0, 0, 0, 7]),
+            ResponseFrame::decode(Bytes::from_static(&[1, 0, 0, 0, 0, 0, 0, 0, 7])),
             Err(DecodeError::InvalidCompletionLength { .. })
         ));
         let mut overlong_completion = vec![1, 0, 0, 0, 0, 0, 0, 0, 7];
         overlong_completion.extend_from_slice(&[0; PeerTip::ENCODED_LEN + 1]);
         assert!(matches!(
-            ResponseFrame::decode(&overlong_completion),
+            ResponseFrame::decode(overlong_completion.into()),
             Err(DecodeError::InvalidCompletionLength { .. })
         ));
     }
@@ -258,7 +267,7 @@ mod tests {
         assert!(matches!(
             ResponseFrame::Block {
                 request_id: 1,
-                block: block.clone(),
+                block: block.clone().into(),
             }
             .encode(),
             Err(EncodeError::OversizedResponseBlock { .. })
@@ -266,7 +275,7 @@ mod tests {
         let mut encoded = vec![0, 0, 0, 0, 0, 0, 0, 0, 1];
         encoded.extend_from_slice(&block);
         assert!(matches!(
-            ResponseFrame::decode(&encoded),
+            ResponseFrame::decode(encoded.into()),
             Err(DecodeError::OversizedResponseBlock { .. })
         ));
     }

--- a/crates/p2p/src/runtime.rs
+++ b/crates/p2p/src/runtime.rs
@@ -1,6 +1,7 @@
 use std::{collections::HashMap, net::SocketAddr, path::Path, sync::Arc, time::Duration};
 
 use alloy_primitives::{Address as EthereumAddress, B256};
+use bytes::Bytes;
 use commonware_cryptography::ed25519::PublicKey;
 use commonware_p2p::{AddressableManager as _, Recipients, Sender as _, authenticated::lookup};
 use commonware_runtime::{IoBuf, Runner as _, Spawner as _};
@@ -33,7 +34,10 @@ const EVENT_BACKLOG: usize = 128;
 type CommonwareSender = lookup::Sender<PublicKey, commonware_runtime::tokio::Context>;
 type CommonwareReceiver = lookup::Receiver<PublicKey>;
 
-fn into_bounded_payload(bytes: IoBuf, max_size: usize) -> Result<Vec<u8>, usize> {
+/// Takes ownership of one received frame, rejecting oversized frames before the event is built.
+///
+/// `IoBuf` into [`Bytes`] shares the pooled receive buffer; `IoBuf` into `Vec<u8>` would copy it.
+fn into_bounded_payload(bytes: IoBuf, max_size: usize) -> Result<Bytes, usize> {
     let size = bytes.len();
     if size > max_size {
         return Err(size);
@@ -228,22 +232,19 @@ pub enum P2pEvent {
     /// A follower received an encoded sealed block from its configured leader.
     BlockReceived {
         leader_ed25519_public_key: PublicKey,
-        block: Vec<u8>,
+        block: Bytes,
     },
     /// A follower received a proposed settlement statement from the leader.
-    SettlementProposalReceived {
-        leader: PublicKey,
-        proposal: Vec<u8>,
-    },
+    SettlementProposalReceived { leader: PublicKey, proposal: Bytes },
     /// The leader received a settlement signature from a follower.
     SettlementSignatureReceived {
         follower: PublicKey,
-        signature: Vec<u8>,
+        signature: Bytes,
     },
     /// A quorum member received a raw transaction from an authenticated follower.
     TransactionReceived {
         follower_ed25519_public_key: PublicKey,
-        transaction: Vec<u8>,
+        transaction: Bytes,
     },
 }
 


### PR DESCRIPTION
Commonware hands the receive path an `IoBuf` backed by a pooled or aligned buffer. `From<IoBuf> for Vec<u8>` copies that buffer while `From<IoBuf> for Bytes` shares it, so every inbound block, transaction, settlement proposal and signature paid one full copy of its payload before the event was built, and backfill response frames copied the block a second time out of the frame.

The P2P event payloads, `BackfillResponse` and the backfill response frame now carry `bytes::Bytes`, and the frame decoder slices the block out of the received buffer. The wire format is unchanged. A `Bytes` built from a pooled buffer keeps that buffer checked out until the last handle drops; the pool falls back to a plain allocation when exhausted rather than blocking, and the node drops the received bytes right after decoding, so retention is bounded by the existing 128-slot event and response channels.

Measured with a throwaway release-mode harness: the removed copy costs 0.2 µs for an 8 KB block, 0.7 µs at 46 KB and 4.3 µs at 252 KB, per message. Split out of #1388, which keeps the decode-once change; this can land after #1392, which consumes the same settlement payloads.
