### PR TITLE
fix(precompiles): gate T11 semantics on Z1

### DIFF
--- a/crates/precompiles/src/execution.rs
+++ b/crates/precompiles/src/execution.rs
@@ -48,14 +48,19 @@ pub struct ZonePrecompileEnv {
 
 impl ZonePrecompileEnv {
     /// Captures the active EVM configuration and transaction-local storage accounting state.
+    /// Zone-wrapped Tempo precompiles retain T10 semantics until Z1 activates.
     pub fn new(
         cfg: &revm::context::CfgEnv<TempoHardfork>,
         zone_hardfork: ZoneHardfork,
         actions: StorageActions,
         non_creditable_slots: Rc<RefCell<NonCreditableSlots>>,
     ) -> Self {
+        let mut cfg = cfg.clone();
+        if cfg.spec.is_t11() && !zone_hardfork.is_z1() {
+            cfg.spec = TempoHardfork::T10;
+        }
         Self {
-            cfg: cfg.clone(),
+            cfg,
             zone_hardfork,
             actions,
             non_creditable_slots,
@@ -425,15 +430,19 @@ mod tests {
     }
 
     #[test]
-    fn input_gas_threshold_tracks_t11() {
+    fn input_gas_threshold_tracks_zone_hardfork() {
         let calldata = [0u8; 32];
 
-        for (spec, required_gas) in [(TempoHardfork::T10, 6), (TempoHardfork::T11, 30)] {
+        for (spec, zone_hardfork, required_gas) in [
+            (TempoHardfork::T10, ZoneHardfork::Z0, 6),
+            (TempoHardfork::T11, ZoneHardfork::Z0, 6),
+            (TempoHardfork::T11, ZoneHardfork::Z1, 30),
+        ] {
             let mut cfg = revm::context::CfgEnv::<TempoHardfork>::default();
             cfg.spec = spec;
             let env = ZonePrecompileEnv::new(
                 &cfg,
-                zone_hardfork::ZoneHardfork::Z0,
+                zone_hardfork,
                 StorageActions::disabled(),
                 Rc::new(RefCell::new(NonCreditableSlots::empty())),
             );
@@ -448,13 +457,16 @@ mod tests {
             assert_eq!(
                 insufficient.halt_reason(),
                 Some(&PrecompileHalt::OutOfGas),
-                "{spec:?} must require {required_gas} input gas"
+                "{spec:?}/{zone_hardfork:?} must require {required_gas} input gas"
             );
 
             let sufficient = precompile
                 .call(input(&mut ctx, &calldata, Address::ZERO, required_gas))
                 .unwrap();
-            assert!(!sufficient.is_halt(), "{spec:?} must accept its exact cost");
+            assert!(
+                !sufficient.is_halt(),
+                "{spec:?}/{zone_hardfork:?} must accept its exact cost"
+            );
         }
     }
 

--- a/crates/precompiles/src/test_utils/local.rs
+++ b/crates/precompiles/src/test_utils/local.rs
@@ -58,9 +58,17 @@ pub(crate) fn test_storage_provider(
 
 /// Create the ordinary precompile environment for a local unit test.
 pub(crate) fn test_env(ctx: &TestContext) -> ZonePrecompileEnv {
+    test_env_at(ctx, zone_hardfork::ZoneHardfork::Z0)
+}
+
+/// Create a precompile environment at a specific Zone hardfork for a local unit test.
+pub(crate) fn test_env_at(
+    ctx: &TestContext,
+    zone_hardfork: zone_hardfork::ZoneHardfork,
+) -> ZonePrecompileEnv {
     ZonePrecompileEnv::new(
         &ctx.cfg,
-        zone_hardfork::ZoneHardfork::Z0,
+        zone_hardfork,
         StorageActions::disabled(),
         Rc::new(RefCell::new(NonCreditableSlots::empty())),
     )

--- a/crates/precompiles/src/ztip20/mod.rs
+++ b/crates/precompiles/src/ztip20/mod.rs
@@ -165,10 +165,11 @@ mod tests {
     use crate::{
         TempoState,
         test_utils::{
-            MockL1Reader, TestContext, call_precompile, test_context, test_env,
+            MockL1Reader, TestContext, call_precompile, test_context, test_env, test_env_at,
             test_storage_provider,
         },
     };
+    use zone_hardfork::ZoneHardfork;
 
     const TEMPO_BLOCK_NUMBER: u64 = 7;
     const PORTAL_ADDRESS: Address = address!("0x0000000000000000000000000000000000000b01");
@@ -220,6 +221,10 @@ mod tests {
         }
 
         fn new_at(spec: TempoHardfork) -> eyre::Result<Self> {
+            Self::new_at_zone(spec, ZoneHardfork::Z0)
+        }
+
+        fn new_at_zone(spec: TempoHardfork, zone_hardfork: ZoneHardfork) -> eyre::Result<Self> {
             let token = PATH_USD_ADDRESS;
             let admin = address!("0x00000000000000000000000000000000000000a1");
             let alice = address!("0x00000000000000000000000000000000000000a2");
@@ -251,7 +256,7 @@ mod tests {
                 })?;
             }
 
-            let env = test_env(&ctx);
+            let env = test_env_at(&ctx, zone_hardfork);
             let precompile = crate::create_tip20_precompile(token, &env);
 
             Ok(Self {
@@ -536,7 +541,7 @@ mod tests {
 
     #[test]
     fn t11_strict_decoding_precedes_read_privacy() -> eyre::Result<()> {
-        let mut harness = PrecompileHarness::new_at(TempoHardfork::T11)?;
+        let mut harness = PrecompileHarness::new_at_zone(TempoHardfork::T11, ZoneHardfork::Z1)?;
         let mut calldata = ITIP20::balanceOfCall {
             account: harness.alice,
         }


### PR DESCRIPTION
## Summary

- preserve T10 gas pricing and permissive ABI decoding for Zone-wrapped Tempo precompiles while Z0 is active
- enable Tempo T11 precompile semantics when the independently scheduled Z1 hardfork activates
- cover the T11/Z0 compatibility boundary and T11/Z1 activation boundary with regression tests

## Root cause

The T11 dependency update keyed wrapped precompile behavior directly to `TempoHardfork`. The nextfork-backed Zone already executes with Tempo T11 but has not activated Z1, so historical block `15013` re-executed with the new 30-gas-per-word input cost instead of the stored 6-gas-per-word cost, producing a 696-gas receipt mismatch.

## Testing

- `cargo test -p zone-precompiles --lib --no-fail-fast`
- `cargo +nightly clippy -p zone-precompiles --lib --tests -- -D warnings`

Prompted by: @legion2002