### PR TITLE
refactor(sequencer): settle finalized payloads in one worker

### DIFF
--- a/crates/node/src/node.rs
+++ b/crates/node/src/node.rs
@@ -1616,20 +1616,15 @@ where
             zone_provider,
             prover_config,
             tokio_util::sync::CancellationToken::new(),
+            None,
+            None,
         )
         .await;
         info!(target: "reth::cli", "Sequencer tasks spawned");
 
-        // Critical task — node shuts down if either exits.
-        task_executor.spawn_critical_task("zone-monitor", async move {
-            tokio::select! {
-                res = seq_handle.withdrawal_handle => {
-                    tracing::error!(target: "reth::cli", ?res, "Withdrawal processor task exited");
-                }
-                res = seq_handle.monitor_handle => {
-                    tracing::error!(target: "reth::cli", ?res, "Zone monitor task exited");
-                }
-            }
+        task_executor.spawn_critical_task("zone-settlement", async move {
+            let result = seq_handle.await;
+            panic!("settlement worker exited: {result:?}");
         });
 
         // Flush unpersisted blocks on shutdown.

--- a/crates/node/src/role.rs
+++ b/crates/node/src/role.rs
@@ -5,7 +5,6 @@ use std::{sync::Arc, time::Duration};
 use alloy_consensus::BlockHeader as _;
 use alloy_eips::NumHash;
 use alloy_primitives::Address;
-use eyre::WrapErr as _;
 use reth_chain_state::PersistedBlockSubscriptions;
 use reth_node_api::ConsensusEngineHandle;
 use reth_payload_builder::PayloadBuilderHandle;
@@ -256,6 +255,7 @@ pub(crate) struct Sequencing<P> {
     status: SharedRoleStatus,
     active: watch::Sender<bool>,
     finalized: mpsc::Sender<NumHash>,
+    settlement: Option<mpsc::Sender<NumHash>>,
     observed_through: Option<u64>,
 }
 
@@ -338,7 +338,13 @@ where
         self.finalized
             .send(block)
             .await
-            .wrap_err("P2P finalized block channel closed")?;
+            .expect("P2P finalized block channel closed");
+        if let Some(settlement) = &self.settlement {
+            settlement
+                .send(block)
+                .await
+                .expect("settlement worker channel closed");
+        }
         Ok(true)
     }
 }
