### PR TITLE
fix(bench): validate reference runtimes with T12

### DIFF
--- a/contrib/bench/provision-topology.sh
+++ b/contrib/bench/provision-topology.sh
@@ -125,6 +125,26 @@ wait_for_chain_advance() {
     die "timed out waiting for $label chain to advance past block $start_block"
 }
 
+verify_shared_runtimes() {
+    local url="$1" label="$2" block spec contract address expected observed
+    block="$(rpc "$url" eth_blockNumber)" || die "$label failed to read the runtime verification block"
+    (( $(hex_to_dec "$block") > 0 )) || die "$label has not produced a block to verify shared runtimes"
+    for spec in \
+        ZonePortal:0x5AD1000000000000000000000000000000000000 \
+        Verifier:0x5a56000000000000000000000000000000000000 \
+        ZoneMessenger:0x5A4d000000000000000000000000000000000000
+    do
+        contract="${spec%%:*}" address="${spec#*:}"
+        expected="$(jq -er '.deployedBytecode.object | sub("^0x"; "") | select(test("^([0-9a-fA-F]{2})+$"))' \
+            "$ZONES_ROOT/crates/contracts/out/$contract.sol/$contract.json")" \
+            || die "invalid or missing $contract deployed bytecode artifact"
+        observed="$(rpc "$url" eth_getCode "[\"$address\",\"$block\"]")" \
+            || die "$label failed to read $contract runtime at $address"
+        [[ "${observed,,}" == "0x${expected,,}" ]] \
+            || die "$label $contract runtime at $address differs from the local artifact after block $block; refusing to benchmark replaced runtimes"
+    done
+}
+
 verify_history_storage() {
     local url="$1"
     local label="$2"
@@ -871,6 +891,8 @@ provision_up() {
     wait_for_peer "$l1_b_rpc" "Tempo validator B" "$rpc_timeout"
     wait_for_chain_advance "$l1_a_rpc" "Tempo validator A" "$rpc_timeout"
     wait_for_chain_advance "$l1_b_rpc" "Tempo validator B" "$rpc_timeout"
+    verify_shared_runtimes "$l1_a_rpc" "Tempo validator A"
+    verify_shared_runtimes "$l1_b_rpc" "Tempo validator B"
     verify_history_storage "$l1_a_rpc" "Tempo validator A"
     verify_history_storage "$l1_b_rpc" "Tempo validator B"
 

--- a/xtask/src/install_reference_zone_factory.rs
+++ b/xtask/src/install_reference_zone_factory.rs
@@ -17,6 +17,7 @@ use std::{
 use tempo_contracts::{
     precompiles::INITIAL_FACTORY_OWNER,
     zones::{
+        T12_ZONE_MESSENGER_RUNTIME, T12_ZONE_PORTAL_RUNTIME, T12_ZONE_VERIFIER_RUNTIME,
         ZONE_MESSENGER_RUNTIME as TEMPO_ZONE_MESSENGER_RUNTIME,
         ZONE_PORTAL_RUNTIME as TEMPO_ZONE_PORTAL_RUNTIME,
         ZONE_VERIFIER_RUNTIME as TEMPO_ZONE_VERIFIER_RUNTIME,
@@ -212,36 +213,37 @@ fn install_native_zone_factory(
         }
     }
 
-    for (name, address, code, tempo_code) in [
+    for (name, address, code, tempo_codes) in [
         (
             "ZonePortal implementation",
             ZONE_PORTAL_IMPL_ADDRESS,
             artifacts.portal,
-            TEMPO_ZONE_PORTAL_RUNTIME,
+            [TEMPO_ZONE_PORTAL_RUNTIME, T12_ZONE_PORTAL_RUNTIME],
         ),
         (
             "Verifier",
             ZONE_VERIFIER_ADDRESS,
             artifacts.verifier,
-            TEMPO_ZONE_VERIFIER_RUNTIME,
+            [TEMPO_ZONE_VERIFIER_RUNTIME, T12_ZONE_VERIFIER_RUNTIME],
         ),
         (
             "ZoneMessenger",
             ZONE_MESSENGER_ADDRESS,
             artifacts.messenger,
-            TEMPO_ZONE_MESSENGER_RUNTIME,
+            [TEMPO_ZONE_MESSENGER_RUNTIME, T12_ZONE_MESSENGER_RUNTIME],
         ),
     ] {
         let expected = GenesisAccount::default()
             .with_nonce(Some(1))
             .with_code(Some(code));
-        let tempo_runtime = GenesisAccount::default().with_code(Some(tempo_code));
+        let known_tempo_runtimes =
+            tempo_codes.map(|code| GenesisAccount::default().with_code(Some(code)));
         match genesis.alloc.get(&address) {
             None => {
                 genesis.alloc.insert(address, expected);
             }
             Some(existing) if existing == &expected => {}
-            Some(existing) if existing == &tempo_runtime => {
+            Some(existing) if known_tempo_runtimes.contains(existing) => {
                 genesis.alloc.insert(address, expected);
             }
             Some(_) => {
@@ -295,6 +297,23 @@ mod tests {
 
     #[test]
     fn replaces_pinned_tempo_shared_runtimes() {
+        assert_replaces_shared_runtimes([
+            TEMPO_ZONE_PORTAL_RUNTIME,
+            TEMPO_ZONE_VERIFIER_RUNTIME,
+            TEMPO_ZONE_MESSENGER_RUNTIME,
+        ]);
+    }
+
+    #[test]
+    fn replaces_t12_tempo_shared_runtimes() {
+        assert_replaces_shared_runtimes([
+            T12_ZONE_PORTAL_RUNTIME,
+            T12_ZONE_VERIFIER_RUNTIME,
+            T12_ZONE_MESSENGER_RUNTIME,
+        ]);
+    }
+
+    fn assert_replaces_shared_runtimes([portal, verifier, messenger]: [Bytes; 3]) {
         let owner = address!("0x0000000000000000000000000000000000000001");
         let mut genesis = Genesis::default();
         genesis.alloc.insert(
@@ -302,9 +321,9 @@ mod tests {
             native_factory_account(INITIAL_FACTORY_OWNER),
         );
         for (address, code) in [
-            (ZONE_PORTAL_IMPL_ADDRESS, TEMPO_ZONE_PORTAL_RUNTIME),
-            (ZONE_VERIFIER_ADDRESS, TEMPO_ZONE_VERIFIER_RUNTIME),
-            (ZONE_MESSENGER_ADDRESS, TEMPO_ZONE_MESSENGER_RUNTIME),
+            (ZONE_PORTAL_IMPL_ADDRESS, portal),
+            (ZONE_VERIFIER_ADDRESS, verifier),
+            (ZONE_MESSENGER_ADDRESS, messenger),
         ] {
             genesis
                 .alloc
@@ -338,12 +357,58 @@ mod tests {
 
     #[test]
     fn rejects_unknown_shared_runtime() {
+        for (name, address) in [
+            ("ZonePortal implementation", ZONE_PORTAL_IMPL_ADDRESS),
+            ("Verifier", ZONE_VERIFIER_ADDRESS),
+            ("ZoneMessenger", ZONE_MESSENGER_ADDRESS),
+        ] {
+            assert_rejects_shared_runtime(
+                name,
+                address,
+                GenesisAccount::default().with_code(Some(Bytes::from_static(&[0xff]))),
+            );
+        }
+    }
+
+    #[test]
+    fn rejects_known_shared_runtimes_with_non_default_state() {
+        for (name, address, codes) in [
+            (
+                "ZonePortal implementation",
+                ZONE_PORTAL_IMPL_ADDRESS,
+                [TEMPO_ZONE_PORTAL_RUNTIME, T12_ZONE_PORTAL_RUNTIME],
+            ),
+            (
+                "Verifier",
+                ZONE_VERIFIER_ADDRESS,
+                [TEMPO_ZONE_VERIFIER_RUNTIME, T12_ZONE_VERIFIER_RUNTIME],
+            ),
+            (
+                "ZoneMessenger",
+                ZONE_MESSENGER_ADDRESS,
+                [TEMPO_ZONE_MESSENGER_RUNTIME, T12_ZONE_MESSENGER_RUNTIME],
+            ),
+        ] {
+            for code in codes {
+                let account = GenesisAccount::default().with_code(Some(code));
+                for conflicting in [
+                    account.clone().with_nonce(Some(1)),
+                    account.clone().with_balance(U256::ONE),
+                    account.with_storage(Some(BTreeMap::from([(
+                        B256::ZERO,
+                        B256::with_last_byte(1),
+                    )]))),
+                ] {
+                    assert_rejects_shared_runtime(name, address, conflicting);
+                }
+            }
+        }
+    }
+
+    fn assert_rejects_shared_runtime(name: &str, address: Address, account: GenesisAccount) {
         let owner = address!("0x0000000000000000000000000000000000000001");
         let mut genesis = Genesis::default();
-        genesis.alloc.insert(
-            ZONE_PORTAL_IMPL_ADDRESS,
-            GenesisAccount::default().with_code(Some(Bytes::from_static(&[0xff]))),
-        );
+        genesis.alloc.insert(address, account.clone());
 
         let error = install_native_zone_factory(
             &mut genesis,
@@ -357,7 +422,8 @@ mod tests {
         .unwrap_err();
         assert_eq!(
             error.to_string(),
-            "refusing to replace conflicting ZonePortal implementation allocation at 0x5AD1000000000000000000000000000000000000"
+            format!("refusing to replace conflicting {name} allocation at {address}")
         );
+        assert_eq!(genesis.alloc[&address], account);
     }
 }

--- a/xtask/src/install_reference_zone_factory.rs
+++ b/xtask/src/install_reference_zone_factory.rs
@@ -296,24 +296,20 @@ mod tests {
     }
 
     #[test]
-    fn replaces_pinned_tempo_shared_runtimes() {
-        assert_replaces_shared_runtimes([
+    fn validates_tempo_shared_runtimes() {
+        assert_validates_shared_runtimes([
             TEMPO_ZONE_PORTAL_RUNTIME,
             TEMPO_ZONE_VERIFIER_RUNTIME,
             TEMPO_ZONE_MESSENGER_RUNTIME,
         ]);
-    }
-
-    #[test]
-    fn replaces_t12_tempo_shared_runtimes() {
-        assert_replaces_shared_runtimes([
+        assert_validates_shared_runtimes([
             T12_ZONE_PORTAL_RUNTIME,
             T12_ZONE_VERIFIER_RUNTIME,
             T12_ZONE_MESSENGER_RUNTIME,
         ]);
     }
 
-    fn assert_replaces_shared_runtimes([portal, verifier, messenger]: [Bytes; 3]) {
+    fn assert_validates_shared_runtimes([portal, verifier, messenger]: [Bytes; 3]) {
         let owner = address!("0x0000000000000000000000000000000000000001");
         let mut genesis = Genesis::default();
         genesis.alloc.insert(
@@ -330,6 +326,7 @@ mod tests {
                 .insert(address, GenesisAccount::default().with_code(Some(code)));
         }
 
+        let upstream_alloc = genesis.alloc.clone();
         let artifacts = NativeArtifacts {
             portal: Bytes::from_static(&[1]),
             verifier: Bytes::from_static(&[2]),
@@ -352,60 +349,22 @@ mod tests {
                     .with_nonce(Some(1))
                     .with_code(Some(code))
             );
-        }
-    }
-
-    #[test]
-    fn rejects_unknown_shared_runtime() {
-        for (name, address) in [
-            ("ZonePortal implementation", ZONE_PORTAL_IMPL_ADDRESS),
-            ("Verifier", ZONE_VERIFIER_ADDRESS),
-            ("ZoneMessenger", ZONE_MESSENGER_ADDRESS),
-        ] {
-            assert_rejects_shared_runtime(
-                name,
-                address,
-                GenesisAccount::default().with_code(Some(Bytes::from_static(&[0xff]))),
-            );
-        }
-    }
-
-    #[test]
-    fn rejects_known_shared_runtimes_with_non_default_state() {
-        for (name, address, codes) in [
-            (
-                "ZonePortal implementation",
-                ZONE_PORTAL_IMPL_ADDRESS,
-                [TEMPO_ZONE_PORTAL_RUNTIME, T12_ZONE_PORTAL_RUNTIME],
-            ),
-            (
-                "Verifier",
-                ZONE_VERIFIER_ADDRESS,
-                [TEMPO_ZONE_VERIFIER_RUNTIME, T12_ZONE_VERIFIER_RUNTIME],
-            ),
-            (
-                "ZoneMessenger",
-                ZONE_MESSENGER_ADDRESS,
-                [TEMPO_ZONE_MESSENGER_RUNTIME, T12_ZONE_MESSENGER_RUNTIME],
-            ),
-        ] {
-            for code in codes {
-                let account = GenesisAccount::default().with_code(Some(code));
-                for conflicting in [
-                    account.clone().with_nonce(Some(1)),
-                    account.clone().with_balance(U256::ONE),
-                    account.with_storage(Some(BTreeMap::from([(
-                        B256::ZERO,
-                        B256::with_last_byte(1),
-                    )]))),
-                ] {
-                    assert_rejects_shared_runtime(name, address, conflicting);
-                }
+            let account = &upstream_alloc[&address];
+            for conflicting in [
+                account.clone().with_code(Some(Bytes::from_static(&[0xff]))),
+                account.clone().with_nonce(Some(1)),
+                account.clone().with_balance(U256::ONE),
+                account.clone().with_storage(Some(BTreeMap::from([(
+                    B256::ZERO,
+                    B256::with_last_byte(1),
+                )]))),
+            ] {
+                assert_rejects_shared_runtime(address, conflicting);
             }
         }
     }
 
-    fn assert_rejects_shared_runtime(name: &str, address: Address, account: GenesisAccount) {
+    fn assert_rejects_shared_runtime(address: Address, account: GenesisAccount) {
         let owner = address!("0x0000000000000000000000000000000000000001");
         let mut genesis = Genesis::default();
         genesis.alloc.insert(address, account.clone());
@@ -419,11 +378,9 @@ mod tests {
                 messenger: Bytes::from_static(&[3]),
             },
         )
-        .unwrap_err();
-        assert_eq!(
-            error.to_string(),
-            format!("refusing to replace conflicting {name} allocation at {address}")
-        );
+        .unwrap_err()
+        .to_string();
+        assert!(error.starts_with("refusing to replace conflicting"));
         assert_eq!(genesis.alloc[&address], account);
     }
 }


### PR DESCRIPTION
Tempo's `generate-localnet` enables T12 at genesis by default. Accept either pinned Tempo runtime generation for the portal, verifier, and messenger so the benchmark genesis installer recognizes valid T12 allocations. Full-account matching continues to reject unknown bytecode and non-default account state.

After both validators advance, compare all three shared runtimes at a fixed non-genesis block on each validator against the local Foundry artifacts. Abort before Zone creation if any runtime differs, is missing, or cannot be read. This catches Tempo's T12 hook replacing divergent reference artifacts; it detects that incompatibility but does not prevent the replacement. Hardfork configuration is unchanged.

One shared Rust test covers both runtime triplets, unknown code, and changed nonce, balance, and storage. Rejected accounts remain unchanged.

Validation:
- Formatting and diff checks passed; Bash syntax check passed.
- 36 mocked cases passed against the actual shell verification function: both validators, all three addresses, matching code, replaced/missing code, RPC failures, genesis/invalid block responses, malformed artifacts, and hex normalization.
- Full validator topology was not run locally. Local Rust tests were previously stopped while compiling RocksDB; CI validation remains separate.

Prompted by: @0xrusowsky
