### PR TITLE
fix(bench): align contract runtimes across Tempo forks

### DIFF
--- a/.github/workflows/zones-benchmark.yml
+++ b/.github/workflows/zones-benchmark.yml
@@ -614,6 +614,11 @@ jobs:
           git -C "$TEMPO_ROOT" apply --check "$GITHUB_WORKSPACE/$patch"
           git -C "$TEMPO_ROOT" apply "$GITHUB_WORKSPACE/$patch"
 
+      - uses: actions/setup-node@249970729cb0ef3589644e2896645e5dc5ba9c38 # v6
+        with:
+          node-version: "24"
+          package-manager-cache: false
+
       - name: Embed benchmark contracts in Tempo fork runtimes
         run: |
           set -euo pipefail

--- a/.github/workflows/zones-benchmark.yml
+++ b/.github/workflows/zones-benchmark.yml
@@ -614,6 +614,13 @@ jobs:
           git -C "$TEMPO_ROOT" apply --check "$GITHUB_WORKSPACE/$patch"
           git -C "$TEMPO_ROOT" apply "$GITHUB_WORKSPACE/$patch"
 
+      - name: Embed benchmark contracts in Tempo fork runtimes
+        run: |
+          set -euo pipefail
+          node --test contrib/bench/prepare-tempo-runtimes.test.mjs
+          forge build --root crates/contracts --skip test --no-lint
+          node contrib/bench/prepare-tempo-runtimes.mjs "$TEMPO_ROOT" crates/contracts/out
+
       - name: Prepare persistent build directories
         env:
           RUNNER_TOOL_CACHE_DIR: ${{ runner.tool_cache }}
@@ -688,17 +695,19 @@ jobs:
           set -euo pipefail
           cargo build --target-dir "$ZONES_BENCH_ZONES_TARGET_DIR" \
             --profile profiling -p tempo-zone -p tempo-zone-prover-utils -p tempo-xtask
-          nu -c "source '$TEMPO_ROOT/tempo.nu'; build-in-worktree --no-default-features \
-            '$TEMPO_ROOT' '$ZONES_BENCH_TEMPO_REF' profiling \
-            'jemalloc,asm-keccak,keccak-cache-global,otlp' \
-            '$ZONES_BENCH_TEMPO_REF'"
+          # Build the patched source directly: the shared Tempo binary cache is
+          # keyed by upstream SHA and must neither supply nor store this binary.
+          cargo build --target-dir "$ZONES_BENCH_TEMPO_TARGET_DIR" \
+            --manifest-path "$TEMPO_ROOT/Cargo.toml" --profile profiling \
+            --no-default-features --features jemalloc,asm-keccak,keccak-cache-global,otlp \
+            --bin tempo
           cargo build --target-dir "$ZONES_BENCH_TEMPO_TARGET_DIR" \
             --manifest-path "$TEMPO_ROOT/Cargo.toml" --profile profiling -p tempo-xtask
           {
             echo "ZONE_BIN=$ZONES_BENCH_ZONES_TARGET_DIR/profiling/tempo-zone"
             echo "SPF_BIN=$ZONES_BENCH_ZONES_TARGET_DIR/profiling/tempo-zone-prover-utils"
             echo "ZONES_XTASK_BIN=$ZONES_BENCH_ZONES_TARGET_DIR/profiling/tempo-xtask"
-            echo "TEMPO_BIN=$TEMPO_ROOT/target/profiling/tempo"
+            echo "TEMPO_BIN=$ZONES_BENCH_TEMPO_TARGET_DIR/profiling/tempo"
             echo "TEMPO_XTASK_BIN=$ZONES_BENCH_TEMPO_TARGET_DIR/profiling/tempo-xtask"
           } >> "$GITHUB_ENV"
 

