### PR TITLE
fix(l1): reconcile prover with subscriber state refactor

### DIFF
--- a/crates/l1/Cargo.toml
+++ b/crates/l1/Cargo.toml
@@ -55,4 +55,5 @@ url = "2"
 [dev-dependencies]
 alloy-rlp.workspace = true
 const-hex.workspace = true
+reth-provider = { workspace = true, features = ["test-utils"] }
 serde_json.workspace = true

--- a/crates/l1/src/lib.rs
+++ b/crates/l1/src/lib.rs
@@ -102,5 +102,3 @@ pub use subscriber::{
 
 #[cfg(test)]
 pub(crate) use queue::PendingDeposits;
-#[cfg(test)]
-pub(crate) use subscriber::LocalTempoCheckpointReader;

--- a/crates/l1/src/subscriber.rs
+++ b/crates/l1/src/subscriber.rs
@@ -1,4 +1,7 @@
 use super::*;
+use crate::{
+    EncryptionKeyRing, L1StateCache, metrics::L1SubscriberMetrics, state::EnabledTokenRegistry,
+};
 use eyre::{OptionExt as _, WrapErr as _};
 use std::collections::HashSet;
 use tempo_contracts::precompiles::{ITIP20::TransferPolicyUpdate, TIP403_REGISTRY_ADDRESS};
@@ -364,54 +367,34 @@ pub struct L1SubscriberConfig {
     pub l1_rpc_url: String,
     /// ZonePortal contract address on L1.
     pub portal_address: Address,
-    /// Shared registry of tokens enabled for this zone.
-    pub enabled_tokens: crate::state::EnabledTokenRegistry,
-    /// Shared L1 state cache. The subscriber updates the cache anchor on each
-    /// finalized block.
-    pub l1_state_cache: crate::state::cache::L1StateCache,
-    /// Validated and applied L1 anchors shared with follower block import.
-    pub block_tracker: L1BlockTracker,
     /// Maximum number of concurrent header and receipt fetches while syncing a
     /// finalized L1 range.
     pub l1_fetch_concurrency: usize,
     /// Interval between L1 connection attempts.
     pub retry_connection_interval: std::time::Duration,
-    /// Optional sink that receives leadership transitions before the block that
-    /// recorded them is enqueued.
-    pub leadership_sink: Option<Arc<dyn LeadershipSink>>,
-    /// Private encryption keys bound by finalized Portal rotation events.
-    pub encryption_keys: Option<crate::EncryptionKeyRing>,
     /// Whether to retain authenticated Portal logs for external observers.
     pub retain_portal_evidence: bool,
 }
 
-pub(crate) trait LocalTempoCheckpointReader: Send + Sync {
-    fn latest_tempo_checkpoint(&self) -> eyre::Result<NumHash>;
-}
-
-struct ProviderLocalTempoCheckpointReader<P> {
-    provider: P,
-}
-
-impl<P> LocalTempoCheckpointReader for ProviderLocalTempoCheckpointReader<P>
-where
-    P: StateProviderFactory + Clone + Send + Sync + 'static,
-{
-    fn latest_tempo_checkpoint(&self) -> eyre::Result<NumHash> {
-        let state = self.provider.latest()?;
-        Ok(state.tempo_num_hash()?)
-    }
-}
-
 /// L1 chain subscriber that listens for new blocks and extracts deposit events.
 #[derive(Clone)]
-pub struct L1Subscriber {
+pub struct L1Subscriber<P> {
     pub(crate) config: L1SubscriberConfig,
-    pub(crate) local_state: Arc<dyn LocalTempoCheckpointReader>,
+    pub(crate) zone_provider: P,
     /// Finalized L1 blocks retained until a Zone consumer processes them.
     pub(crate) deposit_queue: DepositQueue,
+    /// Shared registry of tokens enabled for this zone.
+    pub(crate) enabled_tokens: EnabledTokenRegistry,
+    /// Shared L1 state cache updated after each finalized block.
+    pub(crate) l1_state_cache: L1StateCache,
+    /// Validated and applied L1 anchors shared with follower block import.
+    pub(crate) block_tracker: L1BlockTracker,
+    /// Optional sink for leadership transitions.
+    pub(crate) leadership_sink: Option<Arc<dyn LeadershipSink>>,
+    /// Private encryption keys bound by finalized Portal rotation events.
+    pub(crate) encryption_keys: Option<EncryptionKeyRing>,
     /// L1 subscriber metrics for connection health, backfill, and event ingestion.
-    pub(crate) subscriber_metrics: crate::metrics::L1SubscriberMetrics,
+    pub(crate) subscriber_metrics: L1SubscriberMetrics,
 }
 
 #[derive(Debug, thiserror::Error)]
@@ -445,22 +428,31 @@ impl L1SubscriberError {
 
 type HeaderStream = Pin<Box<dyn Stream<Item = ()> + Send>>;
 
-impl L1Subscriber {
+impl<P> L1Subscriber<P>
+where
+    P: StateProviderFactory + Sync,
+{
     /// Create an L1 subscriber.
-    pub fn new<P>(
+    #[expect(clippy::too_many_arguments)]
+    pub fn new(
         config: L1SubscriberConfig,
-        local_state_provider: P,
+        zone_provider: P,
         deposit_queue: DepositQueue,
-    ) -> Self
-    where
-        P: StateProviderFactory + Clone + Send + Sync + 'static,
-    {
+        enabled_tokens: EnabledTokenRegistry,
+        l1_state_cache: L1StateCache,
+        block_tracker: L1BlockTracker,
+        leadership_sink: Option<Arc<dyn LeadershipSink>>,
+        encryption_keys: Option<EncryptionKeyRing>,
+    ) -> Self {
         Self {
             config,
-            local_state: Arc::new(ProviderLocalTempoCheckpointReader {
-                provider: local_state_provider,
-            }),
+            zone_provider,
             deposit_queue,
+            enabled_tokens,
+            l1_state_cache,
+            block_tracker,
+            leadership_sink,
+            encryption_keys,
             subscriber_metrics: Default::default(),
         }
     }
@@ -529,7 +521,8 @@ impl L1Subscriber {
     /// where ingestion resumes. A non-zero hash distinguishes an L1-anchored
     /// block-zero genesis from the unanchored template.
     pub(crate) fn resolve_start_block(&self) -> Result<u64, L1SubscriberError> {
-        let local_checkpoint = self.local_state.latest_tempo_checkpoint()?;
+        let state = self.zone_provider.latest().map_err(eyre::Report::from)?;
+        let local_checkpoint = state.tempo_num_hash().map_err(eyre::Report::from)?;
         if local_checkpoint.hash == B256::ZERO {
             return Err(eyre::eyre!("zone genesis is not anchored to an L1 block").into());
         }
@@ -546,7 +539,6 @@ impl L1Subscriber {
             .last_enqueued()
             .map(|last| last.number.saturating_add(1));
         let observed = self
-            .config
             .block_tracker
             .latest()
             .map(|last| last.number.saturating_add(1));
@@ -559,8 +551,7 @@ impl L1Subscriber {
 
         // Only the persisted zone checkpoint proves consumption.
         // Queue and observation cursors are fetch high-water marks.
-        self.config
-            .block_tracker
+        self.block_tracker
             .initialize_consumed_through(resolved.saturating_sub(1));
         Ok(next)
     }
@@ -650,7 +641,7 @@ impl L1Subscriber {
 
         let concurrency = self.config.l1_fetch_concurrency.max(1);
         let subscriber_metrics = self.subscriber_metrics.clone();
-        let block_tracker = self.config.block_tracker.clone();
+        let block_tracker = self.block_tracker.clone();
 
         let mut fetched = stream::iter(from..=to)
             .map(move |block_number| {
@@ -724,7 +715,7 @@ impl L1Subscriber {
             let portal_evidence = portal_logs.map(|logs| (sealed.parent_hash(), logs));
             // Publish the leadership transition _before_ the activation block becomes
             // consumable.
-            if let Some(sink) = &self.config.leadership_sink {
+            if let Some(sink) = &self.leadership_sink {
                 let transition =
                     events
                         .final_leader_transition()
@@ -745,7 +736,7 @@ impl L1Subscriber {
                         ))?;
                 }
             }
-            if let Some(keys) = &self.config.encryption_keys {
+            if let Some(keys) = &self.encryption_keys {
                 for rotation in &events.encryption_key_rotations {
                     keys.apply_rotation(rotation)
                         .map_err(L1SubscriberError::fatal_from_err(
@@ -761,15 +752,14 @@ impl L1Subscriber {
                     format!("unexpected discontinuity while enqueueing L1 block {block_number}")
                 })?;
             if let Some((parent_hash, logs)) = portal_evidence {
-                self.config.block_tracker.record_with_portal_evidence(
+                self.block_tracker.record_with_portal_evidence(
                     anchor,
                     parent_hash,
                     events.clone(),
                     logs,
                 )?;
             } else {
-                self.config
-                    .block_tracker
+                self.block_tracker
                     .record_with_portal_events(anchor, events.clone())?;
             }
             // Publish derived L1 state only after the header has been admitted to every
@@ -828,7 +818,7 @@ impl L1Subscriber {
             .await;
 
             if let Err(error) = result {
-                // Retry ordinary errors; finalized event decoding and application errors are fatal.
+                // Retry connection and sync errors, finalized event errors are fatal.
                 if error.should_retry() {
                     let retry_interval = self.config.retry_connection_interval;
                     self.subscriber_metrics.reconnects.increment(1);
@@ -937,7 +927,7 @@ impl L1Subscriber {
             return;
         }
 
-        let mut enabled_tokens = self.config.enabled_tokens.write();
+        let mut enabled_tokens = self.enabled_tokens.write();
         for enabled in &portal_events.enabled_tokens {
             if enabled_tokens.insert(enabled.token) {
                 info!(token = %enabled.token, "New token enabled");
@@ -951,8 +941,7 @@ impl L1Subscriber {
         number: u64,
         invalidated_accounts: &HashSet<Address>,
     ) {
-        self.config
-            .l1_state_cache
+        self.l1_state_cache
             .lock()
             .invalidate_and_set_anchor(number, invalidated_accounts.iter().copied());
     }

--- a/crates/l1/src/tests.rs
+++ b/crates/l1/src/tests.rs
@@ -5,11 +5,9 @@ use alloy_primitives::{Bloom, Bytes, address};
 use alloy_rpc_types_eth::{Header as RpcHeader, TransactionReceipt};
 use alloy_sol_types::SolEvent;
 use alloy_transport::mock::Asserter;
+use reth_provider::test_utils::{ExtendedAccount, MockEthProvider};
 use serde::Deserialize;
-use std::{
-    collections::{HashSet, VecDeque},
-    time::Duration,
-};
+use std::{collections::HashSet, time::Duration};
 use tempo_alloy::rpc::{TempoHeaderResponse, TempoTransactionReceipt};
 use tempo_contracts::precompiles::TIP403_REGISTRY_ADDRESS;
 use tempo_primitives::{TempoReceipt, TempoTxType};
@@ -123,60 +121,50 @@ fn make_withdrawal_bounce_back(amount: u128) -> L1Deposit {
     })
 }
 
-struct SequenceLocalTempoCheckpointReader {
-    values: Mutex<VecDeque<NumHash>>,
-    last_value: NumHash,
+fn set_tempo_checkpoint(provider: &MockEthProvider, checkpoint: NumHash) {
+    provider.add_account(
+        crate::abi::TEMPO_STATE_ADDRESS,
+        ExtendedAccount::new(0, U256::ZERO).extend_storage([
+            (
+                B256::from(
+                    crate::precompiles::tempo_state::slots::TEMPO_BLOCK_NUMBER.to_be_bytes(),
+                ),
+                U256::from(checkpoint.number),
+            ),
+            (
+                B256::from(crate::precompiles::tempo_state::slots::TEMPO_BLOCK_HASH.to_be_bytes()),
+                U256::from_be_slice(checkpoint.hash.as_slice()),
+            ),
+        ]),
+    );
 }
 
-impl SequenceLocalTempoCheckpointReader {
-    fn new(values: impl Into<VecDeque<u64>>) -> Self {
-        let values = values
-            .into()
-            .into_iter()
-            .map(|number| NumHash::new(number, B256::with_last_byte(1)))
-            .collect::<VecDeque<_>>();
-        let last_value = values.back().copied().unwrap_or_default();
-        Self {
-            values: Mutex::new(values),
-            last_value,
-        }
-    }
-
-    fn unanchored() -> Self {
-        Self {
-            values: Mutex::new(VecDeque::from([NumHash::default()])),
-            last_value: NumHash::default(),
-        }
-    }
-}
-
-impl LocalTempoCheckpointReader for SequenceLocalTempoCheckpointReader {
-    fn latest_tempo_checkpoint(&self) -> eyre::Result<NumHash> {
-        let mut values = self.values.lock();
-        Ok(values.pop_front().unwrap_or(self.last_value))
-    }
-}
-
-fn test_subscriber(local_state: Arc<dyn LocalTempoCheckpointReader>) -> L1Subscriber {
+fn test_subscriber_with_checkpoint(checkpoint: NumHash) -> L1Subscriber<MockEthProvider> {
     let portal_address = address!("0x0000000000000000000000000000000000000ABC");
+    let zone_provider = MockEthProvider::new();
+    set_tempo_checkpoint(&zone_provider, checkpoint);
 
     L1Subscriber {
         config: L1SubscriberConfig {
             l1_rpc_url: "http://127.0.0.1:8545".to_owned(),
             portal_address,
-            enabled_tokens: crate::state::EnabledTokenRegistry::default(),
-            l1_state_cache: crate::L1StateCache::new(),
-            block_tracker: L1BlockTracker::default(),
             l1_fetch_concurrency: 1,
             retry_connection_interval: Duration::from_secs(1),
-            leadership_sink: None,
-            encryption_keys: None,
             retain_portal_evidence: false,
         },
-        local_state,
+        zone_provider,
         deposit_queue: DepositQueue::default(),
+        enabled_tokens: crate::state::EnabledTokenRegistry::default(),
+        l1_state_cache: crate::L1StateCache::new(),
+        block_tracker: L1BlockTracker::default(),
+        leadership_sink: None,
+        encryption_keys: None,
         subscriber_metrics: Default::default(),
     }
+}
+
+fn test_subscriber(block_number: u64) -> L1Subscriber<MockEthProvider> {
+    test_subscriber_with_checkpoint(NumHash::new(block_number, B256::with_last_byte(1)))
 }
 
 #[tokio::test]
@@ -392,7 +380,7 @@ fn l1_block_tracker_rejects_first_observation_above_persisted_successor() {
 
 #[test]
 fn subscriber_applies_state_and_records_observation() {
-    let subscriber = test_subscriber(Arc::new(SequenceLocalTempoCheckpointReader::new([9])));
+    let subscriber = test_subscriber(9);
     let header = make_test_header(10);
     let sealed = seal(header);
     let anchor = sealed.num_hash();
@@ -401,23 +389,22 @@ fn subscriber_applies_state_and_records_observation() {
     let cached_value = B256::with_last_byte(2);
 
     {
-        let mut cache = subscriber.config.l1_state_cache.lock();
+        let mut cache = subscriber.l1_state_cache.lock();
         cache.invalidate_and_set_anchor(9, []);
         cache.set(cached_address, cached_slot, 9, cached_value);
     }
     subscriber.update_l1_state_anchor(10, &HashSet::new());
-    subscriber.config.block_tracker.record(anchor).unwrap();
+    subscriber.block_tracker.record(anchor).unwrap();
 
     assert_eq!(
         subscriber
-            .config
             .l1_state_cache
             .lock()
             .get(cached_address, cached_slot, 10),
         Some(cached_value)
     );
     assert_eq!(
-        subscriber.config.block_tracker.observed_hash(10),
+        subscriber.block_tracker.observed_hash(10),
         Some(anchor.hash)
     );
 }
@@ -680,24 +667,21 @@ fn assert_tempo_header_rejected(input: &[u8]) {
 
 #[test]
 fn update_l1_state_anchor_applies_raw_mutations_before_publishing_coverage() {
-    let subscriber = test_subscriber(Arc::new(SequenceLocalTempoCheckpointReader::new([0])));
+    let subscriber = test_subscriber(0);
     let slot = B256::with_last_byte(1);
     let value = B256::with_last_byte(2);
     let stable_account = address!("0x0000000000000000000000000000000000000ABC");
     let stable_slot = B256::with_last_byte(3);
     let stable_value = B256::with_last_byte(4);
     subscriber
-        .config
         .l1_state_cache
         .lock()
         .invalidate_and_set_anchor(9, []);
     subscriber
-        .config
         .l1_state_cache
         .lock()
         .set(TIP403_REGISTRY_ADDRESS, slot, 10, value);
     subscriber
-        .config
         .l1_state_cache
         .lock()
         .set(stable_account, stable_slot, 10, stable_value);
@@ -705,7 +689,6 @@ fn update_l1_state_anchor_applies_raw_mutations_before_publishing_coverage() {
     subscriber.update_l1_state_anchor(10, &HashSet::new());
     assert_eq!(
         subscriber
-            .config
             .l1_state_cache
             .lock()
             .get(TIP403_REGISTRY_ADDRESS, slot, 10),
@@ -713,7 +696,7 @@ fn update_l1_state_anchor_applies_raw_mutations_before_publishing_coverage() {
     );
 
     subscriber.update_l1_state_anchor(11, &HashSet::from([TIP403_REGISTRY_ADDRESS]));
-    let mut cache = subscriber.config.l1_state_cache.lock();
+    let mut cache = subscriber.l1_state_cache.lock();
     assert_eq!(
         cache.get(stable_account, stable_slot, 11),
         Some(stable_value)
@@ -735,22 +718,24 @@ fn deposit_hash_chain(previous_hash: B256, deposits: &[L1Deposit]) -> B256 {
 
 #[test]
 fn test_resolve_start_block_reads_live_local_state_each_time() {
-    let subscriber = test_subscriber(Arc::new(SequenceLocalTempoCheckpointReader::new(
-        VecDeque::from([10, 11]),
-    )));
+    let subscriber = test_subscriber(10);
     assert_eq!(subscriber.resolve_start_block().unwrap(), 11);
+    set_tempo_checkpoint(
+        &subscriber.zone_provider,
+        NumHash::new(11, B256::with_last_byte(1)),
+    );
     assert_eq!(subscriber.resolve_start_block().unwrap(), 12);
 }
 
 #[test]
 fn test_resolve_start_block_accepts_block_zero_with_nonzero_hash() {
-    let subscriber = test_subscriber(Arc::new(SequenceLocalTempoCheckpointReader::new([0])));
+    let subscriber = test_subscriber(0);
     assert_eq!(subscriber.resolve_start_block().unwrap(), 1);
 }
 
 #[test]
 fn test_resolve_start_block_rejects_unanchored_genesis() {
-    let subscriber = test_subscriber(Arc::new(SequenceLocalTempoCheckpointReader::unanchored()));
+    let subscriber = test_subscriber_with_checkpoint(NumHash::default());
     assert!(
         subscriber
             .resolve_start_block()
@@ -762,7 +747,7 @@ fn test_resolve_start_block_rejects_unanchored_genesis() {
 
 #[tokio::test]
 async fn test_follow_finalized_uses_new_heads_to_sync_missing_finalized_range() {
-    let subscriber = test_subscriber(Arc::new(SequenceLocalTempoCheckpointReader::new([9])));
+    let subscriber = test_subscriber(9);
     let asserter = Asserter::new();
     let l1_provider =
         ProviderBuilder::new_with_network::<TempoNetwork>().connect_mocked_client(asserter.clone());
@@ -797,7 +782,7 @@ async fn test_follow_finalized_uses_new_heads_to_sync_missing_finalized_range() 
         vec![10, 11, 12]
     );
     assert_eq!(
-        subscriber.config.block_tracker.observed_hash(12),
+        subscriber.block_tracker.observed_hash(12),
         Some(anchor_12.hash),
         "a queue-backed subscriber must retain observations until its consumer prunes them"
     );
@@ -806,7 +791,7 @@ async fn test_follow_finalized_uses_new_heads_to_sync_missing_finalized_range() 
 
 #[tokio::test]
 async fn test_subscribe_block_headers_falls_back_to_http_block_filter() {
-    let subscriber = test_subscriber(Arc::new(SequenceLocalTempoCheckpointReader::new([10])));
+    let subscriber = test_subscriber(10);
     let asserter = Asserter::new();
     let l1_provider = ProviderBuilder::new_with_network::<TempoNetwork>()
         .connect_mocked_client(asserter.clone())
@@ -829,7 +814,7 @@ async fn test_subscribe_block_headers_falls_back_to_http_block_filter() {
 
 #[tokio::test]
 async fn test_sync_finalized_once_does_not_refetch_current_cursor() {
-    let subscriber = test_subscriber(Arc::new(SequenceLocalTempoCheckpointReader::new([10])));
+    let subscriber = test_subscriber(10);
     let asserter = Asserter::new();
     let l1_provider =
         ProviderBuilder::new_with_network::<TempoNetwork>().connect_mocked_client(asserter.clone());
@@ -889,7 +874,7 @@ fn test_push_log_decodes_withdrawal_bounce_back() {
 
 #[test]
 fn confirmed_token_enabled_event_updates_registry() {
-    let subscriber = test_subscriber(Arc::new(SequenceLocalTempoCheckpointReader::new([0])));
+    let subscriber = test_subscriber(0);
     let token = address!("0x20c0000000000000000000000000000000000001");
     let events = L1PortalEvents {
         enabled_tokens: vec![EnabledToken {
@@ -903,7 +888,7 @@ fn confirmed_token_enabled_event_updates_registry() {
 
     subscriber.apply_enabled_token_events(&events);
 
-    assert!(subscriber.config.enabled_tokens.read().contains(&token));
+    assert!(subscriber.enabled_tokens.read().contains(&token));
 }
 
 #[test]
@@ -1653,7 +1638,7 @@ fn corrupt_recognized_portal_log(portal: Address) -> Log {
 
 #[test]
 fn extract_events_fails_closed_on_corrupt_recognized_portal_log() {
-    let mut subscriber = test_subscriber(Arc::new(SequenceLocalTempoCheckpointReader::new([9])));
+    let mut subscriber = test_subscriber(9);
     subscriber.config.retain_portal_evidence = true;
     let portal = subscriber.config.portal_address;
 
@@ -1687,12 +1672,12 @@ fn extract_events_fails_closed_on_corrupt_recognized_portal_log() {
 
 #[test]
 fn pause_events_invalidate_cached_portal_storage() {
-    let subscriber = test_subscriber(Arc::new(SequenceLocalTempoCheckpointReader::new([9])));
+    let subscriber = test_subscriber(9);
     let portal = subscriber.config.portal_address;
     let account = address!("0x0000000000000000000000000000000000000123");
     let pause_slot = B256::with_last_byte(25);
     {
-        let mut cache = subscriber.config.l1_state_cache.lock();
+        let mut cache = subscriber.l1_state_cache.lock();
         cache.set(portal, pause_slot, 0, B256::with_last_byte(0x42));
     }
     let logs = vec![
@@ -1721,18 +1706,14 @@ fn pause_events_invalidate_cached_portal_storage() {
     assert!(invalidated.contains(&portal));
     subscriber.update_l1_state_anchor(1, &invalidated);
     assert_eq!(
-        subscriber
-            .config
-            .l1_state_cache
-            .lock()
-            .get(portal, pause_slot, 1),
+        subscriber.l1_state_cache.lock().get(portal, pause_slot, 1),
         None
     );
 }
 
 #[tokio::test]
 async fn sync_classifies_corrupt_recognized_portal_log_as_fatal() {
-    let subscriber = test_subscriber(Arc::new(SequenceLocalTempoCheckpointReader::new([9])));
+    let subscriber = test_subscriber(9);
     let portal = subscriber.config.portal_address;
     let queue = subscriber.deposit_queue.clone();
 
@@ -1762,7 +1743,7 @@ async fn sync_classifies_corrupt_recognized_portal_log_as_fatal() {
         }
     ));
     assert_eq!(queue.last_enqueued(), None);
-    assert_eq!(subscriber.config.block_tracker.latest(), None);
+    assert_eq!(subscriber.block_tracker.latest(), None);
 }
 
 #[test]
@@ -1792,7 +1773,7 @@ impl LeadershipSink for RecordingLeadershipSink {
 
 #[tokio::test]
 async fn sync_applies_leadership_transition_before_enqueueing_the_activation_block() {
-    let mut subscriber = test_subscriber(Arc::new(SequenceLocalTempoCheckpointReader::new([9])));
+    let mut subscriber = test_subscriber(9);
     let portal = subscriber.config.portal_address;
     let queue = subscriber.deposit_queue.clone();
     let sink = Arc::new(RecordingLeadershipSink {
@@ -1800,7 +1781,7 @@ async fn sync_applies_leadership_transition_before_enqueueing_the_activation_blo
         seen: parking_lot::Mutex::new(Vec::new()),
         fail: false,
     });
-    subscriber.config.leadership_sink = Some(sink.clone());
+    subscriber.leadership_sink = Some(sink.clone());
 
     let new_leader = address!("0x0000000000000000000000000000000000002222");
     let log = leader_updated_log(portal, Address::ZERO, new_leader, 2, 10);
@@ -1839,10 +1820,10 @@ async fn sync_applies_leadership_transition_before_enqueueing_the_activation_blo
 
 #[tokio::test]
 async fn sync_fails_fatally_when_the_leadership_sink_rejects_the_transition() {
-    let mut subscriber = test_subscriber(Arc::new(SequenceLocalTempoCheckpointReader::new([9])));
+    let mut subscriber = test_subscriber(9);
     let portal = subscriber.config.portal_address;
     let queue = subscriber.deposit_queue.clone();
-    subscriber.config.leadership_sink = Some(Arc::new(RecordingLeadershipSink {
+    subscriber.leadership_sink = Some(Arc::new(RecordingLeadershipSink {
         queue: queue.clone(),
         seen: parking_lot::Mutex::new(Vec::new()),
         fail: true,
@@ -1877,5 +1858,5 @@ async fn sync_fails_fatally_when_the_leadership_sink_rejects_the_transition() {
 
     // Nothing was enqueued and no observation advanced: the block was not half-applied.
     assert_eq!(queue.last_enqueued(), None);
-    assert_eq!(subscriber.config.block_tracker.latest(), None);
+    assert_eq!(subscriber.block_tracker.latest(), None);
 }

--- a/crates/node/src/node.rs
+++ b/crates/node/src/node.rs
@@ -225,6 +225,8 @@ pub struct ZoneNode {
     enabled_tokens: EnabledTokenRegistry,
     /// L1 anchors independently observed and applied by the subscriber.
     l1_block_tracker: L1BlockTracker,
+    /// Private encryption keys bound by finalized Portal rotation events.
+    encryption_keys: Option<EncryptionKeyRing>,
     /// Address of the L1 deposit portal contract.
     portal_address: Address,
     /// Number of zone blocks between withdrawal batch boundaries.
@@ -257,13 +259,8 @@ impl ZoneNode {
         let l1_config = L1SubscriberConfig {
             l1_rpc_url: l1_rpc_url.clone(),
             portal_address,
-            enabled_tokens: enabled_tokens.clone(),
-            l1_state_cache: l1_state_cache.clone(),
-            block_tracker: l1_block_tracker.clone(),
             l1_fetch_concurrency,
             retry_connection_interval,
-            leadership_sink: None,
-            encryption_keys: None,
             retain_portal_evidence: false,
         };
 
@@ -281,6 +278,7 @@ impl ZoneNode {
             l1_state_cache,
             enabled_tokens,
             l1_block_tracker,
+            encryption_keys: None,
             portal_address,
             withdrawal_batch_interval_blocks: DEFAULT_WITHDRAWAL_BATCH_INTERVAL_BLOCKS,
             withdrawal_reveal_encryptor: None,
@@ -322,7 +320,6 @@ impl ZoneNode {
         keys: impl IntoIterator<Item = SecretKey>,
     ) -> Self {
         let ring = self
-            .l1_config
             .encryption_keys
             .get_or_insert_with(EncryptionKeyRing::default);
         for key in keys {
@@ -401,7 +398,7 @@ impl ZoneNode {
 
     /// Returns the shared encrypted-deposit key ring, when configured.
     pub fn deposit_decryption_keys(&self) -> Option<EncryptionKeyRing> {
-        self.l1_config.encryption_keys.clone()
+        self.encryption_keys.clone()
     }
 }
 
@@ -430,6 +427,14 @@ where
     deposit_queue: DepositQueue,
     /// Configuration for the L1 event subscriber
     l1_config: L1SubscriberConfig,
+    /// Shared L1 state cache updated by the subscriber.
+    l1_state_cache: L1StateCache,
+    /// Shared registry of tokens enabled for this zone.
+    enabled_tokens: EnabledTokenRegistry,
+    /// L1 anchors independently observed and applied by the subscriber.
+    l1_block_tracker: L1BlockTracker,
+    /// Private encryption keys bound by finalized Portal rotation events.
+    encryption_keys: Option<EncryptionKeyRing>,
     /// ZonePortal address on L1.
     portal_address: Address,
     /// Redacted RPC configuration.
@@ -460,6 +465,10 @@ where
     pub fn new(
         deposit_queue: DepositQueue,
         l1_config: L1SubscriberConfig,
+        l1_state_cache: L1StateCache,
+        enabled_tokens: EnabledTokenRegistry,
+        l1_block_tracker: L1BlockTracker,
+        encryption_keys: Option<EncryptionKeyRing>,
         portal_address: Address,
         redacted_rpc_config: ZoneRedactedRpcConfig,
         sequencer_config: Option<ZoneSequencerAddOnsConfig>,
@@ -477,6 +486,10 @@ where
             ),
             deposit_queue,
             l1_config,
+            l1_state_cache,
+            enabled_tokens,
+            l1_block_tracker,
+            encryption_keys,
             portal_address,
             redacted_rpc_config,
             sequencer_config,
@@ -583,7 +596,7 @@ where
 
         self.resolve_and_seed_tokens(&l1_provider, tempo_block_number)
             .await?;
-        if let Some(keys) = self.l1_config.encryption_keys.clone() {
+        if let Some(keys) = self.encryption_keys.clone() {
             self.resolve_and_seed_encryption_keys(&l1_provider, tempo_block_number, &keys)
                 .await?;
         }
@@ -592,55 +605,63 @@ where
         // snapshot at the local Tempo anchor, and install the transition sink before
         // the subscriber starts so no block is ever consumed ahead of its
         // leadership transition.
-        if let Some(p2p) = self.p2p_config.as_ref() {
-            let schedule = p2p.leadership();
-            let snapshot_anchor = tempo_block_number;
-            // Freeze the replay/live boundary before the subscriber starts. Historical identities
-            // may authenticate transitions that were already finalized when this process began,
-            // but must never authorize a leader selected later.
-            let finalized_replay_boundary = async {
-                l1_provider
-                    .get_header_by_number(BlockNumberOrTag::Finalized)
-                    .await
-                    .map_err(|err| {
-                        eyre::eyre!("failed reading finalized L1 replay boundary: {err}")
-                    })?
-                    .map(|header| header.number())
-                    .ok_or_else(|| eyre::eyre!("L1 finalized block is not available"))
-            };
-            let (historical_replay_through, ()) = tokio::try_join!(
-                finalized_replay_boundary,
-                seed_leadership_schedule(
+        let leadership_sink: Option<Arc<dyn LeadershipSink>> =
+            if let Some(p2p) = self.p2p_config.as_ref() {
+                let schedule = p2p.leadership();
+                let snapshot_anchor = tempo_block_number;
+                // Freeze the replay/live boundary before the subscriber starts. Historical identities
+                // may authenticate transitions that were already finalized when this process began,
+                // but must never authorize a leader selected later.
+                let finalized_replay_boundary = async {
+                    l1_provider
+                        .get_header_by_number(BlockNumberOrTag::Finalized)
+                        .await
+                        .map_err(|err| {
+                            eyre::eyre!("failed reading finalized L1 replay boundary: {err}")
+                        })?
+                        .map(|header| header.number())
+                        .ok_or_else(|| eyre::eyre!("L1 finalized block is not available"))
+                };
+                let (historical_replay_through, ()) = tokio::try_join!(
+                    finalized_replay_boundary,
+                    seed_leadership_schedule(
+                        &l1_provider,
+                        self.portal_address,
+                        snapshot_anchor,
+                        p2p.manifest(),
+                        &schedule,
+                    ),
+                )?;
+                // Seed the applied anchor from the persisted checkpoint so it targets the leader
+                // of the next anchor from the very start (and not after the first post-restart block)
+                schedule.record_applied_anchor(snapshot_anchor);
+                install_manifest_forced_recovery(
+                    ctx.node.provider(),
                     &l1_provider,
                     self.portal_address,
                     snapshot_anchor,
                     p2p.manifest(),
                     &schedule,
-                ),
-            )?;
-            // Seed the applied anchor from the persisted checkpoint so it targets the leader
-            // of the next anchor from the very start (and not after the first post-restart block)
-            schedule.record_applied_anchor(snapshot_anchor);
-            install_manifest_forced_recovery(
-                ctx.node.provider(),
-                &l1_provider,
-                self.portal_address,
-                snapshot_anchor,
-                p2p.manifest(),
-                &schedule,
-            )
-            .await?;
-            self.l1_config.leadership_sink = Some(Arc::new(ScheduleLeadershipSink {
-                schedule,
-                manifest: p2p.manifest().clone(),
-                historical_replay_through,
-            }));
-        }
+                )
+                .await?;
+                Some(Arc::new(ScheduleLeadershipSink {
+                    schedule,
+                    manifest: p2p.manifest().clone(),
+                    historical_replay_through,
+                }))
+            } else {
+                None
+            };
 
         let l1_subscriber = L1Subscriber::new(
             self.l1_config.clone(),
             ctx.node.provider().clone(),
             self.deposit_queue.clone(),
+            self.enabled_tokens.clone(),
+            self.l1_state_cache.clone(),
+            self.l1_block_tracker.clone(),
+            leadership_sink,
+            self.encryption_keys.clone(),
         );
         let task_executor = ctx.node.task_executor().clone();
         task_executor.spawn_critical_task("l1-block-subscriber", Box::pin(l1_subscriber.run()));
@@ -662,7 +683,7 @@ where
                         .unwrap_or_default(),
                     self.l1_config.l1_rpc_url.clone(),
                     self.l1_config.retry_connection_interval,
-                    self.l1_config.encryption_keys.clone().unwrap_or_default(),
+                    self.encryption_keys.clone().unwrap_or_default(),
                     &task_executor,
                     &sequencer_rpc_slot,
                 )
@@ -740,7 +761,7 @@ where
             self.l1_config.l1_rpc_url.clone(),
             self.l1_config.retry_connection_interval,
             self.l1_config.portal_address,
-            self.l1_config.enabled_tokens.clone(),
+            self.enabled_tokens.clone(),
             chain_id,
             max_response_size,
         )
@@ -789,9 +810,9 @@ where
                 payload_builder,
                 chain_spec: provider.chain_spec(),
                 deposit_queue: self.deposit_queue.clone(),
-                l1_block_tracker: self.l1_config.block_tracker.clone(),
+                l1_block_tracker: self.l1_block_tracker.clone(),
                 // Follower-only nodes have no private keys and never construct an engine.
-                encryption_keys: self.l1_config.encryption_keys.clone().unwrap_or_default(),
+                encryption_keys: self.encryption_keys.clone().unwrap_or_default(),
                 commands,
                 backfill_commands,
                 attestation,
@@ -1308,7 +1329,7 @@ where
             "Discovered enabled tokens from L1"
         );
 
-        let mut registry = self.l1_config.enabled_tokens.write();
+        let mut registry = self.enabled_tokens.write();
         registry.clear();
         registry.extend(enabled_tokens);
         Ok(())
@@ -1390,11 +1411,10 @@ where
             ctx.beacon_engine_handle.clone(),
             ctx.node.payload_builder_handle().clone(),
             self.deposit_queue.clone(),
-            self.l1_config.block_tracker.clone(),
+            self.l1_block_tracker.clone(),
             last_header,
             fee_recipient,
-            self.l1_config
-                .encryption_keys
+            self.encryption_keys
                 .clone()
                 .expect("sequencer mode configures deposit decryption keys"),
             self.portal_address,
@@ -1591,6 +1611,10 @@ where
         ZoneAddOns::new(
             self.deposit_queue.clone(),
             self.l1_config.clone(),
+            self.l1_state_cache.clone(),
+            self.enabled_tokens.clone(),
+            self.l1_block_tracker.clone(),
+            self.encryption_keys.clone(),
             self.portal_address,
             self.redacted_rpc_config.clone(),
             self.sequencer_config.clone(),


### PR DESCRIPTION
The merge of [#1320](https://github.com/tempoxyz/zones/pull/1320) with `main` fails to compile because [#1356](https://github.com/tempoxyz/zones/pull/1356) moved subscriber state out of `L1SubscriberConfig` and removed the checkpoint-reader test helper. This blocks tests, Clippy, Docker builds, and ABI/storage conformance before those checks can run.

Merge `main` into `prover` and update finalized-target tracking to use the subscriber's block tracker, deferred recovery to read the checkpoint from the zone provider, and finalized-sync tests to use the new mock-provider helper. This PR targets `prover` so the fix feeds into #1320.

Validation: `cargo +nightly fmt --all -- --check` and `git diff --check` pass locally. [CI Clippy](https://github.com/tempoxyz/zones/actions/runs/33908418895/job/101138802192) and [the complete test-artifact build](https://github.com/tempoxyz/zones/actions/runs/33908418296/job/101138799801) pass, confirming both production and test code compile. Test execution and the Docker build are still pending. The local L1 test build was stopped after CI compiled the complete test suite.

Prompted by: @rkrasiuk
