### PR TITLE
refactor(l1): deliver finalized blocks over a channel

### DIFF
--- a/crates/l1/src/subscriber.rs
+++ b/crates/l1/src/subscriber.rs
@@ -446,6 +446,8 @@ pub struct L1Subscriber<P> {
     /// Optional observational channel for finalized accepted batch submissions.
     pub(crate) finalized_batch_submissions:
         Option<tokio::sync::mpsc::Sender<FinalizedBatchSubmission>>,
+    /// Ordered finalized blocks, delivered after their events and caches are applied.
+    pub(crate) block_sender: Option<tokio::sync::mpsc::Sender<L1BlockDeposits>>,
     /// Private encryption keys bound by finalized Portal rotation events.
     pub(crate) encryption_keys: Option<EncryptionKeyRing>,
     /// L1 subscriber metrics for connection health, backfill, and event ingestion.
@@ -509,9 +511,17 @@ where
             block_tracker,
             leadership_sink,
             finalized_batch_submissions,
+            block_sender: None,
             encryption_keys,
             subscriber_metrics: Default::default(),
         }
+    }
+
+    /// Deliver every finalized block, including blocks without deposits, to the sequencer.
+    /// A bounded channel applies backpressure; a closed receiver stops ingestion.
+    pub fn with_block_sender(mut self, sender: tokio::sync::mpsc::Sender<L1BlockDeposits>) -> Self {
+        self.block_sender = Some(sender);
+        self
     }
 
     /// Connect to the L1 node.
@@ -751,7 +761,7 @@ where
         }
         let appended = self
             .deposit_queue
-            .try_enqueue_sealed(sealed, events.clone())
+            .try_enqueue_sealed(sealed.clone(), events.clone())
             .wrap_err_with(|| {
                 format!("unexpected discontinuity while enqueueing L1 block {block_number}")
             })?;
@@ -782,6 +792,19 @@ where
         // configured retention sink and the contiguous observation tracker.
         self.apply_enabled_token_events(&events);
         self.update_l1_state_anchor(block_number, &invalidated);
+        if let Some(sender) = &self.block_sender {
+            sender
+                .send(L1BlockDeposits {
+                    header: sealed,
+                    events,
+                })
+                .await
+                .map_err(|_| L1SubscriberError::Fatal {
+                    block_number,
+                    stage: "sequencer block delivery",
+                    source: eyre::eyre!("sequencer block receiver is unavailable"),
+                })?;
+        }
         if appended {
             self.subscriber_metrics.blocks_enqueued.increment(1);
         }

--- a/crates/l1/src/tests.rs
+++ b/crates/l1/src/tests.rs
@@ -159,6 +159,7 @@ fn test_subscriber_with_checkpoint(checkpoint: NumHash) -> L1Subscriber<MockEthP
         block_tracker: L1BlockTracker::default(),
         leadership_sink: None,
         finalized_batch_submissions: None,
+        block_sender: None,
         encryption_keys: None,
         subscriber_metrics: Default::default(),
     }
@@ -773,7 +774,8 @@ fn test_resolve_start_block_rejects_unanchored_genesis() {
 
 #[tokio::test]
 async fn test_sync_finalized_ingests_missing_finalized_range() {
-    let subscriber = test_subscriber(9);
+    let (sender, mut blocks_rx) = tokio::sync::mpsc::channel(3);
+    let subscriber = test_subscriber(9).with_block_sender(sender);
     let asserter = Asserter::new();
     let l1_provider =
         ProviderBuilder::new_with_network::<TempoNetwork>().connect_mocked_client(asserter.clone());
@@ -803,6 +805,12 @@ async fn test_sync_finalized_ingests_missing_finalized_range() {
         .await
         .unwrap();
     assert_eq!(next_block, 13);
+    for expected in [10, 11, 12] {
+        let block = blocks_rx.try_recv().unwrap();
+        assert_eq!(block.header.number(), expected);
+        assert!(block.events.deposits.is_empty());
+    }
+    assert!(blocks_rx.try_recv().is_err());
 
     let blocks = subscriber.deposit_queue.drain();
     assert_eq!(
@@ -2065,4 +2073,25 @@ async fn sync_fails_fatally_when_the_leadership_sink_rejects_the_transition() {
     // Nothing was enqueued and no observation advanced: the block was not half-applied.
     assert_eq!(queue.last_enqueued(), None);
     assert_eq!(subscriber.block_tracker.latest(), None);
+}
+
+#[tokio::test]
+async fn closed_sequencer_channel_stops_ingestion_without_advancing_cursor() {
+    let (sender, receiver) = tokio::sync::mpsc::channel(1);
+    drop(receiver);
+    let subscriber = test_subscriber(9).with_block_sender(sender);
+    let asserter = Asserter::new();
+    let provider =
+        ProviderBuilder::new_with_network::<TempoNetwork>().connect_mocked_client(asserter.clone());
+    let header = make_test_header(10);
+    asserter.push_success(&Some(header_response(header.clone())));
+    push_header_and_empty_receipts(&asserter, header);
+    let mut next_block = 10;
+    let error = subscriber
+        .sync_finalized(&provider, &mut next_block)
+        .await
+        .unwrap_err();
+    assert!(!error.should_retry());
+    assert_eq!(next_block, 10);
+    assert!(error.to_string().contains("sequencer block delivery"));
 }

--- a/crates/node/src/node.rs
+++ b/crates/node/src/node.rs
@@ -726,6 +726,7 @@ where
                 None
             };
 
+        let (l1_blocks_tx, l1_blocks_rx) = tokio::sync::mpsc::channel(128);
         let l1_subscriber = L1Subscriber::new(
             self.l1_config.clone(),
             ctx.node.provider().clone(),
@@ -737,6 +738,11 @@ where
             finalized_batch_submission_sender,
             self.encryption_keys.clone(),
         );
+        let l1_subscriber = if self.p2p_config.is_some() {
+            l1_subscriber.with_block_sender(l1_blocks_tx)
+        } else {
+            l1_subscriber
+        };
         let task_executor = ctx.node.task_executor().clone();
         task_executor.spawn_critical_task(
             "l1-block-subscriber",
@@ -934,8 +940,10 @@ where
                 peer_tips,
                 status: role_status,
             };
-            task_executor
-                .spawn_critical_task("zone-role-controller", run_role_controller(context, sinks));
+            task_executor.spawn_critical_task(
+                "zone-role-controller",
+                run_role_controller(context, sinks, l1_blocks_rx),
+            );
 
             // Flush unpersisted blocks on shutdown.
             let engine_shutdown = handle.engine_shutdown.clone();

--- a/crates/node/src/role.rs
+++ b/crates/node/src/role.rs
@@ -619,6 +619,7 @@ where
 pub(crate) async fn run_role_controller<P, Pool>(
     context: RoleControllerContext<P, Pool>,
     sinks: EventSinks,
+    mut l1_blocks: mpsc::Receiver<zone_l1::L1BlockDeposits>,
 ) where
     P: BlockNumReader
         + BlockReader<Block = Block>
@@ -780,6 +781,11 @@ pub(crate) async fn run_role_controller<P, Pool>(
         };
         tokio::select! {
             biased;
+            block = l1_blocks.recv() => {
+                if block.is_none() {
+                    panic!("L1 subscriber block channel closed");
+                }
+            }
             changed = schedule_changes.changed() => {
                 if changed.is_err() {
                     error!(target: "zone::role", "Leadership schedule notifier closed");


### PR DESCRIPTION
This PR delivers finalized L1 blocks and Portal events to the sequencer over a bounded channel, after applying leadership and cached state.

Stacked on #1400.
