### PR TITLE
fix(node): enforce first-header leader for recovery blocks

### DIFF
--- a/crates/node/src/engine.rs
+++ b/crates/node/src/engine.rs
@@ -60,10 +60,10 @@ use zone_l1::{DepositQueue, EncryptionKeyRing, FinalizedTarget, L1BlockDeposits,
 use zone_p2p::{LeadershipSchedule, P2pPeerId};
 use zone_payload::{TempoImport, ZonePayloadAttributes, ZonePayloadTypes};
 
-/// Full-block production permit backed by the effective leadership schedule.
+/// Block production permit backed by the effective leadership schedule.
 ///
-/// Full blocks require the leader assigned to their imported Tempo header. Checkpoint-only blocks
-/// are leader-neutral and bypass this permit. An optimistic override is open-ended until the next
+/// Blocks require the leader assigned to their first imported Tempo header, including checkpoint
+/// ranges that cross a leadership change. An optimistic override is open-ended until the next
 /// finalized portal transition supplies the ordinary-authority boundary.
 #[derive(Debug, Clone)]
 pub struct ProductionPermit {
@@ -80,7 +80,7 @@ impl ProductionPermit {
         }
     }
 
-    /// Decide whether this node may produce the full zone block embedding `tempo_anchor`.
+    /// Decide whether this node may produce the zone block beginning at `tempo_anchor`.
     ///
     /// `None` authorizes production; `Some(exit)` is the reason the engine must stop.
     pub fn check(&self, tempo_anchor: u64) -> Option<EngineExit> {
@@ -478,11 +478,9 @@ impl AvailableBlockDrain for ZoneEngine {
     }
 
     fn permit(&self, block: &Self::Block) -> Option<EngineExit> {
-        self.production_permit.as_ref().and_then(|permit| {
-            block
-                .leader_anchor()
-                .and_then(|anchor| permit.check(anchor))
-        })
+        self.production_permit
+            .as_ref()
+            .and_then(|permit| permit.check(block.leader_anchor()))
     }
 
     async fn advance_one(&mut self, block: Self::Block) -> eyre::Result<()> {
@@ -499,12 +497,12 @@ struct AvailableTempoImport {
 impl AvailableTempoImport {
     /// Tempo anchor whose leader must produce this Zone block.
     ///
-    /// Checkpoint-only blocks have no designated leader. A full block imports exactly one Tempo
-    /// header, whose effective leader supplies its production authority.
-    fn leader_anchor(&self) -> Option<u64> {
+    /// The first imported header selects the leader even if later headers cross a handoff.
+    fn leader_anchor(&self) -> u64 {
         self.checkpoint_headers
-            .is_empty()
-            .then(|| self.l1_block.header.number())
+            .first()
+            .unwrap_or(&self.l1_block.header)
+            .number()
     }
 }
 
@@ -641,16 +639,55 @@ mod tests {
     }
 
     #[test]
-    fn checkpoint_import_is_not_leader_restricted() {
+    fn checkpoint_import_uses_first_header_leader() {
+        use commonware_cryptography::{Signer as _, ed25519::PrivateKey};
+        use zone_p2p::LeadershipState;
+
+        let outgoing = PrivateKey::from_seed(1).public_key();
+        let incoming = PrivateKey::from_seed(2).public_key();
+        let schedule = LeadershipSchedule::seeded(LeadershipState::new(1, outgoing.clone(), 0));
+        schedule
+            .publish(LeadershipState::new(2, incoming.clone(), 100))
+            .unwrap();
+        let outgoing_permit = ProductionPermit::new(schedule.clone(), outgoing);
+        let incoming_permit = ProductionPermit::new(schedule, incoming);
         let available = AvailableTempoImport {
             l1_block: L1BlockDeposits {
                 header: header(90, 90),
                 events: Default::default(),
             },
-            checkpoint_headers: vec![header(90, 90), header(110, 110)],
+            checkpoint_headers: (90..=110).map(|number| header(number, number)).collect(),
         };
 
-        assert_eq!(available.leader_anchor(), None);
+        assert_eq!(available.leader_anchor(), 90);
+        assert_eq!(outgoing_permit.check(available.leader_anchor()), None);
+        assert_eq!(
+            incoming_permit.check(available.leader_anchor()),
+            Some(EngineExit::Demoted {
+                tempo_anchor: 90,
+                epoch: 1
+            })
+        );
+
+        // The next range independently selects the incoming leader, as does a full import.
+        for checkpoint_headers in [vec![header(111, 111)], Vec::new()] {
+            let next = AvailableTempoImport {
+                l1_block: L1BlockDeposits {
+                    header: header(111, 111),
+                    events: Default::default(),
+                },
+                checkpoint_headers,
+            };
+            assert_eq!(next.leader_anchor(), 111);
+            assert_eq!(incoming_permit.check(next.leader_anchor()), None);
+            assert_eq!(
+                outgoing_permit.check(next.leader_anchor()),
+                Some(EngineExit::Demoted {
+                    tempo_anchor: 111,
+                    epoch: 2
+                })
+            );
+        }
     }
 
     #[test]

--- a/crates/node/src/replication.rs
+++ b/crates/node/src/replication.rs
@@ -707,9 +707,9 @@ pub(crate) async fn collect_follower_settlement_signatures<P>(
 
 /// Import live/backfilled blocks in canonical order on a follower.
 ///
-/// Live full blocks are only imported when the sender equals the leader for their imported Tempo
-/// header. Checkpoint-only blocks have no designated leader and may be imported from any authorized
-/// P2P peer. The full-block check resolves accidental split brain using the finalized schedule.
+/// Live blocks are only imported when the sender equals the leader for their first imported Tempo
+/// header. This also applies to checkpoint-only ranges that cross a leadership change, resolving
+/// accidental split brain using the finalized schedule.
 ///
 /// Backfilled blocks carry no producer claim and are judged by
 /// parent/anchor/execution/conflict validation alone. The loop exits when `stop` fires.
@@ -1198,10 +1198,9 @@ where
         }
         Err(PeerAnchorWaitError::Other(error)) => return Err(error),
     }
-    // Resolve live full-block production authority after observing its imported header, which may
-    // publish the leadership transition governing that same anchor. Checkpoint-only blocks are
-    // leader-neutral, and backfilled blocks carry no producer claim.
-    validate_live_import_sender(
+    // Resolve production authority after observing the imported range, which may publish the
+    // leadership transition governing its first header. Backfilled blocks carry no producer claim.
+    validate_live_block_sender(
         schedule,
         peer_block.live_sender.as_ref(),
         leader_anchor,
@@ -1279,18 +1278,6 @@ fn validate_live_block_sender(
              record governs",
         ),
     }
-}
-
-fn validate_live_import_sender(
-    schedule: &LeadershipSchedule,
-    live_sender: Option<&P2pPeerId>,
-    leader_anchor: Option<u64>,
-    block_number: u64,
-) -> eyre::Result<()> {
-    let Some(anchor_number) = leader_anchor else {
-        return Ok(());
-    };
-    validate_live_block_sender(schedule, live_sender, anchor_number, block_number)
 }
 
 fn reconcile_canonical_import(
@@ -1504,13 +1491,12 @@ impl DecodedTempoImport {
 
     /// Tempo anchor whose leader must produce this Zone block.
     ///
-    /// Checkpoint-only blocks have no designated leader. A full block imports exactly one Tempo
-    /// header, whose effective leader supplies its production authority.
-    fn leader_anchor(&self) -> Option<u64> {
-        match self {
-            Self::Full { header, .. } => Some(header.number()),
-            Self::CheckpointOnly { .. } => None,
-        }
+    /// The first imported header selects the leader even if later headers cross a handoff.
+    fn leader_anchor(&self) -> u64 {
+        self.headers()
+            .first()
+            .expect("decoded nonempty Tempo import")
+            .number()
     }
 }
 
@@ -1994,7 +1980,7 @@ mod tests {
     }
 
     #[test]
-    fn checkpoint_live_producer_is_not_leader_restricted() {
+    fn checkpoint_live_producer_uses_first_header_leader() {
         use commonware_cryptography::{Signer as _, ed25519::PrivateKey};
         use reth_primitives_traits::SealedHeader;
         use tempo_primitives::TempoHeader;
@@ -2006,7 +1992,7 @@ mod tests {
             .publish(LeadershipState::new(2, incoming.clone(), 100))
             .unwrap();
 
-        let headers = [90, 110]
+        let headers = (90..=110)
             .map(|number| {
                 SealedHeader::seal_slow(TempoHeader {
                     inner: alloy_consensus::Header {
@@ -2016,13 +2002,15 @@ mod tests {
                     ..Default::default()
                 })
             })
-            .to_vec();
+            .collect();
         let tempo_import = super::DecodedTempoImport::CheckpointOnly { headers };
 
         let leader_anchor = tempo_import.leader_anchor();
-        assert_eq!(leader_anchor, None);
-        super::validate_live_import_sender(&schedule, Some(&outgoing), leader_anchor, 7).unwrap();
-        super::validate_live_import_sender(&schedule, Some(&incoming), leader_anchor, 7).unwrap();
+        assert_eq!(leader_anchor, 90);
+        super::validate_live_block_sender(&schedule, Some(&outgoing), leader_anchor, 7).unwrap();
+        let error = super::validate_live_block_sender(&schedule, Some(&incoming), leader_anchor, 7)
+            .expect_err("a crossed handoff must not change the catch-up producer");
+        assert!(error.to_string().contains(&outgoing.to_string()));
 
         let full_import = super::DecodedTempoImport::Full {
             header: Box::new(SealedHeader::seal_slow(TempoHeader {
@@ -2036,11 +2024,10 @@ mod tests {
             enabled_tokens: Vec::new(),
         };
         let leader_anchor = full_import.leader_anchor();
-        assert_eq!(leader_anchor, Some(110));
-        super::validate_live_import_sender(&schedule, Some(&incoming), leader_anchor, 8).unwrap();
-        let error =
-            super::validate_live_import_sender(&schedule, Some(&outgoing), leader_anchor, 8)
-                .expect_err("the final full block must be produced by its effective leader");
+        assert_eq!(leader_anchor, 110);
+        super::validate_live_block_sender(&schedule, Some(&incoming), leader_anchor, 8).unwrap();
+        let error = super::validate_live_block_sender(&schedule, Some(&outgoing), leader_anchor, 8)
+            .expect_err("the final full block must be produced by its effective leader");
         assert!(error.to_string().contains(&incoming.to_string()));
     }
 


### PR DESCRIPTION
Ref: https://tips.sh/1096

Header-only recovery blocks bypassed the production permit and live P2P sender check, allowing different sequencers to build competing catch-up chains. Select the leader at the first imported Tempo header for both checks, even when the range crosses a leadership change. Each subsequent block derives its leader independently from its own first header using the existing schedule and forced-recovery override.
