### PR TITLE
refactor(precompiles): cleanup crypto helpers

### DIFF
--- a/crates/l1/src/block.rs
+++ b/crates/l1/src/block.rs
@@ -65,10 +65,7 @@ impl L1BlockDeposits {
                         let decryption = abi::DecryptionData {
                             sharedSecret: dec.proof.shared_secret,
                             sharedSecretYParity: dec.proof.shared_secret_y_parity,
-                            cpProof: abi::ChaumPedersenProof {
-                                s: dec.proof.cp_proof_s,
-                                c: dec.proof.cp_proof_c,
-                            },
+                            cpProof: dec.proof.cp_proof,
                         };
                         queued_deposits.push(queued);
                         decryptions.push(decryption);
@@ -92,10 +89,7 @@ impl L1BlockDeposits {
                         let decryption = abi::DecryptionData {
                             sharedSecret: proof.shared_secret,
                             sharedSecretYParity: proof.shared_secret_y_parity,
-                            cpProof: abi::ChaumPedersenProof {
-                                s: proof.cp_proof_s,
-                                c: proof.cp_proof_c,
-                            },
+                            cpProof: proof.cp_proof,
                         };
                         queued_deposits.push(queued);
                         decryptions.push(decryption);

--- a/crates/precompiles/src/aes_gcm.rs
+++ b/crates/precompiles/src/aes_gcm.rs
@@ -16,43 +16,33 @@ const AES_GCM_BASE_GAS: u64 = 1_000;
 /// Additional gas per byte of authenticated AES-GCM input.
 const AES_GCM_PER_BYTE_GAS: u64 = 3;
 
-/// AES-256-GCM decryption helper.
+/// Charge the native gas cost for AES-GCM authenticated input.
+pub(crate) fn charge_gas(ciphertext_len: usize, aad_len: usize) -> tempo_precompiles::Result<()> {
+    let len = u64::try_from(ciphertext_len.saturating_add(aad_len)).unwrap_or(u64::MAX);
+    let gas = AES_GCM_BASE_GAS
+        .checked_add(AES_GCM_PER_BYTE_GAS.saturating_mul(len))
+        .ok_or_else(TempoPrecompileError::under_overflow)?;
+    StorageCtx::default().deduct_gas(gas)
+}
+
+/// Decrypt AES-256-GCM ciphertext with tag verification.
 ///
-/// Decrypts ciphertext using the provided key, nonce, and AAD, and verifies
-/// the GCM authentication tag. Returns `(plaintext, true)` on success or
-/// `(empty, false)` if tag verification fails.
-pub struct AesGcmDecrypt;
+/// The ciphertext, AAD, and tag are passed separately. Returns `(plaintext, true)` on success,
+/// or `(empty, false)` on failure.
+pub(crate) fn decrypt(
+    key: &[u8; 32],
+    nonce: &[u8; 12],
+    ciphertext: &[u8],
+    aad: &[u8],
+    tag: &[u8; 16],
+) -> (Vec<u8>, bool) {
+    let cipher = Aes256Gcm::new(key.into());
+    let gcm_nonce = Nonce::from_slice(nonce);
+    let mut plaintext = ciphertext.to_vec();
 
-impl AesGcmDecrypt {
-    /// Charge the native gas cost for AES-GCM authenticated input.
-    pub fn charge_gas(ciphertext_len: usize, aad_len: usize) -> tempo_precompiles::Result<()> {
-        let len = u64::try_from(ciphertext_len.saturating_add(aad_len)).unwrap_or(u64::MAX);
-        let gas = AES_GCM_BASE_GAS
-            .checked_add(AES_GCM_PER_BYTE_GAS.saturating_mul(len))
-            .ok_or_else(TempoPrecompileError::under_overflow)?;
-        StorageCtx::default().deduct_gas(gas)
-    }
-
-    /// Decrypt AES-256-GCM ciphertext with tag verification.
-    ///
-    /// The ciphertext, AAD, and tag are passed separately (matching the Solidity interface).
-    /// Returns `(plaintext, true)` on success, or `(empty, false)` on failure.
-    pub fn decrypt(
-        key: &[u8; 32],
-        nonce: &[u8; 12],
-        ciphertext: &[u8],
-        aad: &[u8],
-        tag: &[u8; 16],
-    ) -> (Vec<u8>, bool) {
-        let cipher = Aes256Gcm::new(key.into());
-        let gcm_nonce = Nonce::from_slice(nonce);
-        let mut plaintext = ciphertext.to_vec();
-
-        match cipher.decrypt_in_place_detached(gcm_nonce, aad, &mut plaintext, Tag::from_slice(tag))
-        {
-            Ok(()) => (plaintext, true),
-            Err(_) => (Vec::new(), false),
-        }
+    match cipher.decrypt_in_place_detached(gcm_nonce, aad, &mut plaintext, Tag::from_slice(tag)) {
+        Ok(()) => (plaintext, true),
+        Err(_) => (Vec::new(), false),
     }
 }
 
@@ -96,8 +86,8 @@ mod tests {
         let mut storage = test_storage_provider(&mut ctx, u64::MAX, true);
         let gas_before = storage.gas_used();
         let (plaintext, valid) = StorageCtx::enter(&mut storage, || {
-            AesGcmDecrypt::charge_gas(ciphertext.len(), aad.len()).expect("charge native gas");
-            AesGcmDecrypt::decrypt(key, nonce, ciphertext, aad, tag)
+            charge_gas(ciphertext.len(), aad.len()).expect("charge native gas");
+            decrypt(key, nonce, ciphertext, aad, tag)
         });
 
         (plaintext, valid, storage.gas_used() - gas_before)
@@ -116,7 +106,7 @@ mod tests {
         let ct = &encrypted[..encrypted.len() - 16];
         let tag: [u8; 16] = encrypted[encrypted.len() - 16..].try_into().unwrap();
 
-        let (decrypted, valid) = AesGcmDecrypt::decrypt(&key, &nonce_bytes, ct, &[], &tag);
+        let (decrypted, valid) = decrypt(&key, &nonce_bytes, ct, &[], &tag);
         assert!(valid);
         assert_eq!(decrypted, plaintext);
     }
@@ -134,7 +124,7 @@ mod tests {
         let ct = &encrypted[..encrypted.len() - 16];
         let bad_tag = [0xFFu8; 16];
 
-        let (decrypted, valid) = AesGcmDecrypt::decrypt(&key, &nonce_bytes, ct, &[], &bad_tag);
+        let (decrypted, valid) = decrypt(&key, &nonce_bytes, ct, &[], &bad_tag);
         assert!(!valid);
         assert!(decrypted.is_empty());
     }
@@ -161,7 +151,7 @@ mod tests {
         let ct = &encrypted[..encrypted.len() - 16];
         let tag: [u8; 16] = encrypted[encrypted.len() - 16..].try_into().unwrap();
 
-        let (decrypted, valid) = AesGcmDecrypt::decrypt(&key, &nonce_bytes, ct, aad, &tag);
+        let (decrypted, valid) = decrypt(&key, &nonce_bytes, ct, aad, &tag);
         assert!(valid);
         assert_eq!(decrypted, plaintext);
     }
@@ -217,7 +207,7 @@ mod tests {
         let ct = &encrypted[..encrypted.len() - 16];
         let tag: [u8; 16] = encrypted[encrypted.len() - 16..].try_into().unwrap();
 
-        let (decrypted, valid) = AesGcmDecrypt::decrypt(&key, &nonce_bytes, ct, b"wrong", &tag);
+        let (decrypted, valid) = decrypt(&key, &nonce_bytes, ct, b"wrong", &tag);
         assert!(!valid);
         assert!(decrypted.is_empty());
     }
@@ -244,7 +234,7 @@ mod tests {
         let ct = &encrypted[..encrypted.len() - 16];
         let tag: [u8; 16] = encrypted[encrypted.len() - 16..].try_into().unwrap();
 
-        let (decrypted, valid) = AesGcmDecrypt::decrypt(&key, &nonce_bytes, ct, &[], &tag);
+        let (decrypted, valid) = decrypt(&key, &nonce_bytes, ct, &[], &tag);
         assert!(!valid);
         assert!(decrypted.is_empty());
     }
@@ -264,7 +254,7 @@ mod tests {
 
         ct[0] ^= 0x01;
 
-        let (decrypted, valid) = AesGcmDecrypt::decrypt(&key, &nonce_bytes, &ct, &[], &tag);
+        let (decrypted, valid) = decrypt(&key, &nonce_bytes, &ct, &[], &tag);
         assert!(!valid);
         assert!(decrypted.is_empty());
     }
@@ -282,7 +272,7 @@ mod tests {
         let ct = &encrypted[..encrypted.len() - 16];
         let tag: [u8; 16] = encrypted[encrypted.len() - 16..].try_into().unwrap();
 
-        let (decrypted, valid) = AesGcmDecrypt::decrypt(&key, &nonce_bytes, ct, &[], &tag);
+        let (decrypted, valid) = decrypt(&key, &nonce_bytes, ct, &[], &tag);
         assert!(valid);
         assert!(decrypted.is_empty());
     }

--- a/crates/precompiles/src/chaum_pedersen.rs
+++ b/crates/precompiles/src/chaum_pedersen.rs
@@ -21,6 +21,7 @@ use k256::{
     },
 };
 use tempo_precompiles::storage::StorageCtx;
+use tempo_zone_contracts::ChaumPedersenProof;
 
 /// Gas cost for Chaum-Pedersen proof verification (two EC muls + hashing).
 const CP_VERIFY_GAS: u64 = 6_000;
@@ -40,8 +41,7 @@ pub(crate) fn verify(
     shared_secret_y_parity: u8,
     sequencer_pub_x: &[u8; 32],
     sequencer_pub_y_parity: u8,
-    s_bytes: &[u8; 32],
-    c_bytes: &[u8; 32],
+    proof: &ChaumPedersenProof,
 ) -> bool {
     // Recover points
     let Some(ephemeral_pub) = recover_point(ephemeral_pub_x, ephemeral_pub_y_parity) else {
@@ -55,8 +55,8 @@ pub(crate) fn verify(
     };
 
     // Deserialize proof scalars by reducing modulo the group order.
-    let s = <Scalar as Reduce<k256::U256>>::reduce_bytes(&(*s_bytes).into());
-    let c = <Scalar as Reduce<k256::U256>>::reduce_bytes(&(*c_bytes).into());
+    let s = <Scalar as Reduce<k256::U256>>::reduce_bytes(&proof.s.0.into());
+    let c = <Scalar as Reduce<k256::U256>>::reduce_bytes(&proof.c.0.into());
 
     // R1 = s*G - c*pubSeq
     let r1 = ProjectivePoint::GENERATOR * s - ProjectivePoint::from(sequencer_pub) * c;
@@ -126,7 +126,15 @@ pub(crate) fn challenge_hash(
 #[cfg(test)]
 mod tests {
     use super::*;
+    use alloy_primitives::B256;
     use k256::elliptic_curve::{Field, PrimeField};
+
+    fn proof(s: [u8; 32], c: [u8; 32]) -> ChaumPedersenProof {
+        ChaumPedersenProof {
+            s: B256::from(s),
+            c: B256::from(c),
+        }
+    }
 
     #[test]
     fn test_recover_point_generator() {
@@ -169,8 +177,7 @@ mod tests {
             ss_enc.as_bytes()[0],
             ps_enc.x().unwrap().as_slice().try_into().unwrap(),
             ps_enc.as_bytes()[0],
-            &s.to_repr().into(),
-            &c.to_repr().into(),
+            &proof(s.to_repr().into(), c.to_repr().into()),
         );
 
         assert!(valid, "valid Chaum-Pedersen proof should verify");
@@ -197,8 +204,7 @@ mod tests {
             ss_enc.as_bytes()[0],
             ps_enc.x().unwrap().as_slice().try_into().unwrap(),
             ps_enc.as_bytes()[0],
-            &[0xAAu8; 32],
-            &[0xBBu8; 32],
+            &proof([0xAAu8; 32], [0xBBu8; 32]),
         );
 
         assert!(!valid, "invalid proof should not verify");
@@ -242,8 +248,7 @@ mod tests {
             ss_enc.as_bytes()[0],
             ps_enc.x().unwrap().as_slice().try_into().unwrap(),
             ps_enc.as_bytes()[0],
-            &s_tampered.to_repr().into(),
-            &c.to_repr().into(),
+            &proof(s_tampered.to_repr().into(), c.to_repr().into()),
         );
 
         assert!(!valid, "tampered s should not verify");
@@ -276,8 +281,7 @@ mod tests {
             ss_enc.as_bytes()[0],
             ps_enc.x().unwrap().as_slice().try_into().unwrap(),
             ps_enc.as_bytes()[0],
-            &s.to_repr().into(),
-            &c_tampered.to_repr().into(),
+            &proof(s.to_repr().into(), c_tampered.to_repr().into()),
         );
 
         assert!(!valid, "tampered c should not verify");
@@ -311,8 +315,7 @@ mod tests {
             flipped_ss_parity,
             ps_enc.x().unwrap().as_slice().try_into().unwrap(),
             ps_enc.as_bytes()[0],
-            &s.to_repr().into(),
-            &c.to_repr().into(),
+            &proof(s.to_repr().into(), c.to_repr().into()),
         );
 
         assert!(!valid, "wrong shared secret parity should not verify");
@@ -346,8 +349,7 @@ mod tests {
             ss_enc.as_bytes()[0],
             ps_enc.x().unwrap().as_slice().try_into().unwrap(),
             ps_enc.as_bytes()[0],
-            &s.to_repr().into(),
-            &c.to_repr().into(),
+            &proof(s.to_repr().into(), c.to_repr().into()),
         );
 
         assert!(!valid, "wrong ephemeral pubkey parity should not verify");
@@ -376,8 +378,7 @@ mod tests {
             ss_enc.as_bytes()[0],
             ps_enc.x().unwrap().as_slice().try_into().unwrap(),
             ps_enc.as_bytes()[0],
-            &s.to_repr().into(),
-            &c.to_repr().into(),
+            &proof(s.to_repr().into(), c.to_repr().into()),
         );
 
         assert!(

--- a/crates/precompiles/src/chaum_pedersen.rs
+++ b/crates/precompiles/src/chaum_pedersen.rs
@@ -1,7 +1,14 @@
 //! Chaum-Pedersen DLOG equality proof verification for encrypted Zone deposits.
 //!
-//! Verifies that the sequencer correctly derived the ECDH shared secret from the
-//! depositor's ephemeral public key without revealing the sequencer's private key.
+//! Verifies the ECDH computation by proving knowledge of `privSeq` such that:
+//! - `pubSeq = privSeq * G` (their public key)
+//! - `sharedSecretPoint = privSeq * ephemeralPub`
+//!
+//! Verification equations:
+//! - `R1 = s*G - c*pubSeq`
+//! - `R2 = s*ephemeralPub - c*sharedSecretPoint`
+//! - `c' = keccak256(G, ephemeralPub, pubSeq, sharedSecretPoint, R1, R2)`
+//! - Check: `c == c'`
 //!
 //! Uses the NCC-audited [`k256`] crate (v0.13.4) for secp256k1 operations.
 
@@ -18,82 +25,66 @@ use tempo_precompiles::storage::StorageCtx;
 /// Gas cost for Chaum-Pedersen proof verification (two EC muls + hashing).
 const CP_VERIFY_GAS: u64 = 6_000;
 
-/// Chaum-Pedersen DLOG equality proof verifier.
+/// Charge the gas cost for Chaum-Pedersen proof verification.
+pub(crate) fn charge_gas() -> tempo_precompiles::Result<()> {
+    StorageCtx::default().deduct_gas(CP_VERIFY_GAS)
+}
+
+/// Verify a Chaum-Pedersen DLOG equality proof on secp256k1.
 ///
-/// Verifies that the sequencer knows `privSeq` such that:
-/// - `pubSeq = privSeq * G` (their public key)
-/// - `sharedSecretPoint = privSeq * ephemeralPub` (the ECDH computation)
-///
-/// Verification equations:
-/// - `R1 = s*G - c*pubSeq`
-/// - `R2 = s*ephemeralPub - c*sharedSecretPoint`
-/// - `c' = keccak256(G, ephemeralPub, pubSeq, sharedSecretPoint, R1, R2)`
-/// - Check: `c == c'`
-pub struct ChaumPedersenVerify;
+/// Proves knowledge of scalar `x` such that `pubSeq = x*G` AND `sharedSecret = x*ephemeralPub`.
+pub(crate) fn verify(
+    ephemeral_pub_x: &[u8; 32],
+    ephemeral_pub_y_parity: u8,
+    shared_secret_x: &[u8; 32],
+    shared_secret_y_parity: u8,
+    sequencer_pub_x: &[u8; 32],
+    sequencer_pub_y_parity: u8,
+    s_bytes: &[u8; 32],
+    c_bytes: &[u8; 32],
+) -> bool {
+    // Recover points
+    let Some(ephemeral_pub) = recover_point(ephemeral_pub_x, ephemeral_pub_y_parity) else {
+        return false;
+    };
+    let Some(shared_secret_point) = recover_point(shared_secret_x, shared_secret_y_parity) else {
+        return false;
+    };
+    let Some(sequencer_pub) = recover_point(sequencer_pub_x, sequencer_pub_y_parity) else {
+        return false;
+    };
 
-impl ChaumPedersenVerify {
-    /// Charge the gas cost for Chaum-Pedersen proof verification.
-    pub fn verify_chaum_pedersen_gas() -> tempo_precompiles::Result<()> {
-        StorageCtx::default().deduct_gas(CP_VERIFY_GAS)
-    }
+    // Deserialize proof scalars by reducing modulo the group order.
+    let s = <Scalar as Reduce<k256::U256>>::reduce_bytes(&(*s_bytes).into());
+    let c = <Scalar as Reduce<k256::U256>>::reduce_bytes(&(*c_bytes).into());
 
-    /// Verify a Chaum-Pedersen DLOG equality proof on secp256k1.
-    ///
-    /// Proves knowledge of scalar `x` such that `pubSeq = x*G` AND `sharedSecret = x*ephemeralPub`.
-    pub(crate) fn verify(
-        ephemeral_pub_x: &[u8; 32],
-        ephemeral_pub_y_parity: u8,
-        shared_secret_x: &[u8; 32],
-        shared_secret_y_parity: u8,
-        sequencer_pub_x: &[u8; 32],
-        sequencer_pub_y_parity: u8,
-        s_bytes: &[u8; 32],
-        c_bytes: &[u8; 32],
-    ) -> bool {
-        // Recover points
-        let Some(ephemeral_pub) = recover_point(ephemeral_pub_x, ephemeral_pub_y_parity) else {
-            return false;
-        };
-        let Some(shared_secret_point) = recover_point(shared_secret_x, shared_secret_y_parity)
-        else {
-            return false;
-        };
-        let Some(sequencer_pub) = recover_point(sequencer_pub_x, sequencer_pub_y_parity) else {
-            return false;
-        };
+    // R1 = s*G - c*pubSeq
+    let r1 = ProjectivePoint::GENERATOR * s - ProjectivePoint::from(sequencer_pub) * c;
 
-        // Deserialize proof scalars by reducing modulo the group order.
-        let s = <Scalar as Reduce<k256::U256>>::reduce_bytes(&(*s_bytes).into());
-        let c = <Scalar as Reduce<k256::U256>>::reduce_bytes(&(*c_bytes).into());
+    // R2 = s*ephemeralPub - c*sharedSecretPoint
+    let r2 =
+        ProjectivePoint::from(ephemeral_pub) * s - ProjectivePoint::from(shared_secret_point) * c;
 
-        // R1 = s*G - c*pubSeq
-        let r1 = ProjectivePoint::GENERATOR * s - ProjectivePoint::from(sequencer_pub) * c;
+    let r1_affine = AffinePoint::from(r1);
+    let r2_affine = AffinePoint::from(r2);
 
-        // R2 = s*ephemeralPub - c*sharedSecretPoint
-        let r2 = ProjectivePoint::from(ephemeral_pub) * s
-            - ProjectivePoint::from(shared_secret_point) * c;
+    // Recompute challenge and compare
+    let c_prime = challenge_hash(
+        &ephemeral_pub,
+        &sequencer_pub,
+        &shared_secret_point,
+        &r1_affine,
+        &r2_affine,
+    );
 
-        let r1_affine = AffinePoint::from(r1);
-        let r2_affine = AffinePoint::from(r2);
-
-        // Recompute challenge and compare
-        let c_prime = challenge_hash(
-            &ephemeral_pub,
-            &sequencer_pub,
-            &shared_secret_point,
-            &r1_affine,
-            &r2_affine,
-        );
-
-        c == c_prime
-    }
+    c == c_prime
 }
 
 /// Recover a secp256k1 affine point from compressed form (x coordinate + y parity).
 ///
 /// `y_parity` follows SEC1: `0x02` for even y, `0x03` for odd y. `0x05` Compact encoding for even
 /// points is also accepted.
-pub fn recover_point(x_bytes: &[u8; 32], y_parity: u8) -> Option<AffinePoint> {
+pub(crate) fn recover_point(x_bytes: &[u8; 32], y_parity: u8) -> Option<AffinePoint> {
     let mut encoded = [0u8; 33];
     encoded[0] = y_parity;
     encoded[1..].copy_from_slice(x_bytes);
@@ -107,7 +98,7 @@ pub fn recover_point(x_bytes: &[u8; 32], y_parity: u8) -> Option<AffinePoint> {
 /// `c = keccak256(G || ephemeralPub || pubSeq || sharedSecretPoint || R1 || R2)`
 ///
 /// Shared between the verifier (precompile) and prover (ecies module).
-pub fn challenge_hash(
+pub(crate) fn challenge_hash(
     ephemeral_pub: &AffinePoint,
     sequencer_pub: &AffinePoint,
     shared_secret: &AffinePoint,
@@ -171,7 +162,7 @@ mod tests {
         let ss_enc = shared_secret.to_encoded_point(true);
         let ps_enc = pub_seq.to_encoded_point(true);
 
-        let valid = ChaumPedersenVerify::verify(
+        let valid = verify(
             eph_enc.x().unwrap().as_slice().try_into().unwrap(),
             eph_enc.as_bytes()[0],
             ss_enc.x().unwrap().as_slice().try_into().unwrap(),
@@ -199,7 +190,7 @@ mod tests {
         let ss_enc = shared_secret.to_encoded_point(true);
         let ps_enc = pub_seq.to_encoded_point(true);
 
-        let valid = ChaumPedersenVerify::verify(
+        let valid = verify(
             eph_enc.x().unwrap().as_slice().try_into().unwrap(),
             eph_enc.as_bytes()[0],
             ss_enc.x().unwrap().as_slice().try_into().unwrap(),
@@ -244,7 +235,7 @@ mod tests {
         let ss_enc = shared_secret.to_encoded_point(true);
         let ps_enc = pub_seq.to_encoded_point(true);
 
-        let valid = ChaumPedersenVerify::verify(
+        let valid = verify(
             eph_enc.x().unwrap().as_slice().try_into().unwrap(),
             eph_enc.as_bytes()[0],
             ss_enc.x().unwrap().as_slice().try_into().unwrap(),
@@ -278,7 +269,7 @@ mod tests {
         let ss_enc = shared_secret.to_encoded_point(true);
         let ps_enc = pub_seq.to_encoded_point(true);
 
-        let valid = ChaumPedersenVerify::verify(
+        let valid = verify(
             eph_enc.x().unwrap().as_slice().try_into().unwrap(),
             eph_enc.as_bytes()[0],
             ss_enc.x().unwrap().as_slice().try_into().unwrap(),
@@ -313,7 +304,7 @@ mod tests {
         let ss_parity = ss_enc.as_bytes()[0];
         let flipped_ss_parity = if ss_parity == 0x02 { 0x03 } else { 0x02 };
 
-        let valid = ChaumPedersenVerify::verify(
+        let valid = verify(
             eph_enc.x().unwrap().as_slice().try_into().unwrap(),
             eph_enc.as_bytes()[0],
             ss_enc.x().unwrap().as_slice().try_into().unwrap(),
@@ -348,7 +339,7 @@ mod tests {
         let eph_parity = eph_enc.as_bytes()[0];
         let flipped_eph_parity = if eph_parity == 0x02 { 0x03 } else { 0x02 };
 
-        let valid = ChaumPedersenVerify::verify(
+        let valid = verify(
             eph_enc.x().unwrap().as_slice().try_into().unwrap(),
             flipped_eph_parity,
             ss_enc.x().unwrap().as_slice().try_into().unwrap(),
@@ -378,7 +369,7 @@ mod tests {
         let ss_enc = shared_secret.to_encoded_point(true);
         let ps_enc = pub_seq.to_encoded_point(true);
 
-        let valid = ChaumPedersenVerify::verify(
+        let valid = verify(
             eph_enc.x().unwrap().as_slice().try_into().unwrap(),
             eph_enc.as_bytes()[0],
             ss_enc.x().unwrap().as_slice().try_into().unwrap(),

--- a/crates/precompiles/src/ecies.rs
+++ b/crates/precompiles/src/ecies.rs
@@ -12,7 +12,7 @@ use k256::{
     AffinePoint, ProjectivePoint, Scalar,
     elliptic_curve::{PrimeField, sec1::ToEncodedPoint},
 };
-use tempo_zone_contracts::Withdrawal;
+use tempo_zone_contracts::{ChaumPedersenProof, Withdrawal};
 
 use crate::{
     aes_gcm,
@@ -63,8 +63,7 @@ pub struct EcdhProofResult {
     /// Y parity of the shared secret point (0x02 or 0x03).
     pub shared_secret_y_parity: u8,
     /// Chaum-Pedersen proof of correct shared secret derivation.
-    pub cp_proof_s: B256,
-    pub cp_proof_c: B256,
+    pub cp_proof: ChaumPedersenProof,
 }
 
 /// Result of sequencer-side ECIES decryption of an encrypted deposit.
@@ -115,8 +114,10 @@ pub fn compute_ecdh_proof(
     Some(EcdhProofResult {
         shared_secret: B256::from(shared_secret_x),
         shared_secret_y_parity,
-        cp_proof_s: B256::from_slice(s.to_repr().as_ref()),
-        cp_proof_c: B256::from_slice(c.to_repr().as_ref()),
+        cp_proof: ChaumPedersenProof {
+            s: B256::from_slice(s.to_repr().as_ref()),
+            c: B256::from_slice(c.to_repr().as_ref()),
+        },
     })
 }
 
@@ -660,8 +661,7 @@ mod tests {
         let proof_a = compute_ecdh_proof(&f.seq_key, &f.eph_pub_x, f.eph_pub_y_parity).unwrap();
         let proof_b = compute_ecdh_proof(&f.seq_key, &f.eph_pub_x, f.eph_pub_y_parity).unwrap();
 
-        assert_eq!(proof_a.cp_proof_s, proof_b.cp_proof_s);
-        assert_eq!(proof_a.cp_proof_c, proof_b.cp_proof_c);
+        assert_eq!(proof_a.cp_proof, proof_b.cp_proof);
     }
 
     #[test]

--- a/crates/precompiles/src/ecies.rs
+++ b/crates/precompiles/src/ecies.rs
@@ -6,7 +6,7 @@
 
 use alloc::vec::Vec;
 
-use aes_gcm::{Aes256Gcm, KeyInit, Nonce, aead::Aead};
+use ::aes_gcm::{Aes256Gcm, KeyInit, Nonce, aead::Aead};
 use alloy_primitives::{Address, B256};
 use k256::{
     AffinePoint, ProjectivePoint, Scalar,
@@ -15,7 +15,7 @@ use k256::{
 use tempo_zone_contracts::Withdrawal;
 
 use crate::{
-    aes_gcm::AesGcmDecrypt,
+    aes_gcm,
     chaum_pedersen::{challenge_hash, recover_point},
 };
 
@@ -148,7 +148,7 @@ pub fn decrypt_deposit(
     let aes_key = hkdf_sha256(&proof.shared_secret.0, b"ecies-aes-key", &info);
 
     // AES-256-GCM decrypt
-    let (plaintext, valid) = AesGcmDecrypt::decrypt(&aes_key, nonce, ciphertext, &[], tag);
+    let (plaintext, valid) = aes_gcm::decrypt(&aes_key, nonce, ciphertext, &[], tag);
     if !valid || plaintext.len() != ENCRYPTED_PAYLOAD_PLAINTEXT_SIZE {
         return None;
     }
@@ -396,7 +396,7 @@ pub fn decrypt_authenticated_withdrawal(
     let info = authenticated_withdrawal_hkdf_info(&eph_pubkey);
     let aes_key = hkdf_sha256(&shared_secret_x, b"authenticated-withdrawal-aes-key", &info);
 
-    let (plaintext, valid) = AesGcmDecrypt::decrypt(&aes_key, &nonce, ciphertext, &[], &tag);
+    let (plaintext, valid) = aes_gcm::decrypt(&aes_key, &nonce, ciphertext, &[], &tag);
     if !valid || plaintext.len() != AUTHENTICATED_WITHDRAWAL_PLAINTEXT_SIZE {
         return None;
     }

--- a/crates/precompiles/src/inbox/mod.rs
+++ b/crates/precompiles/src/inbox/mod.rs
@@ -38,7 +38,7 @@ use tempo_zone_contracts::{
 use zone_primitives::constants::{ZONE_INBOX_ADDRESS, ZONE_OUTBOX_ADDRESS};
 
 use crate::{
-    AesGcmDecrypt, ChaumPedersenVerify, ZonePrecompileError, ZoneResult,
+    ZonePrecompileError, ZoneResult, aes_gcm, chaum_pedersen,
     ecies::{ENCRYPTED_PAYLOAD_PLAINTEXT_SIZE, hkdf_info, hkdf_sha256},
     execution::NoCallRules,
     outbox::ZoneOutbox,
@@ -406,8 +406,8 @@ fn recover_encrypted_payload(
     decryption: &DecryptionData,
     (key_x, key_y_parity): (B256, u8),
 ) -> ZoneResult<Option<(Address, B256)>> {
-    ChaumPedersenVerify::verify_chaum_pedersen_gas()?;
-    if !ChaumPedersenVerify::verify(
+    chaum_pedersen::charge_gas()?;
+    if !chaum_pedersen::verify(
         &deposit.encrypted.ephemeralPubkeyX.0,
         deposit.encrypted.ephemeralPubkeyYParity,
         &decryption.sharedSecret.0,
@@ -427,8 +427,8 @@ fn recover_encrypted_payload(
         &deposit.sender,
     );
     let key = hkdf_sha256(&decryption.sharedSecret.0, b"ecies-aes-key", &info);
-    AesGcmDecrypt::charge_gas(deposit.encrypted.ciphertext.len(), 0)?;
-    let (plaintext, valid) = AesGcmDecrypt::decrypt(
+    aes_gcm::charge_gas(deposit.encrypted.ciphertext.len(), 0)?;
+    let (plaintext, valid) = aes_gcm::decrypt(
         &key,
         &deposit.encrypted.nonce.0,
         &deposit.encrypted.ciphertext,

--- a/crates/precompiles/src/inbox/mod.rs
+++ b/crates/precompiles/src/inbox/mod.rs
@@ -414,8 +414,7 @@ fn recover_encrypted_payload(
         decryption.sharedSecretYParity,
         &key_x.0,
         key_y_parity,
-        &decryption.cpProof.s.0,
-        &decryption.cpProof.c.0,
+        &decryption.cpProof,
     ) {
         return Ok(None);
     }

--- a/crates/precompiles/src/inbox/tests.rs
+++ b/crates/precompiles/src/inbox/tests.rs
@@ -315,10 +315,7 @@ fn failed_deposit_gas(deposits: usize, token_enablements: usize) -> eyre::Result
     let decryption = DecryptionData {
         sharedSecret: decrypted.proof.shared_secret,
         sharedSecretYParity: decrypted.proof.shared_secret_y_parity,
-        cpProof: tempo_zone_contracts::ChaumPedersenProof {
-            s: decrypted.proof.cp_proof_s,
-            c: decrypted.proof.cp_proof_c,
-        },
+        cpProof: decrypted.proof.cp_proof,
     };
 
     let mut queued_deposits = Vec::with_capacity(deposits);
@@ -726,10 +723,7 @@ fn deposit_uses_child_anchor_key_and_mints_plaintext_recipient() -> eyre::Result
                 vec![DecryptionData {
                     sharedSecret: decrypted.proof.shared_secret,
                     sharedSecretYParity: decrypted.proof.shared_secret_y_parity,
-                    cpProof: tempo_zone_contracts::ChaumPedersenProof {
-                        s: decrypted.proof.cp_proof_s,
-                        c: decrypted.proof.cp_proof_c,
-                    },
+                    cpProof: decrypted.proof.cp_proof,
                 }],
             )
             .abi_encode(),
@@ -815,10 +809,7 @@ fn receive_policy_blocked_deposit_enqueues_bounce_back() -> eyre::Result<()> {
                 vec![DecryptionData {
                     sharedSecret: decrypted.proof.shared_secret,
                     sharedSecretYParity: decrypted.proof.shared_secret_y_parity,
-                    cpProof: tempo_zone_contracts::ChaumPedersenProof {
-                        s: decrypted.proof.cp_proof_s,
-                        c: decrypted.proof.cp_proof_c,
-                    },
+                    cpProof: decrypted.proof.cp_proof,
                 }],
             )
             .abi_encode(),

--- a/crates/precompiles/src/lib.rs
+++ b/crates/precompiles/src/lib.rs
@@ -51,8 +51,8 @@ macro_rules! zone_precompile {
 pub mod error;
 pub use error::{Result, ZonePrecompileError, ZoneResult};
 
-pub mod aes_gcm;
-pub mod chaum_pedersen;
+mod aes_gcm;
+mod chaum_pedersen;
 pub mod ecies;
 pub mod outbox;
 
@@ -81,8 +81,6 @@ pub mod zone_fee_manager;
 pub mod zone_state;
 pub mod ztip20;
 
-pub use aes_gcm::AesGcmDecrypt;
-pub use chaum_pedersen::ChaumPedersenVerify;
 pub use inbox::{ADVANCE_TEMPO_SELECTOR, ZoneInbox};
 pub use outbox::ZoneOutbox;
 pub use storage::{L1State, L1StateError, L1StorageReader};

--- a/crates/precompiles/src/lib.rs
+++ b/crates/precompiles/src/lib.rs
@@ -10,9 +10,9 @@
 //!
 //! ## Cryptography
 //!
-//! - **Chaum-Pedersen verification** ([`chaum_pedersen`]) — verifies DLOG equality proofs
-//!   for ECDH shared secret derivation inside the native inbox.
-//! - **AES-256-GCM decryption** ([`aes_gcm`]) — decrypts ECIES ciphertext and verifies
+//! - **Chaum-Pedersen verification** — verifies DLOG equality proofs for ECDH shared secret
+//!   derivation inside the native inbox.
+//! - **AES-256-GCM decryption** — decrypts ECIES ciphertext and verifies
 //!   the GCM authentication tag inside the native inbox.
 //! - **ECIES** ([`ecies`]) — sequencer-side ECIES decryption logic.
 //!

--- a/crates/precompiles/src/test_utils/local.rs
+++ b/crates/precompiles/src/test_utils/local.rs
@@ -96,8 +96,8 @@ pub(crate) fn assert_cp_proof_valid(
     ephemeral_pub: &AffinePoint,
     sequencer_pub: &AffinePoint,
 ) {
-    let s = <Scalar as Reduce<k256::U256>>::reduce_bytes(&dec.proof.cp_proof_s.0.into());
-    let c = <Scalar as Reduce<k256::U256>>::reduce_bytes(&dec.proof.cp_proof_c.0.into());
+    let s = <Scalar as Reduce<k256::U256>>::reduce_bytes(&dec.proof.cp_proof.s.0.into());
+    let c = <Scalar as Reduce<k256::U256>>::reduce_bytes(&dec.proof.cp_proof.c.0.into());
     let shared_pt =
         recover_point(&dec.proof.shared_secret.0, dec.proof.shared_secret_y_parity).unwrap();
 


### PR DESCRIPTION
following the work of #1220, this PR drops the old crypto precompile "unit" structs and turns them into free functions.