### PR TITLE
feat(ci): allow skipping prover image builds

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -18,6 +18,10 @@ on:
         description: "Tempo genesis JSON URL to embed in the prover image"
         type: string
         default: "https://devnet-assets.tempoxyz.dev/tempo-devnet-nextfork.json"
+      skip_prover:
+        description: "Skip building the Zone prover image and PCR measurements"
+        type: boolean
+        default: false
   workflow_call:
     inputs:
       tempo_genesis_url:
@@ -25,6 +29,11 @@ on:
         required: false
         type: string
         default: "https://devnet-assets.tempoxyz.dev/tempo-devnet-nextfork.json"
+      skip_prover:
+        description: "Skip building the Zone prover image and PCR measurements"
+        required: false
+        type: boolean
+        default: false
   schedule:
     - cron: "5 9 * * *"
     - cron: "30 20 * * *"
@@ -95,6 +104,7 @@ jobs:
             type=ref,event=pr
 
       - name: Docker metadata for tempo-zone-prover
+        if: ${{ !inputs.skip_prover }}
         id: meta-tempo-zone-prover
         uses: docker/metadata-action@80c7e94dd9b9319bd5eb7a0e0fe9291e23a2a2e9 # v6.1.0
         with:
@@ -124,6 +134,7 @@ jobs:
         run: echo "shortsha=${GITHUB_SHA::7}" >> "$GITHUB_OUTPUT"
 
       - name: Download Tempo devnet genesis
+        if: ${{ !inputs.skip_prover }}
         shell: bash
         run: |
           set -euo pipefail
@@ -160,6 +171,7 @@ jobs:
 
       # Nitro CLI converts an image from the runner's local Docker image store.
       - name: Load tempo-zone-prover enclave payload
+        if: ${{ !inputs.skip_prover }}
         uses: depot/bake-action@1d58c2668346981089b088b7ef36755b206b20e9 # v1.13.0
         with:
           files: docker/docker-bake.hcl
@@ -173,6 +185,7 @@ jobs:
           pull: ${{ github.event_name == 'schedule' }}
 
       - name: Load tempo-zone-prover EIF builder
+        if: ${{ !inputs.skip_prover }}
         uses: depot/bake-action@1d58c2668346981089b088b7ef36755b206b20e9 # v1.13.0
         with:
           files: docker/docker-bake.hcl
@@ -184,6 +197,7 @@ jobs:
           pull: ${{ github.event_name == 'schedule' }}
 
       - name: Build tempo-zone-prover EIF
+        if: ${{ !inputs.skip_prover }}
         env:
           PROVER_IMAGE: tempo-zone-prover-enclave:eif-source
           EIF_BUILDER_IMAGE: tempo-zone-prover-eif-builder:local
@@ -204,6 +218,7 @@ jobs:
             | tee "$EIF_OUTPUT_DIR/measurements.json"
 
       - name: Build and push tempo-zone-prover
+        if: ${{ !inputs.skip_prover }}
         uses: depot/bake-action@1d58c2668346981089b088b7ef36755b206b20e9 # v1.13.0
         with:
           files: |
@@ -219,6 +234,7 @@ jobs:
           pull: ${{ github.event_name == 'schedule' }}
 
       - name: Upload tempo-zone-prover PCR measurements
+        if: ${{ !inputs.skip_prover }}
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: tempo-zone-prover-measurements-${{ steps.shortsha.outputs.shortsha }}


### PR DESCRIPTION
## Summary

- add a `skip_prover` input to the Zones Docker workflow
- skip prover metadata, EIF generation, image build, and PCR artifact upload when enabled
- preserve existing prover builds for all normal workflow triggers

## Validation

- parsed `.github/workflows/docker.yml` with Nushell
- `git diff --check`

Prompted by: @shekhirin