### PR TITLE
refactor(node): keep sequencing and P2P loops alive across role changes

### DIFF
--- a/crates/node/src/engine.rs
+++ b/crates/node/src/engine.rs
@@ -31,13 +31,14 @@
 //!
 //! The deposit queue uses a **peek / confirm** pattern: the engine peeks at
 //! the next L1 block, wraps it into [`ZonePayloadAttributes`], and only
-//! confirms (removes) the block after `newPayload` succeeds. A failed build
+//! confirms (removes) the block after `newPayload` and the final forkchoice update succeed. A failed build
 //! leaves the block in the queue for retry.
 //!
 //! The zone assumes **instant finality** — head, safe, and finalized all point
 //! to the same block.
 
 use alloy_consensus::BlockHeader as _;
+use alloy_eips::NumHash;
 use alloy_primitives::{Address, B256};
 use alloy_rpc_types_engine::{ForkchoiceState, PayloadAttributes as EthPayloadAttributes};
 use eyre::OptionExt;
@@ -81,7 +82,7 @@ impl ProductionPermit {
 
     /// Decide whether this node may produce the zone block embedding `tempo_anchor`.
     ///
-    /// `None` authorizes production; `Some(exit)` is the reason the engine must stop.
+    /// `None` authorizes production; `Some(exit)` explains why production is fenced.
     pub fn check(&self, tempo_anchor: u64) -> Option<EngineExit> {
         match self.schedule.leader_for(tempo_anchor) {
             None => Some(EngineExit::Fenced { tempo_anchor }),
@@ -164,7 +165,8 @@ where
 /// 3. Sends FCU with payload attributes to start a build
 /// 4. Resolves the built payload
 /// 5. Submits via `newPayload`
-/// 6. Confirms the L1 block in the queue (removes it)
+/// 6. Finalizes the payload with a forkchoice update
+/// 7. Confirms the L1 block in the queue (removes it)
 ///
 /// On failure the L1 block stays in the queue and is retried.
 #[derive(Debug)]
@@ -222,6 +224,27 @@ impl ZoneEngine {
     pub fn with_production_permit(mut self, permit: ProductionPermit) -> Self {
         self.production_permit = Some(permit);
         self
+    }
+
+    /// Produce one available anchor using the current canonical parent.
+    /// Called by the persistent sequencer between peer imports.
+    pub(crate) async fn produce_next(
+        &mut self,
+        parent: SealedHeader<TempoHeader>,
+    ) -> eyre::Result<Option<NumHash>> {
+        let Some(block) = self.deposit_queue.peek() else {
+            return Ok(None);
+        };
+        if self
+            .production_permit
+            .as_ref()
+            .is_some_and(|permit| permit.check(block.header.number()).is_some())
+        {
+            return Ok(None);
+        }
+        self.last_header = parent;
+        self.advance(block).await?;
+        Ok(Some(self.last_header.num_hash()))
     }
 
     /// Runs the main Zone engine loop until cancelled or halted by the leadership permit.
@@ -328,7 +351,7 @@ impl ZoneEngine {
     /// Wraps the given L1 block into [`ZonePayloadAttributes`], sends FCU
     /// with those attributes, waits for the payload to be built, then submits
     /// via `newPayload`. Only confirms (removes) the L1 block from the
-    /// deposit queue after `newPayload` succeeds.
+    /// deposit queue after `newPayload` and the final forkchoice update succeed.
     async fn advance(&mut self, l1_block: L1BlockDeposits) -> eyre::Result<()> {
         let l1_num_hash = l1_block.header.num_hash();
 
@@ -399,21 +422,21 @@ impl ZoneEngine {
             eyre::bail!("Invalid payload for block {block_number}");
         }
 
-        // newPayload succeeded — remove the exact finalized L1 block that
-        // produced it. A mismatch indicates an internal consumer-ordering bug.
+        // Publish and release the anchor only after FCU has finalized this payload. A failed
+        // FCU leaves the queue intact so the same anchor can be retried from the canonical head.
+        let result = self
+            .to_engine
+            .fork_choice_updated(ForkchoiceState::same_hash(header.hash()), None)
+            .await?;
+        eyre::ensure!(
+            result.is_valid(),
+            "Invalid post-payload forkchoice: {result:?}"
+        );
+        self.last_header = header;
         self.deposit_queue.confirm(l1_num_hash)?;
         self.l1_block_tracker.prune_through(l1_num_hash.number);
         if let Some(permit) = &self.production_permit {
             permit.record_applied_anchor(l1_num_hash.number);
-        }
-
-        self.last_header = header;
-
-        // Canonicalize the new head — FCU-with-attrs above only set the
-        // *previous* head as canonical; this bare FCU makes the just-built
-        // block the EL's canonical head.
-        if let Err(e) = self.update_forkchoice_state().await {
-            error!(target: "zone::engine", "Error sending post-newPayload FCU: {:?}", e);
         }
 
         Ok(())

--- a/crates/node/src/follower.rs
+++ b/crates/node/src/follower.rs
@@ -185,7 +185,7 @@ impl PeerTipRegistry {
             .collect()
     }
 }
-/// Shared state required to validate and import blocks in a follower generation.
+/// Shared state required to validate and import peer blocks.
 pub(crate) struct FollowerBlockSyncContext<P> {
     pub(crate) provider: P,
     pub(crate) engine: ConsensusEngineHandle<ZonePayloadTypes>,
@@ -196,7 +196,7 @@ pub(crate) struct FollowerBlockSyncContext<P> {
     pub(crate) peer_tips: PeerTipRegistry,
 }
 
-/// Live P2P and backfill channels owned by one follower sync generation.
+/// Stable P2P and backfill channels owned by the sequencer.
 pub(crate) struct BlockSyncP2p {
     pub(crate) events: mpsc::Receiver<P2pEvent>,
     pub(crate) commands: mpsc::Sender<P2pCommand>,
@@ -204,10 +204,7 @@ pub(crate) struct BlockSyncP2p {
     pub(crate) backfill_commands: mpsc::Sender<BackfillCommand>,
 }
 
-/// State and channels owned by one follower block-sync generation.
-///
-/// A role transition drops this value only after cancelling [`Self::stop`], so no dependency of
-/// the import loop escapes the generation that owns it.
+/// Persistent block sync state. The channel loop also owns local block production.
 pub(crate) struct FollowerBlockSync<P> {
     context: FollowerBlockSyncContext<P>,
     p2p: BlockSyncP2p,
@@ -250,7 +247,13 @@ where
         }
     }
 
-    pub(crate) async fn run(mut self) {
+    pub(crate) async fn run(
+        mut self,
+        mut sequencing: crate::role::Sequencing<P>,
+        mut l1_blocks: mpsc::Receiver<zone_l1::L1BlockDeposits>,
+    ) {
+        let mut schedule = self.context.schedule.subscribe();
+        let mut role_retry = tokio::time::interval(Duration::from_millis(500));
         // Always probe on startup to see if we're behind
         let mut retry = tokio::time::interval(BACKFILL_RETRY_INTERVAL);
         retry.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Delay);
@@ -260,12 +263,29 @@ where
         tokio::pin!(inactivity);
 
         loop {
+            // Production and import execute outside select: neither may be cancelled halfway
+            // through an Engine API update by another channel becoming ready.
+            let produced = match sequencing.advance().await {
+                Ok(produced) => produced,
+                Err(error) => {
+                    tracing::error!(%error, "Failed to advance the sequencer");
+                    false
+                }
+            };
             tokio::select! {
-            biased;
+
                 () = self.stop.cancelled() => {
                     debug!(target: "zone::p2p", "Follower block sync stopped");
                     return;
                 }
+                block = l1_blocks.recv() => {
+                    sequencing.observed(block.expect("L1 subscriber block channel closed"));
+                }
+                changed = schedule.changed() => {
+                    changed.expect("leadership schedule channel closed");
+                }
+                _ = role_retry.tick() => {}
+                () = tokio::task::yield_now(), if produced => {}
                 response = self.p2p.backfill_responses.recv() => {
                     let Some(response) = response else {
                         debug!(target: "zone::p2p", "Backfill response channel closed");
@@ -273,6 +293,7 @@ where
                     };
                     match response {
                         BackfillResponse::Block { block, .. } => {
+                            if sequencing.is_leader() { continue; }
                             let block = match decode_peer_block(&block) {
                                 Ok(block) => block,
                                 Err(err) => {
@@ -320,6 +341,7 @@ where
                             }
                         }
                         P2pEvent::BlockReceived { leader_ed25519_public_key, block } => {
+                            if sequencing.is_leader() { continue; }
                             let block = match decode_peer_block(&block) {
                                 Ok(block) => block,
                                 Err(err) => {
@@ -1129,7 +1151,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn peer_anchor_wait_stops_promptly_on_generation_cancellation() {
+    async fn peer_anchor_wait_stops_promptly_on_shutdown() {
         use commonware_cryptography::{Signer as _, ed25519::PrivateKey};
 
         let leader = PrivateKey::from_seed(1).public_key();
@@ -1152,7 +1174,7 @@ mod tests {
             PEER_ANCHOR_WAIT_TIMEOUT,
         )
         .await
-        .expect_err("cancelled generation must stop waiting for its peer anchor");
+        .expect_err("cancelled sync must stop waiting for its peer anchor");
 
         assert!(matches!(error, PeerAnchorWaitError::Cancelled));
     }

--- a/crates/node/src/lib.rs
+++ b/crates/node/src/lib.rs
@@ -13,6 +13,7 @@ pub mod engine;
 mod follower;
 pub mod genesis;
 pub mod node;
+mod p2p_engine;
 mod replication;
 pub mod role;
 pub mod rpc;

--- a/crates/node/src/node.rs
+++ b/crates/node/src/node.rs
@@ -6,11 +6,11 @@
 use crate::{
     ZoneEngine,
     follower::PeerTipRegistry,
+    p2p_engine::{ZoneP2pEngine, route_backfill_requests},
     replication::{BACKFILL_SERVE_QUEUE_CAPACITY, serve_backfill_requests},
     role::{
-        EventSinks, LeaderSequencerDeps, RoleControllerContext, SharedRoleStatus,
-        canonical_recovery_height, route_backfill_requests, route_backfill_responses,
-        route_events_to_generations, run_role_controller,
+        LeaderSequencerDeps, SequencerContext, SharedRoleStatus, canonical_recovery_height,
+        run_sequencer,
     },
     rpc::{
         NodeZoneDebugApi, OperatorWeb3Api, OperatorZoneApi, SequencerRpcContext,
@@ -544,7 +544,7 @@ where
 
 /// P2P services that continue running after the network is initialized.
 struct P2PRuntime {
-    sinks: EventSinks,
+    sinks: ZoneP2pEngine,
     commands: Sender<P2pCommand>,
     backfill_commands: Sender<BackfillCommand>,
     attestation: AttestationContext,
@@ -898,9 +898,8 @@ where
             backfill_requests_rx,
         }) = p2p_runtime
         {
-            // Backfill serving is role-neutral: every role serves the same canonical
-            // provider, so the server outlives role generations and a leadership handoff
-            // can never drop an accepted request.
+            // Every node serves canonical blocks through a process-lifetime backfill server,
+            // retaining accepted requests across leadership changes.
             task_executor.spawn_critical_task(
                 "zone-backfill-server",
                 serve_backfill_requests(
@@ -920,7 +919,7 @@ where
                 )?),
                 None => None,
             };
-            let context = RoleControllerContext {
+            let context = SequencerContext {
                 local_ed25519_public_key,
                 schedule,
                 provider: provider.clone(),
@@ -941,8 +940,8 @@ where
                 status: role_status,
             };
             task_executor.spawn_critical_task(
-                "zone-role-controller",
-                run_role_controller(context, sinks, l1_blocks_rx),
+                "zone-sequencer",
+                run_sequencer(context, sinks, l1_blocks_rx),
             );
 
             // Flush unpersisted blocks on shutdown.
@@ -1305,15 +1304,14 @@ where
 
     /// Start the Commonware network and the long-lived P2P event demultiplexer.
     ///
-    /// Role-specific consumers are attached later by the role controller through the returned
-    /// [`EventSinks`]. Generic events and typed backfill ports are routed for the process lifetime.
+    /// The returned [`ZoneP2pEngine`] retains stable consumers for the process lifetime.
     fn launch_p2p_network(
         config: P2pConfig,
         network_id: P2pNetworkId,
         task_executor: &reth_tasks::TaskExecutor,
         backfill_requests: tokio::sync::mpsc::Sender<BackfillRequest>,
     ) -> eyre::Result<(
-        EventSinks,
+        ZoneP2pEngine,
         tokio::sync::mpsc::Sender<zone_p2p::P2pCommand>,
         tokio::sync::mpsc::Sender<BackfillCommand>,
     )> {
@@ -1327,18 +1325,13 @@ where
             backfill,
         } = handle.into_parts();
 
-        let sinks = EventSinks::default();
-        task_executor.spawn_critical_task(
-            "zone-p2p-event-router",
-            route_events_to_generations(events, sinks.clone()),
-        );
+        let sinks = ZoneP2pEngine {
+            events,
+            backfill: backfill.responses,
+        };
         task_executor.spawn_critical_task(
             "zone-p2p-backfill-request-router",
             route_backfill_requests(backfill.requests, backfill_requests),
-        );
-        task_executor.spawn_critical_task(
-            "zone-p2p-backfill-response-router",
-            route_backfill_responses(backfill.responses, sinks.clone()),
         );
 
         task_executor.spawn_critical_with_graceful_shutdown_signal(
@@ -1378,7 +1371,7 @@ where
         Ok((sinks, commands, backfill.commands))
     }
 
-    /// Build the leader-generation sequencer dependencies (activated only while leader).
+    /// Build settlement dependencies (active only while sequencing).
     fn build_leader_sequencer_deps(
         config: ZoneSequencerAddOnsConfig,
         l1_rpc_url: String,

--- a/crates/node/src/p2p_engine.rs
+++ b/crates/node/src/p2p_engine.rs
@@ -1,0 +1,135 @@
+//! Process-lifetime P2P routes. Sequencing decisions belong to the local sequencer.
+
+use tokio::sync::mpsc;
+use zone_p2p::{BackfillRequest, BackfillResponse, P2pEvent};
+
+/// Propagation and inbound routing for the lifetime of the node.
+/// The sequencer supplies finalized blocks; this engine never selects a producer.
+pub(crate) struct ZoneP2pEngine {
+    pub events: mpsc::Receiver<P2pEvent>,
+    pub backfill: mpsc::Receiver<BackfillResponse>,
+}
+
+pub(crate) struct P2pEventRoutes {
+    pub blocks: mpsc::Sender<P2pEvent>,
+    pub transactions: mpsc::Sender<P2pEvent>,
+    pub signatures: mpsc::Sender<P2pEvent>,
+    pub backfill: mpsc::Sender<BackfillResponse>,
+}
+
+impl ZoneP2pEngine {
+    pub(crate) async fn run<P: crate::replication::PersistedBlockSource>(
+        self,
+        provider: P,
+        commands: mpsc::Sender<zone_p2p::P2pCommand>,
+        finalized: mpsc::Receiver<alloy_eips::NumHash>,
+        routes: P2pEventRoutes,
+    ) {
+        let backfill = routes.backfill.clone();
+        tokio::select! {
+            () = route_events(self.events, routes) => panic!("P2P event routing stopped"),
+            () = route_backfill_responses(self.backfill, backfill) => panic!("P2P backfill routing stopped"),
+            result = crate::replication::broadcast_finalized_blocks(provider, commands, finalized) => {
+                panic!("finalized block propagation stopped: {result:?}");
+            }
+        }
+    }
+}
+
+pub(crate) async fn route_events(mut events: mpsc::Receiver<P2pEvent>, routes: P2pEventRoutes) {
+    while let Some(event) = events.recv().await {
+        let sink = match &event {
+            P2pEvent::TransactionReceived { .. } => &routes.transactions,
+            P2pEvent::SettlementSignatureReceived { .. } => &routes.signatures,
+            _ => &routes.blocks,
+        };
+        match sink.try_send(event) {
+            Ok(()) => {}
+            Err(mpsc::error::TrySendError::Full(_)) => {
+                // Backfill, pool reconciliation and proposal retries recover full queues.
+                metrics::counter!("zone_leadership_events_dropped_backpressure_total").increment(1);
+            }
+            Err(mpsc::error::TrySendError::Closed(_)) => panic!("zone P2P consumer stopped"),
+        }
+    }
+    panic!("P2P event channel closed");
+}
+
+pub(crate) async fn route_backfill_requests(
+    mut requests: mpsc::Receiver<BackfillRequest>,
+    backfill: mpsc::Sender<BackfillRequest>,
+) {
+    while let Some(request) = requests.recv().await {
+        if let Err(error) = backfill.try_send(request) {
+            metrics::counter!("zone_leadership_backfill_requests_dropped_total").increment(1);
+            tracing::warn!(%error, "Dropped backfill request because the serving queue is unavailable");
+        }
+    }
+}
+
+pub(crate) async fn route_backfill_responses(
+    mut responses: mpsc::Receiver<BackfillResponse>,
+    backfill: mpsc::Sender<BackfillResponse>,
+) {
+    while let Some(response) = responses.recv().await {
+        match backfill.try_send(response) {
+            Ok(()) => {}
+            Err(mpsc::error::TrySendError::Full(_)) => {
+                metrics::counter!("zone_leadership_events_dropped_backpressure_total").increment(1);
+            }
+            Err(mpsc::error::TrySendError::Closed(_)) => panic!("zone backfill consumer stopped"),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use alloy_primitives::B256;
+    use commonware_cryptography::{Signer as _, ed25519::PrivateKey};
+    use zone_p2p::PeerTip;
+
+    #[tokio::test]
+    async fn accepted_backfill_requests_reach_the_server_before_sequencing_starts() {
+        let (network, incoming) = mpsc::channel(1);
+        let (server, mut received) = mpsc::channel(1);
+        network
+            .send(BackfillRequest {
+                peer: PrivateKey::from_seed(1).public_key(),
+                request_id: 7,
+                start: 42,
+            })
+            .await
+            .unwrap();
+        drop(network);
+        route_backfill_requests(incoming, server).await;
+        let request = received.recv().await.unwrap();
+        assert_eq!((request.request_id, request.start), (7, 42));
+    }
+
+    #[tokio::test]
+    async fn a_full_backfill_consumer_does_not_block_network_routing() {
+        let (network, incoming) = mpsc::channel(2);
+        let (consumer, mut received) = mpsc::channel(1);
+        for height in [1, 2] {
+            network
+                .send(BackfillResponse::Completed {
+                    peer: PrivateKey::from_seed(1).public_key(),
+                    tip: PeerTip {
+                        zone_height: height,
+                        zone_hash: B256::ZERO,
+                        tempo_block_number: height,
+                        tempo_block_hash: B256::ZERO,
+                    },
+                })
+                .await
+                .unwrap();
+        }
+        drop(network);
+        route_backfill_responses(incoming, consumer).await;
+        assert!(
+            matches!(received.recv().await, Some(BackfillResponse::Completed { tip, .. }) if tip.zone_height == 1)
+        );
+        assert!(received.recv().await.is_none());
+    }
+}

--- a/crates/node/src/replication.rs
+++ b/crates/node/src/replication.rs
@@ -1,6 +1,5 @@
 //! Node-side leader replication and role-neutral backfill serving.
 
-use alloy_consensus::BlockHeader as _;
 use alloy_primitives::B256;
 use futures::{StreamExt as _, stream::BoxStream};
 use reth_chain_state::PersistedBlockSubscriptions;
@@ -8,7 +7,7 @@ use reth_primitives_traits::SealedBlock;
 use reth_provider::HeaderProvider;
 use reth_storage_api::{BlockNumReader, BlockReader, ReceiptProvider, StateProviderFactory};
 use tempo_primitives::{Block, TempoHeader};
-use tokio::sync::{mpsc, oneshot};
+use tokio::sync::mpsc;
 use tokio_util::sync;
 use tracing::{debug, info};
 use zone_l1::TempoStateExt as _;
@@ -19,38 +18,15 @@ use eyre::{OptionExt as _, WrapErr as _};
 
 use crate::settlement_attestation::{AttestationContext, build_settlement_attestation};
 
-#[derive(Debug, Clone, Copy)]
-pub(crate) struct PersistedTip {
-    number: u64,
-    hash: B256,
-}
-
 pub(crate) struct EncodedPersistedBlock {
-    number: u64,
     hash: B256,
     encoded: Vec<u8>,
-}
-
-/// The one shutdown decision the role controller makes for a leader's block broadcaster.
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub(crate) enum BroadcasterShutdown {
-    /// The engine has stopped, so wait for its frozen canonical tail to become durable.
-    Drain,
-    /// The engine stop was not proven; flush only the durable prefix and abandon the rest.
-    Stop,
 }
 
 /// Interface used by the replication task to keep track of blocks that are persisted vs broadcast
 pub(crate) trait PersistedBlockSource: Clone + Send + Sync + 'static {
     fn last_block_number(&self) -> eyre::Result<u64>;
-    /// The canonical head, which may be ahead of the persisted head (reth persists lazily).
-    ///
-    /// This is a drain *target*, never a broadcast height: a canonical-only block lives in
-    /// reth's volatile in-memory state and would vanish from this node on restart. Read it only
-    /// after the engine has stopped, and publish the blocks it names through the persisted
-    /// stream.
-    fn canonical_block_number(&self) -> eyre::Result<u64>;
-    fn persisted_block_stream(&self) -> BoxStream<'static, PersistedTip>;
+    fn persisted_block_stream(&self) -> BoxStream<'static, ()>;
     fn encoded_block_by_number(&self, number: u64) -> eyre::Result<EncodedPersistedBlock>;
 }
 
@@ -62,16 +38,9 @@ where
         Ok(BlockNumReader::last_block_number(self)?)
     }
 
-    fn canonical_block_number(&self) -> eyre::Result<u64> {
-        Ok(BlockNumReader::best_block_number(self)?)
-    }
-
-    fn persisted_block_stream(&self) -> BoxStream<'static, PersistedTip> {
+    fn persisted_block_stream(&self) -> BoxStream<'static, ()> {
         PersistedBlockSubscriptions::persisted_block_stream(self)
-            .map(|tip| PersistedTip {
-                number: tip.number,
-                hash: tip.hash,
-            })
+            .map(|_| ())
             .boxed()
     }
 
@@ -81,222 +50,43 @@ where
             .ok_or_else(|| eyre::eyre!("persisted zone block {number} is missing"))?;
         let sealed = SealedBlock::seal_slow(block);
         Ok(EncodedPersistedBlock {
-            number: sealed.number(),
             hash: sealed.hash(),
             encoded: alloy_rlp::encode(sealed.into_block()),
         })
     }
 }
 
-/// Broadcast every newly persisted leader block in canonical order until cancelled.
-///
-/// A single shutdown command decides how to handle the leader's final block:
-///
-/// * [`BroadcasterShutdown::Drain`] is the graceful path. The role controller sends it only
-///   after the engine task has returned, which freezes the canonical head and lets this task wait
-///   for the final block to persist before publishing it.
-/// * [`BroadcasterShutdown::Stop`] is the abrupt path. It flushes what is already durable and
-///   abandons the rest.
-///
-/// Neither path ever broadcasts a canonical-only block.
-pub(crate) async fn broadcast_persisted_blocks<P>(
+/// Publish exactly the locally produced blocks, after they are durable. Peer imports never
+/// enter this channel, and a role change cannot truncate the previous leader's durable tail.
+pub(crate) async fn broadcast_finalized_blocks<P: PersistedBlockSource>(
     provider: P,
     commands: mpsc::Sender<P2pCommand>,
-    mut shutdown: oneshot::Receiver<BroadcasterShutdown>,
-) where
-    P: PersistedBlockSource,
-{
-    // Handle race conditions carefully at startup. Read before subscribing, then reconcile after subscribing.
-    // This closes both startup windows: a block persisted before the subscription is found by the
-    // second read, while a block persisted after the subscription is retained by the stream.
-    let mut last_broadcast = match provider.last_block_number() {
-        Ok(number) => number,
-        Err(err) => {
-            tracing::error!(target: "zone::p2p", %err, "Failed reading persisted zone head");
-            return;
-        }
-    };
+    mut blocks: mpsc::Receiver<alloy_eips::NumHash>,
+) -> eyre::Result<()> {
     let mut persisted = provider.persisted_block_stream();
-    let startup_tip = match provider.last_block_number() {
-        Ok(number) => number,
-        Err(err) => {
-            tracing::error!(target: "zone::p2p", %err, "Failed reconciling persisted zone head");
-            return;
+    while let Some(block) = blocks.recv().await {
+        while provider.last_block_number()? < block.number {
+            persisted
+                .next()
+                .await
+                .ok_or_eyre("persisted block stream closed")?;
         }
-    };
-
-    if let Err(err) =
-        broadcast_persisted_range(&provider, &commands, &mut last_broadcast, startup_tip, None)
-            .await
-    {
-        tracing::error!(target: "zone::p2p", %err, "Failed broadcasting persisted zone blocks");
-        return;
-    }
-
-    loop {
-        let persisted_tip = tokio::select! {
-            biased;
-            command = &mut shutdown => {
-                match command {
-                    Ok(BroadcasterShutdown::Drain) => {
-                        if let Err(err) = drain_persisted_blocks_after_engine_stop(
-                            &provider,
-                            &commands,
-                            &mut last_broadcast,
-                            &mut persisted,
-                        )
-                        .await
-                        {
-                            tracing::error!(target: "zone::p2p", %err, "Failed draining persisted zone blocks after the leader engine stopped");
-                        }
-                    }
-                    Ok(BroadcasterShutdown::Stop) => {
-                        // Stopped without an engine-complete drain, so the canonical head is
-                        // still moving and cannot be a flush target. Publish what is already
-                        // durable and abandon the rest: a canonical-only block would disappear
-                        // from this node on restart, leaving followers on a height no replica can
-                        // serve.
-                        match provider.last_block_number() {
-                            Ok(persisted_head) => {
-                                if let Err(err) = broadcast_persisted_range(
-                                    &provider,
-                                    &commands,
-                                    &mut last_broadcast,
-                                    persisted_head,
-                                    None,
-                                )
-                                .await
-                                {
-                                    tracing::error!(target: "zone::p2p", %err, "Failed flushing persisted zone blocks on stop");
-                                }
-                            }
-                            Err(err) => {
-                                tracing::error!(target: "zone::p2p", %err, "Failed reading the persisted zone head for the stop flush");
-                            }
-                        }
-                        debug!(target: "zone::p2p", "Persisted block broadcaster stopped");
-                    }
-                    Err(_) => {
-                        debug!(target: "zone::p2p", "Persisted block broadcaster shutdown control dropped");
-                    }
-                }
-                return;
-            }
-            tip = persisted.next() => match tip {
-                Some(tip) => tip,
-                None => break,
-            },
-        };
-        if persisted_tip.number < last_broadcast {
-            tracing::error!(
-                target: "zone::p2p",
-                persisted = persisted_tip.number,
-                last_broadcast,
-                "Persisted zone head moved backwards"
-            );
-            return;
-        }
-
-        if let Err(err) = broadcast_persisted_range(
-            &provider,
-            &commands,
-            &mut last_broadcast,
-            persisted_tip.number,
-            Some(persisted_tip.hash),
-        )
-        .await
-        {
-            tracing::error!(target: "zone::p2p", %err, "Failed broadcasting persisted zone blocks");
-            return;
-        }
-    }
-    debug!(target: "zone::p2p", "Persisted block stream closed");
-}
-
-/// Publish the outgoing leader's final blocks once they are durable.
-///
-/// The caller must have observed the engine task return before signalling this, which is what
-/// makes the loop terminate: cancelling the generation token is not a block boundary, because an
-/// in-flight advance still completes before the engine yields. Only a stopped engine pins the
-/// canonical head, and only a pinned target can be waited for.
-///
-/// Blocks still go out through [`broadcast_persisted_range`] with the hash the persisted stream
-/// reported, so the durable-source invariant holds on this path too.
-async fn drain_persisted_blocks_after_engine_stop<P>(
-    provider: &P,
-    commands: &mpsc::Sender<P2pCommand>,
-    last_broadcast: &mut u64,
-    persisted: &mut BoxStream<'static, PersistedTip>,
-) -> eyre::Result<()>
-where
-    P: PersistedBlockSource,
-{
-    let canonical = provider.canonical_block_number()?;
-    let persisted_head = provider.last_block_number()?;
-    broadcast_persisted_range(provider, commands, last_broadcast, persisted_head, None).await?;
-
-    while *last_broadcast < canonical {
-        let persisted_tip = persisted.next().await.ok_or_else(|| {
-            eyre::eyre!("persisted zone block stream closed before the canonical tail persisted")
-        })?;
-        if persisted_tip.number < *last_broadcast {
-            eyre::bail!(
-                "persisted zone head moved backwards while draining after the leader engine stopped: persisted={}, last_broadcast={}",
-                persisted_tip.number,
-                *last_broadcast,
-            );
-        }
-        broadcast_persisted_range(
-            provider,
-            commands,
-            last_broadcast,
-            persisted_tip.number,
-            Some(persisted_tip.hash),
-        )
-        .await?;
-    }
-
-    debug!(target: "zone::p2p", canonical, broadcast = *last_broadcast, "Drained the canonical tail after the leader engine stopped");
-    Ok(())
-}
-
-async fn broadcast_persisted_range<P>(
-    provider: &P,
-    commands: &mpsc::Sender<P2pCommand>,
-    last_broadcast: &mut u64,
-    tip_number: u64,
-    expected_tip_hash: Option<B256>,
-) -> eyre::Result<()>
-where
-    P: PersistedBlockSource,
-{
-    for number in last_broadcast.saturating_add(1)..=tip_number {
-        let block = provider.encoded_block_by_number(number)?;
-        let number = block.number;
-        let hash = block.hash;
-        if number == tip_number
-            && let Some(expected) = expected_tip_hash
-            && hash != expected
-        {
-            eyre::bail!(
-                "persisted zone block hash does not match notification at height {number}: expected={expected}, actual={hash}"
-            );
-        }
+        let encoded = provider.encoded_block_by_number(block.number)?;
+        eyre::ensure!(
+            encoded.hash == block.hash,
+            "finalized block changed before propagation"
+        );
         commands
-            .send(P2pCommand::BroadcastBlock(block.encoded))
+            .send(P2pCommand::BroadcastBlock(encoded.encoded))
             .await
-            .map_err(|_| eyre::eyre!("P2P command channel closed"))?;
-        debug!(target: "zone::p2p", number, ?hash, "Queued persisted block for followers");
-        *last_broadcast = number;
+            .wrap_err("P2P command channel closed")?;
     }
     Ok(())
 }
 
-const BACKFILL_PAGE_SIZE: u64 = 64;
-/// Bounds queued requests at the process-lifetime backfill server. Requesters keep at most
-/// one request outstanding per peer, so manifest size bounds the live queue depth; the
-/// headroom absorbs requests arriving before the server task starts.
+/// Bounded queue for role-neutral canonical block serving.
 pub(crate) const BACKFILL_SERVE_QUEUE_CAPACITY: usize = 128;
+const BACKFILL_PAGE_SIZE: u64 = 64;
 
 fn serve_backfill_page<P>(
     provider: &P,
@@ -350,9 +140,8 @@ where
 /// Serve block backfill requests for the process lifetime.
 ///
 /// Backfill serving is role-neutral: leaders, followers, and fenced nodes all serve the
-/// same canonical provider. Running one server outside the role generations means a
-/// generation switch can never drop or abandon an accepted request, which would suppress
-/// the requesting peer until its response timeout and stall a leadership handoff.
+/// same canonical provider. The process-lifetime server retains accepted requests across
+/// leadership changes, so peers can complete their backfill during a handoff.
 /// Exits when the request channel closes.
 pub(crate) async fn serve_backfill_requests<P>(
     provider: P,
@@ -392,13 +181,7 @@ pub(crate) async fn serve_backfill_requests<P>(
     }
 }
 
-/// Collect and verify follower settlement signatures on the leader, without ever
-/// requesting or importing peer blocks.
-///
-/// While this runs, [`ZoneEngine`](crate::ZoneEngine) is the sole chain-head
-/// writer. Backfill requests are served by the process-lifetime
-/// [`serve_backfill_requests`] task, never by role generations. The loop exits
-/// when `stop` fires.
+/// Validate a follower signature against its authenticated identity and canonical settlement.
 async fn store_follower_settlement_signature<P>(
     provider: &P,
     follower: &P2pPeerId,
@@ -513,98 +296,34 @@ pub(crate) async fn collect_follower_settlement_signatures<P>(
 
 #[cfg(test)]
 mod tests {
+    use super::*;
+    use alloy_eips::NumHash;
     use std::sync::{
         Arc,
-        atomic::{AtomicU64, AtomicUsize, Ordering},
+        atomic::{AtomicU64, Ordering},
     };
-
-    use futures::{StreamExt as _, stream};
-    use tokio::sync::{oneshot, watch};
-
-    use super::{
-        BroadcasterShutdown, EncodedPersistedBlock, PersistedBlockSource, PersistedTip,
-        broadcast_persisted_blocks,
-    };
-    use alloy_primitives::B256;
-    use zone_p2p::P2pCommand;
+    use tokio::sync::watch;
 
     #[derive(Clone)]
-    struct StartupRaceSource {
-        reads: Arc<AtomicUsize>,
-        tip: PersistedTip,
-    }
-
-    impl PersistedBlockSource for StartupRaceSource {
-        fn last_block_number(&self) -> eyre::Result<u64> {
-            let read = self.reads.fetch_add(1, Ordering::SeqCst);
-            Ok(if read == 0 {
-                self.tip.number - 1
-            } else {
-                self.tip.number
-            })
-        }
-
-        fn canonical_block_number(&self) -> eyre::Result<u64> {
-            Ok(self.tip.number)
-        }
-
-        fn persisted_block_stream(&self) -> futures::stream::BoxStream<'static, PersistedTip> {
-            stream::iter([self.tip]).boxed()
-        }
-
-        fn encoded_block_by_number(&self, number: u64) -> eyre::Result<EncodedPersistedBlock> {
-            assert_eq!(number, self.tip.number);
-            Ok(EncodedPersistedBlock {
-                number,
-                hash: self.tip.hash,
-                encoded: vec![number as u8],
-            })
-        }
-    }
-
-    /// A provider whose canonical head sits above its persisted head, which is the window the
-    /// stop flush and the demotion drain both have to get right.
-    #[derive(Clone)]
-    struct DivergentHeadSource {
-        canonical: u64,
+    struct Source {
         persisted: Arc<AtomicU64>,
-        /// The persisted head observed while the broadcaster subscribes. Subsequent reads see
-        /// `persisted`, allowing tests to model a block that becomes durable during shutdown.
-        startup_persisted: u64,
-        startup_reads: Arc<AtomicUsize>,
-        updates: watch::Receiver<PersistedTip>,
+        updates: watch::Receiver<()>,
     }
 
-    impl PersistedBlockSource for DivergentHeadSource {
+    impl PersistedBlockSource for Source {
         fn last_block_number(&self) -> eyre::Result<u64> {
-            let read = self.startup_reads.fetch_add(1, Ordering::SeqCst);
-            Ok(if read < 2 {
-                self.startup_persisted
-            } else {
-                self.persisted.load(Ordering::SeqCst)
-            })
+            Ok(self.persisted.load(Ordering::SeqCst))
         }
-
-        fn canonical_block_number(&self) -> eyre::Result<u64> {
-            Ok(self.canonical)
-        }
-
-        fn persisted_block_stream(&self) -> futures::stream::BoxStream<'static, PersistedTip> {
-            stream::unfold(self.updates.clone(), |mut updates| async move {
+        fn persisted_block_stream(&self) -> BoxStream<'static, ()> {
+            futures::stream::unfold(self.updates.clone(), |mut updates| async move {
                 updates.changed().await.ok()?;
-                let tip = *updates.borrow_and_update();
-                Some((tip, updates))
+                Some(((), updates))
             })
             .boxed()
         }
-
         fn encoded_block_by_number(&self, number: u64) -> eyre::Result<EncodedPersistedBlock> {
-            assert!(
-                number <= self.persisted.load(Ordering::SeqCst),
-                "encoded a block that is not durable yet: {number}"
-            );
+            assert!(number <= self.persisted.load(Ordering::SeqCst));
             Ok(EncodedPersistedBlock {
-                number,
                 hash: B256::repeat_byte(number as u8),
                 encoded: vec![number as u8],
             })
@@ -612,109 +331,60 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn broadcasts_block_persisted_during_startup_reconciliation_once() {
-        let source = StartupRaceSource {
-            reads: Arc::new(AtomicUsize::new(0)),
-            tip: PersistedTip {
-                number: 1,
-                hash: B256::repeat_byte(0x11),
-            },
-        };
-        let (commands, mut command_rx) = tokio::sync::mpsc::channel(4);
-        let (_shutdown, shutdown_rx) = oneshot::channel();
-
-        broadcast_persisted_blocks(source, commands, shutdown_rx).await;
-
-        assert_eq!(
-            command_rx.recv().await,
-            Some(P2pCommand::BroadcastBlock(vec![1]))
-        );
-        assert_eq!(command_rx.recv().await, None);
-    }
-
-    #[tokio::test]
-    async fn stop_flush_never_broadcasts_a_canonical_only_block() {
-        // Exactly the reported window: block N is canonical but only N-1 is durable.
-        let source = DivergentHeadSource {
-            canonical: 2,
-            persisted: Arc::new(AtomicU64::new(1)),
-            startup_persisted: 0,
-            startup_reads: Arc::new(AtomicUsize::new(0)),
-            updates: watch::channel(PersistedTip {
-                number: 1,
-                hash: B256::repeat_byte(1),
-            })
-            .1,
-        };
-        let (commands, mut command_rx) = tokio::sync::mpsc::channel(4);
-        let (shutdown, shutdown_rx) = oneshot::channel();
-        shutdown
-            .send(BroadcasterShutdown::Stop)
-            .expect("the broadcaster must retain the shutdown receiver");
-
-        broadcast_persisted_blocks(source, commands, shutdown_rx).await;
-
-        // Block 1 is durable and must be flushed; block 2 exists only in memory and would be
-        // lost on restart, stranding any follower that imported it.
-        assert_eq!(
-            command_rx.recv().await,
-            Some(P2pCommand::BroadcastBlock(vec![1]))
-        );
-        assert_eq!(
-            command_rx.recv().await,
-            None,
-            "the stop flush broadcast a canonical-but-unpersisted block"
-        );
-    }
-
-    #[tokio::test]
-    async fn drain_after_engine_stop_waits_for_the_canonical_tail_to_persist() {
+    async fn propagation_waits_for_persistence_and_drains_after_producer_closes() {
         let persisted = Arc::new(AtomicU64::new(1));
-        let (updates, update_rx) = watch::channel(PersistedTip {
-            number: 1,
-            hash: B256::repeat_byte(1),
-        });
-        let source = DivergentHeadSource {
-            canonical: 2,
+        let (updates, update_rx) = watch::channel(());
+        let source = Source {
             persisted: persisted.clone(),
-            startup_persisted: 0,
-            startup_reads: Arc::new(AtomicUsize::new(0)),
             updates: update_rx,
         };
-        let (commands, mut command_rx) = tokio::sync::mpsc::channel(4);
-        let (shutdown, shutdown_rx) = oneshot::channel();
-        let task = tokio::spawn(broadcast_persisted_blocks(source, commands, shutdown_rx));
-
-        shutdown
-            .send(BroadcasterShutdown::Drain)
-            .expect("the broadcaster must retain the shutdown receiver");
-
-        // The durable prefix goes out immediately.
-        assert_eq!(
-            command_rx.recv().await,
-            Some(P2pCommand::BroadcastBlock(vec![1]))
-        );
-        // The canonical tail must not, until it persists.
+        let (commands, mut received) = mpsc::channel(4);
+        let (blocks, block_rx) = mpsc::channel(4);
+        blocks
+            .send(NumHash::new(2, B256::repeat_byte(2)))
+            .await
+            .unwrap();
+        drop(blocks);
+        let task = tokio::spawn(broadcast_finalized_blocks(source, commands, block_rx));
         assert!(
-            tokio::time::timeout(std::time::Duration::from_millis(50), command_rx.recv())
+            tokio::time::timeout(std::time::Duration::from_millis(20), received.recv())
                 .await
-                .is_err(),
-            "the drain broadcast the canonical tail before it was durable"
+                .is_err()
         );
-
+        assert!(!task.is_finished());
         persisted.store(2, Ordering::SeqCst);
-        updates
-            .send(PersistedTip {
-                number: 2,
-                hash: B256::repeat_byte(2),
-            })
-            .expect("the broadcaster must retain the persisted-block stream");
-
+        updates.send(()).unwrap();
+        task.await.unwrap().unwrap();
         assert_eq!(
-            command_rx.recv().await,
+            received.recv().await,
             Some(P2pCommand::BroadcastBlock(vec![2]))
         );
-        task.await.expect("the broadcaster task must not panic");
-        assert_eq!(command_rx.recv().await, None);
+        assert_eq!(received.recv().await, None);
+    }
+
+    #[tokio::test]
+    async fn propagation_sends_only_named_blocks_and_rejects_hash_mismatch() {
+        let (_updates, update_rx) = watch::channel(());
+        let source = Source {
+            persisted: Arc::new(AtomicU64::new(4)),
+            updates: update_rx,
+        };
+        let (commands, mut received) = mpsc::channel(4);
+        let (blocks, block_rx) = mpsc::channel(4);
+        blocks
+            .send(NumHash::new(2, B256::repeat_byte(2)))
+            .await
+            .unwrap();
+        blocks.send(NumHash::new(4, B256::ZERO)).await.unwrap();
+        drop(blocks);
+        let error = broadcast_finalized_blocks(source, commands, block_rx)
+            .await
+            .unwrap_err();
+        assert!(error.to_string().contains("changed before propagation"));
+        assert_eq!(
+            received.recv().await,
+            Some(P2pCommand::BroadcastBlock(vec![2]))
+        );
+        assert_eq!(received.recv().await, None);
     }
 }

--- a/crates/node/src/role.rs
+++ b/crates/node/src/role.rs
@@ -1,19 +1,9 @@
-//! Dynamic role supervision for multi-sequencer zone nodes.
-//!
-//! The [`RoleController`] switches complete role generations — block production or import,
-//! broadcast, transaction flow, settlement, and sequencer background tasks — as one fenced
-//! unit, driven by the effective [`LeadershipSchedule`].
-//!
-//! The control rule is about the **next anchor**, never the last applied one: for the next
-//! Tempo anchor `N` to be consumed, if `schedule.leader_for(N)` is this node and the zone
-//! block embedding `N − 1` is locally canonical, the controller runs the leader generation
-//! and the engine produces `N`; otherwise it runs the follower generation and imports. The
-//! per-anchor [`ProductionPermit`](crate::ProductionPermit) inside the engine and the
-//! anchor-aware sender fence inside follower import are the protocol fences; generation
-//! switching is lifecycle management.
+//! Per-anchor sequencing decisions. Leadership changes update state in one persistent loop.
 
 use std::{sync::Arc, time::Duration};
 
+use alloy_consensus::BlockHeader as _;
+use alloy_eips::NumHash;
 use alloy_primitives::Address;
 use eyre::WrapErr as _;
 use reth_chain_state::PersistedBlockSubscriptions;
@@ -25,21 +15,18 @@ use reth_storage_api::{BlockNumReader, BlockReader, ReceiptProvider, StateProvid
 use reth_transaction_pool::TransactionPool;
 use tempo_primitives::{Block, TempoHeader};
 use tokio::{
-    sync::{mpsc, oneshot},
+    sync::{mpsc, watch},
     task::JoinSet,
 };
 use tokio_util::{sync::CancellationToken, task::AbortOnDropHandle};
-use tracing::{debug, error, info, warn};
+use tracing::error;
 use zone_chainspec::ZoneChainSpec;
 use zone_l1::{DepositQueue, EncryptionKeyRing, L1BlockTracker, TempoStateExt as _};
-use zone_p2p::{
-    BackfillCommand, BackfillRequest, BackfillResponse, LeadershipSchedule, P2pCommand, P2pEvent,
-    P2pPeerId,
-};
+use zone_p2p::{BackfillCommand, LeadershipSchedule, P2pCommand, P2pPeerId};
 use zone_payload::ZonePayloadTypes;
 use zone_sequencer::{
-    ShadowProverConfig, ZoneSequencerConfig, ZoneSequencerHandle, ZoneSequencerProvider,
-    resolve_portal_zone_anchor, spawn_zone_sequencer,
+    ShadowProverConfig, ZoneSequencerConfig, ZoneSequencerProvider, resolve_portal_zone_anchor,
+    spawn_zone_sequencer,
 };
 use zone_transaction_pool_alias::TempoPooledTransaction;
 
@@ -48,29 +35,16 @@ mod zone_transaction_pool_alias {
 }
 
 use crate::{
-    EngineExit, ProductionPermit, ZoneEngine, ZoneSequencerAddOnsConfig,
+    ProductionPermit, ZoneEngine, ZoneSequencerAddOnsConfig,
     follower::{BlockSyncP2p, FollowerBlockSync, FollowerBlockSyncContext, PeerTipRegistry},
-    replication::{
-        BroadcasterShutdown, broadcast_persisted_blocks, collect_follower_settlement_signatures,
-    },
+    p2p_engine::{P2pEventRoutes, ZoneP2pEngine},
+    replication::collect_follower_settlement_signatures,
     settlement_attestation::{AttestationContext, collect_leader_settlements},
     tx_forwarding::{forward_new_transactions, insert_forwarded_transactions},
 };
 
-/// Backoff after a transient role or promotion-readiness derivation failure.
-const ROLE_DECISION_RETRY_BACKOFF: Duration = Duration::from_millis(500);
-/// How long a stopping generation may take before its remaining tasks are aborted.
-///
-/// Must cover the longest in-flight L1 confirmation (`processWithdrawals` and `submitBatch`
-/// both wait up to 30s for a receipt) plus a 10s margin so demotion does not abort those waits.
-const GENERATION_STOP_TIMEOUT: Duration = Duration::from_secs(40);
-/// Backoff after a generation task fails unexpectedly.
-const GENERATION_RESTART_BACKOFF: Duration = Duration::from_millis(500);
-/// Buffer size for per-generation event channels.
-const GENERATION_EVENT_BACKLOG: usize = 128;
-
-/// Everything a role generation needs to start its tasks.
-pub(crate) struct RoleControllerContext<P, Pool> {
+/// Resources shared by the persistent sequencer and its background services.
+pub(crate) struct SequencerContext<P, Pool> {
     pub local_ed25519_public_key: P2pPeerId,
     pub schedule: LeadershipSchedule,
     pub provider: P,
@@ -85,8 +59,7 @@ pub(crate) struct RoleControllerContext<P, Pool> {
     pub backfill_commands: mpsc::Sender<BackfillCommand>,
     pub attestation: AttestationContext,
     pub portal_address: Address,
-    /// Sequencer resources constructed unconditionally at startup; activation is gated by
-    /// the leader generation. `None` means this node can never lead.
+    /// `None` means this node can never lead.
     pub sequencer: Option<LeaderSequencerDeps>,
     /// Tip evidence advertised by peers via backfill completions.
     pub peer_tips: PeerTipRegistry,
@@ -99,7 +72,7 @@ pub(crate) struct RoleControllerContext<P, Pool> {
 pub struct RoleStatus {
     /// `"leader"`, `"follower"`, or `"fenced"`.
     pub role: &'static str,
-    /// Monotonic generation counter.
+    /// Monotonic role transition counter (retains the existing RPC field name).
     pub generation: u64,
     /// Epoch of the record governing the next anchor, when known.
     pub epoch: Option<u64>,
@@ -119,143 +92,7 @@ pub(crate) struct LeaderSequencerDeps {
     pub prover_config: Option<ShadowProverConfig>,
 }
 
-/// Sinks for the long-lived P2P event demultiplexer.
-///
-/// Role generations receive typed substreams, so dropping one generation never drops the
-/// underlying network event stream.
-#[derive(Clone, Default)]
-pub(crate) struct EventSinks {
-    inner: Arc<std::sync::Mutex<GenerationSinks>>,
-}
-
-impl EventSinks {
-    fn install(
-        &self,
-        sync: mpsc::Sender<P2pEvent>,
-        transactions: Option<mpsc::Sender<P2pEvent>>,
-        backfill_responses: Option<mpsc::Sender<BackfillResponse>>,
-    ) {
-        let mut sinks = self.inner.lock().expect("poisoned");
-        sinks.sync = Some(sync);
-        sinks.transactions = transactions;
-        sinks.backfill_responses = backfill_responses;
-    }
-
-    fn clear(&self) {
-        let mut sinks = self.inner.lock().expect("poisoned");
-        sinks.sync = None;
-        sinks.transactions = None;
-        sinks.backfill_responses = None;
-    }
-
-    fn sink_for(&self, event: &P2pEvent) -> Option<mpsc::Sender<P2pEvent>> {
-        let sinks = self.inner.lock().expect("poisoned");
-        if matches!(event, P2pEvent::TransactionReceived { .. }) {
-            sinks.transactions.clone()
-        } else {
-            sinks.sync.clone()
-        }
-    }
-
-    fn backfill_response_sink(&self) -> Option<mpsc::Sender<BackfillResponse>> {
-        self.inner
-            .lock()
-            .expect("poisoned")
-            .backfill_responses
-            .clone()
-    }
-}
-
-#[derive(Default)]
-struct GenerationSinks {
-    sync: Option<mpsc::Sender<P2pEvent>>,
-    transactions: Option<mpsc::Sender<P2pEvent>>,
-    backfill_responses: Option<mpsc::Sender<BackfillResponse>>,
-}
-
-/// Long-lived P2P event demultiplexer for non-backfill protocols.
-///
-/// It owns the generic event receiver for the process lifetime and forwards events to the active
-/// generation's substream. Events arriving between generations are dropped because the successor
-/// re-derives its state from the provider and schedule. Generation delivery is deliberately
-/// non-blocking so a slow generation cannot block process-lifetime protocol work.
-pub(crate) async fn route_events_to_generations(
-    mut events: mpsc::Receiver<P2pEvent>,
-    sinks: EventSinks,
-) {
-    while let Some(event) = events.recv().await {
-        let Some(sink) = sinks.sink_for(&event) else {
-            metrics::counter!("zone_leadership_events_dropped_between_generations_total")
-                .increment(1);
-            debug!(target: "zone::role", "Dropping P2P event with no active generation consumer");
-            continue;
-        };
-        match sink.try_send(event) {
-            Ok(()) => {}
-            Err(mpsc::error::TrySendError::Full(_)) => {
-                // Live blocks are recovered by the follower's periodic backfill probe, and
-                // transaction forwarding reconciles from the pool. Keep this router non-blocking.
-                metrics::counter!("zone_leadership_events_dropped_backpressure_total").increment(1);
-                debug!(
-                    target: "zone::role",
-                    "Dropping generation event because its bounded sink is full"
-                );
-            }
-            Err(mpsc::error::TrySendError::Closed(_)) => {
-                // The generation stopped after we snapshotted its sink; the next generation
-                // installs fresh channels and re-derives its state, so late generation-specific
-                // events must not leak into the successor.
-                metrics::counter!("zone_leadership_events_dropped_between_generations_total")
-                    .increment(1);
-            }
-        }
-    }
-    error!(target: "zone::role", "P2P event channel closed");
-}
-
-/// Routes process-lifetime backfill requests to the canonical provider server.
-pub(crate) async fn route_backfill_requests(
-    mut requests: mpsc::Receiver<BackfillRequest>,
-    backfill: mpsc::Sender<BackfillRequest>,
-) {
-    while let Some(request) = requests.recv().await {
-        let start = request.start;
-        if let Err(err) = backfill.try_send(request) {
-            metrics::counter!("zone_leadership_backfill_requests_dropped_total").increment(1);
-            warn!(target: "zone::role", %err, start, "Dropped a block backfill request because the serving queue is unavailable");
-        }
-    }
-    error!(target: "zone::role", "Typed P2P backfill request channel closed");
-}
-
-/// Routes accepted backfill responses to the currently active follower generation.
-pub(crate) async fn route_backfill_responses(
-    mut responses: mpsc::Receiver<BackfillResponse>,
-    sinks: EventSinks,
-) {
-    while let Some(response) = responses.recv().await {
-        let Some(sink) = sinks.backfill_response_sink() else {
-            metrics::counter!("zone_leadership_events_dropped_between_generations_total")
-                .increment(1);
-            debug!(target: "zone::role", "Dropping backfill response with no active follower consumer");
-            continue;
-        };
-        match sink.try_send(response) {
-            Ok(()) => {}
-            Err(mpsc::error::TrySendError::Full(_)) => {
-                metrics::counter!("zone_leadership_events_dropped_backpressure_total").increment(1);
-                debug!(target: "zone::role", "Dropping backfill response because the generation sink is full");
-            }
-            Err(mpsc::error::TrySendError::Closed(_)) => {
-                metrics::counter!("zone_leadership_events_dropped_between_generations_total")
-                    .increment(1);
-            }
-        }
-    }
-    error!(target: "zone::role", "Typed P2P backfill response channel closed");
-}
-
-/// The role a generation runs, derived from the next-anchor rule.
+/// Sequencing mode derived from the next canonical anchor.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 enum DesiredRole {
     Leader {
@@ -296,204 +133,6 @@ impl DesiredRole {
             Self::Fenced => None,
         }
     }
-
-    /// Whether two roles are the same variant, ignoring the epoch.
-    ///
-    /// Generations are switched per variant, not per epoch: an epoch bump that leaves this
-    /// node in the same role must not tear down and rebuild its task graph.
-    fn same_variant(self, other: Self) -> bool {
-        std::mem::discriminant(&self) == std::mem::discriminant(&other)
-    }
-}
-
-/// Outcome of one generation task, tagged for supervision decisions.
-#[derive(Debug)]
-enum TaskEnd {
-    Engine(EngineExit),
-    SequencerStopped,
-    Ended(&'static str),
-}
-
-/// Whether a generation stopped with its canonical-state boundary proven.
-///
-/// A failed stop must fence the role controller: an aborted engine task may have an already
-/// enqueued Engine API message that Reth can still apply after the task has gone away.
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-enum GenerationStopOutcome {
-    Stopped,
-    Failed,
-}
-
-/// Supervise the two long-running sequencer children as one role-generation task.
-///
-/// An unexpected child exit must restart the whole generation immediately. During an intentional
-/// generation stop, however, both children retain the graceful shutdown window needed to finish
-/// in-flight L1 transactions.
-async fn supervise_sequencer_tasks(
-    handle: ZoneSequencerHandle,
-    stop: CancellationToken,
-) -> TaskEnd {
-    let mut withdrawal = AbortOnDropHandle::new(handle.withdrawal_handle);
-    let mut monitor = AbortOnDropHandle::new(handle.monitor_handle);
-
-    tokio::select! {
-        biased;
-        () = stop.cancelled() => {
-            // Both children observe the same token at their poll boundaries. Keep both handles
-            // alive until they finish; the outer generation timeout will abort this supervisor
-            // and AbortOnDropHandle will then abort either child that is still stuck.
-            let (withdrawal_result, monitor_result) =
-                tokio::join!(&mut withdrawal, &mut monitor);
-            if let Err(err) = withdrawal_result {
-                warn!(target: "zone::role", %err, "Withdrawal processor task failed during shutdown");
-            }
-            if let Err(err) = monitor_result {
-                warn!(target: "zone::role", %err, "Zone monitor task failed during shutdown");
-            }
-            TaskEnd::SequencerStopped
-        }
-        result = &mut withdrawal => {
-            match result {
-                Ok(()) => warn!(target: "zone::role", "Withdrawal processor task stopped unexpectedly"),
-                Err(err) => warn!(target: "zone::role", %err, "Withdrawal processor task failed"),
-            }
-            // Returning drops and aborts the monitor handle. The role controller observes
-            // TaskEnd::Ended and restarts the complete generation.
-            TaskEnd::Ended("withdrawal-processor")
-        }
-        result = &mut monitor => {
-            match result {
-                Ok(()) => warn!(target: "zone::role", "Zone monitor task stopped unexpectedly"),
-                Err(err) => warn!(target: "zone::role", %err, "Zone monitor task failed"),
-            }
-            // Returning drops and aborts the withdrawal handle before the generation restarts.
-            TaskEnd::Ended("zone-monitor")
-        }
-    }
-}
-
-/// Leader-only controls that must either both exist or both be absent.
-struct LeaderShutdown {
-    /// Fires when the leader engine task returns.
-    engine_done: oneshot::Receiver<()>,
-    /// Receives exactly one shutdown decision for the persisted-block broadcaster.
-    broadcaster: oneshot::Sender<BroadcasterShutdown>,
-}
-
-struct RunningGeneration {
-    id: u64,
-    role: DesiredRole,
-    token: CancellationToken,
-    leader_shutdown: Option<LeaderShutdown>,
-    tasks: JoinSet<TaskEnd>,
-}
-
-impl RunningGeneration {
-    async fn stop(mut self, sinks: &EventSinks) -> GenerationStopOutcome {
-        sinks.clear();
-        self.token.cancel();
-        let deadline = tokio::time::Instant::now() + GENERATION_STOP_TIMEOUT;
-
-        let mut outcome = GenerationStopOutcome::Stopped;
-
-        // Cancellation is not a block boundary: an in-flight advance still completes before the
-        // engine returns, so the canonical head keeps moving after `token.cancel()`. The
-        // broadcaster can only be given a drain target once the engine has actually stopped.
-        let mut leader_shutdown = self.leader_shutdown.take();
-        let draining = match leader_shutdown.as_mut() {
-            Some(LeaderShutdown { engine_done, .. }) => {
-                match tokio::time::timeout_at(deadline, engine_done).await {
-                    Ok(Ok(())) => true,
-                    Ok(Err(_)) => {
-                        outcome = GenerationStopOutcome::Failed;
-                        error!(
-                            target: "zone::role",
-                            generation = self.id,
-                            "Engine task ended without acknowledging a clean stop; fencing role controller"
-                        );
-                        false
-                    }
-                    Err(_) => {
-                        outcome = GenerationStopOutcome::Failed;
-                        error!(
-                            target: "zone::role",
-                            generation = self.id,
-                            "Engine did not stop within the timeout; fencing role controller"
-                        );
-                        false
-                    }
-                }
-            }
-            // Not a leader generation, so there is no canonical tail to drain.
-            None => false,
-        };
-        if let Some(LeaderShutdown { broadcaster, .. }) = leader_shutdown {
-            let command = if draining {
-                BroadcasterShutdown::Drain
-            } else {
-                BroadcasterShutdown::Stop
-            };
-            if broadcaster.send(command).is_err() {
-                outcome = GenerationStopOutcome::Failed;
-                error!(
-                    target: "zone::role",
-                    generation = self.id,
-                    ?command,
-                    "Persisted block broadcaster exited before its shutdown could be acknowledged; fencing role controller"
-                );
-            }
-        }
-        loop {
-            match tokio::time::timeout_at(deadline, self.tasks.join_next()).await {
-                Ok(Some(result)) => {
-                    if let Err(err) = result
-                        && !err.is_cancelled()
-                    {
-                        warn!(target: "zone::role", generation = self.id, %err, "Generation task panicked during stop");
-                    }
-                }
-                Ok(None) => break,
-                Err(_) => {
-                    warn!(
-                        target: "zone::role",
-                        generation = self.id,
-                        "Generation did not stop within the timeout; aborting remaining tasks"
-                    );
-                    outcome = GenerationStopOutcome::Failed;
-                    self.tasks.abort_all();
-                    while self.tasks.join_next().await.is_some() {}
-                    break;
-                }
-            }
-        }
-        match outcome {
-            GenerationStopOutcome::Stopped => {
-                info!(target: "zone::role", generation = self.id, role = self.role.name(), "Role generation stopped");
-            }
-            GenerationStopOutcome::Failed => {
-                error!(target: "zone::role", generation = self.id, role = self.role.name(), "Role generation teardown was not proven safe");
-            }
-        }
-        outcome
-    }
-}
-
-/// Stop the active generation and keep the controller fenced if its teardown is unproven.
-///
-/// Returns `false` when the controller must exit rather than allow a successor generation to
-/// start after a failed teardown.
-async fn stop_current_generation(
-    current: &mut Option<RunningGeneration>,
-    sinks: &EventSinks,
-) -> bool {
-    if let Some(generation) = current.take()
-        && generation.stop(sinks).await == GenerationStopOutcome::Failed
-    {
-        error!(target: "zone::role", "Role controller exiting after an unproven generation teardown");
-        return false;
-    }
-
-    true
 }
 
 /// Derive the desired role for the next anchor from local canonical state and the schedule.
@@ -607,19 +246,107 @@ where
     Ok(recovery_height)
 }
 
-/// Run the role controller until the process shuts down.
-///
-/// `sinks` must be the same [`EventSinks`] handed to [`route_events_to_generations`] — the
-/// router is long-lived while generations come and go.
-///
-/// Subscribes to schedule notifications plus generation task completion, re-derives the desired
-/// role by the next-anchor rule, and switches role generations.
-/// Observation alone never switches roles — the trigger is consumption progress reaching
-/// the boundary, which this loop tracks by re-reading the local Tempo checkpoint.
-pub(crate) async fn run_role_controller<P, Pool>(
-    context: RoleControllerContext<P, Pool>,
-    sinks: EventSinks,
-    mut l1_blocks: mpsc::Receiver<zone_l1::L1BlockDeposits>,
+/// Block production state owned by the same loop that imports peer blocks.
+/// There is only one canonical head writer, including across leadership transitions.
+pub(crate) struct Sequencing<P> {
+    provider: P,
+    schedule: LeadershipSchedule,
+    local: P2pPeerId,
+    engine: Option<ZoneEngine>,
+    status: SharedRoleStatus,
+    active: watch::Sender<bool>,
+    finalized: mpsc::Sender<NumHash>,
+    observed_through: Option<u64>,
+}
+
+impl<P> Sequencing<P>
+where
+    P: StateProviderFactory + BlockNumReader + HeaderProvider<Header = TempoHeader>,
+{
+    pub(crate) fn observed(&mut self, block: zone_l1::L1BlockDeposits) {
+        self.observed_through = Some(block.header.number());
+    }
+
+    pub(crate) fn is_leader(&self) -> bool {
+        *self.active.borrow()
+    }
+
+    /// Produce at most one block, then return to the channel loop before the next boundary.
+    pub(crate) async fn advance(&mut self) -> eyre::Result<bool> {
+        let can_lead = self.engine.is_some() && self.schedule.is_quorum_member(&self.local);
+        let mut reasons = Vec::new();
+        let mut desired = match desired_role(&self.provider, &self.schedule, &self.local, can_lead)
+        {
+            Ok(role) => role,
+            Err(error) => {
+                reasons.push(format!("cannot read the canonical L1 checkpoint: {error}"));
+                DesiredRole::Fenced
+            }
+        };
+        if let DesiredRole::Leader { next_anchor, .. } = desired
+            && let Readiness::Conflicted(reason) =
+                promotion_readiness(&self.provider, &self.schedule, &self.local, next_anchor)
+        {
+            reasons.push(reason);
+            desired = DesiredRole::Fenced;
+        }
+        if !can_lead {
+            reasons.push("rpc-only nodes cannot get promoted".to_owned());
+        }
+        let leader = matches!(desired, DesiredRole::Leader { .. });
+        self.active.send_if_modified(|active| {
+            if *active == leader {
+                false
+            } else {
+                *active = leader;
+                true
+            }
+        });
+        {
+            let mut status = self.status.lock().expect("poisoned");
+            if status.role != desired.name() {
+                status.generation += 1;
+                metrics::counter!("zone_leadership_transitions_total", "to" => desired.name())
+                    .increment(1);
+            }
+            status.role = desired.name();
+            status.epoch = desired.epoch();
+            status.ready_for_promotion = reasons.is_empty();
+            status.promotion_reasons = reasons;
+            metrics::gauge!("zone_leadership_ready_for_promotion")
+                .set(if status.ready_for_promotion { 1.0 } else { 0.0 });
+        }
+        metrics::gauge!("zone_leadership_role").set(desired.gauge());
+        if let Some(epoch) = desired.epoch() {
+            metrics::gauge!("zone_leadership_epoch").set(epoch as f64);
+        }
+        let DesiredRole::Leader { next_anchor, .. } = desired else {
+            return Ok(false);
+        };
+        if self
+            .observed_through
+            .is_none_or(|observed| observed < next_anchor)
+        {
+            return Ok(false);
+        }
+        let engine = self.engine.as_mut().expect("leader requires an engine");
+        // Imports may have advanced the head since this node last produced a block.
+        let parent = latest_sealed_header(&self.provider)?;
+        let Some(block) = engine.produce_next(parent).await? else {
+            return Ok(false);
+        };
+        self.finalized
+            .send(block)
+            .await
+            .wrap_err("P2P finalized block channel closed")?;
+        Ok(true)
+    }
+}
+
+pub(crate) async fn run_sequencer<P, Pool>(
+    context: SequencerContext<P, Pool>,
+    p2p: ZoneP2pEngine,
+    l1_blocks: mpsc::Receiver<zone_l1::L1BlockDeposits>,
 ) where
     P: BlockNumReader
         + BlockReader<Block = Block>
@@ -634,466 +361,161 @@ pub(crate) async fn run_role_controller<P, Pool>(
         + 'static,
     Pool: TransactionPool<Transaction = TempoPooledTransaction> + Clone + 'static,
 {
-    let mut schedule_changes = context.schedule.subscribe();
-
-    let mut generation_id: u64 = 0;
-    let mut current: Option<RunningGeneration> = None;
-
-    loop {
-        // An rpc-only member is not registered with `ZonePortal`, so it can never be named
-        // leader by a finalized transition. Fencing it explicitly means a corrupt or wrongly
-        // provisioned record cannot start a producer whose blocks nobody could settle.
-        let can_lead = context.sequencer.is_some()
-            && context
-                .schedule
-                .is_quorum_member(&context.local_ed25519_public_key);
-        let mut retry_decision = false;
-        let mut desired = match desired_role(
-            &context.provider,
-            &context.schedule,
-            &context.local_ed25519_public_key,
-            can_lead,
-        ) {
-            Ok(desired) => desired,
-            Err(err) => {
-                error!(target: "zone::role", %err, "Failed reading the local Tempo checkpoint; fencing");
-                retry_decision = true;
-                DesiredRole::Fenced
-            }
-        };
-
-        // Only forced recovery has an additional promotion barrier. Normal transitions are
-        // complete when the local next anchor is assigned to this node.
-        let mut promotion_reasons = if can_lead {
-            Vec::new()
-        } else {
-            vec!["rpc-only nodes cannot get promoted".to_owned()]
-        };
-        if let DesiredRole::Leader { epoch, next_anchor } = desired
-            && !current
-                .as_ref()
-                .is_some_and(|generation| generation.role.same_variant(desired))
-        {
-            match promotion_readiness(
-                &context.provider,
-                &context.schedule,
-                &context.local_ed25519_public_key,
-                next_anchor,
-            ) {
-                Readiness::Ready => {
-                    info!(target: "zone::role", epoch, next_anchor, "Promotion barrier satisfied");
-                }
-                Readiness::Conflicted(detail) => {
-                    error!(
-                        target: "zone::role",
-                        epoch,
-                        %detail,
-                        "Conflicting promotion evidence; fencing instead of promoting"
-                    );
-                    promotion_reasons = vec![detail];
-                    desired = DesiredRole::Fenced;
-                }
-            }
-        }
-        if !current
-            .as_ref()
-            .is_some_and(|generation| generation.role.same_variant(desired))
-        {
-            if !stop_current_generation(&mut current, &sinks).await {
-                return;
-            }
-            generation_id += 1;
-            match start_generation(&context, &sinks, desired, generation_id).await {
-                Ok(generation) => {
-                    current = Some(generation);
-                }
-                Err(err) => {
-                    // Starting a role generation is atomic: none of its task graph remains
-                    // active after a startup failure. Leave the node fenced and retry the
-                    // complete desired generation after the decision backoff.
-                    sinks.clear();
-                    retry_decision = true;
-                    promotion_reasons = vec![format!(
-                        "failed to start {} generation: {err:#}",
-                        desired.name()
-                    )];
-                    error!(
-                        target: "zone::role",
-                        generation = generation_id,
-                        role = desired.name(),
-                        %err,
-                        "Role generation failed to start; fencing before retry"
-                    );
-                }
-            }
-
-            let active_role = current
-                .as_ref()
-                .map(|generation| generation.role)
-                .unwrap_or(DesiredRole::Fenced);
-            metrics::counter!(
-                "zone_leadership_transitions_total",
-                "to" => active_role.name(),
-            )
-            .increment(1);
-            metrics::gauge!("zone_leadership_role").set(active_role.gauge());
-            if active_role.same_variant(desired)
-                && let Some(epoch) = desired.epoch()
-            {
-                metrics::gauge!("zone_leadership_epoch").set(epoch as f64);
-            }
-        }
-
-        let active_role = current
-            .as_ref()
-            .map(|generation| generation.role)
-            .unwrap_or(DesiredRole::Fenced);
-        // Readiness is exactly "nothing is blocking promotion", so it is derived rather than
-        // tracked alongside the reasons it would have to stay consistent with.
-        let ready_for_promotion = promotion_reasons.is_empty();
-        {
-            let mut status = context.status.lock().expect("poisoned");
-            status.role = active_role.name();
-            status.epoch = if active_role.same_variant(desired) {
-                desired.epoch()
-            } else {
-                None
-            };
-            status.generation = generation_id;
-            status.ready_for_promotion = ready_for_promotion;
-            status.promotion_reasons = promotion_reasons;
-        }
-        metrics::gauge!("zone_leadership_ready_for_promotion").set(if ready_for_promotion {
-            1.0
-        } else {
-            0.0
-        });
-        // A fenced generation has no tasks; an empty JoinSet's join_next() is immediately
-        // ready with None, so polling it would spin this loop hot. Stay pending instead and
-        // wake only on an explicit change or a retry for a failed/pending decision.
-        let task_end = async {
-            match current.as_mut() {
-                Some(generation) if !generation.tasks.is_empty() => {
-                    generation.tasks.join_next().await
-                }
-                _ => std::future::pending().await,
-            }
-        };
-        tokio::select! {
-            biased;
-            block = l1_blocks.recv() => {
-                if block.is_none() {
-                    panic!("L1 subscriber block channel closed");
-                }
-            }
-            changed = schedule_changes.changed() => {
-                if changed.is_err() {
-                    error!(target: "zone::role", "Leadership schedule notifier closed");
-                    return;
-                }
-            }
-            result = task_end => {
-                match result {
-                    Some(Ok(TaskEnd::Engine(EngineExit::Demoted { tempo_anchor, epoch }))) => {
-                        info!(
-                            target: "zone::role",
-                            tempo_anchor,
-                            epoch,
-                            "Engine halted at the activation boundary; demoting"
-                        );
-                        // Stop here rather than letting the next iteration notice the role
-                        // change, so the broadcaster drains this leader's final blocks before
-                        // the successor starts producing.
-                        if !stop_current_generation(&mut current, &sinks).await {
-                            return;
-                        }
-                        // The next loop iteration derives Follower from the same schedule.
-                    }
-                    Some(Ok(TaskEnd::Engine(EngineExit::Fenced { tempo_anchor }))) => {
-                        error!(
-                            target: "zone::role",
-                            tempo_anchor,
-                            "Engine fenced on an ungoverned anchor"
-                        );
-                        if !stop_current_generation(&mut current, &sinks).await {
-                            return;
-                        }
-                        tokio::time::sleep(GENERATION_RESTART_BACKOFF).await;
-                    }
-                    Some(Ok(TaskEnd::Engine(EngineExit::Cancelled)))
-                    | Some(Ok(TaskEnd::SequencerStopped)) => {}
-                    Some(Ok(TaskEnd::Ended(name))) => {
-                        // A generation task ended while its generation is still desired:
-                        // restart the whole generation to keep the task graph coherent.
-                        error!(target: "zone::role", task = name, "Generation task ended unexpectedly; restarting generation");
-                        if !stop_current_generation(&mut current, &sinks).await {
-                            return;
-                        }
-                        tokio::time::sleep(GENERATION_RESTART_BACKOFF).await;
-                    }
-                    Some(Err(err)) => {
-                        error!(target: "zone::role", %err, "Generation task panicked; restarting generation");
-                        if !stop_current_generation(&mut current, &sinks).await {
-                            return;
-                        }
-                        tokio::time::sleep(GENERATION_RESTART_BACKOFF).await;
-                    }
-                    // Unreachable: join_next() is only polled while the set is non-empty.
-                    None => {}
-                }
-            }
-            _ = async {
-                if retry_decision {
-                    tokio::time::sleep(ROLE_DECISION_RETRY_BACKOFF).await;
-                } else {
-                    std::future::pending().await
-                }
-            } => {}
-        }
+    let stop = CancellationToken::new();
+    let _cancel = stop.clone().drop_guard();
+    let (active_tx, active_rx) = watch::channel(false);
+    let (finalized_tx, finalized_rx) = mpsc::channel(128);
+    let engine = context.sequencer.as_ref().map(|sequencer| {
+        build_engine(
+            &context,
+            sequencer,
+            latest_sealed_header(&context.provider)
+                .expect("canonical head is required to start the sequencer"),
+        )
+    });
+    let sequencing = Sequencing {
+        provider: context.provider.clone(),
+        schedule: context.schedule.clone(),
+        local: context.local_ed25519_public_key.clone(),
+        engine,
+        status: context.status.clone(),
+        active: active_tx,
+        finalized: finalized_tx,
+        // Programmatic dev nodes with a zero Portal inject already-applied L1 fixtures.
+        observed_through: context.portal_address.is_zero().then_some(u64::MAX),
+    };
+    let (blocks_tx, blocks_rx) = mpsc::channel(128);
+    let (transactions_tx, transactions_rx) = mpsc::channel(128);
+    let (signatures_tx, signatures_rx) = mpsc::channel(128);
+    let (backfill_tx, backfill_rx) = mpsc::channel(128);
+    let sync = FollowerBlockSync::new(
+        FollowerBlockSyncContext {
+            provider: context.provider.clone(),
+            engine: context.engine_handle.clone(),
+            l1_block_tracker: context.l1_block_tracker.clone(),
+            deposit_queue: context.deposit_queue.clone(),
+            attestation: context.attestation.clone(),
+            schedule: context.schedule.clone(),
+            peer_tips: context.peer_tips.clone(),
+        },
+        BlockSyncP2p {
+            events: blocks_rx,
+            commands: context.commands.clone(),
+            backfill_responses: backfill_rx,
+            backfill_commands: context.backfill_commands.clone(),
+        },
+        stop.clone(),
+    );
+    let mut tasks = JoinSet::new();
+    tasks.spawn(sync.run(sequencing, l1_blocks));
+    tasks.spawn(p2p.run(
+        context.provider.clone(),
+        context.commands.clone(),
+        finalized_rx,
+        P2pEventRoutes {
+            blocks: blocks_tx,
+            transactions: transactions_tx,
+            signatures: signatures_tx,
+            backfill: backfill_tx,
+        },
+    ));
+    tasks.spawn(collect_follower_settlement_signatures(
+        context.provider.clone(),
+        signatures_rx,
+        context.attestation.clone(),
+        stop.clone(),
+    ));
+    let pool = context.pool.clone();
+    tasks.spawn(forward_new_transactions(
+        pool.clone(),
+        pool.new_transactions_listener(),
+        context.commands.clone(),
+    ));
+    tasks.spawn(insert_forwarded_transactions(
+        context.pool.clone(),
+        transactions_rx,
+    ));
+    if context.sequencer.is_some() {
+        tasks.spawn(run_leader_services(context, active_rx, stop));
     }
+    let result = tasks.join_next().await;
+    panic!("zone sequencer task stopped unexpectedly: {result:?}");
 }
 
-async fn start_generation<P, Pool>(
-    context: &RoleControllerContext<P, Pool>,
-    sinks: &EventSinks,
-    desired: DesiredRole,
-    id: u64,
-) -> eyre::Result<RunningGeneration>
-where
-    P: BlockNumReader
-        + BlockReader<Block = Block>
-        + HeaderProvider<Header = TempoHeader>
-        + StateProviderFactory
-        + ReceiptProvider
-        + PersistedBlockSubscriptions
-        + ZoneSequencerProvider
-        + Clone
-        + Send
-        + Sync
-        + 'static,
-    Pool: TransactionPool<Transaction = TempoPooledTransaction> + Clone + 'static,
+/// Keep settlement services alive across role changes, draining L1 transactions on demotion.
+async fn run_leader_services<P, Pool>(
+    context: SequencerContext<P, Pool>,
+    mut active: watch::Receiver<bool>,
+    stop: CancellationToken,
+) where
+    P: ZoneSequencerProvider + PersistedBlockSubscriptions,
+    Pool: Send + 'static,
 {
-    let token = CancellationToken::new();
-    let mut leader_shutdown = None;
-    let mut tasks = JoinSet::new();
-
-    match desired {
-        DesiredRole::Fenced => {
-            sinks.clear();
-            warn!(
-                target: "zone::role",
-                generation = id,
-                "Leadership is uninitialized or this node cannot lead; all role tasks fenced"
-            );
+    let deps = context
+        .sequencer
+        .as_ref()
+        .expect("sequencer resources required");
+    loop {
+        if active.wait_for(|active| *active).await.is_err() {
+            return;
         }
-        DesiredRole::Follower { epoch } => {
-            let (sync_tx, sync_rx) = mpsc::channel(GENERATION_EVENT_BACKLOG);
-            let (transactions_tx, transactions_rx) = mpsc::channel(GENERATION_EVENT_BACKLOG);
-            let (backfill_tx, backfill_rx) = mpsc::channel(GENERATION_EVENT_BACKLOG);
-            sinks.install(sync_tx, Some(transactions_tx), Some(backfill_tx));
-
-            let follower_token = token.clone();
-            let sync_context = FollowerBlockSyncContext {
-                provider: context.provider.clone(),
-                engine: context.engine_handle.clone(),
-                l1_block_tracker: context.l1_block_tracker.clone(),
-                deposit_queue: context.deposit_queue.clone(),
-                attestation: context.attestation.clone(),
-                schedule: context.schedule.clone(),
-                peer_tips: context.peer_tips.clone(),
-            };
-            let sync_p2p = BlockSyncP2p {
-                events: sync_rx,
-                commands: context.commands.clone(),
-                backfill_responses: backfill_rx,
-                backfill_commands: context.backfill_commands.clone(),
-            };
-            tasks.spawn(async move {
-                FollowerBlockSync::new(sync_context, sync_p2p, follower_token.clone())
-                    .run()
-                    .await;
-                if follower_token.is_cancelled() {
-                    TaskEnd::Ended("follower-block-sync (cancelled)")
-                } else {
-                    TaskEnd::Ended("follower-block-sync")
-                }
-            });
-
-            // Restarting this task performs a full txpool reconciliation on its first tick,
-            // so pending transactions converge on the replacement leader.
-            let pool = context.pool.clone();
-            let listener = pool.new_transactions_listener();
-            let commands = context.commands.clone();
-            let forward_token = token.clone();
-            tasks.spawn(async move {
-                tokio::select! {
-                    () = forward_token.cancelled() => TaskEnd::Ended("transaction-forwarding (cancelled)"),
-                    () = forward_new_transactions(pool, listener, commands) => {
-                        TaskEnd::Ended("transaction-forwarding")
-                    }
-                }
-            });
-
-            // Quorum followers retain transactions received from originating peers so a future
-            // promotion cannot lose traffic submitted immediately before the handoff. RPC-only
-            // followers receive no transaction events from the P2P transport.
-            let pool = context.pool.clone();
-            let import_token = token.clone();
-            tasks.spawn(async move {
-                tokio::select! {
-                    () = import_token.cancelled() => TaskEnd::Ended("transaction-import (cancelled)"),
-                    () = insert_forwarded_transactions(pool, transactions_rx) => {
-                        TaskEnd::Ended("transaction-import")
-                    }
-                }
-            });
-            info!(target: "zone::role", generation = id, epoch, "Follower generation started");
+        let token = stop.child_token();
+        let portal_anchor = match resolve_portal_zone_anchor(
+            &context.provider,
+            context.portal_address,
+            &context.attestation.l1_provider,
+        )
+        .await
+        {
+            Ok(anchor) => anchor,
+            Err(error) => {
+                error!(%error, "Cannot restore settlement anchor");
+                tokio::time::sleep(Duration::from_secs(1)).await;
+                continue;
+            }
+        };
+        context
+            .attestation
+            .store
+            .remove_submitted(portal_anchor.block_number);
+        let proposals = collect_leader_settlements(
+            context.provider.clone(),
+            context.commands.clone(),
+            context.attestation.clone(),
+            portal_anchor.block_number,
+        );
+        let signer = deps
+            .config
+            .l1_transaction_signer
+            .clone()
+            .unwrap_or_else(|| deps.config.sequencer_signer.clone());
+        let handle = spawn_zone_sequencer(
+            deps.sequencer_config.clone(),
+            signer,
+            context.provider.clone(),
+            deps.prover_config.clone(),
+            token.clone(),
+        )
+        .await;
+        let mut withdrawal = AbortOnDropHandle::new(handle.withdrawal_handle);
+        let mut monitor = AbortOnDropHandle::new(handle.monitor_handle);
+        tokio::pin!(proposals);
+        tokio::select! {
+            _ = active.wait_for(|active| !*active) => {}
+            () = stop.cancelled() => {}
+            () = &mut proposals => panic!("settlement proposal collector stopped"),
+            result = &mut withdrawal => panic!("withdrawal worker stopped: {result:?}"),
+            result = &mut monitor => panic!("batch submission worker stopped: {result:?}"),
         }
-        DesiredRole::Leader { epoch, .. } => {
-            let sequencer = context
-                .sequencer
-                .as_ref()
-                .expect("leader generation requires sequencer resources");
-
-            // Acquire every fallible prerequisite before installing sinks or spawning any
-            // leader task. Otherwise a transient head-read failure could leave a partial
-            // generation classified as Leader without its canonical head writer.
-            let last_header = latest_sealed_header(&context.provider)?;
-            let portal_anchor = resolve_portal_zone_anchor(
-                &context.provider,
-                context.portal_address,
-                &context.attestation.l1_provider,
-            )
-            .await
-            .wrap_err("failed to resolve portal-confirmed Zone height for leader recovery")?;
-
-            // The outgoing leader may have one final submitBatch in flight while leadership
-            // rotates. That can make this anchor one boundary stale, but rotations fence the old
-            // leader before promotion, so recovery remains bounded by one configured batch
-            // interval (120 Zone blocks in production) rather than replaying history from genesis.
-
-            // Remove any submitted attestations for the portal-confirmed anchor, so the new leader
-            // can start from here.
-            let portal_confirmed_height = portal_anchor.block_number;
-            info!(
-                target: "zone::role",
-                portal_confirmed_height,
-                portal_block_hash = %portal_anchor.block_hash,
-                "Seeded leader settlement recovery from the portal anchor"
-            );
-            context
-                .attestation
-                .store
-                .remove_submitted(portal_confirmed_height);
-
-            let (sync_tx, sync_rx) = mpsc::channel(GENERATION_EVENT_BACKLOG);
-            let (transactions_tx, transactions_rx) = mpsc::channel(GENERATION_EVENT_BACKLOG);
-            sinks.install(sync_tx, Some(transactions_tx), None);
-
-            // Canonical head writer: the engine with the per-anchor production permit.
-            let engine = build_engine(context, sequencer, last_header);
-            let engine_token = token.clone();
-            let (engine_done_tx, engine_done_rx) = oneshot::channel();
-            tasks.spawn(async move {
-                let exit = engine.run_until(engine_token).await;
-                // Signalled before the task resolves so `stop` learns the canonical head is
-                // pinned without having to drain the JoinSet first.
-                let _ = engine_done_tx.send(());
-                TaskEnd::Engine(exit)
-            });
-
-            // The broadcaster outlives the generation token on purpose: it must still be able to
-            // publish the engine's final blocks after every other task has been cancelled.
-            let (broadcaster_tx, broadcaster_rx) = oneshot::channel();
-            leader_shutdown = Some(LeaderShutdown {
-                engine_done: engine_done_rx,
-                broadcaster: broadcaster_tx,
-            });
-            let provider = context.provider.clone();
-            let commands = context.commands.clone();
-            tasks.spawn(async move {
-                broadcast_persisted_blocks(provider, commands, broadcaster_rx).await;
-                TaskEnd::Ended("block-broadcast")
-            });
-
-            let server_token = token.clone();
-            let provider = context.provider.clone();
-            let attestation = context.attestation.clone();
-            tasks.spawn(async move {
-                collect_follower_settlement_signatures(
-                    provider,
-                    sync_rx,
-                    attestation,
-                    server_token,
-                )
-                .await;
-                TaskEnd::Ended("leader-settlement-signatures")
-            });
-
-            let pool = context.pool.clone();
-            let import_token = token.clone();
-            tasks.spawn(async move {
-                tokio::select! {
-                    () = import_token.cancelled() => TaskEnd::Ended("transaction-import (cancelled)"),
-                    () = insert_forwarded_transactions(pool, transactions_rx) => {
-                        TaskEnd::Ended("transaction-import")
-                    }
-                }
-            });
-
-            let provider = context.provider.clone();
-            let commands = context.commands.clone();
-            let attestation = context.attestation.clone();
-            let settlement_token = token.clone();
-            tasks.spawn(async move {
-                tokio::select! {
-                    () = settlement_token.cancelled() => TaskEnd::Ended("settlement-collection (cancelled)"),
-                    () = collect_leader_settlements(
-                        provider,
-                        commands,
-                        attestation,
-                        portal_confirmed_height,
-                    ) => {
-                        TaskEnd::Ended("settlement-collection")
-                    }
-                }
-            });
-
-            // Sequencer background tasks (batch submission + withdrawal processing) stop
-            // gracefully: they observe the token at their poll boundaries, letting in-flight
-            // L1 transactions resolve before teardown.
-            let sequencer_config = sequencer.sequencer_config.clone();
-            let signer = sequencer
-                .config
-                .l1_transaction_signer
-                .clone()
-                .unwrap_or_else(|| sequencer.config.sequencer_signer.clone());
-            let zone_provider = context.provider.clone();
-            let prover_config = sequencer.prover_config.clone();
-            let sequencer_token = token.clone();
-            tasks.spawn(async move {
-                let handle = spawn_zone_sequencer(
-                    sequencer_config,
-                    signer,
-                    zone_provider,
-                    prover_config,
-                    sequencer_token.clone(),
-                )
-                .await;
-                supervise_sequencer_tasks(handle, sequencer_token).await
-            });
-
-            info!(target: "zone::role", generation = id, epoch, "Leader generation started");
+        token.cancel();
+        // Never drop an in-flight L1 receipt wait at a leadership boundary.
+        let (withdrawal, monitor) = tokio::join!(withdrawal, monitor);
+        withdrawal.expect("withdrawal worker failed during demotion");
+        monitor.expect("batch worker failed during demotion");
+        if stop.is_cancelled() {
+            return;
         }
     }
-
-    Ok(RunningGeneration {
-        id,
-        role: desired,
-        token,
-        leader_shutdown,
-        tasks,
-    })
 }
 
 fn latest_sealed_header<P>(provider: &P) -> eyre::Result<SealedHeader<TempoHeader>>
@@ -1108,7 +530,7 @@ where
 }
 
 fn build_engine<P, Pool>(
-    context: &RoleControllerContext<P, Pool>,
+    context: &SequencerContext<P, Pool>,
     sequencer: &LeaderSequencerDeps,
     last_header: SealedHeader<TempoHeader>,
 ) -> ZoneEngine
@@ -1134,31 +556,12 @@ where
 
 #[cfg(test)]
 mod tests {
-    use std::{future::pending, time::Duration};
 
-    use commonware_cryptography::{Signer as _, ed25519::PrivateKey};
     use reth_primitives_traits::SealedHeader;
     use reth_provider::test_utils::MockEthProvider;
     use tempo_primitives::{TempoHeader, TempoPrimitives};
-    use tokio::sync::{mpsc, oneshot};
-    use tokio_util::sync::CancellationToken;
-    use zone_p2p::{BackfillRequest, BackfillResponse};
-    use zone_sequencer::ZoneSequencerHandle;
 
-    use super::{
-        EventSinks, TaskEnd, canonical_recovery_height, latest_sealed_header,
-        route_backfill_requests, route_backfill_responses, supervise_sequencer_tasks,
-    };
-
-    struct DropSignal(Option<oneshot::Sender<()>>);
-
-    impl Drop for DropSignal {
-        fn drop(&mut self) {
-            if let Some(signal) = self.0.take() {
-                let _ = signal.send(());
-            }
-        }
-    }
+    use super::{canonical_recovery_height, latest_sealed_header};
 
     #[test]
     fn unavailable_canonical_head_fails_leader_prerequisite() {
@@ -1199,178 +602,5 @@ mod tests {
 
         let error = canonical_recovery_height(&provider, noncanonical_hash).unwrap_err();
         assert!(error.to_string().contains("is not canonical at height 7"));
-    }
-
-    #[tokio::test]
-    async fn sequencer_supervisor_reports_panicking_child_without_waiting_for_sibling() {
-        let (monitor_started_tx, monitor_started_rx) = oneshot::channel();
-        let (monitor_dropped_tx, monitor_dropped_rx) = oneshot::channel();
-        let monitor_handle = tokio::spawn(async move {
-            let _drop_signal = DropSignal(Some(monitor_dropped_tx));
-            let _ = monitor_started_tx.send(());
-            pending::<()>().await;
-        });
-        monitor_started_rx
-            .await
-            .expect("monitor task must start before the panic");
-
-        let withdrawal_handle = tokio::spawn(async move {
-            panic!("simulated withdrawal processor panic");
-        });
-        let handle = ZoneSequencerHandle {
-            withdrawal_handle,
-            monitor_handle,
-        };
-
-        let outcome = tokio::time::timeout(
-            Duration::from_secs(1),
-            supervise_sequencer_tasks(handle, CancellationToken::new()),
-        )
-        .await
-        .expect("supervisor waited for the healthy long-running sibling");
-        assert!(matches!(outcome, TaskEnd::Ended("withdrawal-processor")));
-        tokio::time::timeout(Duration::from_secs(1), monitor_dropped_rx)
-            .await
-            .expect("sibling was not aborted when the supervisor returned")
-            .expect("monitor drop signal was lost");
-    }
-
-    #[tokio::test]
-    async fn sequencer_supervisor_waits_for_both_children_during_graceful_stop() {
-        let stop = CancellationToken::new();
-        let (ready_tx, mut ready_rx) = mpsc::channel(2);
-
-        let withdrawal_stop = stop.clone();
-        let withdrawal_ready = ready_tx.clone();
-        let withdrawal_handle = tokio::spawn(async move {
-            withdrawal_ready.send(()).await.unwrap();
-            withdrawal_stop.cancelled().await;
-        });
-
-        let monitor_stop = stop.clone();
-        let (monitor_stopping_tx, monitor_stopping_rx) = oneshot::channel();
-        let (release_monitor_tx, release_monitor_rx) = oneshot::channel();
-        let monitor_handle = tokio::spawn(async move {
-            ready_tx.send(()).await.unwrap();
-            monitor_stop.cancelled().await;
-            let _ = monitor_stopping_tx.send(());
-            let _ = release_monitor_rx.await;
-        });
-
-        for _ in 0..2 {
-            tokio::time::timeout(Duration::from_secs(1), ready_rx.recv())
-                .await
-                .expect("sequencer child did not start")
-                .expect("sequencer child readiness channel closed");
-        }
-
-        let supervisor = tokio::spawn(supervise_sequencer_tasks(
-            ZoneSequencerHandle {
-                withdrawal_handle,
-                monitor_handle,
-            },
-            stop.clone(),
-        ));
-        stop.cancel();
-        tokio::time::timeout(Duration::from_secs(1), monitor_stopping_rx)
-            .await
-            .expect("monitor did not observe graceful shutdown")
-            .expect("monitor stopping signal was lost");
-        tokio::task::yield_now().await;
-        assert!(
-            !supervisor.is_finished(),
-            "supervisor aborted the slower child during graceful shutdown"
-        );
-
-        let _ = release_monitor_tx.send(());
-        let outcome = tokio::time::timeout(Duration::from_secs(1), supervisor)
-            .await
-            .expect("supervisor did not finish after both children stopped")
-            .expect("supervisor task panicked");
-        assert!(matches!(outcome, TaskEnd::SequencerStopped));
-    }
-
-    /// Reproduces the startup ordering from the native stress test: the P2P router is live
-    /// and receives a peer's backfill request before the role controller installs its first
-    /// generation sink. The request must reach the process-lifetime backfill server anyway —
-    /// losing it leaves the requester blocked behind the P2P backfill response timeout.
-    #[tokio::test]
-    async fn backfill_request_bypasses_generation_sinks() {
-        let (network_requests, request_rx) = mpsc::channel(1);
-        let (backfill_tx, mut backfill_rx) = mpsc::channel(1);
-        let router = tokio::spawn(route_backfill_requests(request_rx, backfill_tx));
-        let peer = PrivateKey::from_seed(1).public_key();
-
-        network_requests
-            .send(BackfillRequest {
-                peer: peer.clone(),
-                request_id: 7,
-                start: 42,
-            })
-            .await
-            .unwrap();
-
-        let request = tokio::time::timeout(Duration::from_secs(1), backfill_rx.recv())
-            .await
-            .expect("backfill request never reached the serving channel")
-            .expect("backfill serving channel closed");
-        assert_eq!(request.peer, peer);
-        assert_eq!(request.request_id, 7);
-        assert_eq!(request.start, 42);
-
-        drop(network_requests);
-        tokio::time::timeout(Duration::from_secs(1), router)
-            .await
-            .expect("event router did not stop")
-            .expect("event router task panicked");
-    }
-
-    #[tokio::test]
-    async fn backfill_response_drops_on_generation_backpressure() {
-        let sinks = EventSinks::default();
-        let (generation_response_tx, mut generation_response_rx) = mpsc::channel(1);
-        sinks.install(mpsc::channel(1).0, None, Some(generation_response_tx));
-        let (network_responses, response_rx) = mpsc::channel(4);
-        let router = tokio::spawn(route_backfill_responses(response_rx, sinks));
-        let peer = PrivateKey::from_seed(1).public_key();
-
-        network_responses
-            .send(BackfillResponse::Completed {
-                peer: peer.clone(),
-                tip: zone_p2p::PeerTip {
-                    zone_height: 1,
-                    zone_hash: alloy_primitives::B256::ZERO,
-                    tempo_block_number: 1,
-                    tempo_block_hash: alloy_primitives::B256::ZERO,
-                },
-            })
-            .await
-            .unwrap();
-        network_responses
-            .send(BackfillResponse::Completed {
-                peer,
-                tip: zone_p2p::PeerTip {
-                    zone_height: 2,
-                    zone_hash: alloy_primitives::B256::ZERO,
-                    tempo_block_number: 2,
-                    tempo_block_hash: alloy_primitives::B256::ZERO,
-                },
-            })
-            .await
-            .unwrap();
-
-        let forwarded = tokio::time::timeout(Duration::from_secs(1), generation_response_rx.recv())
-            .await
-            .expect("the first backfill response was not forwarded")
-            .expect("generation response channel closed");
-        assert!(
-            matches!(forwarded, BackfillResponse::Completed { tip, .. } if tip.zone_height == 1)
-        );
-
-        drop(network_responses);
-        tokio::time::timeout(Duration::from_secs(1), router)
-            .await
-            .expect("event router did not stop")
-            .expect("event router task panicked");
     }
 }

--- a/crates/node/tests/it/network_chaos_p2p_e2e.rs
+++ b/crates/node/tests/it/network_chaos_p2p_e2e.rs
@@ -749,8 +749,30 @@ async fn test_handoff_recovers_across_settlement_boundary() -> eyre::Result<()> 
     // The transaction remains private to B while every P2P path involving B is down. Commonware
     // may include it in a local proposal, but that proposal must not reach A/C or settle on L1.
     // Its canonical inclusion under B after reconnection creates the boundary this test follows.
+    // Observing the transition does not mean the outgoing prefix has been imported yet.
+    // Wait for A's last authorized anchor and let C import that exact prefix before asserting
+    // isolation. Catching up on A's durable tail is valid while B remains disconnected.
+    let activation = cluster.nodes[0]
+        .leadership()
+        .latest()
+        .expect("observed leadership transition")
+        .activation_tempo_block();
+    cluster.nodes[0]
+        .wait_for_tempo_block_number(activation.saturating_sub(1), NETWORK_TIMEOUT)
+        .await?;
+    eyre::ensure!(
+        cluster.nodes[0].tempo_block_number().await? == activation.saturating_sub(1),
+        "A advanced beyond its last authorized L1 anchor"
+    );
     let a_fenced_height = cluster.nodes[0].provider().get_block_number().await?;
+    cluster.nodes[2]
+        .wait_for_block_number(a_fenced_height, NETWORK_TIMEOUT)
+        .await?;
     let c_fenced_height = cluster.nodes[2].provider().get_block_number().await?;
+    eyre::ensure!(
+        a_fenced_height == c_fenced_height,
+        "C advanced beyond A's authorized prefix while B was isolated"
+    );
     let withdrawal_hash = account.submit_withdrawal(WITHDRAWAL_AMOUNT).await?;
     eyre::ensure!(
         cluster.nodes[0]


### PR DESCRIPTION
This PR keeps one sequencer loop alive across leadership changes and serializes production with peer import. The P2P engine handles routing and propagates finalized blocks after they persist.

Stacked on #1418.
