### PR TITLE
feat(bench): select Tempo hardfork != `latest`

### DIFF
--- a/.github/workflows/zones-benchmark.yml
+++ b/.github/workflows/zones-benchmark.yml
@@ -141,6 +141,11 @@ on:
         type: string
         required: false
         default: ""
+      tempo-hardfork:
+        description: Latest Tempo hardfork active during the benchmark, or `latest`.
+        type: string
+        required: false
+        default: latest
       txgen-ref:
         description: Exact txgen commit SHA; empty resolves the current txgen HEAD.
         type: string
@@ -198,6 +203,7 @@ jobs:
       setup-settlement-timeout-secs: ${{ steps.config.outputs.setup-settlement-timeout-secs }}
       drain-timeout: ${{ steps.config.outputs.drain-timeout }}
       seed: ${{ steps.config.outputs.seed }}
+      tempo-hardfork: ${{ steps.config.outputs.tempo-hardfork }}
       tempo-ref: ${{ steps.config.outputs.tempo-ref }}
       txgen-ref: ${{ steps.config.outputs.txgen-ref }}
     steps:
@@ -234,6 +240,7 @@ jobs:
           INPUT_SETUP_SETTLEMENT_TIMEOUT_SECS: ${{ inputs.setup-settlement-timeout-secs || '120' }}
           INPUT_DRAIN_TIMEOUT: ${{ inputs.drain-timeout || '300' }}
           INPUT_SEED: ${{ inputs.seed || '' }}
+          INPUT_TEMPO_HARDFORK: ${{ inputs.tempo-hardfork || 'latest' }}
           INPUT_TXGEN_REF: ${{ inputs.txgen-ref || '' }}
           RUN_ID: ${{ github.run_id }}
           RUN_ATTEMPT: ${{ github.run_attempt }}
@@ -241,6 +248,11 @@ jobs:
           set -euo pipefail
 
           INPUT_TEMPO_REF="$(sed -nE 's/^tempo-alloy.*rev = "([0-9a-f]{40})".*/\1/p' Cargo.toml)"
+          INPUT_TEMPO_HARDFORK="${INPUT_TEMPO_HARDFORK,,}"
+          if [[ "$INPUT_TEMPO_HARDFORK" != latest && ! "$INPUT_TEMPO_HARDFORK" =~ ^t[0-9]+[a-z]*$ ]]; then
+            echo "::error::tempo-hardfork must be latest or a hardfork such as t11"
+            exit 1
+          fi
 
           if [ -z "$INPUT_TXGEN_REF" ]; then
             INPUT_TXGEN_REF="$(git ls-remote https://github.com/tempoxyz/txgen HEAD | awk '{print $1}')"
@@ -437,6 +449,7 @@ jobs:
             echo "setup-settlement-timeout-secs=$INPUT_SETUP_SETTLEMENT_TIMEOUT_SECS"
             echo "drain-timeout=$INPUT_DRAIN_TIMEOUT"
             echo "seed=$INPUT_SEED"
+            echo "tempo-hardfork=$INPUT_TEMPO_HARDFORK"
             echo "tempo-ref=$INPUT_TEMPO_REF"
             echo "txgen-ref=$INPUT_TXGEN_REF"
           } >> "$GITHUB_OUTPUT"
@@ -477,6 +490,7 @@ jobs:
       ZONES_BENCH_SETUP_SETTLEMENT_TIMEOUT_SECS: ${{ needs.authorize.outputs.setup-settlement-timeout-secs }}
       ZONES_BENCH_DRAIN_TIMEOUT: ${{ needs.authorize.outputs.drain-timeout }}
       ZONES_BENCH_SEED: ${{ needs.authorize.outputs.seed }}
+      ZONES_BENCH_TEMPO_HARDFORK: ${{ needs.authorize.outputs.tempo-hardfork }}
       ZONES_BENCH_TEMPO_REF: ${{ needs.authorize.outputs.tempo-ref }}
       ZONES_BENCH_TXGEN_REF: ${{ needs.authorize.outputs.txgen-ref }}
       ZONES_BENCH_ZONES_REF: ${{ needs.authorize.outputs.sha }}
@@ -736,6 +750,7 @@ jobs:
           fi
           {
             echo "ZONES_BENCH_L1_CACHE_REBUILT=$ZONES_BENCH_L1_CACHE_REBUILT"
+            echo "ZONES_BENCH_TEMPO_HARDFORK=$ZONES_BENCH_TEMPO_HARDFORK"
             echo "ZONES_BENCH_L1_CACHE_KEY=$ZONES_BENCH_L1_CACHE_KEY"
             echo "ZONES_BENCH_L1_CACHE_GENERATION=$ZONES_BENCH_L1_CACHE_GENERATION"
           } >> "$GITHUB_ENV"
