### PR TITLE
refactor(checker): trim activity logs to dashboard fields

### DIFF
--- a/crates/checker/README.md
+++ b/crates/checker/README.md
@@ -134,27 +134,27 @@ head advances.
 ### Verified activity logs
 
 After a Zone block is durably verified, the checker emits structured
-`zone::checker` logs for authenticated bridge activity. Zero-value Portal
+`zone::checker` INFO logs for authenticated bridge activity. Zero-value Portal
 refund claims are accounting no-ops and are omitted. Within that block,
 `authenticated` denotes canonical protocol evidence, `accounted` denotes a
 ghost-liability change, and `verified` denotes additional reconciliation
 against TIP-20 movements and exact post-block state.
 
-These fields form the stable schema for log-backed dashboards:
+Activity logs contain only the fields needed by log-backed activity dashboards:
 
-- `activity_schema_version`: currently `1`.
 - `activity_event`: the stable event name from the table below.
-- `activity_source`: `tempo` for Portal activity or `zone` for Zone activity.
 - `activity_id`: `v<schema_version>:<zone_hash>:<activity_source>:<activity_index>`,
   which remains stable if recovery replays the same canonical block under the
-  same schema.
-- `activity_index`: the event's canonical order within its source for the Zone
-  block.
-- `zone_block`, `zone_hash`, `tempo_block`, and `tempo_hash`: exact verified
-  coordinates.
-- Event-specific fields such as `token`, `recipient`, `sender`,
-  `deposit_number`, `withdrawal_index`, and `callback_success`. Monetary
-  `amount` and `fee` fields are decimal strings for both Tempo and Zone values.
+  same schema. The ID retains version `1`, the verified Zone block hash, source
+  (`tempo` or `zone`), and zero-based canonical index within that source.
+- `callback_success`: emitted only for `portal_withdrawal_processed`, allowing
+  dashboards to distinguish successful and failed withdrawal callbacks.
+
+The ID components are not repeated as separate fields. Activity logs omit
+descriptive messages, block heights, Tempo hashes, token and account addresses,
+amounts, fees, and deposit/withdrawal numbers. Kubernetes pod and namespace
+metadata supplied by the log collector still identify the verifier and Zone.
+Operational warnings and errors retain their diagnostic fields.
 
 | `activity_event` | Meaning |
 | --- | --- |

