### PR TITLE
chore: bump workspace version to 0.3.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -11768,7 +11768,7 @@ dependencies = [
 
 [[package]]
 name = "tempo-vsock-proxy"
-version = "0.2.2"
+version = "0.3.0"
 dependencies = [
  "clap",
  "libc",
@@ -11781,7 +11781,7 @@ dependencies = [
 
 [[package]]
 name = "tempo-xtask"
-version = "0.2.2"
+version = "0.3.0"
 dependencies = [
  "alloy",
  "alloy-eips",
@@ -11821,7 +11821,7 @@ dependencies = [
 
 [[package]]
 name = "tempo-zone"
-version = "0.2.2"
+version = "0.3.0"
 dependencies = [
  "reth-cli-util",
  "reth-node-core",
@@ -11831,7 +11831,7 @@ dependencies = [
 
 [[package]]
 name = "tempo-zone-contracts"
-version = "0.2.2"
+version = "0.3.0"
 dependencies = [
  "alloy-contract",
  "alloy-network",
@@ -11850,7 +11850,7 @@ dependencies = [
 
 [[package]]
 name = "tempo-zone-prover-enclave"
-version = "0.2.2"
+version = "0.3.0"
 dependencies = [
  "alloy-consensus",
  "alloy-genesis",
@@ -11873,7 +11873,7 @@ dependencies = [
 
 [[package]]
 name = "tempo-zone-prover-utils"
-version = "0.2.2"
+version = "0.3.0"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -13726,7 +13726,7 @@ checksum = "29666d0abbfad1e3dc4dcf6144730dd3a3ab225bbbdac83319345b1b44ccfc1b"
 
 [[package]]
 name = "zone-chainspec"
-version = "0.2.2"
+version = "0.3.0"
 dependencies = [
  "alloy-eips",
  "alloy-evm",
@@ -13746,7 +13746,7 @@ dependencies = [
 
 [[package]]
 name = "zone-checker"
-version = "0.2.2"
+version = "0.3.0"
 dependencies = [
  "alloy-consensus",
  "alloy-contract",
@@ -13793,7 +13793,7 @@ dependencies = [
 
 [[package]]
 name = "zone-evm"
-version = "0.2.2"
+version = "0.3.0"
 dependencies = [
  "alloy-consensus",
  "alloy-evm",
@@ -13828,7 +13828,7 @@ dependencies = [
 
 [[package]]
 name = "zone-hardfork"
-version = "0.2.2"
+version = "0.3.0"
 dependencies = [
  "alloy-hardforks",
  "paste",
@@ -13836,7 +13836,7 @@ dependencies = [
 
 [[package]]
 name = "zone-l1"
-version = "0.2.2"
+version = "0.3.0"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -13876,7 +13876,7 @@ dependencies = [
 
 [[package]]
 name = "zone-node"
-version = "0.2.2"
+version = "0.3.0"
 dependencies = [
  "alloy",
  "alloy-chains",
@@ -13972,7 +13972,7 @@ dependencies = [
 
 [[package]]
 name = "zone-p2p"
-version = "0.2.2"
+version = "0.3.0"
 dependencies = [
  "alloy-primitives",
  "alloy-signer-local",
@@ -13996,7 +13996,7 @@ dependencies = [
 
 [[package]]
 name = "zone-payload"
-version = "0.2.2"
+version = "0.3.0"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -14037,7 +14037,7 @@ dependencies = [
 
 [[package]]
 name = "zone-precompiles"
-version = "0.2.2"
+version = "0.3.0"
 dependencies = [
  "aes-gcm",
  "alloy",
@@ -14068,7 +14068,7 @@ dependencies = [
 
 [[package]]
 name = "zone-primitives"
-version = "0.2.2"
+version = "0.3.0"
 dependencies = [
  "alloy-primitives",
  "tempo-hardfork",
@@ -14077,7 +14077,7 @@ dependencies = [
 
 [[package]]
 name = "zone-prover"
-version = "0.2.2"
+version = "0.3.0"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -14096,7 +14096,7 @@ dependencies = [
 
 [[package]]
 name = "zone-rpc"
-version = "0.2.2"
+version = "0.3.0"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -14135,7 +14135,7 @@ dependencies = [
 
 [[package]]
 name = "zone-sequencer"
-version = "0.2.2"
+version = "0.3.0"
 dependencies = [
  "alloy-chains",
  "alloy-consensus",
@@ -14182,7 +14182,7 @@ dependencies = [
 
 [[package]]
 name = "zone-spf"
-version = "0.2.2"
+version = "0.3.0"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,5 @@
 [workspace.package]
-version = "0.2.2"
+version = "0.3.0"
 edition = "2024"
 rust-version = "1.95.0"
 license = "MIT OR Apache-2.0"


### PR DESCRIPTION
Bump the Zones workspace version from 0.2.2 to 0.3.0 and update all 20 workspace package entries in Cargo.lock.

Validated with cargo metadata --locked --offline --format-version 1 and git diff --check.