@@ -938,6 +953,7 @@ jobs:
             echo "- Target: \`${ZONES_BENCH_TARGET_ID:-unavailable}\`"
             echo "- Zones revision: \`$ZONES_BENCH_ZONES_REF\`"
             echo "- Tempo revision: \`$ZONES_BENCH_TEMPO_REF\`"
+            echo "- Tempo hardfork: \`${ZONES_BENCH_TEMPO_HARDFORK:-unavailable}\`"
             echo "- Txgen revision: \`$ZONES_BENCH_TXGEN_REF\`"
             echo "- Earn revision: \`${ZONES_BENCH_EARN_REVISION:-unavailable}\`"
             echo "- Build: \`$ZONES_BENCH_BUILD_PROFILE\`, \`RUSTFLAGS=$RUSTFLAGS\`"
@@ -965,6 +981,7 @@ jobs:
           jq -n \
             --arg zonesRevision "$ZONES_BENCH_ZONES_REF" \
             --arg tempoRevision "$ZONES_BENCH_TEMPO_REF" \
+            --arg tempoHardfork "${ZONES_BENCH_TEMPO_HARDFORK:-}" \
             --arg txgenRevision "$ZONES_BENCH_TXGEN_REF" \
             --arg earnRevision "${ZONES_BENCH_EARN_REVISION:-}" \
             --arg buildProfile "$ZONES_BENCH_BUILD_PROFILE" \
@@ -1010,6 +1027,7 @@ jobs:
             '{
               zonesRevision: $zonesRevision,
               tempoRevision: $tempoRevision,
+              tempoHardfork: $tempoHardfork,
               txgenRevision: $txgenRevision,
               earnRevision: $earnRevision,
               buildProfile: $buildProfile,

--- a/.github/workflows/zones-benchmark.yml
+++ b/.github/workflows/zones-benchmark.yml
@@ -58,11 +58,6 @@ on:
         type: string
         required: true
         default: "2000000"
-      activity-amount:
-        description: Amount for each ordinary Zone TIP-20 transfer.
-        type: string
-        required: true
-        default: "1"
       withdrawal-amount:
         description: Net amount for each Zone withdrawal request.
         type: string
@@ -224,7 +219,7 @@ jobs:
           INPUT_FORCE_BLOAT: ${{ inputs.force-bloat == true }}
           INPUT_DEPOSIT_AMOUNT: ${{ inputs.deposit-amount || '2000000' }}
           INPUT_BOOTSTRAP_DEPOSIT_AMOUNT: ${{ inputs.bootstrap-deposit-amount || '10000000' }}
-          INPUT_ACTIVITY_AMOUNT: ${{ inputs.activity-amount || '1' }}
+          INPUT_ACTIVITY_AMOUNT: "1"
           INPUT_WITHDRAWAL_AMOUNT: ${{ inputs.withdrawal-amount || '1000000' }}
           INPUT_SWAP_MECHANISM: direct-swap
           INPUT_RECIPIENT_MODE: ${{ inputs.recipient-mode || 'existing' }}

--- a/contrib/bench/l1-snapshot.sh
+++ b/contrib/bench/l1-snapshot.sh
@@ -9,6 +9,7 @@ set -Eeuo pipefail
 readonly L1_SNAPSHOT_SCRIPT_DIR="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)"
 readonly L1_SNAPSHOT_ZONES_ROOT="$(cd -- "$L1_SNAPSHOT_SCRIPT_DIR/../.." && pwd)"
 readonly L1_SNAPSHOT_SCHEMA=1
+readonly L1_SNAPSHOT_FUTURE_HARDFORK_TIME=4102444800
 readonly L1_SNAPSHOT_ZONE_FACTORY="0x5aF2000000000000000000000000000000000000"
 readonly L1_SNAPSHOT_PORTAL_IMPL="0x5AD1000000000000000000000000000000000000"
 readonly L1_SNAPSHOT_VERIFIER="0x5a56000000000000000000000000000000000000"
