### PR TITLE
fix(ci): pin Foundry setup with GitHub CLI bootstrap

### DIFF
--- a/.github/workflows/contracts.yml
+++ b/.github/workflows/contracts.yml
@@ -48,7 +48,7 @@ jobs:
           version: v0.15.0
 
       - name: Install Foundry
-        uses: tempoxyz/gh-actions/actions/setup-foundry@16356ec5155405ba5e33f5558e80b5bf77eb70ab
+        uses: tempoxyz/gh-actions/actions/setup-foundry@22a3c7b7fd5e0975bd7c1aaa9de61905afb1da9d
         with:
           version: nightly
 
@@ -72,7 +72,7 @@ jobs:
           persist-credentials: false
 
       - name: Install Foundry
-        uses: tempoxyz/gh-actions/actions/setup-foundry@16356ec5155405ba5e33f5558e80b5bf77eb70ab
+        uses: tempoxyz/gh-actions/actions/setup-foundry@22a3c7b7fd5e0975bd7c1aaa9de61905afb1da9d
         with:
           version: nightly
 
@@ -107,7 +107,7 @@ jobs:
           persist-credentials: false
 
       - name: Install Foundry
-        uses: tempoxyz/gh-actions/actions/setup-foundry@16356ec5155405ba5e33f5558e80b5bf77eb70ab
+        uses: tempoxyz/gh-actions/actions/setup-foundry@22a3c7b7fd5e0975bd7c1aaa9de61905afb1da9d
         with:
           version: nightly
 

--- a/.github/workflows/storage-layout.yml
+++ b/.github/workflows/storage-layout.yml
@@ -24,7 +24,7 @@ jobs:
           persist-credentials: false
 
       - name: Install Foundry
-        uses: tempoxyz/gh-actions/actions/setup-foundry@16356ec5155405ba5e33f5558e80b5bf77eb70ab
+        uses: tempoxyz/gh-actions/actions/setup-foundry@22a3c7b7fd5e0975bd7c1aaa9de61905afb1da9d
         with:
           version: nightly
 

--- a/.github/workflows/sync-tempo-zone-runtimes.yml
+++ b/.github/workflows/sync-tempo-zone-runtimes.yml
@@ -29,7 +29,7 @@ jobs:
           persist-credentials: false
 
       - name: Install Foundry
-        uses: tempoxyz/gh-actions/actions/setup-foundry@16356ec5155405ba5e33f5558e80b5bf77eb70ab
+        uses: tempoxyz/gh-actions/actions/setup-foundry@22a3c7b7fd5e0975bd7c1aaa9de61905afb1da9d
         with:
           version: nightly
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -59,7 +59,7 @@ jobs:
         with:
           tool: nextest@0.9.124
       - name: Install Foundry
-        uses: tempoxyz/gh-actions/actions/setup-foundry@16356ec5155405ba5e33f5558e80b5bf77eb70ab
+        uses: tempoxyz/gh-actions/actions/setup-foundry@22a3c7b7fd5e0975bd7c1aaa9de61905afb1da9d
         with:
           version: nightly
 

--- a/.github/workflows/zones-benchmark.yml
+++ b/.github/workflows/zones-benchmark.yml
@@ -572,7 +572,7 @@ jobs:
         with:
           version: v0.15.0
 
-      - uses: tempoxyz/gh-actions/actions/setup-foundry@16356ec5155405ba5e33f5558e80b5bf77eb70ab
+      - uses: tempoxyz/gh-actions/actions/setup-foundry@22a3c7b7fd5e0975bd7c1aaa9de61905afb1da9d
         with:
           version: nightly
 


### PR DESCRIPTION
Update all seven `setup-foundry` references across five workflows to the latest `gh-actions` revision, [`22a3c7b`](https://github.com/tempoxyz/gh-actions/commit/22a3c7b7fd5e0975bd7c1aaa9de61905afb1da9d), which includes the merged [GitHub CLI bootstrap fix](https://github.com/tempoxyz/gh-actions/pull/126).

This addresses the `gh: command not found` failure during Foundry setup on the self-hosted benchmark runner in [run 34127842878](https://github.com/tempoxyz/zones/actions/runs/34127842878). The updated action provisions a verified CLI when missing or incompatible and retains Foundry attestation verification.

Validation: confirmed the latest upstream revision contains the fix, all seven references use that SHA, Actionlint passed for all five changed workflows (ShellCheck disabled), and `git diff --check` passed. The benchmark has not been rerun; a new run must use the updated workflow after merge.

Prompted by: @0xrusowsky