--- a/crates/checker/src/accounting/effects.rs
+++ b/crates/checker/src/accounting/effects.rs
@@ -270,7 +270,6 @@ mod tests {
             .unwrap();
         let enqueued = L1PortalEvent::WithdrawalBounceBack { token, amount: 10 };
         let failed = L1PortalEvent::WithdrawalProcessed {
-            to: recipient,
             token,
             amount: 10,
             callback_success: false,
@@ -326,7 +325,6 @@ mod tests {
             .unwrap();
         let enqueued = L1PortalEvent::WithdrawalBounceBack { token, amount: 10 };
         let failed = L1PortalEvent::WithdrawalProcessed {
-            to: recipient,
             token,
             amount: 10,
             callback_success: false,
@@ -399,11 +397,7 @@ mod tests {
         assert_eq!(token_state.pending_tempo_refunds, amount);
         assert_eq!(token_state.liability().unwrap(), amount);
 
-        let claimed = L1PortalEvent::RefundClaimed {
-            recipient: Address::repeat_byte(2),
-            token,
-            amount: 10,
-        };
+        let claimed = L1PortalEvent::RefundClaimed { token, amount: 10 };
         state.apply(&from_tempo_events([&claimed])).unwrap();
         let token_state = state.token(token).unwrap();
         assert_eq!(token_state.pending_tempo_refunds, U256::ZERO);
@@ -413,11 +407,7 @@ mod tests {
     #[test]
     fn handles_tempo_refunds_for_unknown_tokens_by_amount() {
         let token = Address::repeat_byte(1);
-        let refund = |amount| L1PortalEvent::RefundClaimed {
-            recipient: Address::repeat_byte(2),
-            token,
-            amount,
-        };
+        let refund = |amount| L1PortalEvent::RefundClaimed { token, amount };
         let mut state = crate::accounting::State::default();
 
         let zero_refund = from_tempo_events([&refund(0)]);

--- a/crates/checker/src/l1/events.rs
+++ b/crates/checker/src/l1/events.rs
@@ -15,19 +15,22 @@ pub(crate) enum L1PortalEvent {
     DepositMade {
         token: Address,
         net_amount: u128,
-        deposit_number: u64,
     },
     /// A TIP-20 token newly enabled for bridging.
-    TokenEnabled { token: Address },
+    TokenEnabled {
+        token: Address,
+    },
     WithdrawalProcessed {
-        to: Address,
         token: Address,
         amount: u128,
         callback_success: bool,
     },
     /// A withdrawal bounce-back — recycles existing Portal backing, not a new
     /// external deposit.  Kept distinct from [`Self::DepositMade`].
-    WithdrawalBounceBack { token: Address, amount: u128 },
+    WithdrawalBounceBack {
+        token: Address,
+        amount: u128,
+    },
     /// A deposit bounce-back processed on L1 (fee deducted, refund sent).
     DepositBounceBack {
         token: Address,
@@ -41,7 +44,6 @@ pub(crate) enum L1PortalEvent {
         bounceback_fee: u128,
     },
     RefundClaimed {
-        recipient: Address,
         token: Address,
         amount: u128,
     },
@@ -119,7 +121,6 @@ fn decode_portal_event(log: &Log, block: u64) -> eyre::Result<Option<L1PortalEve
             L1PortalEvent::DepositMade {
                 token: e.token,
                 net_amount: e.netAmount,
-                deposit_number: e.depositNumber,
             }
         }
         ZonePortal::TokenEnabled::SIGNATURE_HASH => {
@@ -133,7 +134,6 @@ fn decode_portal_event(log: &Log, block: u64) -> eyre::Result<Option<L1PortalEve
             let e =
                 decode_event::<ZonePortal::WithdrawalProcessed>(log, "WithdrawalProcessed", block)?;
             L1PortalEvent::WithdrawalProcessed {
-                to: e.to,
                 token: e.token,
                 amount: e.amount,
                 callback_success: e.callbackSuccess,
@@ -173,7 +173,6 @@ fn decode_portal_event(log: &Log, block: u64) -> eyre::Result<Option<L1PortalEve
         ZonePortal::RefundClaimed::SIGNATURE_HASH => {
             let e = decode_event::<ZonePortal::RefundClaimed>(log, "RefundClaimed", block)?;
             L1PortalEvent::RefundClaimed {
-                recipient: e.recipient,
                 token: e.token,
                 amount: e.amount,
             }
@@ -398,7 +397,7 @@ mod tests {
         assert!(matches!(
             events[0],
             L1PortalEvent::DepositMade {
-                deposit_number: 7,
+                net_amount: 500,
                 ..
             }
         ));

--- a/crates/checker/src/l1/mod.rs
+++ b/crates/checker/src/l1/mod.rs
@@ -56,7 +56,6 @@ impl From<L1ReadError> for AttemptError {
 /// Recognized Portal events for one exact anchored L1 block.
 #[derive(Debug)]
 pub(crate) struct L1BlockEvidence {
-    block: BlockNumHash,
     events: Vec<L1PortalEvent>,
 }
 
@@ -89,10 +88,6 @@ pub(crate) fn validate_rpc_header(
 }
 
 impl L1BlockEvidence {
-    pub(crate) const fn block(&self) -> BlockNumHash {
-        self.block
-    }
-
     /// Return authenticated Portal events in receipt order.
     pub(crate) fn portal_events(&self) -> impl Iterator<Item = &L1PortalEvent> {
         self.events.iter()
@@ -140,7 +135,6 @@ fn collect_tracked_l1_block_evidence(
             .map_err(finding)?;
     }
     Ok(L1BlockEvidence {
-        block: evidence.block,
         events: collector.finish(),
     })
 }
@@ -247,7 +241,7 @@ fn collect_l1_block_evidence(
             .map_err(finding)?;
     }
     let events = event_collector.finish();
-    Ok(L1BlockEvidence { block, events })
+    Ok(L1BlockEvidence { events })
 }
 
 fn classify_contract_error(error: alloy_contract::Error) -> L1ReadError {
@@ -403,7 +397,6 @@ mod tests {
         };
 
         let evidence = collect_tracked_l1_block_evidence(portal, parent, tracked).unwrap();
-        assert_eq!(evidence.block(), BlockNumHash::new(BLOCK, HASH));
         assert!(matches!(
             evidence.portal_events().next(),
             Some(L1PortalEvent::TokenEnabled { token: observed }) if *observed == token

--- a/crates/checker/src/telemetry.rs
+++ b/crates/checker/src/telemetry.rs
@@ -59,16 +59,14 @@ impl ActivitySource {
 /// Coordinates shared by one structured activity log.
 struct ActivityContext {
     zone: BlockRef,
-    tempo: BlockRef,
     source: ActivitySource,
     index: u64,
 }
 
 impl ActivityContext {
-    const fn new(zone: BlockRef, tempo: BlockRef, source: ActivitySource, index: u64) -> Self {
+    const fn new(zone: BlockRef, source: ActivitySource, index: u64) -> Self {
         Self {
             zone,
-            tempo,
             source,
             index,
         }
@@ -107,15 +105,8 @@ macro_rules! activity_log {
         let context = $context;
         tracing::info!(
             target: "zone::checker",
-            activity_schema_version = ACTIVITY_SCHEMA_VERSION,
             activity_event = $event,
-            activity_source = context.source.as_str(),
             activity_id = %context.id(),
-            activity_index = context.index,
-            zone_block = context.zone.number,
-            zone_hash = %context.zone.hash,
-            tempo_block = context.tempo.number,
-            tempo_hash = %context.tempo.hash,
             $($fields)*
         )
     }};
@@ -167,190 +158,79 @@ impl CheckerMetrics {
 
 /// Log authenticated protocol activity after a Zone block is verified.
 pub(crate) fn log_verified_activity(tempo: &L1BlockEvidence, l2: &L2BlockEvidence, zone: BlockRef) {
-    let tempo_ref = BlockRef::from(tempo.block());
     for (index, event) in (0u64..).zip(tempo.portal_events()) {
         log_tempo_event(
             event,
-            &ActivityContext::new(zone, tempo_ref, ActivitySource::Tempo, index),
+            &ActivityContext::new(zone, ActivitySource::Tempo, index),
         );
     }
     for (index, action) in (0u64..).zip(l2.bridge_actions()) {
         log_zone_action(
             action,
-            &ActivityContext::new(zone, tempo_ref, ActivitySource::Zone, index),
+            &ActivityContext::new(zone, ActivitySource::Zone, index),
         );
     }
 }
 
 fn log_tempo_event(event: &L1PortalEvent, context: &ActivityContext) {
     match event {
-        L1PortalEvent::DepositMade {
-            token,
-            net_amount,
-            deposit_number,
-        } => activity_log!(
-            context,
-            activity_event::PORTAL_DEPOSIT_ACCOUNTED,
-            %token,
-            amount = %net_amount,
-            deposit_number,
-            "accounted authenticated Portal deposit"
-        ),
-        L1PortalEvent::TokenEnabled { token } => activity_log!(
-            context,
-            activity_event::PORTAL_TOKEN_ENABLED,
-            %token,
-            "added Portal token to accounting coverage"
-        ),
+        L1PortalEvent::DepositMade { .. } => {
+            activity_log!(context, activity_event::PORTAL_DEPOSIT_ACCOUNTED,)
+        }
+        L1PortalEvent::TokenEnabled { .. } => {
+            activity_log!(context, activity_event::PORTAL_TOKEN_ENABLED,)
+        }
         L1PortalEvent::WithdrawalProcessed {
-            to,
-            token,
-            amount,
-            callback_success,
+            callback_success, ..
         } => activity_log!(
             context,
             activity_event::PORTAL_WITHDRAWAL_PROCESSED,
-            %token,
-            recipient = %to,
-            %amount,
             callback_success,
-            "authenticated Portal withdrawal result"
         ),
-        L1PortalEvent::WithdrawalBounceBack { token, amount } => activity_log!(
-            context,
-            activity_event::PORTAL_WITHDRAWAL_BOUNCE_BACK,
-            %token,
-            %amount,
-            "accounted authenticated Portal withdrawal bounce-back"
-        ),
-        L1PortalEvent::DepositBounceBack {
-            token,
-            amount,
-            bounceback_fee,
-        } => activity_log!(
-            context,
-            activity_event::PORTAL_DEPOSIT_BOUNCE_BACK,
-            %token,
-            %amount,
-            fee = %bounceback_fee,
-            "accounted authenticated Portal deposit bounce-back"
-        ),
-        L1PortalEvent::DepositBounceBackPending {
-            token,
-            amount,
-            bounceback_fee,
-        } => activity_log!(
-            context,
-            activity_event::PORTAL_DEPOSIT_BOUNCE_BACK_PENDING,
-            %token,
-            %amount,
-            fee = %bounceback_fee,
-            "accounted authenticated pending Portal deposit bounce-back"
-        ),
+        L1PortalEvent::WithdrawalBounceBack { .. } => {
+            activity_log!(context, activity_event::PORTAL_WITHDRAWAL_BOUNCE_BACK,)
+        }
+        L1PortalEvent::DepositBounceBack { .. } => {
+            activity_log!(context, activity_event::PORTAL_DEPOSIT_BOUNCE_BACK,)
+        }
+        L1PortalEvent::DepositBounceBackPending { .. } => {
+            activity_log!(context, activity_event::PORTAL_DEPOSIT_BOUNCE_BACK_PENDING,)
+        }
         L1PortalEvent::RefundClaimed { amount: 0, .. } => {}
-        L1PortalEvent::RefundClaimed {
-            recipient,
-            token,
-            amount,
-        } => activity_log!(
-            context,
-            activity_event::PORTAL_REFUND_ACCOUNTED,
-            %token,
-            %recipient,
-            %amount,
-            "accounted authenticated Portal refund"
-        ),
+        L1PortalEvent::RefundClaimed { .. } => {
+            activity_log!(context, activity_event::PORTAL_REFUND_ACCOUNTED,)
+        }
     }
 }
 
 fn log_zone_action(action: &L2BridgeAction, context: &ActivityContext) {
     match action {
         L2BridgeAction::Deposit {
-            token,
-            amount,
-            result: DepositResult::Processed { recipient },
-        } => activity_log!(
-            context,
-            activity_event::ZONE_DEPOSIT_MINTED,
-            %token,
-            %recipient,
-            amount = %amount,
-            "verified Zone deposit mint"
-        ),
+            result: DepositResult::Processed { .. },
+            ..
+        } => activity_log!(context, activity_event::ZONE_DEPOSIT_MINTED,),
         L2BridgeAction::Deposit {
-            token,
-            amount,
             result: DepositResult::Failed,
-        } => activity_log!(
-            context,
-            activity_event::ZONE_DEPOSIT_FAILED,
-            %token,
-            amount = %amount,
-            "authenticated Zone deposit failure"
-        ),
-        L2BridgeAction::WithdrawalRequested {
-            withdrawal_index,
-            origin,
-            token,
-            principal,
-            fee,
-        } => match origin {
-            WithdrawalOrigin::DepositBounceBack => activity_log!(
-                context,
-                activity_event::ZONE_DEPOSIT_BOUNCE_BACK_REQUESTED,
-                %token,
-                amount = %principal,
-                withdrawal_index,
-                "authenticated Zone deposit bounce-back request"
-            ),
-            WithdrawalOrigin::User { sender } => activity_log!(
-                context,
-                activity_event::ZONE_WITHDRAWAL_BURNED,
-                %token,
-                %sender,
-                amount = %principal,
-                %fee,
-                withdrawal_index,
-                "verified Zone withdrawal debit and burn"
-            ),
+            ..
+        } => activity_log!(context, activity_event::ZONE_DEPOSIT_FAILED,),
+        L2BridgeAction::WithdrawalRequested { origin, .. } => match origin {
+            WithdrawalOrigin::DepositBounceBack => {
+                activity_log!(context, activity_event::ZONE_DEPOSIT_BOUNCE_BACK_REQUESTED,)
+            }
+            WithdrawalOrigin::User { .. } => {
+                activity_log!(context, activity_event::ZONE_WITHDRAWAL_BURNED,)
+            }
         },
         L2BridgeAction::WithdrawalBounceBack {
-            recipient,
-            token,
-            amount,
             status: WithdrawalBounceBackStatus::Processed,
-        } => activity_log!(
-            context,
-            activity_event::ZONE_WITHDRAWAL_BOUNCE_BACK_MINTED,
-            %token,
-            %recipient,
-            amount = %amount,
-            "verified Zone withdrawal bounce-back mint"
-        ),
+            ..
+        } => activity_log!(context, activity_event::ZONE_WITHDRAWAL_BOUNCE_BACK_MINTED,),
         L2BridgeAction::WithdrawalBounceBack {
-            recipient,
-            token,
-            amount,
             status: WithdrawalBounceBackStatus::Pending,
-        } => activity_log!(
-            context,
-            activity_event::ZONE_WITHDRAWAL_BOUNCE_BACK_PENDING,
-            %token,
-            %recipient,
-            amount = %amount,
-            "authenticated pending Zone withdrawal bounce-back"
-        ),
-        L2BridgeAction::RefundClaimed {
-            recipient,
-            token,
-            amount,
-        } => activity_log!(
-            context,
-            activity_event::ZONE_REFUND_MINTED,
-            %token,
-            %recipient,
-            amount = %amount,
-            "verified Zone refund mint"
-        ),
+            ..
+        } => activity_log!(context, activity_event::ZONE_WITHDRAWAL_BOUNCE_BACK_PENDING,),
+        L2BridgeAction::RefundClaimed { .. } => {
+            activity_log!(context, activity_event::ZONE_REFUND_MINTED,)
+        }
     }
 }


### PR DESCRIPTION
Trim checker activity logs to the fields used by Grafana: `activity_event`, replay-stable `activity_id`, and `callback_success` for withdrawal results. Remove unused internal fields and update the README.

Validation: 60 tests and formatting pass. Clippy passes with the pre-existing `semicolon_in_expressions_from_non_local_macros` warning allowed.

Prompted by: @grandizzy