@@ -37,6 +38,53 @@ l1_snapshot_require_uint() {
     local name="$1"
     local value="${!name:-}"
     [[ "$value" =~ ^[0-9]+$ ]] || l1_snapshot_die "$name must be an unsigned integer"
+}
+
+l1_snapshot_resolve_hardfork() {
+    local requested="${ZONES_BENCH_TEMPO_HARDFORK:-latest}"
+    requested="$(printf '%s' "$requested" | tr '[:upper:]' '[:lower:]')"
+    [[ "$requested" == latest || "$requested" =~ ^t[0-9]+[a-z]*$ ]] \
+        || l1_snapshot_die "ZONES_BENCH_TEMPO_HARDFORK must be latest or a hardfork such as t11"
+
+    L1_SNAPSHOT_SUPPORTED_HARDFORKS=()
+    local hardfork
+    while IFS= read -r hardfork; do
+        L1_SNAPSHOT_SUPPORTED_HARDFORKS+=("$hardfork")
+    done < <(
+        "$L1_SNAPSHOT_TEMPO_XTASK_BIN" generate-localnet --help \
+            | sed -nE 's/^[[:space:]]*--(t[0-9]+[a-z]*)-time([[:space:]].*)?$/\1/p'
+    )
+    (( ${#L1_SNAPSHOT_SUPPORTED_HARDFORKS[@]} > 0 )) \
+        || l1_snapshot_die "could not discover Tempo hardfork arguments"
+
+    if [[ "$requested" == latest ]]; then
+        local last_index
+        last_index=$((${#L1_SNAPSHOT_SUPPORTED_HARDFORKS[@]} - 1))
+        L1_SNAPSHOT_HARDFORK="${L1_SNAPSHOT_SUPPORTED_HARDFORKS[$last_index]}"
+    else
+        local found=0
+        for hardfork in "${L1_SNAPSHOT_SUPPORTED_HARDFORKS[@]}"; do
+            if [[ "$hardfork" == "$requested" ]]; then
+                found=1
+                L1_SNAPSHOT_HARDFORK="$hardfork"
+                break
+            fi
+        done
+        (( found )) \
+            || l1_snapshot_die "Tempo revision does not support hardfork '$requested'; supported: ${L1_SNAPSHOT_SUPPORTED_HARDFORKS[*]}"
+    fi
+
+    L1_SNAPSHOT_HARDFORK_ARGS=()
+    local activation=0 selected=0
+    for hardfork in "${L1_SNAPSHOT_SUPPORTED_HARDFORKS[@]}"; do
+        if (( selected )); then
+            activation=$L1_SNAPSHOT_FUTURE_HARDFORK_TIME
+        fi
+        L1_SNAPSHOT_HARDFORK_ARGS+=("--${hardfork}-time" "$activation")
+        if [[ "$hardfork" == "$L1_SNAPSHOT_HARDFORK" ]]; then
+            selected=1
+        fi
+    done
 }
 
 l1_snapshot_sha256() {
@@ -157,8 +205,10 @@ l1_snapshot_load_config() {
     l1_snapshot_require_command df
     l1_snapshot_require_command forge
     l1_snapshot_require_command jq
+    l1_snapshot_require_command sed
     l1_snapshot_require_command sha256sum
     l1_snapshot_require_command stat
+    l1_snapshot_require_command tr
     l1_snapshot_validate_secret_file
 
     [[ -n "${TEMPO_ROOT:-}" ]] || l1_snapshot_die "TEMPO_ROOT must be set"
@@ -168,6 +218,8 @@ l1_snapshot_load_config() {
     l1_snapshot_require_executable "$L1_SNAPSHOT_TEMPO_BIN"
     l1_snapshot_require_executable "$L1_SNAPSHOT_TEMPO_XTASK_BIN"
     l1_snapshot_require_executable "$L1_SNAPSHOT_ZONES_XTASK_BIN"
+    l1_snapshot_resolve_hardfork
+    ZONES_BENCH_TEMPO_HARDFORK="$L1_SNAPSHOT_HARDFORK"
 
     ZONES_BENCH_ACCOUNT_START="${ZONES_BENCH_ACCOUNT_START:-16}"
     ZONES_BENCH_ACCOUNTS="${ZONES_BENCH_ACCOUNTS:-200}"
@@ -257,6 +309,7 @@ l1_snapshot_prepare_expectations() {
 
     L1_SNAPSHOT_EXPECTED_CONFIG="$(jq -cnS \
         --arg tempoRevision "${tempo_revision,,}" \
+        --arg tempoHardfork "$L1_SNAPSHOT_HARDFORK" \
         --arg tempoPatchSha256 "$tempo_patch_hash" \
         --arg genesisInputsSha256 "$genesis_inputs_hash" \
         --arg factoryArtifactSha256 "$factory_hash" \
@@ -277,7 +330,11 @@ l1_snapshot_prepare_expectations() {
         --argjson localnetSeed "$L1_SNAPSHOT_LOCALNET_SEED" '
         {
           schema: $schema,
-          tempo: {revision: $tempoRevision, mnemonicFilePatchSha256: $tempoPatchSha256},
+          tempo: {
+            revision: $tempoRevision,
+            hardfork: $tempoHardfork,
+            mnemonicFilePatchSha256: $tempoPatchSha256
+          },
           zonesGenesis: {
             inputsSha256: $genesisInputsSha256,
             factoryArtifactSha256: $factoryArtifactSha256,
@@ -389,6 +446,7 @@ l1_snapshot_write_status() {
     local temporary="$L1_SNAPSHOT_STATUS_FILE.tmp.$$"
     (umask 077; {
         printf 'export ZONES_BENCH_L1_CACHE_REBUILT=%q\n' "$rebuilt"
+        printf 'export ZONES_BENCH_TEMPO_HARDFORK=%q\n' "$L1_SNAPSHOT_HARDFORK"
         printf 'export ZONES_BENCH_L1_CACHE_KEY=%q\n' "$L1_SNAPSHOT_CACHE_KEY"
         printf 'export ZONES_BENCH_L1_CACHE_GENERATION=%q\n' "$L1_SNAPSHOT_GENERATION_ID"
     } >"$temporary")
@@ -416,6 +474,7 @@ l1_snapshot_build() {
         --gas-limit "$L1_SNAPSHOT_GAS_LIMIT" \
         --general-gas-limit "$L1_SNAPSHOT_GENERAL_GAS_LIMIT" \
         --validators 127.0.0.2:8000,127.0.0.3:8100 \
+        "${L1_SNAPSHOT_HARDFORK_ARGS[@]}" \
         --seed "$L1_SNAPSHOT_LOCALNET_SEED"
 
     echo "installing the native ZoneFactory marker and shared runtimes in genesis"

--- a/contrib/bench/scenario-reporting.sh
+++ b/contrib/bench/scenario-reporting.sh
@@ -29,6 +29,7 @@ build_scenario_report_args() {
         "drain-timeout-secs:ZONES_BENCH_DRAIN_TIMEOUT"
         "seed:ZONES_BENCH_SEED"
         "force-bloat:ZONES_BENCH_FORCE_BLOAT"
+        "tempo-hardfork:ZONES_BENCH_TEMPO_HARDFORK"
         "tempo-revision:ZONES_BENCH_TEMPO_REF"
         "txgen-revision:ZONES_BENCH_TXGEN_REF"
         "earn-revision:ZONES_BENCH_EARN_REVISION"


### PR DESCRIPTION
## Why

Zone benchmarks currently inherit every Tempo localnet hardfork at genesis. That makes it impossible to benchmark a Zones revision against an earlier compatible protocol lane while newer Zone runtime changes are still staged elsewhere.

## What changes

- Add an optional `tempo-hardfork` workflow-dispatch input, defaulting to `latest`.
- Discover the pinned Tempo revision's supported hardforks from `generate-localnet --help`, so adding a future hardfork requires no Zones workflow update.
- Explicitly activate every fork through the selected fork at genesis and schedule later forks for 2100.
- Include the resolved hardfork in the persistent L1 snapshot configuration/cache key.
- Record the resolved hardfork in the workflow summary, run metadata, and ClickHouse metadata.
- Keep the dispatch API within GitHub's 25-input limit by fixing the ordinary Zone activity amount to its existing default of `1` instead of exposing it as a manual input.

With the current Tempo pin, `latest` resolves to `t12`; callers can select `t11` while Zones `main` remains on the pre-TIP-1096 protocol.

## Validation

- Parsed `.github/workflows/zones-benchmark.yml` as YAML and verified it has exactly 25 dispatch inputs.
- `actionlint 1.7.12 .github/workflows/zones-benchmark.yml`
- `bash -n contrib/bench/l1-snapshot.sh contrib/bench/scenario-reporting.sh`
- `git diff --check`
- Exercised resolution against the exact pinned Tempo `a843c91a` xtask:
  - `latest` resolved to `t12`.
  - `T11` normalized to `t11`.
  - unsupported and malformed forks were rejected.
- Generated a localnet genesis for the `t11` lane and verified `t10Time=0`, `t11Time=0`, and `t12Time=4102444800`.
- [End-to-end benchmark run](https://github.com/tempoxyz/zones/actions/runs/34243708214): the `t11` snapshot rebuilt successfully and the encrypted-deposit workload completed 1/1 journeys with no failures.