--- a/contrib/bench/README.md
+++ b/contrib/bench/README.md
@@ -1,0 +1,37 @@
+# Benchmark fork selection
+
+Set the workflow's `tempo-hardfork` input (or `ZONES_BENCH_TEMPO_HARDFORK`
+locally) to `t11`, `t12`, or another fork supported by the pinned Tempo revision.
+`latest` selects its newest supported fork. Unsupported names fail before
+genesis generation; later forks are scheduled outside the benchmark window.
+
+The benchmark measures the selected **Zones checkout's contracts** under those
+Tempo execution rules. It does not reproduce the historical mainnet contract
+deployment for each fork. Before building Tempo, the workflow compiles the Zones
+contracts and runs:
+
+```sh
+node contrib/bench/prepare-tempo-runtimes.mjs "$TEMPO_ROOT" crates/contracts/out
+```
+
+This embeds the local ZonePortal, Verifier, and ZoneMessenger bytecode into every
+runtime set in the benchmark Tempo checkout, including future fork-prefixed
+sets. Genesis and fork upgrades therefore install the same contracts. Unknown
+source formats or incomplete sets fail preparation instead of silently leaving
+an upgrade unpatched. The post-block bytecode checks on both validators remain
+mandatory.
+
+Build both the Tempo node and its xtask from that patched checkout. Do not use
+the upstream SHA-keyed binary download/upload cache for this build. The L1
+snapshot manifest includes the patched runtime source hash alongside the Tempo
+revision, selected fork, and local contract hashes, so incompatible snapshots
+are rebuilt.
+
+The source transformation can be checked without building the nodes:
+
+```sh
+node --test contrib/bench/prepare-tempo-runtimes.test.mjs
+```
+
+These tests include a synthetic T13 runtime set to exercise future fork handling;
+they do not assert that a given Tempo revision implements T13.

--- a/contrib/bench/README.md
+++ b/contrib/bench/README.md
@@ -16,8 +16,9 @@ node contrib/bench/prepare-tempo-runtimes.mjs "$TEMPO_ROOT" crates/contracts/out
 
 This embeds the local ZonePortal, Verifier, and ZoneMessenger bytecode into every
 runtime set in the benchmark Tempo checkout, including future fork-prefixed
-sets. Genesis and fork upgrades therefore install the same contracts. Unknown
-source formats or incomplete sets fail preparation instead of silently leaving
+sets, including forks that upgrade only one of the three contracts. Genesis and
+fork upgrades therefore install the same contracts. Unknown source formats or
+missing contract definitions fail preparation instead of silently leaving
 an upgrade unpatched. The post-block bytecode checks on both validators remain
 mandatory.
 

