### PR TITLE
chore: bump workspace version to 0.3.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -11768,7 +11768,7 @@ dependencies = [
 
 [[package]]
 name = "tempo-vsock-proxy"
-version = "0.2.2"
+version = "0.3.0"
 dependencies = [
  "clap",
  "libc",
@@ -11781,7 +11781,7 @@ dependencies = [
 
 [[package]]
 name = "tempo-xtask"
-version = "0.2.2"
+version = "0.3.0"
 dependencies = [
  "alloy",
  "alloy-eips",
@@ -11821,7 +11821,7 @@ dependencies = [
 
 [[package]]
 name = "tempo-zone"
-version = "0.2.2"
+version = "0.3.0"
 dependencies = [
  "reth-cli-util",
  "reth-node-core",
@@ -11831,7 +11831,7 @@ dependencies = [
 
 [[package]]
 name = "tempo-zone-contracts"
-version = "0.2.2"
+version = "0.3.0"
 dependencies = [
  "alloy-contract",
  "alloy-network",
@@ -11850,7 +11850,7 @@ dependencies = [
 
 [[package]]
 name = "tempo-zone-prover-enclave"
-version = "0.2.2"
+version = "0.3.0"
 dependencies = [
  "alloy-consensus",
  "alloy-genesis",
@@ -11873,7 +11873,7 @@ dependencies = [
 
 [[package]]
 name = "tempo-zone-prover-utils"
-version = "0.2.2"
+version = "0.3.0"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -13726,7 +13726,7 @@ checksum = "29666d0abbfad1e3dc4dcf6144730dd3a3ab225bbbdac83319345b1b44ccfc1b"
 
 [[package]]
 name = "zone-chainspec"
-version = "0.2.2"
+version = "0.3.0"
 dependencies = [
  "alloy-eips",
  "alloy-evm",
@@ -13746,7 +13746,7 @@ dependencies = [
 
 [[package]]
 name = "zone-checker"
-version = "0.2.2"
+version = "0.3.0"
 dependencies = [
  "alloy-consensus",
  "alloy-contract",
@@ -13793,7 +13793,7 @@ dependencies = [
 
 [[package]]
 name = "zone-evm"
-version = "0.2.2"
+version = "0.3.0"
 dependencies = [
  "alloy-consensus",
  "alloy-evm",
@@ -13828,7 +13828,7 @@ dependencies = [
 
 [[package]]
 name = "zone-hardfork"
-version = "0.2.2"
+version = "0.3.0"
 dependencies = [
  "alloy-hardforks",
  "paste",
@@ -13836,7 +13836,7 @@ dependencies = [
 
 [[package]]
 name = "zone-l1"
-version = "0.2.2"
+version = "0.3.0"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -13876,7 +13876,7 @@ dependencies = [
 
 [[package]]
 name = "zone-node"
-version = "0.2.2"
+version = "0.3.0"
 dependencies = [
  "alloy",
  "alloy-chains",
@@ -13971,7 +13971,7 @@ dependencies = [
 
 [[package]]
 name = "zone-p2p"
-version = "0.2.2"
+version = "0.3.0"
 dependencies = [
  "alloy-primitives",
  "alloy-signer-local",
@@ -13995,7 +13995,7 @@ dependencies = [
 
 [[package]]
 name = "zone-payload"
-version = "0.2.2"
+version = "0.3.0"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -14036,7 +14036,7 @@ dependencies = [
 
 [[package]]
 name = "zone-precompiles"
-version = "0.2.2"
+version = "0.3.0"
 dependencies = [
  "aes-gcm",
  "alloy",
@@ -14067,7 +14067,7 @@ dependencies = [
 
 [[package]]
 name = "zone-primitives"
-version = "0.2.2"
+version = "0.3.0"
 dependencies = [
  "alloy-primitives",
  "tempo-hardfork",
@@ -14076,7 +14076,7 @@ dependencies = [
 
 [[package]]
 name = "zone-prover"
-version = "0.2.2"
+version = "0.3.0"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -14095,7 +14095,7 @@ dependencies = [
 
 [[package]]
 name = "zone-rpc"
-version = "0.2.2"
+version = "0.3.0"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -14134,7 +14134,7 @@ dependencies = [
 
 [[package]]
 name = "zone-sequencer"
-version = "0.2.2"
+version = "0.3.0"
 dependencies = [
  "alloy-chains",
  "alloy-consensus",
@@ -14181,7 +14181,7 @@ dependencies = [
 
 [[package]]
 name = "zone-spf"
-version = "0.2.2"
+version = "0.3.0"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,5 @@
 [workspace.package]
-version = "0.2.2"
+version = "0.3.0"
 edition = "2024"
 rust-version = "1.95.0"
 license = "MIT OR Apache-2.0"


### PR DESCRIPTION
## Summary

- release `v0.3.0` from the runtime source tested on Moderato (`dd12057cfa4a050ca65111740f61b9ebd2ef8ef8`)
- bump the workspace version from `0.2.2` to `0.3.0`
- refresh all workspace package versions in `Cargo.lock`

## Release contents

`v0.3.0` points to `99d99f50206af9d95b52bec659a002b247f17fee`. The runtime contents match the Moderato-tested `dd12057`; the only change after that source commit is the version metadata update in this PR.

Changes included since `v0.2.2`:

- align Zones with Tempo T11 precompile decoding (#1372)
- upgrade Tempo to `v1.14.0` and allow equal block timestamps (#1396)
- batch portal reads with multicall and simplify L1 subscriber startup (#1355, #1348)
- expose prover batch metrics and separate validation failures from operational failures (#1370, #1394)
- publish the prover-utils image, embed PCR measurements, and parallelize prover EIF inputs (#1371, #1373, #1375, #1376)
- update and harden CI action usage (#1350, #1360, #1362, #1363, #1366)
- bump the workspace and lockfile package versions to `0.3.0` (#1404)

## Testing

- runtime source deployed and tested on Moderato
- `cargo metadata --locked --offline --no-deps --format-version 1`
- verified every workspace member reports version `0.3.0`
- `git diff --check`
- verified this PR changes only `Cargo.toml` and `Cargo.lock`