### PR TITLE
fix(ci): use vendored buildx in reproducible builds

### DIFF
--- a/.github/workflows/reproducible-build.yml
+++ b/.github/workflows/reproducible-build.yml
@@ -23,9 +23,10 @@ on:
 
 jobs:
   build:
-    uses: tempoxyz/gh-actions/.github/workflows/reproducible-build.yml@98b1081dcf34361b576aca2ab3041772708582ef
+    uses: tempoxyz/gh-actions/.github/workflows/reproducible-build.yml@5338a3746a2ac2ddd88cbede733c79f907aca3a0
     permissions:
       contents: read
+      id-token: write
     with:
       binary-name: tempo-zone
       ref: ${{ inputs.ref }}


### PR DESCRIPTION
The reproducible build currently calls a shared workflow that uses `docker/setup-buildx-action` directly. The repository action policy rejects that reference before any jobs start ([failed run](https://github.com/tempoxyz/zones/actions/runs/34463450087)), leaving the Argo verifier with an expired artifact from the last successful build.

Update the shared workflow pin to `5338a3746a2ac2ddd88cbede733c79f907aca3a0`, which uses the vendored Buildx action (v4.3.0). Grant `id-token: write` only to the calling build job because the updated shared workflow requires it for its runner security setup.

Validation: `actionlint .github/workflows/reproducible-build.yml` and `git diff --check` pass. Verified the pinned shared workflow and its vendored Buildx reference exist. The reproducible build runs on pushes to main or manual dispatch, so an end-to-end build has not been run for this PR.

Prompted by: @grandizzy