--- a/contrib/bench/l1-snapshot.sh
+++ b/contrib/bench/l1-snapshot.sh
@@ -281,7 +281,7 @@ l1_snapshot_prepare_expectations() {
     echo "building native ZoneFactory shared runtime artifacts"
     forge build --root "$L1_SNAPSHOT_ZONES_ROOT/crates/contracts" --skip test --no-lint >/dev/null
 
-    local factory_hash portal_hash verifier_hash messenger_hash genesis_inputs_hash tempo_patch_hash
+    local factory_hash portal_hash verifier_hash messenger_hash genesis_inputs_hash tempo_patch_hash tempo_runtimes_hash
     factory_hash="$(l1_snapshot_sha256 "$L1_SNAPSHOT_ZONES_ROOT/crates/contracts/src/precompiles/zone_factory.rs")"
     portal_hash="$(l1_snapshot_artifact_hash ZonePortal)"
     verifier_hash="$(l1_snapshot_artifact_hash Verifier)"
@@ -290,6 +290,7 @@ l1_snapshot_prepare_expectations() {
     local tempo_patch="$L1_SNAPSHOT_ZONES_ROOT/contrib/bench/patches/tempo-xtask-mnemonic-file.patch"
     l1_snapshot_require_file "$tempo_patch"
     tempo_patch_hash="$(l1_snapshot_sha256 "$tempo_patch")"
+    tempo_runtimes_hash="$(l1_snapshot_sha256 "$TEMPO_ROOT/crates/contracts/src/zones.rs")"
 
     local tempo_revision="${ZONES_BENCH_TEMPO_REF:-}"
     if [[ -z "$tempo_revision" ]]; then
@@ -311,6 +312,7 @@ l1_snapshot_prepare_expectations() {
         --arg tempoRevision "${tempo_revision,,}" \
         --arg tempoHardfork "$L1_SNAPSHOT_HARDFORK" \
         --arg tempoPatchSha256 "$tempo_patch_hash" \
+        --arg tempoRuntimesSha256 "$tempo_runtimes_hash" \
         --arg genesisInputsSha256 "$genesis_inputs_hash" \
         --arg factoryArtifactSha256 "$factory_hash" \
         --arg portalArtifactSha256 "$portal_hash" \
@@ -333,7 +335,8 @@ l1_snapshot_prepare_expectations() {
           tempo: {
             revision: $tempoRevision,
             hardfork: $tempoHardfork,
-            mnemonicFilePatchSha256: $tempoPatchSha256
+            mnemonicFilePatchSha256: $tempoPatchSha256,
+            zoneRuntimesSha256: $tempoRuntimesSha256
           },
           zonesGenesis: {
             inputsSha256: $genesisInputsSha256,

--- a/contrib/bench/prepare-tempo-runtimes.mjs
+++ b/contrib/bench/prepare-tempo-runtimes.mjs
@@ -25,15 +25,13 @@ export function replaceRuntimes(source, artifacts) {
   const declarations = [...source.matchAll(/pub\s+const\s+((?:[A-Z0-9]+_)*ZONE_(PORTAL|VERIFIER|MESSENGER)_RUNTIME)\s*:/g)];
   if (declarations.length === 0) throw new Error('No Tempo Zone runtime constants found');
   const replaced = new Set();
-  const groups = new Map();
+  const kinds = new Set();
   const patched = source.replace(
     /pub\s+const\s+((?:[A-Z0-9]+_)*ZONE_(PORTAL|VERIFIER|MESSENGER)_RUNTIME)\s*:\s*Bytes\s*=\s*bytes!\(\s*((?:"(?:0x)?[a-fA-F0-9]*"\s*)+)\);/g,
     (_, name, kind) => {
       if (replaced.has(name)) throw new Error(`Duplicate runtime constant: ${name}`);
       replaced.add(name);
-      const prefix = name.slice(0, -`ZONE_${kind}_RUNTIME`.length);
-      if (!groups.has(prefix)) groups.set(prefix, new Set());
-      groups.get(prefix).add(kind);
+      kinds.add(kind);
       const chunks = bytecodes[kind].match(/.{1,112}/g);
       const body = chunks.map((chunk, i) => `    "${i === 0 ? '0x' : ''}${chunk}"`).join('\n');
       return `pub const ${name}: Bytes = bytes!(\n${body}\n);`;
@@ -42,10 +40,8 @@ export function replaceRuntimes(source, artifacts) {
   for (const [, name] of declarations) {
     if (!replaced.has(name)) throw new Error(`Unsupported runtime definition: ${name}`);
   }
-  for (const [prefix, kinds] of groups) {
-    if (kinds.size !== Object.keys(contracts).length) {
-      throw new Error(`Incomplete runtime set: ${prefix || 'initial'}`);
-    }
+  for (const [kind, contract] of Object.entries(contracts)) {
+    if (!kinds.has(kind)) throw new Error(`Missing runtime constants for ${contract}`);
   }
   return { source: patched, constants: [...replaced] };
 }

--- a/contrib/bench/prepare-tempo-runtimes.mjs
+++ b/contrib/bench/prepare-tempo-runtimes.mjs
@@ -1,0 +1,66 @@
+#!/usr/bin/env node
+
+// Benchmark the selected Zones contracts under Tempo's selected execution fork.
+// Keep genesis and every fork's runtime installation consistent with those contracts.
+import { readFileSync, writeFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+import { pathToFileURL } from 'node:url';
+
+const contracts = {
+  PORTAL: 'ZonePortal',
+  VERIFIER: 'Verifier',
+  MESSENGER: 'ZoneMessenger',
+};
+
+export function replaceRuntimes(source, artifacts) {
+  const bytecodes = {};
+  for (const [kind, contract] of Object.entries(contracts)) {
+    const object = artifacts[contract]?.deployedBytecode?.object;
+    if (typeof object !== 'string' || !/^(?:0x)?(?:[a-fA-F0-9]{2})+$/.test(object)) {
+      throw new Error(`Invalid or missing ${contract} deployed bytecode`);
+    }
+    bytecodes[kind] = object.replace(/^0x/, '').toLowerCase();
+  }
+
+  const declarations = [...source.matchAll(/pub\s+const\s+((?:[A-Z0-9]+_)*ZONE_(PORTAL|VERIFIER|MESSENGER)_RUNTIME)\s*:/g)];
+  if (declarations.length === 0) throw new Error('No Tempo Zone runtime constants found');
+  const replaced = new Set();
+  const groups = new Map();
+  const patched = source.replace(
+    /pub\s+const\s+((?:[A-Z0-9]+_)*ZONE_(PORTAL|VERIFIER|MESSENGER)_RUNTIME)\s*:\s*Bytes\s*=\s*bytes!\(\s*((?:"(?:0x)?[a-fA-F0-9]*"\s*)+)\);/g,
+    (_, name, kind) => {
+      if (replaced.has(name)) throw new Error(`Duplicate runtime constant: ${name}`);
+      replaced.add(name);
+      const prefix = name.slice(0, -`ZONE_${kind}_RUNTIME`.length);
+      if (!groups.has(prefix)) groups.set(prefix, new Set());
+      groups.get(prefix).add(kind);
+      const chunks = bytecodes[kind].match(/.{1,112}/g);
+      const body = chunks.map((chunk, i) => `    "${i === 0 ? '0x' : ''}${chunk}"`).join('\n');
+      return `pub const ${name}: Bytes = bytes!(\n${body}\n);`;
+    },
+  );
+  for (const [, name] of declarations) {
+    if (!replaced.has(name)) throw new Error(`Unsupported runtime definition: ${name}`);
+  }
+  for (const [prefix, kinds] of groups) {
+    if (kinds.size !== Object.keys(contracts).length) {
+      throw new Error(`Incomplete runtime set: ${prefix || 'initial'}`);
+    }
+  }
+  return { source: patched, constants: [...replaced] };
+}
+
+if (process.argv[1] && import.meta.url === pathToFileURL(resolve(process.argv[1])).href) {
+  const [tempoRoot, artifactsRoot, ...extra] = process.argv.slice(2);
+  if (!tempoRoot || !artifactsRoot || extra.length) {
+    throw new Error('Usage: prepare-tempo-runtimes.mjs TEMPO_ROOT FOUNDRY_OUT');
+  }
+  const artifacts = Object.fromEntries(Object.values(contracts).map(contract => [
+    contract,
+    JSON.parse(readFileSync(resolve(artifactsRoot, `${contract}.sol`, `${contract}.json`), 'utf8')),
+  ]));
+  const path = resolve(tempoRoot, 'crates/contracts/src/zones.rs');
+  const result = replaceRuntimes(readFileSync(path, 'utf8'), artifacts);
+  writeFileSync(path, result.source);
+  console.log(`Embedded benchmark contracts in Tempo: ${result.constants.join(', ')}`);
+}

--- a/contrib/bench/prepare-tempo-runtimes.test.mjs
+++ b/contrib/bench/prepare-tempo-runtimes.test.mjs
@@ -1,0 +1,47 @@
+import assert from 'node:assert/strict';
+import { test } from 'node:test';
+import { replaceRuntimes } from './prepare-tempo-runtimes.mjs';
+
+const artifacts = {
+  ZonePortal: { deployedBytecode: { object: '0x6001' } },
+  Verifier: { deployedBytecode: { object: '6002' } },
+  ZoneMessenger: { deployedBytecode: { object: '0x60AB' } },
+};
+const runtimes = prefix => ['PORTAL', 'VERIFIER', 'MESSENGER'].map(kind =>
+  `pub const ${prefix}ZONE_${kind}_RUNTIME: Bytes = bytes!(\n    "0x6000"\n    "00"\n);`,
+).join('\n');
+
+test('aligns initial, T12, and future fork runtimes without changing other source', () => {
+  const before = '// preserved\nuse alloy_primitives::{Bytes, bytes};\n';
+  const after = '\npub const UNRELATED: u64 = 12;\n';
+  const source = before + runtimes('') + runtimes('T12_') + runtimes('T13_') + after;
+  const result = replaceRuntimes(source, artifacts);
+  assert.equal(result.constants.length, 9);
+  assert.ok(result.source.startsWith(before));
+  assert.ok(result.source.endsWith(after));
+  for (const prefix of ['', 'T12_', 'T13_']) {
+    for (const [kind, bytecode] of [['PORTAL', '6001'], ['VERIFIER', '6002'], ['MESSENGER', '60ab']]) {
+      assert.ok(result.source.includes(`pub const ${prefix}ZONE_${kind}_RUNTIME: Bytes = bytes!(\n    "0x${bytecode}"\n);`));
+    }
+  }
+  assert.deepEqual(replaceRuntimes(result.source, artifacts), result);
+});
+
+test('supports Tempo revisions with only the initial runtime set', () => {
+  assert.equal(replaceRuntimes(runtimes(''), artifacts).constants.length, 3);
+});
+
+test('rejects empty, odd-length, non-hex and unlinked bytecode', () => {
+  for (const object of ['', '0x', '0x123', '0xgg', '__$library$__']) {
+    assert.throws(() => replaceRuntimes(runtimes(''), {
+      ...artifacts, ZonePortal: { deployedBytecode: { object } },
+    }), /Invalid or missing ZonePortal/);
+  }
+});
+
+test('fails closed when upstream changes the runtime representation', () => {
+  assert.throws(() => replaceRuntimes('', artifacts), /No Tempo Zone runtime/);
+  assert.throws(() => replaceRuntimes(runtimes('').replace('Bytes = bytes!', 'Bytes = include_bytes!'), artifacts), /Unsupported runtime definition/);
+  assert.throws(() => replaceRuntimes(runtimes('').replace('ZONE_VERIFIER_RUNTIME', 'UNRELATED_RUNTIME'), artifacts), /Incomplete runtime set/);
+  assert.throws(() => replaceRuntimes(runtimes('') + runtimes(''), artifacts), /Duplicate runtime constant/);
+});

--- a/contrib/bench/prepare-tempo-runtimes.test.mjs
+++ b/contrib/bench/prepare-tempo-runtimes.test.mjs
@@ -31,6 +31,14 @@ test('supports Tempo revisions with only the initial runtime set', () => {
   assert.equal(replaceRuntimes(runtimes(''), artifacts).constants.length, 3);
 });
 
+test('supports a future fork that upgrades only one contract', () => {
+  const source = runtimes('') + runtimes('T12_') +
+    '\npub const T13_ZONE_PORTAL_RUNTIME: Bytes = bytes!("0x6000");';
+  const result = replaceRuntimes(source, artifacts);
+  assert.equal(result.constants.length, 7);
+  assert.ok(result.source.includes('pub const T13_ZONE_PORTAL_RUNTIME: Bytes = bytes!(\n    "0x6001"\n);'));
+});
+
 test('rejects empty, odd-length, non-hex and unlinked bytecode', () => {
   for (const object of ['', '0x', '0x123', '0xgg', '__$library$__']) {
     assert.throws(() => replaceRuntimes(runtimes(''), {
@@ -42,6 +50,6 @@ test('rejects empty, odd-length, non-hex and unlinked bytecode', () => {
 test('fails closed when upstream changes the runtime representation', () => {
   assert.throws(() => replaceRuntimes('', artifacts), /No Tempo Zone runtime/);
   assert.throws(() => replaceRuntimes(runtimes('').replace('Bytes = bytes!', 'Bytes = include_bytes!'), artifacts), /Unsupported runtime definition/);
-  assert.throws(() => replaceRuntimes(runtimes('').replace('ZONE_VERIFIER_RUNTIME', 'UNRELATED_RUNTIME'), artifacts), /Incomplete runtime set/);
+  assert.throws(() => replaceRuntimes(runtimes('').replace('ZONE_VERIFIER_RUNTIME', 'UNRELATED_RUNTIME'), artifacts), /Missing runtime constants for Verifier/);
   assert.throws(() => replaceRuntimes(runtimes('') + runtimes(''), artifacts), /Duplicate runtime constant/);
 });

--- a/xtask/src/install_reference_zone_factory.rs
+++ b/xtask/src/install_reference_zone_factory.rs
@@ -233,6 +233,9 @@ fn install_native_zone_factory(
             [TEMPO_ZONE_MESSENGER_RUNTIME, T12_ZONE_MESSENGER_RUNTIME],
         ),
     ] {
+        // A benchmark Tempo build embeds these artifacts in every fork's runtime
+        // set. Its generated genesis has the same code without our nonce of one.
+        let benchmark_genesis = GenesisAccount::default().with_code(Some(code.clone()));
         let expected = GenesisAccount::default()
             .with_nonce(Some(1))
             .with_code(Some(code));
@@ -243,6 +246,9 @@ fn install_native_zone_factory(
                 genesis.alloc.insert(address, expected);
             }
             Some(existing) if existing == &expected => {}
+            Some(existing) if existing == &benchmark_genesis => {
+                genesis.alloc.insert(address, expected);
+            }
             Some(existing) if known_tempo_runtimes.contains(existing) => {
                 genesis.alloc.insert(address, expected);
             }
@@ -307,6 +313,46 @@ mod tests {
             T12_ZONE_VERIFIER_RUNTIME,
             T12_ZONE_MESSENGER_RUNTIME,
         ]);
+    }
+
+    #[test]
+    fn accepts_benchmark_runtimes_from_any_fork() {
+        let owner = address!("0x0000000000000000000000000000000000000001");
+        let artifacts = || NativeArtifacts {
+            portal: Bytes::from_static(&[1]),
+            verifier: Bytes::from_static(&[2]),
+            messenger: Bytes::from_static(&[3]),
+        };
+        let mut genesis = Genesis::default();
+        for (address, code) in [
+            (ZONE_PORTAL_IMPL_ADDRESS, artifacts().portal),
+            (ZONE_VERIFIER_ADDRESS, artifacts().verifier),
+            (ZONE_MESSENGER_ADDRESS, artifacts().messenger),
+        ] {
+            let account = GenesisAccount::default().with_code(Some(code));
+            genesis.alloc.insert(address, account.clone());
+            for conflicting in [
+                account.clone().with_nonce(Some(2)),
+                account.clone().with_balance(U256::ONE),
+                account.with_storage(Some(BTreeMap::from([(
+                    B256::ZERO,
+                    B256::with_last_byte(1),
+                )]))),
+            ] {
+                assert_rejects_shared_runtime(address, conflicting);
+            }
+        }
+
+        let mut expected = genesis.alloc.clone();
+        for account in expected.values_mut() {
+            account.nonce = Some(1);
+        }
+        expected.insert(ZONE_FACTORY_ADDRESS, native_factory_account(owner));
+        install_native_zone_factory(&mut genesis, owner, artifacts()).unwrap();
+        assert_eq!(genesis.alloc, expected);
+        // Reapplying the same benchmark allocations is harmless.
+        install_native_zone_factory(&mut genesis, owner, artifacts()).unwrap();
+        assert_eq!(genesis.alloc, expected);
     }
 
     fn assert_validates_shared_runtimes([portal, verifier, messenger]: [Bytes; 3]) {


### PR DESCRIPTION
The benchmark installs the current Zones contracts, but T12 replaces them with Tempo's bundled bytecode and fails the post-block runtime check. Embed the benchmark artifacts in every Tempo runtime set before building, so genesis and fork upgrades agree for the selected fork; keep both validators' bytecode checks intact.

Build the patched Tempo source outside the upstream binary cache and include its runtime hash in snapshot metadata. The genesis installer accepts matching benchmark code while continuing to reject conflicting account state. This measures current Zones contracts under the selected execution fork, not historical mainnet contract deployments.

Validation: all five runtime preparation tests (including full and partial synthetic T13 upgrades) and all three genesis-installer tests pass. Compiled Solidity artifacts match all six patched constants in Tempo's source byte for byte. Nightly Rust formatting, Clippy, shell syntax, and the GitHub Actions scan pass.

Both full-journey workflows passed, including SPF validation, and their published results were verified in ClickHouse:

- [T11](https://github.com/tempoxyz/zones/actions/runs/34402476910): 100/100 journeys, zero failures/timeouts; 1.84 journeys/sec, 6.00s median, 6.55s p95.
- [T12](https://github.com/tempoxyz/zones/actions/runs/34400146527): 100/100 journeys, zero failures/timeouts; 1.74 journeys/sec, 6.45s median, 7.06s p95.

T11 ran the final revision. T12 ran before the partial-upgrade handling refinement; the final script produces byte-for-byte identical Tempo source for that pinned revision. The runs used different runners and seeds, so these timings are validation results rather than a controlled fork performance comparison.

Prompted by: @Rjected
