### PR TITLE
Pin GitHub STS POST action

### DIFF
--- a/.github/workflows/sync-from-upstream.yml
+++ b/.github/workflows/sync-from-upstream.yml
@@ -19,7 +19,7 @@ jobs:
     steps:
       - name: Fetch GitHub token via STS
         id: github-sts
-        uses: tempoxyz/gh-actions/actions/github-sts@8819cf80bdcb39c36c34700e3f2ecc08bde54f23 # main
+        uses: tempoxyz/gh-actions/actions/github-sts@c0292122e255def866c64c55e5844d1e7d5fe7ad # main
         with:
           policy: sync-from-upstream
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -35,7 +35,7 @@ jobs:
           submodules: recursive
       - name: Mint read-only Earn token
         id: earn-token
-        uses: tempoxyz/gh-actions/actions/github-sts@8819cf80bdcb39c36c34700e3f2ecc08bde54f23 # main
+        uses: tempoxyz/gh-actions/actions/github-sts@c0292122e255def866c64c55e5844d1e7d5fe7ad # main
         with:
           scope: tempoxyz/earn
           policy: zones-read

--- a/.github/workflows/zones-benchmark.yml
+++ b/.github/workflows/zones-benchmark.yml
@@ -510,7 +510,7 @@ jobs:
 
       - name: Mint read-only Earn token
         id: earn-token
-        uses: tempoxyz/gh-actions/actions/github-sts@8819cf80bdcb39c36c34700e3f2ecc08bde54f23 # main
+        uses: tempoxyz/gh-actions/actions/github-sts@c0292122e255def866c64c55e5844d1e7d5fe7ad # main
         with:
           scope: tempoxyz/earn
           policy: zones-read


### PR DESCRIPTION
## Summary

- pin all GitHub STS action uses to tempoxyz/gh-actions@c0292122e255def866c64c55e5844d1e7d5fe7ad
- use the action version that sends `POST /sts/exchange`
- preserve all existing scopes, policies, TTLs, and workflow behavior

This is part of the coordinated organization-wide rollout required before retiring legacy GET exchanges.

## Validation

- mechanical pin-only update; repository CI is the behavioral validation