### PR TITLE
fix: activate TIP-1096 at T13

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -11414,7 +11414,7 @@ dependencies = [
 [[package]]
 name = "tempo-alloy"
 version = "1.11.0"
-source = "git+https://github.com/tempoxyz/tempo?rev=a843c91a42a273ccff44e0b6afbee83f9b1021d3#a843c91a42a273ccff44e0b6afbee83f9b1021d3"
+source = "git+https://github.com/tempoxyz/tempo?rev=346c22eb4293ac1f5edd27d4afd1f99323bc527c#346c22eb4293ac1f5edd27d4afd1f99323bc527c"
 dependencies = [
  "alloy-consensus",
  "alloy-contract",
@@ -11460,7 +11460,7 @@ dependencies = [
 [[package]]
 name = "tempo-chainspec"
 version = "1.11.0"
-source = "git+https://github.com/tempoxyz/tempo?rev=a843c91a42a273ccff44e0b6afbee83f9b1021d3#a843c91a42a273ccff44e0b6afbee83f9b1021d3"
+source = "git+https://github.com/tempoxyz/tempo?rev=346c22eb4293ac1f5edd27d4afd1f99323bc527c#346c22eb4293ac1f5edd27d4afd1f99323bc527c"
 dependencies = [
  "alloy-eips",
  "alloy-evm",
@@ -11483,7 +11483,7 @@ dependencies = [
 [[package]]
 name = "tempo-contracts"
 version = "1.11.0"
-source = "git+https://github.com/tempoxyz/tempo?rev=a843c91a42a273ccff44e0b6afbee83f9b1021d3#a843c91a42a273ccff44e0b6afbee83f9b1021d3"
+source = "git+https://github.com/tempoxyz/tempo?rev=346c22eb4293ac1f5edd27d4afd1f99323bc527c#346c22eb4293ac1f5edd27d4afd1f99323bc527c"
 dependencies = [
  "alloy-contract",
  "alloy-primitives",
@@ -11494,8 +11494,8 @@ dependencies = [
 
 [[package]]
 name = "tempo-dkg-onchain-artifacts"
-version = "1.14.0"
-source = "git+https://github.com/tempoxyz/tempo?rev=a843c91a42a273ccff44e0b6afbee83f9b1021d3#a843c91a42a273ccff44e0b6afbee83f9b1021d3"
+version = "1.13.2"
+source = "git+https://github.com/tempoxyz/tempo?rev=346c22eb4293ac1f5edd27d4afd1f99323bc527c#346c22eb4293ac1f5edd27d4afd1f99323bc527c"
 dependencies = [
  "bytes",
  "commonware-codec",
@@ -11506,8 +11506,8 @@ dependencies = [
 
 [[package]]
 name = "tempo-evm"
-version = "1.14.0"
-source = "git+https://github.com/tempoxyz/tempo?rev=a843c91a42a273ccff44e0b6afbee83f9b1021d3#a843c91a42a273ccff44e0b6afbee83f9b1021d3"
+version = "1.13.2"
+source = "git+https://github.com/tempoxyz/tempo?rev=346c22eb4293ac1f5edd27d4afd1f99323bc527c#346c22eb4293ac1f5edd27d4afd1f99323bc527c"
 dependencies = [
  "alloy-consensus",
  "alloy-evm",
@@ -11542,7 +11542,7 @@ dependencies = [
 [[package]]
 name = "tempo-hardfork"
 version = "1.11.0"
-source = "git+https://github.com/tempoxyz/tempo?rev=a843c91a42a273ccff44e0b6afbee83f9b1021d3#a843c91a42a273ccff44e0b6afbee83f9b1021d3"
+source = "git+https://github.com/tempoxyz/tempo?rev=346c22eb4293ac1f5edd27d4afd1f99323bc527c#346c22eb4293ac1f5edd27d4afd1f99323bc527c"
 dependencies = [
  "alloy-eips",
  "alloy-evm",
@@ -11553,8 +11553,8 @@ dependencies = [
 
 [[package]]
 name = "tempo-node"
-version = "1.14.0"
-source = "git+https://github.com/tempoxyz/tempo?rev=a843c91a42a273ccff44e0b6afbee83f9b1021d3#a843c91a42a273ccff44e0b6afbee83f9b1021d3"
+version = "1.13.2"
+source = "git+https://github.com/tempoxyz/tempo?rev=346c22eb4293ac1f5edd27d4afd1f99323bc527c#346c22eb4293ac1f5edd27d4afd1f99323bc527c"
 dependencies = [
  "alloy",
  "alloy-eips",
@@ -11619,8 +11619,8 @@ dependencies = [
 
 [[package]]
 name = "tempo-payload-builder"
-version = "1.14.0"
-source = "git+https://github.com/tempoxyz/tempo?rev=a843c91a42a273ccff44e0b6afbee83f9b1021d3#a843c91a42a273ccff44e0b6afbee83f9b1021d3"
+version = "1.13.2"
+source = "git+https://github.com/tempoxyz/tempo?rev=346c22eb4293ac1f5edd27d4afd1f99323bc527c#346c22eb4293ac1f5edd27d4afd1f99323bc527c"
 dependencies = [
  "alloy-consensus",
  "alloy-eip7928",
@@ -11657,8 +11657,8 @@ dependencies = [
 
 [[package]]
 name = "tempo-payload-types"
-version = "1.14.0"
-source = "git+https://github.com/tempoxyz/tempo?rev=a843c91a42a273ccff44e0b6afbee83f9b1021d3#a843c91a42a273ccff44e0b6afbee83f9b1021d3"
+version = "1.13.2"
+source = "git+https://github.com/tempoxyz/tempo?rev=346c22eb4293ac1f5edd27d4afd1f99323bc527c#346c22eb4293ac1f5edd27d4afd1f99323bc527c"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -11677,8 +11677,8 @@ dependencies = [
 
 [[package]]
 name = "tempo-precompiles"
-version = "1.14.0"
-source = "git+https://github.com/tempoxyz/tempo?rev=a843c91a42a273ccff44e0b6afbee83f9b1021d3#a843c91a42a273ccff44e0b6afbee83f9b1021d3"
+version = "1.13.2"
+source = "git+https://github.com/tempoxyz/tempo?rev=346c22eb4293ac1f5edd27d4afd1f99323bc527c#346c22eb4293ac1f5edd27d4afd1f99323bc527c"
 dependencies = [
  "alloy",
  "alloy-evm",
@@ -11704,8 +11704,8 @@ dependencies = [
 
 [[package]]
 name = "tempo-precompiles-macros"
-version = "1.14.0"
-source = "git+https://github.com/tempoxyz/tempo?rev=a843c91a42a273ccff44e0b6afbee83f9b1021d3#a843c91a42a273ccff44e0b6afbee83f9b1021d3"
+version = "1.13.2"
+source = "git+https://github.com/tempoxyz/tempo?rev=346c22eb4293ac1f5edd27d4afd1f99323bc527c#346c22eb4293ac1f5edd27d4afd1f99323bc527c"
 dependencies = [
  "alloy",
  "proc-macro2",
@@ -11716,7 +11716,7 @@ dependencies = [
 [[package]]
 name = "tempo-primitives"
 version = "1.11.0"
-source = "git+https://github.com/tempoxyz/tempo?rev=a843c91a42a273ccff44e0b6afbee83f9b1021d3#a843c91a42a273ccff44e0b6afbee83f9b1021d3"
+source = "git+https://github.com/tempoxyz/tempo?rev=346c22eb4293ac1f5edd27d4afd1f99323bc527c#346c22eb4293ac1f5edd27d4afd1f99323bc527c"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -11747,8 +11747,8 @@ dependencies = [
 
 [[package]]
 name = "tempo-revm"
-version = "1.14.0"
-source = "git+https://github.com/tempoxyz/tempo?rev=a843c91a42a273ccff44e0b6afbee83f9b1021d3#a843c91a42a273ccff44e0b6afbee83f9b1021d3"
+version = "1.13.2"
+source = "git+https://github.com/tempoxyz/tempo?rev=346c22eb4293ac1f5edd27d4afd1f99323bc527c#346c22eb4293ac1f5edd27d4afd1f99323bc527c"
 dependencies = [
  "alloy-consensus",
  "alloy-evm",
@@ -11770,8 +11770,8 @@ dependencies = [
 
 [[package]]
 name = "tempo-transaction-pool"
-version = "1.14.0"
-source = "git+https://github.com/tempoxyz/tempo?rev=a843c91a42a273ccff44e0b6afbee83f9b1021d3#a843c91a42a273ccff44e0b6afbee83f9b1021d3"
+version = "1.13.2"
+source = "git+https://github.com/tempoxyz/tempo?rev=346c22eb4293ac1f5edd27d4afd1f99323bc527c#346c22eb4293ac1f5edd27d4afd1f99323bc527c"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -101,26 +101,26 @@ incremental = false
 
 [workspace.dependencies]
 # tempo (from upstream)
-tempo-alloy = { git = "https://github.com/tempoxyz/tempo", rev = "a843c91a42a273ccff44e0b6afbee83f9b1021d3" }
-tempo-chainspec = { git = "https://github.com/tempoxyz/tempo", rev = "a843c91a42a273ccff44e0b6afbee83f9b1021d3", default-features = false }
-tempo-consensus = { git = "https://github.com/tempoxyz/tempo", rev = "a843c91a42a273ccff44e0b6afbee83f9b1021d3", default-features = false }
-tempo-contracts = { git = "https://github.com/tempoxyz/tempo", rev = "a843c91a42a273ccff44e0b6afbee83f9b1021d3", default-features = false, features = [
+tempo-alloy = { git = "https://github.com/tempoxyz/tempo", rev = "346c22eb4293ac1f5edd27d4afd1f99323bc527c" }
+tempo-chainspec = { git = "https://github.com/tempoxyz/tempo", rev = "346c22eb4293ac1f5edd27d4afd1f99323bc527c", default-features = false }
+tempo-consensus = { git = "https://github.com/tempoxyz/tempo", rev = "346c22eb4293ac1f5edd27d4afd1f99323bc527c", default-features = false }
+tempo-contracts = { git = "https://github.com/tempoxyz/tempo", rev = "346c22eb4293ac1f5edd27d4afd1f99323bc527c", default-features = false, features = [
   "serde",
 ] }
-tempo-evm = { git = "https://github.com/tempoxyz/tempo", rev = "a843c91a42a273ccff44e0b6afbee83f9b1021d3", default-features = false }
-tempo-hardfork = { git = "https://github.com/tempoxyz/tempo", rev = "a843c91a42a273ccff44e0b6afbee83f9b1021d3", default-features = false }
-tempo-node = { git = "https://github.com/tempoxyz/tempo", rev = "a843c91a42a273ccff44e0b6afbee83f9b1021d3" }
-tempo-payload-types = { git = "https://github.com/tempoxyz/tempo", rev = "a843c91a42a273ccff44e0b6afbee83f9b1021d3", default-features = false }
-tempo-precompiles = { git = "https://github.com/tempoxyz/tempo", rev = "a843c91a42a273ccff44e0b6afbee83f9b1021d3", default-features = false }
-tempo-precompiles-macros = { git = "https://github.com/tempoxyz/tempo", rev = "a843c91a42a273ccff44e0b6afbee83f9b1021d3" }
-tempo-primitives = { git = "https://github.com/tempoxyz/tempo", rev = "a843c91a42a273ccff44e0b6afbee83f9b1021d3", default-features = false, features = [
+tempo-evm = { git = "https://github.com/tempoxyz/tempo", rev = "346c22eb4293ac1f5edd27d4afd1f99323bc527c", default-features = false }
+tempo-hardfork = { git = "https://github.com/tempoxyz/tempo", rev = "346c22eb4293ac1f5edd27d4afd1f99323bc527c", default-features = false }
+tempo-node = { git = "https://github.com/tempoxyz/tempo", rev = "346c22eb4293ac1f5edd27d4afd1f99323bc527c" }
+tempo-payload-types = { git = "https://github.com/tempoxyz/tempo", rev = "346c22eb4293ac1f5edd27d4afd1f99323bc527c", default-features = false }
+tempo-precompiles = { git = "https://github.com/tempoxyz/tempo", rev = "346c22eb4293ac1f5edd27d4afd1f99323bc527c", default-features = false }
+tempo-precompiles-macros = { git = "https://github.com/tempoxyz/tempo", rev = "346c22eb4293ac1f5edd27d4afd1f99323bc527c" }
+tempo-primitives = { git = "https://github.com/tempoxyz/tempo", rev = "346c22eb4293ac1f5edd27d4afd1f99323bc527c", default-features = false, features = [
   "reth",
   "serde",
   "serde-bincode-compat",
   "reth-codec",
 ] }
-tempo-revm = { git = "https://github.com/tempoxyz/tempo", rev = "a843c91a42a273ccff44e0b6afbee83f9b1021d3", default-features = false }
-tempo-transaction-pool = { git = "https://github.com/tempoxyz/tempo", rev = "a843c91a42a273ccff44e0b6afbee83f9b1021d3", default-features = false }
+tempo-revm = { git = "https://github.com/tempoxyz/tempo", rev = "346c22eb4293ac1f5edd27d4afd1f99323bc527c", default-features = false }
+tempo-transaction-pool = { git = "https://github.com/tempoxyz/tempo", rev = "346c22eb4293ac1f5edd27d4afd1f99323bc527c", default-features = false }
 
 # zones
 tempo-zone-contracts = { path = "crates/contracts", default-features = false }

--- a/crates/contracts/src/precompiles/zone_inbox.rs
+++ b/crates/contracts/src/precompiles/zone_inbox.rs
@@ -124,7 +124,7 @@ crate::sol! {
         function processedDepositQueueHash() external view returns (bytes32);
         function processedDepositNumber() external view returns (uint64);
         function processedTokenEnablementHash() external view returns (bytes32);
-        /// Get the number of enabled tokens processed by the Zone Inbox. Active from T12.
+        /// Get the number of enabled tokens processed by the Zone Inbox. Active from T13.
         function processedEnabledTokenCount() external view returns (uint64);
         function tempoPortal() external view returns (address);
         function tempoState() external view returns (address);

--- a/crates/contracts/src/precompiles/zone_portal.rs
+++ b/crates/contracts/src/precompiles/zone_portal.rs
@@ -144,7 +144,7 @@ crate::sol! {
             uint64 lastProcessedDepositNumber
         );
 
-        /// T12 batch event with the processed enabled-token cursor.
+        /// T13 batch event with the processed enabled-token cursor.
         event BatchSubmitted(
             uint64 indexed withdrawalBatchIndex,
             uint256 indexed withdrawalQueueIndex,
@@ -334,7 +334,7 @@ crate::sol! {
             bytes[] calldata signatures
         ) external;
 
-        /// Submit a batch with the enabled-token transition. Active from T12.
+        /// Submit a batch with the enabled-token transition. Active from T13.
         function submitBatch(
             uint64 tempoBlockNumber,
             uint64 recentTempoBlockNumber,
@@ -416,11 +416,11 @@ crate::sol! {
     }
 }
 
-/// ZonePortal entries retired by the T12 hardfork.
-mod pre_t12_retired {
+/// ZonePortal entries retired by the T13 hardfork.
+mod pre_t13_retired {
     crate::sol! {
         #[sol(abi)]
-        contract ZonePortalPreT12Retired {
+        contract ZonePortalPreT13Retired {
             struct BlockTransition {
                 bytes32 prevBlockHash;
                 bytes32 nextBlockHash;
@@ -461,7 +461,7 @@ mod pre_t12_retired {
 }
 
 #[doc(hidden)]
-pub use pre_t12_retired::ZonePortalPreT12Retired;
+pub use pre_t13_retired::ZonePortalPreT13Retired;
 
 #[cfg(feature = "rpc")]
 impl<P: alloy_provider::Provider<N>, N: alloy_network::Network>

--- a/crates/contracts/src/runtime/tempo/ZonePortal.sol
+++ b/crates/contracts/src/runtime/tempo/ZonePortal.sol
@@ -235,7 +235,7 @@ contract ZonePortal is IZonePortal {
     /// @dev Appended after all T10 storage for upgrade safety.
     uint64 public lastProcessedEnabledTokenCount;
 
-    /// @notice Whether the T12 token cursor has been authenticated by an operational batch.
+    /// @notice Whether the T13 token cursor has been authenticated by an operational batch.
     bool public tokenEnablementCursorInitialized;
 
     /*//////////////////////////////////////////////////////////////

--- a/crates/node/src/engine.rs
+++ b/crates/node/src/engine.rs
@@ -540,7 +540,7 @@ fn tempo_import_decision(
     let zone_hardfork = chain_spec.tempo_hardfork_at(next_timestamp_millis / 1000);
     let l1_tip_hardfork = chain_spec.tempo_hardfork_at(latest_l1_header.timestamp());
 
-    if !zone_hardfork.is_t12() {
+    if !zone_hardfork.is_t13() {
         return TempoImportDecision::ImportFull;
     }
     // Zone execution must not activate a hardfork before L1. Wait whenever the prospective Zone
@@ -611,7 +611,7 @@ mod tests {
     fn zone_timestamp_allows_parent_timestamp_when_catching_up_in_same_millisecond() {
         assert_eq!(zone_timestamp_millis(1_000, 2_000, 2_000), 2_000);
     }
-    fn t12_spec(activation: u64) -> ZoneChainSpec {
+    fn t13_spec(activation: u64) -> ZoneChainSpec {
         use reth_chainspec::EthChainSpec as _;
         let mut genesis = tempo_chainspec::spec::DEV.genesis().clone();
         genesis.config.chain_id =
@@ -620,7 +620,7 @@ mod tests {
         genesis
             .config
             .extra_fields
-            .insert_value("t12Time".into(), activation)
+            .insert_value("t13Time".into(), activation)
             .unwrap();
         ZoneChainSpec::from_genesis(genesis).unwrap()
     }
@@ -654,16 +654,16 @@ mod tests {
     }
 
     #[test]
-    fn t12_boundary_waits_for_l1_then_checkpoints_the_t11_prefix() {
-        let spec = t12_spec(100);
-        let t11 = header(1, 99);
-        let t12 = header(2, 100);
+    fn t13_boundary_waits_for_l1_then_checkpoints_the_t12_prefix() {
+        let spec = t13_spec(100);
+        let t12 = header(1, 99);
+        let t13 = header(2, 100);
 
         assert_eq!(
             tempo_import_decision(
                 &spec,
-                std::slice::from_ref(&t11),
-                &t11,
+                std::slice::from_ref(&t12),
+                &t12,
                 finalized_target(1, true),
                 98_000,
                 100_000
@@ -673,8 +673,8 @@ mod tests {
         assert_eq!(
             tempo_import_decision(
                 &spec,
-                std::slice::from_ref(&t11),
-                &t12,
+                std::slice::from_ref(&t12),
+                &t13,
                 None,
                 98_000,
                 100_000,
@@ -684,8 +684,8 @@ mod tests {
         assert_eq!(
             tempo_import_decision(
                 &spec,
-                &[t11, t12.clone()],
-                &t12,
+                &[t12, t13.clone()],
+                &t13,
                 finalized_target(2, false),
                 98_000,
                 100_000,
@@ -695,8 +695,8 @@ mod tests {
         assert_eq!(
             tempo_import_decision(
                 &spec,
-                std::slice::from_ref(&t12),
-                &t12,
+                std::slice::from_ref(&t13),
+                &t13,
                 finalized_target(2, true),
                 99_000,
                 100_000
@@ -706,14 +706,14 @@ mod tests {
     }
 
     #[test]
-    fn pre_t12_zone_block_imports_the_t11_front_normally() {
-        let spec = t12_spec(100);
-        let t11 = header(1, 99);
+    fn pre_t13_zone_block_imports_the_t12_front_normally() {
+        let spec = t13_spec(100);
+        let t12 = header(1, 99);
         assert_eq!(
             tempo_import_decision(
                 &spec,
-                std::slice::from_ref(&t11),
-                &t11,
+                std::slice::from_ref(&t12),
+                &t12,
                 finalized_target(1, true),
                 98_000,
                 99_000
@@ -724,15 +724,15 @@ mod tests {
 
     #[test]
     fn hardfork_gate_does_not_wait_when_l1_is_ahead_of_the_zone() {
-        let spec = t12_spec(100);
-        let t11 = header(1, 99);
-        let t12 = header(2, 100);
+        let spec = t13_spec(100);
+        let t12 = header(1, 99);
+        let t13 = header(2, 100);
 
         assert_eq!(
             tempo_import_decision(
                 &spec,
-                &[t11],
-                &t12,
+                &[t12],
+                &t13,
                 finalized_target(2, true),
                 98_000,
                 99_000,
@@ -743,7 +743,7 @@ mod tests {
 
     #[test]
     fn checkpoint_batching_uses_announced_finalized_target() {
-        let spec = t12_spec(100);
+        let spec = t13_spec(100);
 
         // Backfill has announced 100 missing blocks, but only the first is verified and queued.
         // It must remain a checkpoint-only import instead of becoming a premature full block.

--- a/crates/node/src/settlement_attestation.rs
+++ b/crates/node/src/settlement_attestation.rs
@@ -150,7 +150,7 @@ where
                 match log.topics().first().copied() {
                     Some(TempoAdvanced::SIGNATURE_HASH) => {
                         let event = TempoAdvanced::decode_log(log).wrap_err_with(|| {
-                            format!("invalid post-T12 TempoAdvanced log in block {number}")
+                            format!("invalid post-T13 TempoAdvanced log in block {number}")
                         })?;
                         anchor_hash = Some(event.tempoBlockHash);
                         tempo_block_number = Some(event.tempoBlockNumber);
@@ -712,7 +712,7 @@ mod tests {
     }
 
     #[test]
-    fn previous_batch_skips_checkpoint_only_blocks_across_t12() {
+    fn previous_batch_skips_checkpoint_only_blocks_across_t13() {
         let provider = MockEthProvider::<TempoPrimitives>::new();
 
         let mut first_boundary_header = TempoHeader::default();
@@ -797,7 +797,7 @@ mod tests {
         let previous = previous_batch(&provider, 4).unwrap();
         assert_eq!(previous, (first_boundary_hash, first_deposit_hash, 7, 0));
         assert_eq!(
-            SettlementAbi::T12.token_transition_hash(previous.3, commitments.processed_token_count),
+            SettlementAbi::T13.token_transition_hash(previous.3, commitments.processed_token_count),
             alloy_primitives::keccak256((0_u64, 15_u64).abi_encode())
         );
     }

--- a/crates/node/tests/assets/test-genesis.json
+++ b/crates/node/tests/assets/test-genesis.json
@@ -36,6 +36,7 @@
     "t10Time": 0,
     "t11Time": 0,
     "t12Time": 0,
+    "t13Time": 0,
     "depositContractAddress": "0x0000000000000000000000000000000000000000"
   },
   "nonce": "0x42",

--- a/crates/node/tests/it/utils.rs
+++ b/crates/node/tests/it/utils.rs
@@ -46,7 +46,7 @@ use tempo_contracts::precompiles::{
     account_keychain::IAccountKeychain::{
         IAccountKeychainInstance, KeyRestrictions, SignatureType as KeyInfoSignatureType,
     },
-    t12_zone_factory_state,
+    t13_zone_factory_state,
 };
 use tempo_precompiles::{
     PATH_USD_ADDRESS,
@@ -213,7 +213,7 @@ pub(crate) fn forge_bytecode(contract: &str) -> eyre::Result<alloy_primitives::B
 }
 
 fn install_native_zone_factory(genesis: &mut Genesis, owner: Address) -> eyre::Result<()> {
-    for account in t12_zone_factory_state(owner) {
+    for account in t13_zone_factory_state(owner) {
         let storage = account.storage.map(|(slot, value)| {
             BTreeMap::from([(
                 B256::from(slot.to_be_bytes()),

--- a/crates/precompiles/src/inbox/dispatch.rs
+++ b/crates/precompiles/src/inbox/dispatch.rs
@@ -39,7 +39,7 @@ impl ZoneInbox {
                     processedTokenEnablementHash(call) => {
                         view(call, |_| self.processed_token_enablement_hash.read())
                     },
-                    #[schedule(since = T12)]
+                    #[schedule(since = T13)]
                     processedEnabledTokenCount(call) => {
                         view(call, |_| self.processed_enabled_token_count.read())
                     },
@@ -59,7 +59,7 @@ impl ZoneInbox {
                                 .encode_precompile_result(0, 0, |()| Bytes::new())
                         }
                     },
-                    #[schedule(since = T12)]
+                    #[schedule(since = T13)]
                     advanceTempoHeaders(call) => {
                         if self.storage.is_static() {
                             Ok(self.storage.revert_output(Bytes::new()))

--- a/crates/precompiles/src/inbox/mod.rs
+++ b/crates/precompiles/src/inbox/mod.rs
@@ -108,7 +108,7 @@ impl ZoneInbox {
         let enabled_token_count = call.enabledTokens.len();
         let previous_token_count = StorageCtx
             .spec()
-            .is_t12()
+            .is_t13()
             .then(|| self.processed_enabled_token_count.read())
             .transpose()?;
         let mut next_token_enablement_hash = self.processed_token_enablement_hash.read()?;
@@ -121,7 +121,7 @@ impl ZoneInbox {
             {
                 return Err(ZoneInboxError::invalid_token_enablement_hash().into());
             }
-            // T12 adds the count cursor after zones may already have applied a historical token
+            // T13 adds the count cursor after zones may already have applied a historical token
             // prefix. Bootstrap that prefix once; afterward the hash check authenticates the
             // supplied suffix, so the stored count can advance locally.
             if previous_token_count == Some(0) {
@@ -214,7 +214,7 @@ impl ZoneInbox {
             .ok_or_else(TempoPrecompileError::under_overflow)?;
         self.processed_deposit_number.write(processed_number)?;
 
-        if StorageCtx.spec().is_t12() {
+        if StorageCtx.spec().is_t13() {
             self.emit_event(TempoAdvanced {
                 tempoBlockHash: tempo_block_hash,
                 tempoBlockNumber: tempo_block_number,

--- a/crates/precompiles/src/inbox/tests.rs
+++ b/crates/precompiles/src/inbox/tests.rs
@@ -48,7 +48,7 @@ struct Harness {
 
 impl Harness {
     fn new() -> eyre::Result<Self> {
-        Self::new_with_hardfork(TempoHardfork::T12)
+        Self::new_with_hardfork(TempoHardfork::T13)
     }
 
     fn new_with_hardfork(hardfork: TempoHardfork) -> eyre::Result<Self> {
@@ -420,24 +420,48 @@ fn non_system_advance_reverts_before_selecting_or_reading_l1() -> eyre::Result<(
 }
 
 #[test]
-fn processed_enabled_token_count_activates_at_t12() -> eyre::Result<()> {
-    let mut harness = Harness::new_with_hardfork(TempoHardfork::T11)?;
+fn advance_tempo_headers_activates_at_t13() -> eyre::Result<()> {
+    for hardfork in [TempoHardfork::T12, TempoHardfork::T13] {
+        let mut harness = Harness::new_with_hardfork(hardfork)?;
+        let calldata = IZoneInbox::advanceTempoHeadersCall {
+            headers: vec![encode_header(&harness.child_header())],
+        }
+        .abi_encode();
+        let output = harness.call(Address::ZERO, calldata)?;
+        if hardfork == TempoHardfork::T12 {
+            assert!(output.is_revert());
+            let error = UnknownFunctionSelector::abi_decode(&output.bytes)?;
+            assert_eq!(
+                error.selector.as_slice(),
+                &IZoneInbox::advanceTempoHeadersCall::SELECTOR
+            );
+        } else {
+            assert!(output.is_success());
+        }
+        assert!(harness.l1.storage_requests().is_empty());
+    }
+    Ok(())
+}
+
+#[test]
+fn processed_enabled_token_count_activates_at_t13() -> eyre::Result<()> {
+    let mut harness = Harness::new_with_hardfork(TempoHardfork::T12)?;
     let calldata = IZoneInbox::processedEnabledTokenCountCall {}.abi_encode();
 
-    let pre_t12 = harness.call(ALICE, &calldata)?;
-    assert!(pre_t12.is_revert());
-    let error = UnknownFunctionSelector::abi_decode(&pre_t12.bytes)?;
+    let pre_t13 = harness.call(ALICE, &calldata)?;
+    assert!(pre_t13.is_revert());
+    let error = UnknownFunctionSelector::abi_decode(&pre_t13.bytes)?;
     assert_eq!(
         error.selector.as_slice(),
         &IZoneInbox::processedEnabledTokenCountCall::SELECTOR
     );
 
     let mut harness = Harness::new()?;
-    let t12_env = test_env(&harness.ctx);
-    let t12_precompile = ZoneInbox::create(harness.l1_state.clone(), &t12_env);
-    let post_t12 = call_precompile(
+    let t13_env = test_env(&harness.ctx);
+    let t13_precompile = ZoneInbox::create(harness.l1_state.clone(), &t13_env);
+    let post_t13 = call_precompile(
         &mut harness.ctx,
-        &t12_precompile,
+        &t13_precompile,
         ALICE,
         &calldata,
         GAS,
@@ -445,9 +469,9 @@ fn processed_enabled_token_count_activates_at_t12() -> eyre::Result<()> {
         ZONE_INBOX_ADDRESS,
         ZONE_INBOX_ADDRESS,
     )?;
-    assert!(post_t12.is_success());
+    assert!(post_t13.is_success());
     assert_eq!(
-        IZoneInbox::processedEnabledTokenCountCall::abi_decode_returns(&post_t12.bytes)?,
+        IZoneInbox::processedEnabledTokenCountCall::abi_decode_returns(&post_t13.bytes)?,
         0
     );
     Ok(())

--- a/crates/precompiles/src/tempo_state.rs
+++ b/crates/precompiles/src/tempo_state.rs
@@ -200,11 +200,11 @@ impl TempoState {
                 TempoStateAbi::TempoStateCalls {
                     tempoBlockHash(call) => view(call, |_| self.tempo_block_hash.read()),
                     tempoBlockNumber(call) => view(call, |_| self.tempo_block_number.read()),
-                    #[schedule(until = T12)]
+                    #[schedule(until = T13)]
                     finalizeTempo_0(call) => {
                         self.apply_checkpoints(l1, msg_sender, core::slice::from_ref(&call.header))
                     },
-                    #[schedule(since = T12)]
+                    #[schedule(since = T13)]
                     finalizeTempo_1(call) => {
                         self.apply_checkpoints(l1, msg_sender, &call.headers)
                     },
@@ -424,10 +424,38 @@ mod tests {
     }
 
     #[test]
-    fn legacy_finalize_tempo_works_before_t12() -> eyre::Result<()> {
+    fn finalize_tempo_selectors_switch_at_t13() -> eyre::Result<()> {
+        for hardfork in [TempoHardfork::T12, TempoHardfork::T13] {
+            let genesis = TempoHeader::default();
+            let genesis_hash = keccak256(encode_header(&genesis));
+            let mut harness = TempoStateHarness::new_with_hardfork(&genesis, hardfork)?;
+            let child = child_header(genesis_hash, 1);
+            harness.set_block_timestamp(&child);
+
+            let retired = if hardfork == TempoHardfork::T12 {
+                harness.finalize(ZONE_INBOX_ADDRESS, &child, false)?
+            } else {
+                harness.finalize_legacy(ZONE_INBOX_ADDRESS, &child, false)?
+            };
+            assert!(retired.is_revert());
+            harness.assert_checkpoint(genesis_hash, genesis.number())?;
+
+            let active = if hardfork == TempoHardfork::T12 {
+                harness.finalize_legacy(ZONE_INBOX_ADDRESS, &child, false)?
+            } else {
+                harness.finalize(ZONE_INBOX_ADDRESS, &child, false)?
+            };
+            assert!(active.is_success());
+            harness.assert_checkpoint(keccak256(encode_header(&child)), 1)?;
+        }
+        Ok(())
+    }
+
+    #[test]
+    fn legacy_finalize_tempo_works_before_t13() -> eyre::Result<()> {
         let genesis = TempoHeader::default();
         let genesis_hash = keccak256(encode_header(&genesis));
-        let mut harness = TempoStateHarness::new_with_hardfork(&genesis, TempoHardfork::T11)?;
+        let mut harness = TempoStateHarness::new_with_hardfork(&genesis, TempoHardfork::T12)?;
         let child = child_header(genesis_hash, 1);
         harness.set_block_timestamp(&child);
 

--- a/crates/precompiles/src/test_utils/local.rs
+++ b/crates/precompiles/src/test_utils/local.rs
@@ -35,7 +35,7 @@ pub(crate) type TestContext =
 
 /// Create an empty test EVM context at the latest Tempo hardfork affecting Zones.
 pub(crate) fn test_context() -> TestContext {
-    test_context_with_hardfork(TempoHardfork::T12)
+    test_context_with_hardfork(TempoHardfork::T13)
 }
 
 /// Create a test EVM context with the specified hardfork.

--- a/crates/sequencer/src/attestation.rs
+++ b/crates/sequencer/src/attestation.rs
@@ -53,7 +53,7 @@ sol! {
 
 mod legacy {
     alloy_sol_types::sol! {
-        /// Settlement statement used by the pre-T12 portal ABI.
+        /// Settlement statement used by the pre-T13 portal ABI.
         #[derive(Debug, PartialEq, Eq)]
         struct SettlementAttestation {
             uint32 zoneId;
@@ -70,7 +70,7 @@ mod legacy {
             bytes32 verifierConfigHash;
         }
 
-        /// Signed settlement statement used by the pre-T12 portal ABI.
+        /// Signed settlement statement used by the pre-T13 portal ABI.
         #[derive(Debug, PartialEq, Eq)]
         struct SignedSettlementAttestation {
             SettlementAttestation attestation;
@@ -528,7 +528,7 @@ mod tests {
     }
 
     #[test]
-    fn legacy_settlement_uses_pre_t12_wire_format_and_digest() {
+    fn legacy_settlement_uses_pre_t13_wire_format_and_digest() {
         const LEGACY_PORTAL_TYPE: &str = "SettlementAttestation(uint32 zoneId,uint64 sequencerSetVersion,uint256 zoneHeight,uint256 withdrawalBatchIndex,address verifier,uint64 tempoBlockNumber,uint64 anchorBlockNumber,bytes32 anchorBlockHash,bytes32 blockTransitionHash,bytes32 depositQueueTransitionHash,bytes32 withdrawalQueueHash,bytes32 verifierConfigHash)";
         assert_eq!(
             LegacySettlementAttestation::eip712_encode_type(),

--- a/crates/sequencer/src/monitor.rs
+++ b/crates/sequencer/src/monitor.rs
@@ -1110,7 +1110,7 @@ mod tests {
 
         // Preflight portal hash, live hardfork, then submission metadata with a 2-of-N threshold.
         l1.push_success(&abi_encode_b256(batch_data.prev_block_hash));
-        l1.push_success(&serde_json::json!({ "active": "T12" }));
+        l1.push_success(&serde_json::json!({ "active": "T13" }));
         l1.push_success(&abi_encode_multicall(vec![
             abi_encode_u64(0),
             abi_encode_u64(1),

--- a/crates/sequencer/src/settlement.rs
+++ b/crates/sequencer/src/settlement.rs
@@ -494,7 +494,7 @@ impl BatchSubmitter {
                 }
                 tokio::time::timeout(Duration::from_secs(30), submission.send_sync()).await
             }
-            SettlementAbi::T12 => {
+            SettlementAbi::T13 => {
                 let mut submission = self
                     .portal
                     .submitBatch_1(
@@ -1281,27 +1281,27 @@ pub struct WithdrawalPage {
 /// Settlement ABI selected by the fork rules of the batch's imported Tempo block.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum SettlementAbi {
-    /// Pre-T12 selector and EIP-712 statement.
+    /// Pre-T13 selector and EIP-712 statement.
     Legacy,
-    /// T12 selector and token-enablement-bound EIP-712 statement.
-    T12,
+    /// T13 selector and token-enablement-bound EIP-712 statement.
+    T13,
 }
 
 impl SettlementAbi {
     /// Resolve the settlement selector and attestation format from the live Tempo L1 hardfork.
     pub async fn from_l1(provider: &DynProvider<TempoNetwork>) -> Result<Self> {
-        let t12_active = provider
-            .is_hardfork_active(TempoHardfork::T12)
+        let t13_active = provider
+            .is_hardfork_active(TempoHardfork::T13)
             .await
             .wrap_err("failed reading the live Tempo L1 hardfork")?;
-        Ok(if t12_active { Self::T12 } else { Self::Legacy })
+        Ok(if t13_active { Self::T13 } else { Self::Legacy })
     }
 
     /// Hash the token transition exactly as the selected settlement statement expects.
     pub fn token_transition_hash(self, previous: u64, next: u64) -> B256 {
         match self {
             Self::Legacy => B256::ZERO,
-            Self::T12 => keccak256((previous, next).abi_encode()),
+            Self::T13 => keccak256((previous, next).abi_encode()),
         }
     }
 }
@@ -1698,7 +1698,7 @@ pub(crate) fn read_zone_block_snapshot<P: ZoneSequencerProvider>(
             let (block_number, deposit_hash, deposit_number, token_count) = match *topic {
                 TempoAdvanced::SIGNATURE_HASH => {
                     let event = TempoAdvanced::decode_log(log).map_err(|err| {
-                        eyre::eyre!("invalid post-T12 TempoAdvanced log in block {number}: {err}")
+                        eyre::eyre!("invalid post-T13 TempoAdvanced log in block {number}: {err}")
                     })?;
                     (
                         event.tempoBlockNumber,
@@ -1951,7 +1951,7 @@ mod tests {
     }
 
     #[test]
-    fn settlement_bindings_keep_legacy_and_t12_selectors_distinct() {
+    fn settlement_bindings_keep_legacy_and_t13_selectors_distinct() {
         let legacy: [u8; 4] = keccak256(
             "submitBatch(uint64,uint64,(bytes32,bytes32),(bytes32,bytes32,uint64,uint64),bytes32,bytes,bytes,uint256,bytes[])"
         )[..4]
@@ -1964,31 +1964,31 @@ mod tests {
     #[tokio::test]
     async fn settlement_abi_follows_live_l1_hardfork() {
         let legacy = Asserter::new();
-        legacy.push_success(&serde_json::json!({ "active": "T11" }));
+        legacy.push_success(&serde_json::json!({ "active": "T12" }));
         assert_eq!(
             SettlementAbi::from_l1(&mock_l1(legacy)).await.unwrap(),
             SettlementAbi::Legacy
         );
 
-        let t12 = Asserter::new();
-        t12.push_success(&serde_json::json!({ "active": "T12" }));
+        let t13 = Asserter::new();
+        t13.push_success(&serde_json::json!({ "active": "T13" }));
         assert_eq!(
-            SettlementAbi::from_l1(&mock_l1(t12)).await.unwrap(),
-            SettlementAbi::T12
+            SettlementAbi::from_l1(&mock_l1(t13)).await.unwrap(),
+            SettlementAbi::T13
         );
     }
 
     #[test]
-    fn t12_uses_token_transition_for_legacy_boundary() {
+    fn t13_uses_token_transition_for_legacy_boundary() {
         assert_eq!(
             SettlementAbi::Legacy.token_transition_hash(0, 0),
             B256::ZERO
         );
         assert_eq!(
-            SettlementAbi::T12.token_transition_hash(0, 0),
+            SettlementAbi::T13.token_transition_hash(0, 0),
             keccak256((0_u64, 0_u64).abi_encode())
         );
-        assert_ne!(SettlementAbi::T12.token_transition_hash(0, 0), B256::ZERO);
+        assert_ne!(SettlementAbi::T13.token_transition_hash(0, 0), B256::ZERO);
     }
 
     fn test_prepared_batch(zone_height: u64, tempo_block_number: u64) -> PreparedBatch {

--- a/crates/spf/src/lib.rs
+++ b/crates/spf/src/lib.rs
@@ -12,7 +12,7 @@ use reth_evm::execute::BlockAssemblerInput;
 use reth_primitives_traits::SealedHeader;
 use reth_storage_api::noop::NoopProvider;
 use revm::{Database as _, database::State, database_interface::bal::EvmDatabaseError};
-use tempo_chainspec::spec::TempoHardforks as _;
+use tempo_chainspec::{TempoHardfork, spec::TempoHardforks as _};
 use tempo_evm::{TempoBlockAssembler, TempoEvmConfig};
 use tempo_primitives::{TempoHeader, TempoPrimitives};
 use zone_precompiles::{inbox, outbox, tempo_state};
@@ -33,8 +33,8 @@ pub use types::*;
 ///
 /// `config` is trusted network configuration chosen by the verifier. Every
 /// other value is prover supplied and must be validated against witness-backed
-/// execution. Before T12 the replay may end at an open Zone tip without withdrawal
-/// finalization. Every T12 batch must end at a full block's finalization boundary.
+/// execution. Before T13 the replay may end at an open Zone tip without withdrawal
+/// finalization. Every T13 batch must end at a full block's finalization boundary.
 pub fn prove_zone_batch(config: &SpfConfig, witness: BatchWitness) -> Result<BatchOutput, Error> {
     // The parent header is the committed starting point for this batch. Its
     // hash binds the witness to the previously submitted Zone block, and its
@@ -88,7 +88,7 @@ pub fn prove_zone_batch(config: &SpfConfig, witness: BatchWitness) -> Result<Bat
         inbox::slots::PROCESSED_DEPOSIT_NUMBER,
     )?
     .to::<u64>();
-    // Keep the public transition anchored to the physical pre-state. On the first T12 batch this
+    // Keep the public transition anchored to the physical pre-state. On the first T13 batch this
     // is zero; ZoneInbox authenticates the legacy hash prefix internally before writing the
     // migrated count, so rewriting this value would diverge from settlement attestations.
     let previous_processed_token_count = read_zone_storage(
@@ -168,14 +168,11 @@ pub fn prove_zone_batch(config: &SpfConfig, witness: BatchWitness) -> Result<Bat
             });
         }
 
-        validate_system_inputs(block, block_index)?;
-        if config
-            .chain_spec()
-            .tempo_hardfork_at(block.timestamp)
-            .is_t12()
-        {
+        let hardfork = config.chain_spec().tempo_hardfork_at(block.timestamp);
+        validate_system_inputs(block, block_index, hardfork)?;
+        if hardfork.is_t13() {
             let is_last = block_index + 1 == witness.zone_blocks.len();
-            validate_t12_block_shape(block, is_last)?;
+            validate_t13_block_shape(block, is_last)?;
         }
 
         // The EVM environment uses the verifier-selected fork schedule at this
@@ -436,18 +433,22 @@ fn validate_tempo_anchor(
     Ok(())
 }
 
-fn validate_t12_block_shape(block: &ZoneBlock, is_last: bool) -> Result<(), Error> {
+fn validate_t13_block_shape(block: &ZoneBlock, is_last: bool) -> Result<(), Error> {
     let valid = match &block.tempo_import {
         TempoImport::CheckpointOnly { .. } => !is_last,
         TempoImport::Full { .. } => is_last && block.finalize_withdrawal_batch_count.is_some(),
     };
     if !valid {
-        return Err(Error::InvalidT12BatchShape);
+        return Err(Error::InvalidT13BatchShape);
     }
     Ok(())
 }
 
-fn validate_system_inputs(block: &ZoneBlock, index: usize) -> Result<(), Error> {
+fn validate_system_inputs(
+    block: &ZoneBlock,
+    index: usize,
+    hardfork: TempoHardfork,
+) -> Result<(), Error> {
     if block.tempo_import.headers_rlp().is_empty() {
         return Err(Error::MissingTempoHeaders { block_index: index });
     }
@@ -457,8 +458,9 @@ fn validate_system_inputs(block: &ZoneBlock, index: usize) -> Result<(), Error> 
             enabled_tokens,
             ..
         } => {
-            if deposits.len() > MAX_UNPROCESSED_DEPOSITS
-                || enabled_tokens.len() > MAX_UNPROCESSED_TOKEN_ENABLEMENTS
+            if hardfork.is_t13()
+                && (deposits.len() > MAX_UNPROCESSED_DEPOSITS
+                    || enabled_tokens.len() > MAX_UNPROCESSED_TOKEN_ENABLEMENTS)
             {
                 return Err(Error::PortalWorkCapacityExceeded { block_index: index });
             }
@@ -522,10 +524,10 @@ pub enum Error {
     /// A full block exceeded a protocol-wide outstanding portal-work bound.
     #[error("zone block {block_index} exceeds portal-work capacity")]
     PortalWorkCapacityExceeded { block_index: usize },
-    /// A T12 batch must contain exactly one full operational block at the end, optionally preceded
+    /// A T13 batch must contain exactly one full operational block at the end, optionally preceded
     /// by checkpoint-only blocks.
-    #[error("invalid T12 batch shape")]
-    InvalidT12BatchShape,
+    #[error("invalid T13 batch shape")]
+    InvalidT13BatchShape,
     /// The witness identifies a Zone other than the verifier-selected chain specification.
     #[error("Zone chain ID mismatch: expected {expected}, got {actual}")]
     ChainIdMismatch { expected: u64, actual: u64 },
@@ -838,7 +840,7 @@ mod tests {
     }
 
     #[test]
-    fn t12_batch_shape_rejects_multiple_full_blocks() {
+    fn t13_batch_shape_rejects_multiple_full_blocks() {
         let mut witness = minimal_batch_witness();
         for number in 1..=2 {
             witness.zone_blocks.push(ZoneBlock {
@@ -853,15 +855,15 @@ mod tests {
                 transactions: Vec::new(),
             });
         }
-        validate_system_inputs(&witness.zone_blocks[0], 0).unwrap();
+        validate_system_inputs(&witness.zone_blocks[0], 0, TempoHardfork::T13).unwrap();
         assert_eq!(
-            validate_t12_block_shape(&witness.zone_blocks[0], false),
-            Err(Error::InvalidT12BatchShape)
+            validate_t13_block_shape(&witness.zone_blocks[0], false),
+            Err(Error::InvalidT13BatchShape)
         );
     }
 
     #[test]
-    fn t12_batch_shape_rejects_checkpoint_only_batch() {
+    fn t13_batch_shape_rejects_checkpoint_only_batch() {
         let mut witness = minimal_batch_witness();
         witness.zone_blocks.push(ZoneBlock {
             number: 1,
@@ -874,10 +876,10 @@ mod tests {
             finalize_withdrawal_batch_encrypted_senders: Vec::new(),
             transactions: Vec::new(),
         });
-        validate_system_inputs(&witness.zone_blocks[0], 0).unwrap();
+        validate_system_inputs(&witness.zone_blocks[0], 0, TempoHardfork::T13).unwrap();
         assert_eq!(
-            validate_t12_block_shape(&witness.zone_blocks[0], true),
-            Err(Error::InvalidT12BatchShape)
+            validate_t13_block_shape(&witness.zone_blocks[0], true),
+            Err(Error::InvalidT13BatchShape)
         );
     }
 
@@ -1212,6 +1214,39 @@ mod tests {
     }
 
     #[test]
+    fn portal_work_capacity_activates_at_t13() {
+        for (deposit_count, token_count) in [
+            (MAX_UNPROCESSED_DEPOSITS + 1, 0),
+            (0, MAX_UNPROCESSED_TOKEN_ENABLEMENTS + 1),
+        ] {
+            let block = ZoneBlock {
+                number: 1,
+                parent_hash: B256::ZERO,
+                timestamp: 0,
+                timestamp_millis_part: 0,
+                beneficiary: Address::ZERO,
+                tempo_import: TempoImport::Full {
+                    header_rlp: Bytes::from([0x01]),
+                    deposits: vec![Default::default(); deposit_count],
+                    decryptions: Vec::new(),
+                    enabled_tokens: vec![Default::default(); token_count],
+                },
+                finalize_withdrawal_batch_count: None,
+                finalize_withdrawal_batch_encrypted_senders: Vec::new(),
+                transactions: Vec::new(),
+            };
+            assert_eq!(
+                validate_system_inputs(&block, 0, TempoHardfork::T12),
+                Ok(())
+            );
+            assert_eq!(
+                validate_system_inputs(&block, 0, TempoHardfork::T13),
+                Err(Error::PortalWorkCapacityExceeded { block_index: 0 })
+            );
+        }
+    }
+
+    #[test]
     fn accepts_an_open_snapshot_without_finalization() {
         let witness = minimal_batch_witness();
         let mut block = ZoneBlock {
@@ -1226,10 +1261,13 @@ mod tests {
             transactions: Vec::new(),
         };
 
-        assert_eq!(validate_system_inputs(&block, 0), Ok(()));
+        assert_eq!(
+            validate_system_inputs(&block, 0, TempoHardfork::T13),
+            Ok(())
+        );
         block.tempo_import = checkpoint_import(Vec::new());
         assert_eq!(
-            validate_system_inputs(&block, 0),
+            validate_system_inputs(&block, 0, TempoHardfork::T13),
             Err(Error::MissingTempoHeaders { block_index: 0 })
         );
     }
@@ -1249,7 +1287,10 @@ mod tests {
             transactions: Vec::new(),
         };
 
-        assert_eq!(validate_system_inputs(&block, 0), Ok(()));
+        assert_eq!(
+            validate_system_inputs(&block, 0, TempoHardfork::T13),
+            Ok(())
+        );
     }
 
     #[test]

--- a/crates/spf/src/lib.rs
+++ b/crates/spf/src/lib.rs
@@ -12,7 +12,6 @@ use reth_evm::execute::BlockAssemblerInput;
 use reth_primitives_traits::SealedHeader;
 use reth_storage_api::noop::NoopProvider;
 use revm::{Database as _, database::State, database_interface::bal::EvmDatabaseError};
-use tempo_chainspec::{TempoHardfork, spec::TempoHardforks as _};
 use tempo_evm::{TempoBlockAssembler, TempoEvmConfig};
 use tempo_primitives::{TempoHeader, TempoPrimitives};
 use zone_precompiles::{inbox, outbox, tempo_state};
@@ -33,8 +32,8 @@ pub use types::*;
 ///
 /// `config` is trusted network configuration chosen by the verifier. Every
 /// other value is prover supplied and must be validated against witness-backed
-/// execution. Before T13 the replay may end at an open Zone tip without withdrawal
-/// finalization. Every T13 batch must end at a full block's finalization boundary.
+/// execution. The prover launches with TIP-1096, so every batch must end at a full
+/// block's withdrawal finalization boundary.
 pub fn prove_zone_batch(config: &SpfConfig, witness: BatchWitness) -> Result<BatchOutput, Error> {
     // The parent header is the committed starting point for this batch. Its
     // hash binds the witness to the previously submitted Zone block, and its
@@ -168,12 +167,9 @@ pub fn prove_zone_batch(config: &SpfConfig, witness: BatchWitness) -> Result<Bat
             });
         }
 
-        let hardfork = config.chain_spec().tempo_hardfork_at(block.timestamp);
-        validate_system_inputs(block, block_index, hardfork)?;
-        if hardfork.is_t13() {
-            let is_last = block_index + 1 == witness.zone_blocks.len();
-            validate_t13_block_shape(block, is_last)?;
-        }
+        validate_system_inputs(block, block_index)?;
+        let is_last = block_index + 1 == witness.zone_blocks.len();
+        validate_batch_block_shape(block, is_last)?;
 
         // The EVM environment uses the verifier-selected fork schedule at this
         // block's timestamp. An imported Tempo header changes the L1 reader
@@ -433,22 +429,18 @@ fn validate_tempo_anchor(
     Ok(())
 }
 
-fn validate_t13_block_shape(block: &ZoneBlock, is_last: bool) -> Result<(), Error> {
+fn validate_batch_block_shape(block: &ZoneBlock, is_last: bool) -> Result<(), Error> {
     let valid = match &block.tempo_import {
         TempoImport::CheckpointOnly { .. } => !is_last,
         TempoImport::Full { .. } => is_last && block.finalize_withdrawal_batch_count.is_some(),
     };
     if !valid {
-        return Err(Error::InvalidT13BatchShape);
+        return Err(Error::InvalidBatchShape);
     }
     Ok(())
 }
 
-fn validate_system_inputs(
-    block: &ZoneBlock,
-    index: usize,
-    hardfork: TempoHardfork,
-) -> Result<(), Error> {
+fn validate_system_inputs(block: &ZoneBlock, index: usize) -> Result<(), Error> {
     if block.tempo_import.headers_rlp().is_empty() {
         return Err(Error::MissingTempoHeaders { block_index: index });
     }
@@ -458,9 +450,8 @@ fn validate_system_inputs(
             enabled_tokens,
             ..
         } => {
-            if hardfork.is_t13()
-                && (deposits.len() > MAX_UNPROCESSED_DEPOSITS
-                    || enabled_tokens.len() > MAX_UNPROCESSED_TOKEN_ENABLEMENTS)
+            if deposits.len() > MAX_UNPROCESSED_DEPOSITS
+                || enabled_tokens.len() > MAX_UNPROCESSED_TOKEN_ENABLEMENTS
             {
                 return Err(Error::PortalWorkCapacityExceeded { block_index: index });
             }
@@ -524,10 +515,10 @@ pub enum Error {
     /// A full block exceeded a protocol-wide outstanding portal-work bound.
     #[error("zone block {block_index} exceeds portal-work capacity")]
     PortalWorkCapacityExceeded { block_index: usize },
-    /// A T13 batch must contain exactly one full operational block at the end, optionally preceded
+    /// A batch must contain exactly one full operational block at the end, optionally preceded
     /// by checkpoint-only blocks.
-    #[error("invalid T13 batch shape")]
-    InvalidT13BatchShape,
+    #[error("invalid batch shape")]
+    InvalidBatchShape,
     /// The witness identifies a Zone other than the verifier-selected chain specification.
     #[error("Zone chain ID mismatch: expected {expected}, got {actual}")]
     ChainIdMismatch { expected: u64, actual: u64 },
@@ -840,7 +831,7 @@ mod tests {
     }
 
     #[test]
-    fn t13_batch_shape_rejects_multiple_full_blocks() {
+    fn batch_shape_rejects_multiple_full_blocks() {
         let mut witness = minimal_batch_witness();
         for number in 1..=2 {
             witness.zone_blocks.push(ZoneBlock {
@@ -855,15 +846,15 @@ mod tests {
                 transactions: Vec::new(),
             });
         }
-        validate_system_inputs(&witness.zone_blocks[0], 0, TempoHardfork::T13).unwrap();
+        validate_system_inputs(&witness.zone_blocks[0], 0).unwrap();
         assert_eq!(
-            validate_t13_block_shape(&witness.zone_blocks[0], false),
-            Err(Error::InvalidT13BatchShape)
+            validate_batch_block_shape(&witness.zone_blocks[0], false),
+            Err(Error::InvalidBatchShape)
         );
     }
 
     #[test]
-    fn t13_batch_shape_rejects_checkpoint_only_batch() {
+    fn batch_shape_rejects_checkpoint_only_batch() {
         let mut witness = minimal_batch_witness();
         witness.zone_blocks.push(ZoneBlock {
             number: 1,
@@ -876,10 +867,10 @@ mod tests {
             finalize_withdrawal_batch_encrypted_senders: Vec::new(),
             transactions: Vec::new(),
         });
-        validate_system_inputs(&witness.zone_blocks[0], 0, TempoHardfork::T13).unwrap();
+        validate_system_inputs(&witness.zone_blocks[0], 0).unwrap();
         assert_eq!(
-            validate_t13_block_shape(&witness.zone_blocks[0], true),
-            Err(Error::InvalidT13BatchShape)
+            validate_batch_block_shape(&witness.zone_blocks[0], true),
+            Err(Error::InvalidBatchShape)
         );
     }
 
@@ -1214,7 +1205,7 @@ mod tests {
     }
 
     #[test]
-    fn portal_work_capacity_activates_at_t13() {
+    fn rejects_portal_work_above_capacity() {
         for (deposit_count, token_count) in [
             (MAX_UNPROCESSED_DEPOSITS + 1, 0),
             (0, MAX_UNPROCESSED_TOKEN_ENABLEMENTS + 1),
@@ -1236,18 +1227,14 @@ mod tests {
                 transactions: Vec::new(),
             };
             assert_eq!(
-                validate_system_inputs(&block, 0, TempoHardfork::T12),
-                Ok(())
-            );
-            assert_eq!(
-                validate_system_inputs(&block, 0, TempoHardfork::T13),
+                validate_system_inputs(&block, 0),
                 Err(Error::PortalWorkCapacityExceeded { block_index: 0 })
             );
         }
     }
 
     #[test]
-    fn accepts_an_open_snapshot_without_finalization() {
+    fn final_full_block_requires_withdrawal_finalization() {
         let witness = minimal_batch_witness();
         let mut block = ZoneBlock {
             number: 1,
@@ -1261,13 +1248,16 @@ mod tests {
             transactions: Vec::new(),
         };
 
+        assert_eq!(validate_system_inputs(&block, 0), Ok(()));
         assert_eq!(
-            validate_system_inputs(&block, 0, TempoHardfork::T13),
-            Ok(())
+            validate_batch_block_shape(&block, true),
+            Err(Error::InvalidBatchShape)
         );
+        block.finalize_withdrawal_batch_count = Some(U256::ZERO);
+        assert_eq!(validate_batch_block_shape(&block, true), Ok(()));
         block.tempo_import = checkpoint_import(Vec::new());
         assert_eq!(
-            validate_system_inputs(&block, 0, TempoHardfork::T13),
+            validate_system_inputs(&block, 0),
             Err(Error::MissingTempoHeaders { block_index: 0 })
         );
     }
@@ -1287,10 +1277,7 @@ mod tests {
             transactions: Vec::new(),
         };
 
-        assert_eq!(
-            validate_system_inputs(&block, 0, TempoHardfork::T13),
-            Ok(())
-        );
+        assert_eq!(validate_system_inputs(&block, 0), Ok(()));
     }
 
     #[test]

--- a/crates/spf/src/lib.rs
+++ b/crates/spf/src/lib.rs
@@ -1218,9 +1218,24 @@ mod tests {
                 beneficiary: Address::ZERO,
                 tempo_import: TempoImport::Full {
                     header_rlp: Bytes::from([0x01]),
-                    deposits: vec![Default::default(); deposit_count],
+                    deposits: vec![
+                        tempo_zone_contracts::QueuedDeposit {
+                            depositType: tempo_zone_contracts::DepositType::Deposit,
+                            depositData: Bytes::new(),
+                            rejected: false,
+                        };
+                        deposit_count
+                    ],
                     decryptions: Vec::new(),
-                    enabled_tokens: vec![Default::default(); token_count],
+                    enabled_tokens: vec![
+                        tempo_zone_contracts::EnabledToken {
+                            token: Address::ZERO,
+                            name: String::new(),
+                            symbol: String::new(),
+                            currency: String::new(),
+                        };
+                        token_count
+                    ],
                 },
                 finalize_withdrawal_batch_count: None,
                 finalize_withdrawal_batch_encrypted_senders: Vec::new(),

--- a/xtask/src/check_abi.rs
+++ b/xtask/src/check_abi.rs
@@ -131,9 +131,9 @@ fn zone_inbox_z1_surface() -> eyre::Result<AbiSurface> {
     Ok(AbiSurface::from_abi(&abi))
 }
 
-fn zone_portal_t12_surface() -> eyre::Result<AbiSurface> {
+fn zone_portal_t13_surface() -> eyre::Result<AbiSurface> {
     let abi = AbiProjection {
-        retired: tempo_zone_contracts::ZonePortalPreT12Retired::abi::contract(),
+        retired: tempo_zone_contracts::ZonePortalPreT13Retired::abi::contract(),
     }
     .apply(tempo_zone_contracts::ZonePortal::abi::contract())?;
     Ok(AbiSurface::from_abi(&abi))
@@ -163,7 +163,7 @@ const INTERFACES: &[InterfaceSpec] = &[
         name: "ZonePortal",
         artifact_name: "IZonePortal",
         source: "IZone.sol",
-        rust: zone_portal_t12_surface,
+        rust: zone_portal_t13_surface,
         ignored_functions: &[],
     },
 ];


### PR DESCRIPTION
Ref: https://tips.sh/1096
Ref: https://github.com/tempoxyz/tempo/pull/7521

Move TIP-1096 activation from T12 to T13 across Tempo imports, token cursors and events, recovery production, and settlement ABI selection. The prover launches together with TIP-1096, so its batch-shape and outstanding-work checks apply unconditionally.

Pin Tempo to main revision `346c22eb`, which includes the T13 plumbing and matching L1 runtime activation. Stacked on `prover` (#1320).