@@ -365,6 +371,7 @@ pub(crate) async fn run_sequencer<P, Pool>(
     let _cancel = stop.clone().drop_guard();
     let (active_tx, active_rx) = watch::channel(false);
     let (finalized_tx, finalized_rx) = mpsc::channel(128);
+    let (settlement_tx, settlement_rx) = mpsc::channel(128);
     let engine = context.sequencer.as_ref().map(|sequencer| {
         build_engine(
             &context,
@@ -381,6 +388,7 @@ pub(crate) async fn run_sequencer<P, Pool>(
         status: context.status.clone(),
         active: active_tx,
         finalized: finalized_tx,
+        settlement: context.sequencer.as_ref().map(|_| settlement_tx),
         // Programmatic dev nodes with a zero Portal inject already-applied L1 fixtures.
         observed_through: context.portal_address.is_zero().then_some(u64::MAX),
     };
@@ -436,7 +444,7 @@ pub(crate) async fn run_sequencer<P, Pool>(
         transactions_rx,
     ));
     if context.sequencer.is_some() {
-        tasks.spawn(run_leader_services(context, active_rx, stop));
+        tasks.spawn(run_leader_services(context, active_rx, settlement_rx, stop));
     }
     let result = tasks.join_next().await;
     panic!("zone sequencer task stopped unexpectedly: {result:?}");
@@ -446,6 +454,7 @@ pub(crate) async fn run_sequencer<P, Pool>(
 async fn run_leader_services<P, Pool>(
     context: SequencerContext<P, Pool>,
     mut active: watch::Receiver<bool>,
+    blocks: mpsc::Receiver<NumHash>,
     stop: CancellationToken,
 ) where
     P: ZoneSequencerProvider + PersistedBlockSubscriptions,
@@ -455,11 +464,28 @@ async fn run_leader_services<P, Pool>(
         .sequencer
         .as_ref()
         .expect("sequencer resources required");
+    let signer = deps
+        .config
+        .l1_transaction_signer
+        .clone()
+        .unwrap_or_else(|| deps.config.sequencer_signer.clone());
+    let handle = spawn_zone_sequencer(
+        deps.sequencer_config.clone(),
+        signer,
+        context.provider.clone(),
+        deps.prover_config.clone(),
+        stop.clone(),
+        Some(active.clone()),
+        Some(blocks),
+    )
+    .await;
+    let mut worker = AbortOnDropHandle::new(handle);
     loop {
-        if active.wait_for(|active| *active).await.is_err() {
-            return;
+        tokio::select! {
+            result = active.wait_for(|active| *active) => { if result.is_err() { return; } }
+            () = stop.cancelled() => return,
+            result = &mut worker => panic!("settlement worker stopped: {result:?}"),
         }
-        let token = stop.child_token();
         let portal_anchor = match resolve_portal_zone_anchor(
             &context.provider,
             context.portal_address,
@@ -484,34 +510,13 @@ async fn run_leader_services<P, Pool>(
             context.attestation.clone(),
             portal_anchor.block_number,
         );
-        let signer = deps
-            .config
-            .l1_transaction_signer
-            .clone()
-            .unwrap_or_else(|| deps.config.sequencer_signer.clone());
-        let handle = spawn_zone_sequencer(
-            deps.sequencer_config.clone(),
-            signer,
-            context.provider.clone(),
-            deps.prover_config.clone(),
-            token.clone(),
-        )
-        .await;
-        let mut withdrawal = AbortOnDropHandle::new(handle.withdrawal_handle);
-        let mut monitor = AbortOnDropHandle::new(handle.monitor_handle);
         tokio::pin!(proposals);
         tokio::select! {
             _ = active.wait_for(|active| !*active) => {}
             () = stop.cancelled() => {}
             () = &mut proposals => panic!("settlement proposal collector stopped"),
-            result = &mut withdrawal => panic!("withdrawal worker stopped: {result:?}"),
-            result = &mut monitor => panic!("batch submission worker stopped: {result:?}"),
+            result = &mut worker => panic!("settlement worker stopped: {result:?}"),
         }
-        token.cancel();
-        // Never drop an in-flight L1 receipt wait at a leadership boundary.
-        let (withdrawal, monitor) = tokio::join!(withdrawal, monitor);
-        withdrawal.expect("withdrawal worker failed during demotion");
-        monitor.expect("batch worker failed during demotion");
         if stop.is_cancelled() {
             return;
         }

--- a/crates/node/tests/it/earn_zone_e2e.rs
+++ b/crates/node/tests/it/earn_zone_e2e.rs
@@ -282,7 +282,7 @@ struct EarnZoneFixture {
     contribution_controller: Address,
     access_policy: Option<EarnAccessPolicy>,
     user: ZoneAccount,
-    _sequencer: zone_sequencer::ZoneSequencerHandle,
+    _sequencer: tokio::task::JoinHandle<()>,
 }
 
 impl EarnZoneFixture {

--- a/crates/node/tests/it/l1_e2e.rs
+++ b/crates/node/tests/it/l1_e2e.rs
@@ -694,12 +694,8 @@ async fn test_many_concurrent_withdrawals_are_batched() -> eyre::Result<()> {
             let sequencer = &sequencer;
             async move {
                 eyre::ensure!(
-                    !sequencer.monitor_handle.is_finished(),
-                    "zone monitor exited while processing concurrent withdrawals"
-                );
-                eyre::ensure!(
-                    !sequencer.withdrawal_handle.is_finished(),
-                    "withdrawal processor exited while processing concurrent withdrawals"
+                    !sequencer.is_finished(),
+                    "settlement worker exited while processing concurrent withdrawals"
                 );
 
                 let events = portal
@@ -2173,7 +2169,7 @@ async fn test_global_pause_blocks_deposits_and_l1_withdrawal_processing() -> eyr
     )
     .await?;
     eyre::ensure!(
-        !sequencer.withdrawal_handle.is_finished(),
+        !sequencer.is_finished(),
         "withdrawal processor exited while the portal was paused"
     );
     poll_until(

--- a/crates/node/tests/it/restart_e2e.rs
+++ b/crates/node/tests/it/restart_e2e.rs
@@ -9,6 +9,8 @@
 
 use crate::utils::{L1TestNode, ZoneAccount, ZoneTestNode, spawn_sequencer};
 use alloy::primitives::{Address, U256};
+use alloy_provider::Provider as _;
+use tempo_alloy::provider::ext::TempoProviderBuilderExt as _;
 use tempo_precompiles::PATH_USD_ADDRESS;
 use tempo_zone_contracts::{IZoneOutbox, ZONE_OUTBOX_ADDRESS, ZONE_TOKEN_ADDRESS, ZonePortal};
 
@@ -129,8 +131,7 @@ async fn test_sequencer_restart_resumes_batch_submission() -> eyre::Result<()> {
     );
 
     // --- Phase 2: Restart sequencer ---
-    seq_handle.monitor_handle.abort();
-    seq_handle.withdrawal_handle.abort();
+    seq_handle.abort();
     tokio::time::sleep(std::time::Duration::from_secs(1)).await;
 
     // Respawn — should resume from portal's blockHash, not block 0
@@ -188,14 +189,25 @@ async fn test_sequencer_restart_with_pending_withdrawal_queue() -> eyre::Result<
     l1.fund_user(account.address(), deposit_amount).await?;
     account.deposit(deposit_amount, L1_TIMEOUT, &zone).await?;
 
-    let zone_sequencer::ZoneSequencerHandle {
-        withdrawal_handle,
-        monitor_handle,
-    } = spawn_sequencer(&l1, &zone, portal_address, l1.dev_signer()).await;
-
-    // Keep batch submission running, but stop L1 processing so the portal queue
-    // is guaranteed to remain pending until after the restart.
-    abort_task(withdrawal_handle).await;
+    // Submit the batch but leave its withdrawals pending as a crash-recovery fixture.
+    let monitor_handle = zone
+        .spawn_batch_monitor(
+            zone_sequencer::ZoneMonitorConfig {
+                portal_address,
+                outbox_address: tempo_zone_contracts::ZONE_OUTBOX_ADDRESS,
+                inbox_address: tempo_zone_contracts::ZONE_INBOX_ADDRESS,
+                poll_interval: std::time::Duration::from_millis(100),
+                batch_anchor_config: Default::default(),
+                attestation_store: None,
+            },
+            l1.dev_signer(),
+            alloy_provider::ProviderBuilder::new_with_network::<tempo_alloy::TempoNetwork>()
+                .with_nonce_key_filler()
+                .wallet(alloy_network::EthereumWallet::from(l1.dev_signer()))
+                .connect_http(l1.http_url().clone())
+                .erased(),
+        )
+        .await;
 
     // Request withdrawal — wait for the batch to be submitted to L1
     let withdrawal_amount: u128 = 500_000;
@@ -239,12 +251,9 @@ async fn test_sequencer_restart_with_pending_withdrawal_queue() -> eyre::Result<
             let l1 = &l1;
             let seq_handle2 = &seq_handle2;
             async move {
-                if seq_handle2.monitor_handle.is_finished() {
-                    eyre::bail!("restarted monitor task exited before restoring the pending withdrawal");
-                }
-                if seq_handle2.withdrawal_handle.is_finished() {
+                if seq_handle2.is_finished() {
                     eyre::bail!(
-                        "restarted withdrawal processor exited before processing the pending withdrawal"
+                        "restarted monitor task exited before restoring the pending withdrawal"
                     );
                 }
                 let (head, _) = portal_queue_state(l1, portal_address).await?;
@@ -317,8 +326,7 @@ async fn test_double_sequencer_restart() -> eyre::Result<()> {
     )
     .await?;
 
-    seq1.monitor_handle.abort();
-    seq1.withdrawal_handle.abort();
+    seq1.abort();
     tokio::time::sleep(std::time::Duration::from_secs(1)).await;
 
     // --- Cycle 2 ---
@@ -335,8 +343,7 @@ async fn test_double_sequencer_restart() -> eyre::Result<()> {
     )
     .await?;
 
-    seq2.monitor_handle.abort();
-    seq2.withdrawal_handle.abort();
+    seq2.abort();
     tokio::time::sleep(std::time::Duration::from_secs(1)).await;
 
     // --- Cycle 3 (final) ---
@@ -412,8 +419,7 @@ async fn test_batch_only_restart_no_withdrawals() -> eyre::Result<()> {
     let batches_before = batch_submitted_count(&l1, portal_address).await?;
 
     // Restart
-    seq1.monitor_handle.abort();
-    seq1.withdrawal_handle.abort();
+    seq1.abort();
     tokio::time::sleep(std::time::Duration::from_secs(1)).await;
 
     let _seq2 = spawn_sequencer(&l1, &zone, portal_address, l1.dev_signer()).await;
@@ -487,8 +493,7 @@ async fn test_finalized_withdrawal_survives_sequencer_restart() -> eyre::Result<
     );
 
     // Restart the batch submitter after proving the request block finalized its withdrawal.
-    seq_handle.monitor_handle.abort();
-    seq_handle.withdrawal_handle.abort();
+    seq_handle.abort();
     tokio::time::sleep(std::time::Duration::from_secs(1)).await;
     let _seq_handle2 = spawn_sequencer(&l1, &zone, portal_address, l1.dev_signer()).await;
 

--- a/crates/node/tests/it/stepping_e2e.rs
+++ b/crates/node/tests/it/stepping_e2e.rs
@@ -146,13 +146,8 @@ async fn test_current_tip_batch_submission_lands_in_successor_block() -> eyre::R
             let seq = &seq;
             let l1 = &l1;
             async move {
-                if seq.monitor_handle.is_finished() {
+                if seq.is_finished() {
                     eyre::bail!("monitor task exited before submitting the current-tip batch");
-                }
-                if seq.withdrawal_handle.is_finished() {
-                    eyre::bail!(
-                        "withdrawal processor exited before current-tip batch submission completed"
-                    );
                 }
 
                 let events = portal.BatchSubmitted_filter().from_block(0).query().await?;
@@ -283,12 +278,8 @@ async fn test_batch_submission_after_extended_l1_gap() -> eyre::Result<()> {
             let portal = &portal;
             let seq = &seq;
             async move {
-                if seq.monitor_handle.is_finished() {
+                if seq.is_finished() {
                     eyre::bail!("monitor task exited before submitting a batch");
-                }
-
-                if seq.withdrawal_handle.is_finished() {
-                    eyre::bail!("withdrawal processor exited before batch submission completed");
                 }
 
                 let events = portal.BatchSubmitted_filter().from_block(0).query().await?;
@@ -388,12 +379,8 @@ async fn test_batch_submission_after_configured_short_l1_gap() -> eyre::Result<(
             let portal = &portal;
             let seq = &seq;
             async move {
-                if seq.monitor_handle.is_finished() {
+                if seq.is_finished() {
                     eyre::bail!("monitor task exited before submitting a batch");
-                }
-
-                if seq.withdrawal_handle.is_finished() {
-                    eyre::bail!("withdrawal processor exited before batch submission completed");
                 }
 
                 let events = portal.BatchSubmitted_filter().from_block(0).query().await?;
@@ -497,12 +484,8 @@ async fn test_configured_short_l1_gap_submits_multiple_batch_boundaries() -> eyr
             let seq = &seq;
             let l1 = &l1;
             async move {
-                if seq.monitor_handle.is_finished() {
+                if seq.is_finished() {
                     eyre::bail!("monitor task exited before submitting boundary batches");
-                }
-
-                if seq.withdrawal_handle.is_finished() {
-                    eyre::bail!("withdrawal processor exited before boundary batches completed");
                 }
 
                 let events = portal.BatchSubmitted_filter().from_block(0).query().await?;
@@ -631,12 +614,8 @@ async fn test_boundary_ancestry_submission_uses_recent_anchor() -> eyre::Result<
             let seq = &seq;
             let l1 = &l1;
             async move {
-                if seq.monitor_handle.is_finished() {
+                if seq.is_finished() {
                     eyre::bail!("monitor task exited before submitting a batch");
-                }
-
-                if seq.withdrawal_handle.is_finished() {
-                    eyre::bail!("withdrawal processor exited before batch submission completed");
                 }
 
                 let events = portal.BatchSubmitted_filter().from_block(0).query().await?;

--- a/crates/node/tests/it/utils.rs
+++ b/crates/node/tests/it/utils.rs
@@ -608,11 +608,18 @@ pub(crate) trait TestNodeHandle: Send {
 
     fn node_exit_future_mut(&mut self) -> &mut NodeExitFuture;
 
+    fn spawn_batch_monitor(
+        &self,
+        config: zone_sequencer::ZoneMonitorConfig,
+        signer: alloy_signer_local::PrivateKeySigner,
+        l1: alloy_provider::DynProvider<TempoNetwork>,
+    ) -> Pin<Box<dyn Future<Output = tokio::task::JoinHandle<()>> + Send + '_>>;
+
     fn spawn_sequencer(
         &self,
         config: zone_sequencer::ZoneSequencerConfig,
         signer: alloy_signer_local::PrivateKeySigner,
-    ) -> Pin<Box<dyn Future<Output = zone_sequencer::ZoneSequencerHandle> + Send + '_>>;
+    ) -> Pin<Box<dyn Future<Output = tokio::task::JoinHandle<()>> + Send + '_>>;
 }
 
 impl<Node, AddOns> TestNodeHandle for NodeHandle<Node, AddOns>
@@ -633,11 +640,46 @@ where
         &mut self.node_exit_future
     }
 
+    #[expect(
+        clippy::async_yields_async,
+        reason = "the harness needs the task handle to simulate a crash"
+    )]
+    fn spawn_batch_monitor(
+        &self,
+        config: zone_sequencer::ZoneMonitorConfig,
+        signer: alloy_signer_local::PrivateKeySigner,
+        l1: alloy_provider::DynProvider<TempoNetwork>,
+    ) -> Pin<Box<dyn Future<Output = tokio::task::JoinHandle<()>> + Send + '_>> {
+        let provider = self.node.provider().clone();
+        Box::pin(async move {
+            let mut monitor = zone_sequencer::monitor::ZoneMonitor::new(
+                config,
+                provider,
+                l1,
+                signer,
+                Default::default(),
+                Default::default(),
+            )
+            .await
+            .unwrap();
+            tokio::spawn(async move {
+                monitor
+                    .run(&tokio_util::sync::CancellationToken::new())
+                    .await
+                    .unwrap();
+            })
+        })
+    }
+
+    #[expect(
+        clippy::async_yields_async,
+        reason = "the harness needs the task handle to simulate a crash"
+    )]
     fn spawn_sequencer(
         &self,
         config: zone_sequencer::ZoneSequencerConfig,
         signer: alloy_signer_local::PrivateKeySigner,
-    ) -> Pin<Box<dyn Future<Output = zone_sequencer::ZoneSequencerHandle> + Send + '_>> {
+    ) -> Pin<Box<dyn Future<Output = tokio::task::JoinHandle<()>> + Send + '_>> {
         let provider = self.node.provider().clone();
         Box::pin(async move {
             zone_sequencer::spawn_zone_sequencer(
@@ -646,6 +688,8 @@ where
                 provider,
                 None,
                 tokio_util::sync::CancellationToken::new(),
+                None,
+                None,
             )
             .await
         })
@@ -703,11 +747,23 @@ impl ZoneTestNode {
             .graceful_shutdown_with_timeout(Duration::from_secs(5));
     }
 
+    /// Submit batches without consuming their withdrawal queue, to build a restart fixture.
+    pub(crate) async fn spawn_batch_monitor(
+        &self,
+        config: zone_sequencer::ZoneMonitorConfig,
+        signer: alloy_signer_local::PrivateKeySigner,
+        l1: alloy_provider::DynProvider<TempoNetwork>,
+    ) -> tokio::task::JoinHandle<()> {
+        self.node_handle
+            .spawn_batch_monitor(config, signer, l1)
+            .await
+    }
+
     async fn spawn_sequencer(
         &self,
         config: zone_sequencer::ZoneSequencerConfig,
         signer: alloy_signer_local::PrivateKeySigner,
-    ) -> zone_sequencer::ZoneSequencerHandle {
+    ) -> tokio::task::JoinHandle<()> {
         self.node_handle.spawn_sequencer(config, signer).await
     }
 
@@ -3581,7 +3637,7 @@ pub(crate) async fn spawn_sequencer(
     zone: &ZoneTestNode,
     portal_address: Address,
     sequencer_signer: alloy_signer_local::PrivateKeySigner,
-) -> zone_sequencer::ZoneSequencerHandle {
+) -> tokio::task::JoinHandle<()> {
     spawn_sequencer_with_config(
         l1,
         zone,
@@ -3601,7 +3657,7 @@ pub(crate) async fn spawn_sequencer_with_config(
     sequencer_signer: alloy_signer_local::PrivateKeySigner,
     batch_anchor_config: zone_sequencer::BatchAnchorConfig,
     withdrawal_batch_limits: zone_sequencer::WithdrawalBatchLimits,
-) -> zone_sequencer::ZoneSequencerHandle {
+) -> tokio::task::JoinHandle<()> {
     use tempo_zone_contracts::{ZONE_INBOX_ADDRESS, ZONE_OUTBOX_ADDRESS};
 
     let config = zone_sequencer::ZoneSequencerConfig {

--- a/crates/sequencer/src/lib.rs
+++ b/crates/sequencer/src/lib.rs
@@ -6,6 +6,7 @@
 use std::{sync::Arc, time::Duration};
 
 use alloy_chains::Chain;
+use alloy_eips::NumHash;
 use alloy_primitives::Address;
 use alloy_provider::{DynProvider, Provider, ProviderBuilder};
 use alloy_signer_local::PrivateKeySigner;
@@ -14,7 +15,7 @@ use reth_chain_state::CanonStateSubscriptions;
 use reth_storage_api::{BlockReader, StateProviderFactory};
 use tempo_alloy::{TempoNetwork, provider::ext::TempoProviderBuilderExt};
 use tempo_primitives::{Block, TempoHeader, TempoPrimitives, TempoReceipt, TempoTxEnvelope};
-use tokio::sync::Notify;
+use tokio::sync::{Notify, mpsc, watch};
 
 pub mod abi {
     pub use tempo_zone_contracts::*;
@@ -35,7 +36,7 @@ pub use encryption_key::{
     EncryptionKeyProof, encryption_key_identity, prove_encryption_key_possession,
     register_encryption_key,
 };
-pub use monitor::{ZoneMonitorConfig, ZoneMonitorSharedState};
+pub use monitor::ZoneMonitorConfig;
 pub use prover::{
     SHADOW_PROVER_QUEUE_CAPACITY, ShadowProofAnchor, ShadowProver, ShadowProverConfig,
     spawn_shadow_prover,
@@ -117,38 +118,18 @@ pub struct ZoneSequencerConfig {
     pub attestation_store: Option<AttestationStore>,
 }
 
-/// Handles returned by [`spawn_zone_sequencer`] for managing background tasks.
-pub struct ZoneSequencerHandle {
-    /// Join handle for the withdrawal processor task.
-    pub withdrawal_handle: tokio::task::JoinHandle<()>,
-    /// Join handle for the zone monitor task (which also handles batch submission).
-    pub monitor_handle: tokio::task::JoinHandle<()>,
-}
-
-/// Spawn all zone sequencer background tasks.
-///
-/// This is the top-level POC entrypoint that starts:
-/// - **Zone monitor** — consumes native canonical Zone blocks and receipts, extracts withdrawal
-///   events into the shared store, builds [`crate::BatchData`], and submits each batch
-///   synchronously to the ZonePortal on Tempo L1. Local state only advances on successful
-///   submission.
-/// - **Withdrawal processor** — polls the ZonePortal withdrawal queue on Tempo L1 and calls
-///   `processWithdrawals` for each pending withdrawal.
-/// - **Shadow prover** — when `prover_config` is set, validates finalized batch candidates
-///   observationally without delaying or changing settlement.
-///
-/// Both tasks share a single L1 provider and nonce manager to prevent signing/nonce contention
-/// when submitting concurrent L1 transactions.
-///
-/// `shutdown` stops both tasks gracefully: it is observed at their poll boundaries, so an
-/// in-flight L1 transaction resolves before teardown.
+/// Start the settlement worker. In P2P mode, `active` gates settlement and `blocks` carries
+/// finalized payload references. Legacy single-sequencer nodes use canonical notifications.
+/// Demotion cancels future work but drains transactions already sent to L1.
 pub async fn spawn_zone_sequencer<P: ZoneSequencerProvider>(
     config: ZoneSequencerConfig,
     signer: PrivateKeySigner,
     zone_provider: P,
     prover_config: Option<ShadowProverConfig>,
     shutdown: tokio_util::sync::CancellationToken,
-) -> ZoneSequencerHandle {
+    mut active: Option<watch::Receiver<bool>>,
+    mut blocks: Option<mpsc::Receiver<NumHash>>,
+) -> tokio::task::JoinHandle<()> {
     // Build a single shared L1 provider with the sequencer wallet.
     // Both the batch submitter (inside the zone monitor) and the withdrawal
     // processor use this provider, ensuring nonces are tracked in one place.
@@ -171,7 +152,6 @@ pub async fn spawn_zone_sequencer<P: ZoneSequencerProvider>(
     let sequencer_address = signer.address();
 
     let withdrawal_store: SharedWithdrawalStore = Default::default();
-    let withdrawal_notify = Arc::new(Notify::new());
     let withdrawal_repair_notify = Arc::new(Notify::new());
 
     let withdrawal_config = WithdrawalProcessorConfig {
@@ -189,32 +169,85 @@ pub async fn spawn_zone_sequencer<P: ZoneSequencerProvider>(
         batch_anchor_config: config.batch_anchor_config,
         attestation_store: config.attestation_store,
     };
-    let withdrawal_handle = withdrawals::spawn_withdrawal_processor(
+    let withdrawals = withdrawals::WithdrawalProcessor::new(
         withdrawal_config,
         l1_provider.clone(),
         withdrawal_store.clone(),
-        withdrawal_notify.clone(),
         withdrawal_repair_notify.clone(),
-        shutdown.clone(),
     );
-    let monitor_shared_state = ZoneMonitorSharedState::new(
-        withdrawal_store,
-        withdrawal_notify,
-        withdrawal_repair_notify,
-    );
-    let monitor_handle = monitor::spawn_zone_monitor(
-        monitor_config,
-        zone_provider,
-        l1_provider,
-        signer,
-        monitor_shared_state,
-        shadow_prover,
-        shutdown,
-    );
+    tokio::spawn(async move {
+        loop {
+            if let Some(active) = &mut active {
+                if active.has_changed().is_err() {
+                    return;
+                }
+                tokio::select! {
+                    () = shutdown.cancelled() => return,
+                    result = active.wait_for(|active| *active) => { if result.is_err() { return; } }
+                }
+            }
+            let token = shutdown.child_token();
+            let work = async {
+                while !token.is_cancelled() {
+                    let monitor = monitor::ZoneMonitor::new_with_provider(
+                        monitor_config.clone(),
+                        zone_provider.clone(),
+                        l1_provider.clone(),
+                        Some(signer.clone()),
+                        withdrawal_store.clone(),
+                        withdrawal_repair_notify.clone(),
+                        shadow_prover.clone(),
+                    )
+                    .await;
+                    match monitor {
+                        Ok(mut monitor) => {
+                            if let Err(error) = monitor
+                                .run_settlement(&withdrawals, &mut blocks, &token)
+                                .await
+                            {
+                                tracing::error!(%error, "Settlement failed; restoring from the Portal anchor");
+                            }
+                        }
+                        Err(error) => tracing::error!(%error, "Cannot restore settlement state"),
+                    }
+                    if token
+                        .run_until_cancelled(tokio::time::sleep(Duration::from_secs(5)))
+                        .await
+                        .is_none()
+                    {
+                        return;
+                    }
+                }
+            };
+            finish_on_demotion(work, &token, &shutdown, &mut active).await;
+            if shutdown.is_cancelled() {
+                return;
+            }
+        }
+    })
+}
 
-    ZoneSequencerHandle {
-        withdrawal_handle,
-        monitor_handle,
+/// A role change stops admission of new transactions, never an in-flight receipt wait.
+async fn finish_on_demotion(
+    work: impl std::future::Future<Output = ()>,
+    token: &tokio_util::sync::CancellationToken,
+    shutdown: &tokio_util::sync::CancellationToken,
+    active: &mut Option<watch::Receiver<bool>>,
+) {
+    tokio::pin!(work);
+    let completed = tokio::select! {
+        () = &mut work => true,
+        () = shutdown.cancelled() => false,
+        _ = async {
+            match active {
+                Some(active) => { let _ = active.wait_for(|active| !*active).await; }
+                None => std::future::pending::<()>().await,
+            }
+        } => false,
+    };
+    token.cancel();
+    if !completed {
+        work.await;
     }
 }
 
@@ -258,6 +291,50 @@ mod tests {
         time::{Duration, timeout},
     };
     use tokio_tungstenite::{accept_async, tungstenite::Message};
+
+    #[tokio::test]
+    async fn demotion_drains_an_in_flight_operation_before_returning() {
+        let (role, receiver) = watch::channel(true);
+        let token = tokio_util::sync::CancellationToken::new();
+        let work_token = token.clone();
+        let (draining, drained) = tokio::sync::oneshot::channel();
+        let (release, released) = tokio::sync::oneshot::channel();
+        let task = tokio::spawn(async move {
+            let work = async move {
+                work_token.cancelled().await;
+                draining.send(()).unwrap();
+                released.await.unwrap();
+            };
+            finish_on_demotion(
+                work,
+                &token,
+                &tokio_util::sync::CancellationToken::new(),
+                &mut Some(receiver),
+            )
+            .await;
+        });
+        role.send(false).unwrap();
+        drained.await.unwrap();
+        assert!(
+            !task.is_finished(),
+            "demotion abandoned an in-flight operation"
+        );
+        release.send(()).unwrap();
+        task.await.unwrap();
+    }
+
+    #[tokio::test]
+    async fn completed_work_is_not_polled_again_during_shutdown() {
+        let token = tokio_util::sync::CancellationToken::new();
+        finish_on_demotion(
+            async {},
+            &token,
+            &tokio_util::sync::CancellationToken::new(),
+            &mut None,
+        )
+        .await;
+        assert!(token.is_cancelled());
+    }
 
     async fn serve_block_number(
         stream: TcpStream,

--- a/crates/sequencer/src/monitor.rs
+++ b/crates/sequencer/src/monitor.rs
@@ -54,9 +54,6 @@ const MAX_RETRIES: u32 = 3;
 /// Initial delay between retries (doubles on each attempt).
 const INITIAL_RETRY_DELAY: Duration = Duration::from_millis(200);
 
-/// Backoff before rebuilding the monitor after a start or run failure.
-const RESTART_BACKOFF: Duration = Duration::from_secs(5);
-
 /// Configuration for the [`ZoneMonitor`].
 #[derive(Debug, Clone)]
 pub struct ZoneMonitorConfig {
@@ -72,29 +69,6 @@ pub struct ZoneMonitorConfig {
     pub batch_anchor_config: BatchAnchorConfig,
     /// Shared P2P attestations, required after a settlement signer set is activated.
     pub attestation_store: Option<AttestationStore>,
-}
-
-/// Withdrawal state shared between the zone monitor and withdrawal processor.
-#[derive(Clone)]
-pub struct ZoneMonitorSharedState {
-    withdrawal_store: SharedWithdrawalStore,
-    withdrawal_notify: Arc<Notify>,
-    repair_notify: Arc<Notify>,
-}
-
-impl ZoneMonitorSharedState {
-    /// Create the shared withdrawal state used by the zone monitor.
-    pub fn new(
-        withdrawal_store: SharedWithdrawalStore,
-        withdrawal_notify: Arc<Notify>,
-        repair_notify: Arc<Notify>,
-    ) -> Self {
-        Self {
-            withdrawal_store,
-            withdrawal_notify,
-            repair_notify,
-        }
-    }
 }
 
 /// Monitors the Zone L2 chain for new finalized batch boundaries and submits
@@ -117,9 +91,6 @@ pub struct ZoneMonitor<P: ZoneSequencerProvider> {
     withdrawal_store: SharedWithdrawalStore,
     /// Batch submitter for posting batches to the ZonePortal on **Tempo L1**.
     batch_submitter: BatchSubmitter,
-    /// Notifier for the withdrawal processor — signalled after each successful
-    /// batch submission so it can process newly enqueued withdrawal slots.
-    withdrawal_notify: Arc<Notify>,
     /// Notifier from the withdrawal processor when the current portal head slot
     /// is missing or stale and its bounded recovery page must be refilled.
     repair_notify: Arc<Notify>,
@@ -157,7 +128,6 @@ impl<P: ZoneSequencerProvider> ZoneMonitor<P> {
         l1_provider: DynProvider<TempoNetwork>,
         signer: PrivateKeySigner,
         withdrawal_store: SharedWithdrawalStore,
-        withdrawal_notify: Arc<Notify>,
         repair_notify: Arc<Notify>,
     ) -> Result<Self> {
         Self::new_with_provider(
@@ -166,21 +136,18 @@ impl<P: ZoneSequencerProvider> ZoneMonitor<P> {
             l1_provider,
             Some(signer),
             withdrawal_store,
-            withdrawal_notify,
             repair_notify,
             None,
         )
         .await
     }
 
-    #[expect(clippy::too_many_arguments)]
-    async fn new_with_provider(
+    pub(crate) async fn new_with_provider(
         config: ZoneMonitorConfig,
         provider: P,
         l1_provider: DynProvider<TempoNetwork>,
         signer: Option<PrivateKeySigner>,
         withdrawal_store: SharedWithdrawalStore,
-        withdrawal_notify: Arc<Notify>,
         repair_notify: Arc<Notify>,
         shadow_prover: Option<ShadowProver>,
     ) -> Result<Self> {
@@ -232,7 +199,6 @@ impl<P: ZoneSequencerProvider> ZoneMonitor<P> {
             provider,
             withdrawal_store,
             batch_submitter,
-            withdrawal_notify,
             repair_notify,
             last_submitted_zone_block,
             prev_processed_deposit_hash,
@@ -290,6 +256,55 @@ impl<P: ZoneSequencerProvider> ZoneMonitor<P> {
                             "canonical zone chain reorged while the sequencer was active"
                         ));
                     }
+                }
+            }
+        }
+    }
+
+    /// One worker advances batches, then processes the resulting withdrawal queue.
+    pub(crate) async fn run_settlement(
+        &mut self,
+        withdrawals: &crate::withdrawals::WithdrawalProcessor,
+        blocks: &mut Option<tokio::sync::mpsc::Receiver<alloy_eips::NumHash>>,
+        shutdown: &sync::CancellationToken,
+    ) -> Result<()> {
+        let use_canonical_notifications = blocks.is_none();
+        // Channel-driven nodes still observe reorgs, but ordinary commits wake the worker
+        // through the finalized-payload channel. Legacy nodes use canonical commits directly.
+        let mut canonical = self
+            .provider
+            .canonical_state_stream()
+            .filter(move |notification| {
+                std::future::ready(use_canonical_notifications || notification.reverted().is_some())
+            });
+        let mut fallback = tokio::time::interval(self.config.poll_interval);
+        let mut withdrawal_poll = tokio::time::interval(withdrawals.poll_interval());
+        loop {
+            if shutdown.is_cancelled() {
+                return Ok(());
+            }
+            self.process_available_blocks(shutdown).await;
+            withdrawals.process_cycle(shutdown).await;
+            tokio::select! {
+                biased;
+                () = shutdown.cancelled() => return Ok(()),
+                _ = self.repair_notify.notified() => self.refill_withdrawal_cache().await,
+                _ = fallback.tick() => {}
+                _ = withdrawal_poll.tick() => {}
+                block = async {
+                    match blocks {
+                        Some(blocks) => blocks.recv().await,
+                        None => std::future::pending().await,
+                    }
+                } => {
+                    let block = block.expect("finalized payload channel closed");
+                    let header = self.provider.sealed_header(block.number)?
+                        .ok_or_else(|| eyre::eyre!("finalized payload {} is missing", block.number))?;
+                    eyre::ensure!(header.hash() == block.hash, "finalized payload is no longer canonical");
+                }
+                notification = canonical.next() => {
+                    let notification = notification.ok_or_else(|| eyre::eyre!("canonical zone stream closed"))?;
+                    eyre::ensure!(notification.reverted().is_none(), "canonical zone chain reorged during settlement");
                 }
             }
         }
@@ -375,7 +390,6 @@ impl<P: ZoneSequencerProvider> ZoneMonitor<P> {
                 evicted_tail_slots,
                 "Restored pending withdrawals from chain"
             );
-            self.withdrawal_notify.notify_one();
         } else if previous_slots > 0 {
             info!(
                 page_head,
@@ -635,8 +649,6 @@ impl<P: ZoneSequencerProvider> ZoneMonitor<P> {
                         }
                     }
 
-                    self.withdrawal_notify.notify_one();
-
                     return Ok(());
                 }
                 Err(BatchSubmitError::Cancelled) => return Err(BatchSubmitError::Cancelled),
@@ -829,83 +841,6 @@ impl<P: ZoneSequencerProvider> ZoneMonitor<P> {
     }
 }
 
-/// Spawn the zone monitor as a background task.
-///
-/// The monitor consumes canonical Zone state notifications and submits finalized batch
-/// boundaries to the ZonePortal on Tempo L1. Local state only advances on successful submission.
-///
-/// The `l1_provider` must already include the sequencer wallet for signing L1 transactions.
-pub(crate) fn spawn_zone_monitor<P: ZoneSequencerProvider>(
-    config: ZoneMonitorConfig,
-    zone_provider: P,
-    l1_provider: DynProvider<TempoNetwork>,
-    signer: PrivateKeySigner,
-    shared_state: ZoneMonitorSharedState,
-    shadow_prover: Option<ShadowProver>,
-    shutdown: sync::CancellationToken,
-) -> tokio::task::JoinHandle<()> {
-    let ZoneMonitorSharedState {
-        withdrawal_store,
-        withdrawal_notify,
-        repair_notify,
-    } = shared_state;
-    tokio::spawn(async move {
-        loop {
-            if shutdown.is_cancelled() {
-                info!("Zone monitor stopped before start");
-                return;
-            }
-            let mut monitor = match ZoneMonitor::new_with_provider(
-                config.clone(),
-                zone_provider.clone(),
-                l1_provider.clone(),
-                Some(signer.clone()),
-                withdrawal_store.clone(),
-                withdrawal_notify.clone(),
-                repair_notify.clone(),
-                shadow_prover.clone(),
-            )
-            .await
-            {
-                Ok(monitor) => monitor,
-                Err(e) => {
-                    error!(error = %e, "Zone monitor failed to start, retrying in 5s");
-                    if shutdown
-                        .run_until_cancelled(tokio::time::sleep(RESTART_BACKOFF))
-                        .await
-                        .is_none()
-                    {
-                        info!("Zone monitor stopped before start");
-                        return;
-                    }
-                    continue;
-                }
-            };
-
-            match monitor.run(&shutdown).await {
-                Ok(()) => {
-                    info!("Zone monitor stopped");
-                    return;
-                }
-                Err(e) => {
-                    error!(
-                        error = %e,
-                        "Zone monitor failed; rebuilding from the portal anchor in 5s"
-                    );
-                    if shutdown
-                        .run_until_cancelled(tokio::time::sleep(RESTART_BACKOFF))
-                        .await
-                        .is_none()
-                    {
-                        info!("Zone monitor stopped");
-                        return;
-                    }
-                }
-            }
-        }
-    })
-}
-
 /// Try to decode a ZonePortal revert reason from an eyre error chain.
 ///
 /// Extracts hex-encoded revert data from the error's display string and decodes
@@ -1018,7 +953,6 @@ mod tests {
             provider: zone_provider,
             withdrawal_store: SharedWithdrawalStore::new(),
             batch_submitter: BatchSubmitter::new(portal_address, l1_provider),
-            withdrawal_notify: Arc::new(Notify::new()),
             repair_notify: Arc::new(Notify::new()),
             last_submitted_zone_block: 10,
             prev_processed_deposit_hash: B256::repeat_byte(0xaa),
@@ -1118,7 +1052,6 @@ mod tests {
             mock_provider(l1.clone()),
             None,
             SharedWithdrawalStore::new(),
-            Arc::new(Notify::new()),
             Arc::new(Notify::new()),
             None,
         )

--- a/crates/sequencer/src/withdrawals.rs
+++ b/crates/sequencer/src/withdrawals.rs
@@ -326,7 +326,6 @@ pub struct WithdrawalProcessor {
     provider: DynProvider<TempoNetwork>,
     portal: ZonePortal::ZonePortalInstance<DynProvider<TempoNetwork>, TempoNetwork>,
     store: SharedWithdrawalStore,
-    notify: Arc<Notify>,
     repair_notify: Arc<Notify>,
     metrics: WithdrawalProcessorMetrics,
     sequencer_metrics: SequencerMetrics,
@@ -340,7 +339,6 @@ impl WithdrawalProcessor {
         config: WithdrawalProcessorConfig,
         provider: DynProvider<TempoNetwork>,
         store: SharedWithdrawalStore,
-        notify: Arc<Notify>,
         repair_notify: Arc<Notify>,
     ) -> Self {
         config.batch_limits.assert_valid();
@@ -351,7 +349,6 @@ impl WithdrawalProcessor {
             provider,
             portal,
             store,
-            notify,
             repair_notify,
             metrics: WithdrawalProcessorMetrics::default(),
             sequencer_metrics: SequencerMetrics::default(),
@@ -377,47 +374,19 @@ impl WithdrawalProcessor {
         }
     }
 
-    /// Run the processor loop. This method never returns under normal operation.
-    ///
-    /// Waits for a notification from the batch submitter (or a fallback timeout) before
-    /// checking the L1 withdrawal queue. Returns only when `shutdown` fires; the
-    /// token is observed at the wait boundary so an in-flight processing cycle completes
-    /// first.
-    #[instrument(skip_all, fields(portal = %self.config.portal_address))]
-    pub async fn run(&self, shutdown: &sync::CancellationToken) {
-        info!("Withdrawal processor started");
+    pub(crate) fn poll_interval(&self) -> Duration {
+        self.config.fallback_poll_interval
+    }
 
-        loop {
-            tokio::select! {
-                biased;
-                () = shutdown.cancelled() => {
-                    debug!("Withdrawal processor observed shutdown at the poll boundary");
-                    return;
-                }
-                _ = self.notify.notified() => {
-                    debug!("Woken by batch submission notification");
-                }
-                _ = tokio::time::sleep(self.config.fallback_poll_interval) => {
-                    debug!("Fallback poll interval elapsed");
-                }
-            }
-
-            if let Err(e) = self.process_queue(shutdown).await {
-                error!(error = %e, "Withdrawal processing cycle failed");
-            }
-
-            if shutdown.is_cancelled() {
-                debug!("Withdrawal processor stopped after draining submitted transactions");
-                return;
-            }
-
-            if let Err(error) = self.update_sequencer_metrics().await {
-                warn!(
-                    %error,
-                    sequencer = %self.config.sequencer_address,
-                    "Failed to refresh sequencer PathUSD balance metric"
-                );
-            }
+    /// Drain one withdrawal cycle, including receipts for transactions already sent to L1.
+    pub(crate) async fn process_cycle(&self, shutdown: &sync::CancellationToken) {
+        if let Err(error) = self.process_queue(shutdown).await {
+            error!(%error, "Withdrawal processing cycle failed");
+        }
+        if !shutdown.is_cancelled()
+            && let Err(error) = self.update_sequencer_metrics().await
+        {
+            warn!(%error, "Failed to refresh sequencer balance");
         }
     }
 
@@ -832,27 +801,6 @@ struct SubmitBatches<'a> {
     first_nonce: u64,
     withdrawals: &'a [abi::Withdrawal],
     batches: Vec<WithdrawalBatch>,
-}
-
-/// Spawn the withdrawal processor as a background task.
-///
-/// The processor waits for notifications from the batch submitter (via `notify`) and then
-/// processes withdrawals from the ZonePortal queue on Tempo L1.
-///
-/// The `provider` must already include the sequencer wallet for signing L1 transactions.
-pub fn spawn_withdrawal_processor(
-    config: WithdrawalProcessorConfig,
-    provider: DynProvider<TempoNetwork>,
-    store: SharedWithdrawalStore,
-    notify: Arc<Notify>,
-    repair_notify: Arc<Notify>,
-    shutdown: sync::CancellationToken,
-) -> tokio::task::JoinHandle<()> {
-    tokio::spawn(async move {
-        let processor = WithdrawalProcessor::new(config, provider, store, notify, repair_notify);
-        processor.run(&shutdown).await;
-        info!("Withdrawal processor stopped");
-    })
 }
 
 /// Return the gas reserved for one withdrawal inside a `processWithdrawals` transaction.
@@ -1321,13 +1269,7 @@ mod tests {
             sequencer_address: Address::repeat_byte(0x77),
             batch_limits: WithdrawalBatchLimits::default(),
         };
-        WithdrawalProcessor::new(
-            config,
-            mock_provider(l1),
-            store,
-            Arc::new(Notify::new()),
-            repair_notify,
-        )
+        WithdrawalProcessor::new(config, mock_provider(l1), store, repair_notify)
     }
 
     #[tokio::test]


### PR DESCRIPTION
This PR sends finalized payload references to one worker for batch submission and withdrawals. The worker restores Portal state when sequencing starts and finishes in-flight L1 transactions when leadership changes.

Stacked on #1419.
