### PR TITLE
fix(fees): gate dynamic Zone fees at Tempo T13

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -11378,7 +11378,7 @@ dependencies = [
 [[package]]
 name = "tempo-alloy"
 version = "1.11.0"
-source = "git+https://github.com/tempoxyz/tempo?rev=a843c91a42a273ccff44e0b6afbee83f9b1021d3#a843c91a42a273ccff44e0b6afbee83f9b1021d3"
+source = "git+https://github.com/tempoxyz/tempo?rev=346c22eb4293ac1f5edd27d4afd1f99323bc527c#346c22eb4293ac1f5edd27d4afd1f99323bc527c"
 dependencies = [
  "alloy-consensus",
  "alloy-contract",
@@ -11424,7 +11424,7 @@ dependencies = [
 [[package]]
 name = "tempo-chainspec"
 version = "1.11.0"
-source = "git+https://github.com/tempoxyz/tempo?rev=a843c91a42a273ccff44e0b6afbee83f9b1021d3#a843c91a42a273ccff44e0b6afbee83f9b1021d3"
+source = "git+https://github.com/tempoxyz/tempo?rev=346c22eb4293ac1f5edd27d4afd1f99323bc527c#346c22eb4293ac1f5edd27d4afd1f99323bc527c"
 dependencies = [
  "alloy-eips",
  "alloy-evm",
@@ -11447,7 +11447,7 @@ dependencies = [
 [[package]]
 name = "tempo-contracts"
 version = "1.11.0"
-source = "git+https://github.com/tempoxyz/tempo?rev=a843c91a42a273ccff44e0b6afbee83f9b1021d3#a843c91a42a273ccff44e0b6afbee83f9b1021d3"
+source = "git+https://github.com/tempoxyz/tempo?rev=346c22eb4293ac1f5edd27d4afd1f99323bc527c#346c22eb4293ac1f5edd27d4afd1f99323bc527c"
 dependencies = [
  "alloy-contract",
  "alloy-primitives",
@@ -11458,8 +11458,8 @@ dependencies = [
 
 [[package]]
 name = "tempo-dkg-onchain-artifacts"
-version = "1.14.0"
-source = "git+https://github.com/tempoxyz/tempo?rev=a843c91a42a273ccff44e0b6afbee83f9b1021d3#a843c91a42a273ccff44e0b6afbee83f9b1021d3"
+version = "1.13.2"
+source = "git+https://github.com/tempoxyz/tempo?rev=346c22eb4293ac1f5edd27d4afd1f99323bc527c#346c22eb4293ac1f5edd27d4afd1f99323bc527c"
 dependencies = [
  "bytes",
  "commonware-codec",
@@ -11470,8 +11470,8 @@ dependencies = [
 
 [[package]]
 name = "tempo-evm"
-version = "1.14.0"
-source = "git+https://github.com/tempoxyz/tempo?rev=a843c91a42a273ccff44e0b6afbee83f9b1021d3#a843c91a42a273ccff44e0b6afbee83f9b1021d3"
+version = "1.13.2"
+source = "git+https://github.com/tempoxyz/tempo?rev=346c22eb4293ac1f5edd27d4afd1f99323bc527c#346c22eb4293ac1f5edd27d4afd1f99323bc527c"
 dependencies = [
  "alloy-consensus",
  "alloy-evm",
@@ -11506,7 +11506,7 @@ dependencies = [
 [[package]]
 name = "tempo-hardfork"
 version = "1.11.0"
-source = "git+https://github.com/tempoxyz/tempo?rev=a843c91a42a273ccff44e0b6afbee83f9b1021d3#a843c91a42a273ccff44e0b6afbee83f9b1021d3"
+source = "git+https://github.com/tempoxyz/tempo?rev=346c22eb4293ac1f5edd27d4afd1f99323bc527c#346c22eb4293ac1f5edd27d4afd1f99323bc527c"
 dependencies = [
  "alloy-eips",
  "alloy-evm",
@@ -11517,8 +11517,8 @@ dependencies = [
 
 [[package]]
 name = "tempo-node"
-version = "1.14.0"
-source = "git+https://github.com/tempoxyz/tempo?rev=a843c91a42a273ccff44e0b6afbee83f9b1021d3#a843c91a42a273ccff44e0b6afbee83f9b1021d3"
+version = "1.13.2"
+source = "git+https://github.com/tempoxyz/tempo?rev=346c22eb4293ac1f5edd27d4afd1f99323bc527c#346c22eb4293ac1f5edd27d4afd1f99323bc527c"
 dependencies = [
  "alloy",
  "alloy-eips",
@@ -11583,8 +11583,8 @@ dependencies = [
 
 [[package]]
 name = "tempo-payload-builder"
-version = "1.14.0"
-source = "git+https://github.com/tempoxyz/tempo?rev=a843c91a42a273ccff44e0b6afbee83f9b1021d3#a843c91a42a273ccff44e0b6afbee83f9b1021d3"
+version = "1.13.2"
+source = "git+https://github.com/tempoxyz/tempo?rev=346c22eb4293ac1f5edd27d4afd1f99323bc527c#346c22eb4293ac1f5edd27d4afd1f99323bc527c"
 dependencies = [
  "alloy-consensus",
  "alloy-eip7928",
@@ -11621,8 +11621,8 @@ dependencies = [
 
 [[package]]
 name = "tempo-payload-types"
-version = "1.14.0"
-source = "git+https://github.com/tempoxyz/tempo?rev=a843c91a42a273ccff44e0b6afbee83f9b1021d3#a843c91a42a273ccff44e0b6afbee83f9b1021d3"
+version = "1.13.2"
+source = "git+https://github.com/tempoxyz/tempo?rev=346c22eb4293ac1f5edd27d4afd1f99323bc527c#346c22eb4293ac1f5edd27d4afd1f99323bc527c"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -11641,8 +11641,8 @@ dependencies = [
 
 [[package]]
 name = "tempo-precompiles"
-version = "1.14.0"
-source = "git+https://github.com/tempoxyz/tempo?rev=a843c91a42a273ccff44e0b6afbee83f9b1021d3#a843c91a42a273ccff44e0b6afbee83f9b1021d3"
+version = "1.13.2"
+source = "git+https://github.com/tempoxyz/tempo?rev=346c22eb4293ac1f5edd27d4afd1f99323bc527c#346c22eb4293ac1f5edd27d4afd1f99323bc527c"
 dependencies = [
  "alloy",
  "alloy-evm",
@@ -11668,8 +11668,8 @@ dependencies = [
 
 [[package]]
 name = "tempo-precompiles-macros"
-version = "1.14.0"
-source = "git+https://github.com/tempoxyz/tempo?rev=a843c91a42a273ccff44e0b6afbee83f9b1021d3#a843c91a42a273ccff44e0b6afbee83f9b1021d3"
+version = "1.13.2"
+source = "git+https://github.com/tempoxyz/tempo?rev=346c22eb4293ac1f5edd27d4afd1f99323bc527c#346c22eb4293ac1f5edd27d4afd1f99323bc527c"
 dependencies = [
  "alloy",
  "proc-macro2",
@@ -11680,7 +11680,7 @@ dependencies = [
 [[package]]
 name = "tempo-primitives"
 version = "1.11.0"
-source = "git+https://github.com/tempoxyz/tempo?rev=a843c91a42a273ccff44e0b6afbee83f9b1021d3#a843c91a42a273ccff44e0b6afbee83f9b1021d3"
+source = "git+https://github.com/tempoxyz/tempo?rev=346c22eb4293ac1f5edd27d4afd1f99323bc527c#346c22eb4293ac1f5edd27d4afd1f99323bc527c"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -11711,8 +11711,8 @@ dependencies = [
 
 [[package]]
 name = "tempo-revm"
-version = "1.14.0"
-source = "git+https://github.com/tempoxyz/tempo?rev=a843c91a42a273ccff44e0b6afbee83f9b1021d3#a843c91a42a273ccff44e0b6afbee83f9b1021d3"
+version = "1.13.2"
+source = "git+https://github.com/tempoxyz/tempo?rev=346c22eb4293ac1f5edd27d4afd1f99323bc527c#346c22eb4293ac1f5edd27d4afd1f99323bc527c"
 dependencies = [
  "alloy-consensus",
  "alloy-evm",
@@ -11734,8 +11734,8 @@ dependencies = [
 
 [[package]]
 name = "tempo-transaction-pool"
-version = "1.14.0"
-source = "git+https://github.com/tempoxyz/tempo?rev=a843c91a42a273ccff44e0b6afbee83f9b1021d3#a843c91a42a273ccff44e0b6afbee83f9b1021d3"
+version = "1.13.2"
+source = "git+https://github.com/tempoxyz/tempo?rev=346c22eb4293ac1f5edd27d4afd1f99323bc527c#346c22eb4293ac1f5edd27d4afd1f99323bc527c"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -102,26 +102,26 @@ incremental = false
 
 [workspace.dependencies]
 # tempo (from upstream)
-tempo-alloy = { git = "https://github.com/tempoxyz/tempo", rev = "a843c91a42a273ccff44e0b6afbee83f9b1021d3" }
-tempo-chainspec = { git = "https://github.com/tempoxyz/tempo", rev = "a843c91a42a273ccff44e0b6afbee83f9b1021d3", default-features = false }
-tempo-consensus = { git = "https://github.com/tempoxyz/tempo", rev = "a843c91a42a273ccff44e0b6afbee83f9b1021d3", default-features = false }
-tempo-contracts = { git = "https://github.com/tempoxyz/tempo", rev = "a843c91a42a273ccff44e0b6afbee83f9b1021d3", default-features = false, features = [
+tempo-alloy = { git = "https://github.com/tempoxyz/tempo", rev = "346c22eb4293ac1f5edd27d4afd1f99323bc527c" }
+tempo-chainspec = { git = "https://github.com/tempoxyz/tempo", rev = "346c22eb4293ac1f5edd27d4afd1f99323bc527c", default-features = false }
+tempo-consensus = { git = "https://github.com/tempoxyz/tempo", rev = "346c22eb4293ac1f5edd27d4afd1f99323bc527c", default-features = false }
+tempo-contracts = { git = "https://github.com/tempoxyz/tempo", rev = "346c22eb4293ac1f5edd27d4afd1f99323bc527c", default-features = false, features = [
   "serde",
 ] }
-tempo-evm = { git = "https://github.com/tempoxyz/tempo", rev = "a843c91a42a273ccff44e0b6afbee83f9b1021d3", default-features = false }
-tempo-hardfork = { git = "https://github.com/tempoxyz/tempo", rev = "a843c91a42a273ccff44e0b6afbee83f9b1021d3", default-features = false }
-tempo-node = { git = "https://github.com/tempoxyz/tempo", rev = "a843c91a42a273ccff44e0b6afbee83f9b1021d3" }
-tempo-payload-types = { git = "https://github.com/tempoxyz/tempo", rev = "a843c91a42a273ccff44e0b6afbee83f9b1021d3", default-features = false }
-tempo-precompiles = { git = "https://github.com/tempoxyz/tempo", rev = "a843c91a42a273ccff44e0b6afbee83f9b1021d3", default-features = false }
-tempo-precompiles-macros = { git = "https://github.com/tempoxyz/tempo", rev = "a843c91a42a273ccff44e0b6afbee83f9b1021d3" }
-tempo-primitives = { git = "https://github.com/tempoxyz/tempo", rev = "a843c91a42a273ccff44e0b6afbee83f9b1021d3", default-features = false, features = [
+tempo-evm = { git = "https://github.com/tempoxyz/tempo", rev = "346c22eb4293ac1f5edd27d4afd1f99323bc527c", default-features = false }
+tempo-hardfork = { git = "https://github.com/tempoxyz/tempo", rev = "346c22eb4293ac1f5edd27d4afd1f99323bc527c", default-features = false }
+tempo-node = { git = "https://github.com/tempoxyz/tempo", rev = "346c22eb4293ac1f5edd27d4afd1f99323bc527c" }
+tempo-payload-types = { git = "https://github.com/tempoxyz/tempo", rev = "346c22eb4293ac1f5edd27d4afd1f99323bc527c", default-features = false }
+tempo-precompiles = { git = "https://github.com/tempoxyz/tempo", rev = "346c22eb4293ac1f5edd27d4afd1f99323bc527c", default-features = false }
+tempo-precompiles-macros = { git = "https://github.com/tempoxyz/tempo", rev = "346c22eb4293ac1f5edd27d4afd1f99323bc527c" }
+tempo-primitives = { git = "https://github.com/tempoxyz/tempo", rev = "346c22eb4293ac1f5edd27d4afd1f99323bc527c", default-features = false, features = [
   "reth",
   "serde",
   "serde-bincode-compat",
   "reth-codec",
 ] }
-tempo-revm = { git = "https://github.com/tempoxyz/tempo", rev = "a843c91a42a273ccff44e0b6afbee83f9b1021d3", default-features = false }
-tempo-transaction-pool = { git = "https://github.com/tempoxyz/tempo", rev = "a843c91a42a273ccff44e0b6afbee83f9b1021d3", default-features = false }
+tempo-revm = { git = "https://github.com/tempoxyz/tempo", rev = "346c22eb4293ac1f5edd27d4afd1f99323bc527c", default-features = false }
+tempo-transaction-pool = { git = "https://github.com/tempoxyz/tempo", rev = "346c22eb4293ac1f5edd27d4afd1f99323bc527c", default-features = false }
 
 # zones
 tempo-zone-contracts = { path = "crates/contracts", default-features = false }

--- a/crates/chainspec/src/lib.rs
+++ b/crates/chainspec/src/lib.rs
@@ -214,8 +214,8 @@ impl EthChainSpec for ZoneChainSpec {
     }
 
     fn next_block_base_fee(&self, parent: &TempoHeader, target_timestamp: u64) -> Option<u64> {
-        let fork = self.zone_hardfork_at(target_timestamp);
-        if fork.is_z1() {
+        let fork = self.tempo_hardfork_at(target_timestamp);
+        if fork.is_t13() {
             let parent_base_fee = parent
                 .inner
                 .base_fee_per_gas
@@ -350,6 +350,17 @@ mod tests {
         header
     }
 
+    fn dev_zone_spec_with_t13_at(zone_id: u32, timestamp: Option<u64>) -> ZoneChainSpec {
+        let mut genesis = DEV.genesis().clone();
+        genesis.config.chain_id = zone_chain_id(DEV.chain().id(), zone_id).unwrap();
+        genesis
+            .config
+            .extra_fields
+            .insert_value("t13Time".into(), timestamp)
+            .unwrap();
+        ZoneChainSpec::from_genesis(genesis).unwrap()
+    }
+
     #[test]
     fn delegates_tempo_chain_behavior() {
         let zone = dev_zone_spec(1);
@@ -470,8 +481,8 @@ mod tests {
     }
 
     #[test]
-    fn next_block_base_fee_is_zero_without_z1() {
-        let zone = dev_zone_spec(2);
+    fn next_block_base_fee_is_zero_without_t13() {
+        let zone = dev_zone_spec_with_t13_at(2, None);
         let parent = zone.genesis_header();
         let timestamp = parent.inner.timestamp;
 
@@ -480,18 +491,19 @@ mod tests {
     }
 
     #[test]
-    fn next_block_base_fee_is_zero_before_z1() {
-        let zone = dev_zone_spec_with_z1_at(2, 100);
+    fn next_block_base_fee_is_zero_before_t13() {
+        let zone = dev_zone_spec_with_t13_at(2, Some(100));
         let parent = header(98, TEMPO_T7_BASE_FEE_CAP, TEMPO_T7_BASE_FEE_GAS_TARGET);
 
         assert_eq!(zone.next_block_base_fee(&parent, 99), Some(0));
     }
 
     #[test]
-    fn next_block_base_fee_uses_parent_fee_on_z1_activation() {
-        let zone = dev_zone_spec_with_z1_at(2, 100);
+    fn next_block_base_fee_uses_parent_fee_on_t13_activation() {
+        let zone = dev_zone_spec_with_t13_at(2, Some(100));
         let parent = header(99, 0, 0);
 
+        assert_eq!(zone.zone_hardfork_at(100), ZoneHardfork::Z0);
         assert_eq!(
             zone.next_block_base_fee(&parent, 100),
             Some(tempo_t7_next_block_base_fee(0, 0))
@@ -499,8 +511,8 @@ mod tests {
     }
 
     #[test]
-    fn next_block_base_fee_adjusts_after_z1_activation() {
-        let zone = dev_zone_spec_with_z1_at(2, 100);
+    fn next_block_base_fee_adjusts_after_t13_activation() {
+        let zone = dev_zone_spec_with_t13_at(2, Some(100));
         let empty_parent = header(100, TEMPO_T7_BASE_FEE_CAP, 0);
         let busy_parent = header(
             100,
@@ -520,7 +532,7 @@ mod tests {
 
     #[test]
     fn next_block_base_fee_respects_t7_target_and_bounds() {
-        let zone = dev_zone_spec_with_z1_at(2, 100);
+        let zone = dev_zone_spec_with_t13_at(2, Some(100));
         let at_target = header(100, TEMPO_T7_BASE_FEE_CAP / 2, TEMPO_T7_BASE_FEE_GAS_TARGET);
         let at_floor = header(100, TEMPO_T7_BASE_FEE_FLOOR, 0);
         let at_cap = header(100, TEMPO_T7_BASE_FEE_CAP, TEMPO_T7_BASE_FEE_GAS_TARGET * 3);
@@ -536,6 +548,50 @@ mod tests {
         assert_eq!(
             zone.next_block_base_fee(&at_cap, 101),
             Some(TEMPO_T7_BASE_FEE_CAP)
+        );
+    }
+
+    #[test]
+    fn z1_does_not_activate_dynamic_fees_before_t13() {
+        let mut genesis = dev_zone_spec_with_t13_at(2, Some(100)).genesis().clone();
+        genesis
+            .config
+            .extra_fields
+            .insert_value("z1Time".into(), 0)
+            .unwrap();
+        let zone = ZoneChainSpec::from_genesis(genesis).unwrap();
+
+        assert_eq!(zone.zone_hardfork_at(99), ZoneHardfork::Z1);
+        assert_eq!(zone.tempo_hardfork_at(99), TempoHardfork::T12);
+        assert_eq!(zone.next_block_base_fee(&header(98, 0, 0), 99), Some(0));
+        assert_eq!(
+            zone.next_block_base_fee(&header(99, 0, 0), 100),
+            Some(TEMPO_T7_BASE_FEE_FLOOR)
+        );
+    }
+
+    #[test]
+    fn dynamic_fees_follow_inherited_t13_activation() {
+        let mut l1_genesis = DEV.genesis().clone();
+        l1_genesis
+            .config
+            .extra_fields
+            .insert_value("t13Time".into(), 100)
+            .unwrap();
+        let l1 = TempoChainSpec::from_genesis(l1_genesis);
+        let mut genesis = DEV.genesis().clone();
+        genesis.config.chain_id = zone_chain_id(DEV.chain().id(), 2).unwrap();
+        genesis.config.extra_fields.remove("t13Time");
+        let zone = ZoneChainSpec::from_genesis_with_l1(genesis, &l1).unwrap();
+
+        assert_eq!(
+            zone.tempo_fork_activation(TempoHardfork::T13),
+            ForkCondition::Timestamp(100)
+        );
+        assert_eq!(zone.next_block_base_fee(&header(98, 0, 0), 99), Some(0));
+        assert_eq!(
+            zone.next_block_base_fee(&header(99, 0, 0), 100),
+            Some(TEMPO_T7_BASE_FEE_FLOOR)
         );
     }
 

--- a/crates/node/src/node.rs
+++ b/crates/node/src/node.rs
@@ -1924,8 +1924,8 @@ where
         ctx: &BuilderContext<Node>,
         evm_config: ZoneEvmConfig,
     ) -> eyre::Result<Self::Pool> {
-        // Keep Z0 transactions admissible across the Z1 transition. The pool's current block base
-        // fee still parks transactions that are underpriced once Z1 is active.
+        // Keep pre-T13 transactions admissible across the T13 transition. The pool's current block
+        // base fee still parks transactions that are underpriced once T13 is active.
         let mut pool_config = ctx.pool_config().with_disabled_protocol_base_fee();
         pool_config.max_inflight_delegated_slot_limit = pool_config.max_account_slots;
 

--- a/crates/node/src/rpc.rs
+++ b/crates/node/src/rpc.rs
@@ -43,7 +43,10 @@ use tempo_alloy::{
     provider::ext::TempoProviderExt as _,
     rpc::{TempoCallBuilderExt as _, TempoHeaderResponse, TempoTransactionRequest},
 };
-use tempo_chainspec::spec::{TEMPO_T0_BASE_FEE, TEMPO_T1_BASE_FEE};
+use tempo_chainspec::{
+    hardfork::TempoHardfork,
+    spec::{TEMPO_T0_BASE_FEE, TEMPO_T1_BASE_FEE, TempoHardforks},
+};
 use tempo_contracts::precompiles::{
     ACCOUNT_KEYCHAIN_ADDRESS,
     account_keychain::IAccountKeychain::{self, KeyInfo, getKeyCall},
@@ -53,7 +56,7 @@ use tokio::{
     sync::Mutex,
     time::{MissedTickBehavior, interval},
 };
-use zone_chainspec::{ZoneChainSpec, ZoneHardfork, ZoneHardforks};
+use zone_chainspec::ZoneChainSpec;
 use zone_l1::{TempoStateExt as _, state::EnabledTokenRegistry};
 
 use alloy_rpc_client::{ConnectionConfig, WebSocketConfig};
@@ -833,7 +836,7 @@ where
     Api: FullEthApi + EthApiTypes<NetworkTypes = TempoNetwork> + Send + Sync + 'static,
     Api::Provider: ChainSpecProvider<ChainSpec = ZoneChainSpec>,
 {
-    fn zone_fork(&self) -> Result<ZoneHardfork, JsonRpcError> {
+    fn tempo_fork(&self) -> Result<TempoHardfork, JsonRpcError> {
         let header = self
             .eth
             .api
@@ -846,7 +849,7 @@ where
             .api
             .provider()
             .chain_spec()
-            .zone_hardfork_at(header.timestamp()))
+            .tempo_hardfork_at(header.timestamp()))
     }
 
     fn block_by_id(&self, id: BlockId) -> BoxFut<'_> {
@@ -940,8 +943,8 @@ where
 
     fn gas_price(&self) -> BoxFut<'_> {
         Box::pin(async move {
-            let fork = self.zone_fork()?;
-            if fork.is_z1() {
+            let fork = self.tempo_fork()?;
+            if fork.is_t13() {
                 let base_fee = self
                     .eth
                     .api
@@ -990,7 +993,7 @@ where
                 *trailing_fee = u128::from(successor_fee);
             }
             // Redact gas fields (like `gas_used_ratio`) that can be used to guess tx counts
-            redact_fee_history(&mut history, self.zone_fork()?);
+            redact_fee_history(&mut history, self.tempo_fork()?);
             to_raw(&history)
         })
     }
@@ -1173,8 +1176,8 @@ where
         Box::pin(async move {
             self.enforce_authorized(&mut request, &auth)?;
 
-            let fork = self.zone_fork()?;
-            let (gas_price, max_fee_per_gas) = if fork.is_z1() {
+            let fork = self.tempo_fork()?;
+            let (gas_price, max_fee_per_gas) = if fork.is_t13() {
                 let base_fee = self
                     .eth
                     .api
@@ -1588,8 +1591,8 @@ fn redact_header(header: &mut TempoHeaderResponse) {
 }
 
 /// Clear gas related fields that leak the size (and therefore tx counts)
-fn redact_fee_history(history: &mut FeeHistory, fork: ZoneHardfork) {
-    if !fork.is_z1() {
+fn redact_fee_history(history: &mut FeeHistory, fork: TempoHardfork) {
+    if !fork.is_t13() {
         history.base_fee_per_gas.fill(u128::from(TEMPO_T0_BASE_FEE));
     }
     history.gas_used_ratio.fill(0.0);
@@ -1882,7 +1885,7 @@ mod tests {
             reward: Some(vec![vec![7, 8], vec![9, 10]]),
         };
 
-        redact_fee_history(&mut history, ZoneHardfork::Z0);
+        redact_fee_history(&mut history, TempoHardfork::T12);
 
         assert_eq!(history.oldest_block, 42);
         assert_eq!(
@@ -1896,13 +1899,13 @@ mod tests {
     }
 
     #[test]
-    fn redact_fee_history_preserves_base_fees_at_z1() {
+    fn redact_fee_history_preserves_base_fees_at_t13() {
         let mut history = FeeHistory {
             base_fee_per_gas: vec![1, 2, 3],
             ..Default::default()
         };
 
-        redact_fee_history(&mut history, ZoneHardfork::Z1);
+        redact_fee_history(&mut history, TempoHardfork::T13);
 
         assert_eq!(history.base_fee_per_gas, vec![1, 2, 3]);
     }

--- a/crates/node/tests/it/base_fee.rs
+++ b/crates/node/tests/it/base_fee.rs
@@ -12,7 +12,9 @@ use alloy_eips::eip2718::Encodable2718;
 use alloy_rpc_types_eth::{BlockNumberOrTag, FeeHistory};
 use alloy_signer::SignerSync as _;
 use tempo_alloy::rpc::TempoTransactionRequest;
-use tempo_chainspec::spec::{TEMPO_T7_BASE_FEE_CAP, tempo_t7_next_block_base_fee};
+use tempo_chainspec::spec::{
+    TEMPO_T0_BASE_FEE, TEMPO_T1_BASE_FEE, TEMPO_T7_BASE_FEE_CAP, tempo_t7_next_block_base_fee,
+};
 use tempo_precompiles::PATH_USD_ADDRESS;
 use tempo_primitives::{
     TempoTxEnvelope,
@@ -75,19 +77,63 @@ fn sponsored_transaction(
     Ok(signed.into())
 }
 
-fn z1_genesis() -> eyre::Result<alloy::genesis::Genesis> {
+fn t13_genesis() -> eyre::Result<alloy::genesis::Genesis> {
     let mut genesis = zone_node::genesis::genesis_template()?;
     genesis
         .config
         .extra_fields
-        .insert_value("z1Time".into(), 1)?;
+        .insert_value("t13Time".into(), 1)?;
     Ok(genesis)
 }
 
 #[tokio::test(flavor = "multi_thread")]
-async fn z1_activates_dynamic_base_fee() -> eyre::Result<()> {
+async fn z1_keeps_legacy_fees_without_t13() -> eyre::Result<()> {
+    let mut genesis = zone_node::genesis::genesis_template()?;
+    genesis
+        .config
+        .extra_fields
+        .insert_value("z1Time".into(), 0)?;
+    genesis
+        .config
+        .extra_fields
+        .insert_value("t13Time".into(), None::<u64>)?;
     let (zone, mut fixture) =
-        start_local_zone_with_fixture_and_withdrawal_batch_interval(ZONE_ID, 2, 2, z1_genesis()?)
+        start_local_zone_with_fixture_and_withdrawal_batch_interval(ZONE_ID, 2, 2, genesis).await?;
+    fixture.inject_empty_block(zone.deposit_queue());
+    zone.wait_for_block_number(1, DEFAULT_TIMEOUT).await?;
+    let block = zone
+        .provider()
+        .get_block_by_number(1.into())
+        .await?
+        .expect("first Zone block");
+    assert_eq!(block.header.base_fee_per_gas(), Some(0));
+
+    let rpc = redacted_rpc(&zone).await?;
+    let gas_price = rpc
+        .gas_price()
+        .await
+        .map_err(|err| eyre::eyre!(err.to_string()))?;
+    assert_eq!(
+        serde_json::from_str::<U256>(gas_price.get())?,
+        U256::from(TEMPO_T1_BASE_FEE)
+    );
+    let history = rpc
+        .fee_history(1, BlockNumberOrTag::Number(1), Some(Vec::new()))
+        .await
+        .map_err(|err| eyre::eyre!(err.to_string()))?;
+    let history: FeeHistory = serde_json::from_str(history.get())?;
+    assert_eq!(
+        history.base_fee_per_gas,
+        vec![u128::from(TEMPO_T0_BASE_FEE); 2]
+    );
+    assert_eq!(history.gas_used_ratio, vec![0.0]);
+    Ok(())
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn t13_activates_dynamic_base_fee() -> eyre::Result<()> {
+    let (zone, mut fixture) =
+        start_local_zone_with_fixture_and_withdrawal_batch_interval(ZONE_ID, 2, 2, t13_genesis()?)
             .await?;
 
     let genesis = zone
@@ -108,7 +154,7 @@ async fn z1_activates_dynamic_base_fee() -> eyre::Result<()> {
             genesis.header.base_fee_per_gas().expect("genesis base fee"),
             genesis.header.gas_used(),
         )),
-        "the Z1 activation block must adjust from its parent"
+        "the T13 activation block must adjust from its parent"
     );
     let rpc = redacted_rpc(&zone).await?;
     let gas_price = rpc
@@ -141,7 +187,7 @@ async fn z1_activates_dynamic_base_fee() -> eyre::Result<()> {
                     .expect("first block base fee")
             ),
         ],
-        "fee history must use the canonical Z1 successor fee at the fork boundary"
+        "fee history must use the canonical T13 successor fee at the fork boundary"
     );
 
     fixture.inject_empty_block(zone.deposit_queue());
@@ -169,7 +215,7 @@ async fn z1_activates_dynamic_base_fee() -> eyre::Result<()> {
 #[tokio::test(flavor = "multi_thread")]
 async fn sponsored_transaction_settles_nonzero_base_fee() -> eyre::Result<()> {
     let (zone, mut fixture) =
-        start_local_zone_with_fixture_and_withdrawal_batch_interval(ZONE_ID, 2, 2, z1_genesis()?)
+        start_local_zone_with_fixture_and_withdrawal_batch_interval(ZONE_ID, 2, 2, t13_genesis()?)
             .await?;
     let sender = PrivateKeySigner::random();
     let fee_payer = PrivateKeySigner::random();
@@ -209,7 +255,7 @@ async fn sponsored_transaction_settles_nonzero_base_fee() -> eyre::Result<()> {
     assert!(receipt.status(), "sponsored transaction must succeed");
     assert!(
         receipt.effective_gas_price > 0,
-        "Z1 transaction must pay a nonzero base fee"
+        "T13 transaction must pay a nonzero base fee"
     );
     let block = provider
         .get_block_by_number(

--- a/crates/node/tests/it/redacted_rpc_e2e.rs
+++ b/crates/node/tests/it/redacted_rpc_e2e.rs
@@ -25,7 +25,7 @@ use p256::ecdsa::SigningKey as P256SigningKey;
 use rand::thread_rng;
 use serde_json::{Value, json};
 use std::{collections::HashSet, time::Duration};
-use tempo_chainspec::spec::{TEMPO_T0_BASE_FEE, TEMPO_T1_BASE_FEE};
+use tempo_chainspec::spec::TEMPO_T0_BASE_FEE;
 use tempo_contracts::precompiles::{
     IAccountKeychain, INonce, IStorageCredits, ITIP20 as ContractTip20, ITIP403Registry,
     TIP403_REGISTRY_ADDRESS,
@@ -517,6 +517,9 @@ async fn test_keychain_auth_rejection_cases() -> eyre::Result<()> {
 /// Public methods work for both sequencer and users without leaking private fee activity.
 #[tokio::test(flavor = "multi_thread")]
 async fn test_public_methods() -> eyre::Result<()> {
+    use alloy_consensus::BlockHeader as _;
+    use alloy_provider::Provider as _;
+
     reth_tracing::init_test_tracing();
 
     let ctx = start_zone_with_redacted_rpc().await?;
@@ -538,8 +541,16 @@ async fn test_public_methods() -> eyre::Result<()> {
         );
     }
 
+    // The inherited DEV schedule activates T13 at genesis.
+    let latest = ctx
+        .zone
+        .provider()
+        .get_block_by_number(Default::default())
+        .await?
+        .expect("latest Zone block");
+    let base_fee = latest.header.base_fee_per_gas().expect("Zone base fee");
     for (method, expected) in [
-        ("eth_gasPrice", U256::from(TEMPO_T1_BASE_FEE)),
+        ("eth_gasPrice", U256::from(base_fee)),
         ("eth_maxPriorityFeePerGas", U256::ZERO),
     ] {
         for response in [

--- a/xtask/src/install_reference_zone_factory.rs
+++ b/xtask/src/install_reference_zone_factory.rs
@@ -17,7 +17,7 @@ use std::{
 use tempo_contracts::{
     precompiles::INITIAL_FACTORY_OWNER,
     zones::{
-        T12_ZONE_MESSENGER_RUNTIME, T12_ZONE_PORTAL_RUNTIME, T12_ZONE_VERIFIER_RUNTIME,
+        T13_ZONE_MESSENGER_RUNTIME, T13_ZONE_PORTAL_RUNTIME, T13_ZONE_VERIFIER_RUNTIME,
         ZONE_MESSENGER_RUNTIME as TEMPO_ZONE_MESSENGER_RUNTIME,
         ZONE_PORTAL_RUNTIME as TEMPO_ZONE_PORTAL_RUNTIME,
         ZONE_VERIFIER_RUNTIME as TEMPO_ZONE_VERIFIER_RUNTIME,
@@ -218,19 +218,19 @@ fn install_native_zone_factory(
             "ZonePortal implementation",
             ZONE_PORTAL_IMPL_ADDRESS,
             artifacts.portal,
-            [TEMPO_ZONE_PORTAL_RUNTIME, T12_ZONE_PORTAL_RUNTIME],
+            [TEMPO_ZONE_PORTAL_RUNTIME, T13_ZONE_PORTAL_RUNTIME],
         ),
         (
             "Verifier",
             ZONE_VERIFIER_ADDRESS,
             artifacts.verifier,
-            [TEMPO_ZONE_VERIFIER_RUNTIME, T12_ZONE_VERIFIER_RUNTIME],
+            [TEMPO_ZONE_VERIFIER_RUNTIME, T13_ZONE_VERIFIER_RUNTIME],
         ),
         (
             "ZoneMessenger",
             ZONE_MESSENGER_ADDRESS,
             artifacts.messenger,
-            [TEMPO_ZONE_MESSENGER_RUNTIME, T12_ZONE_MESSENGER_RUNTIME],
+            [TEMPO_ZONE_MESSENGER_RUNTIME, T13_ZONE_MESSENGER_RUNTIME],
         ),
     ] {
         let expected = GenesisAccount::default()
@@ -303,9 +303,9 @@ mod tests {
             TEMPO_ZONE_MESSENGER_RUNTIME,
         ]);
         assert_validates_shared_runtimes([
-            T12_ZONE_PORTAL_RUNTIME,
-            T12_ZONE_VERIFIER_RUNTIME,
-            T12_ZONE_MESSENGER_RUNTIME,
+            T13_ZONE_PORTAL_RUNTIME,
+            T13_ZONE_VERIFIER_RUNTIME,
+            T13_ZONE_MESSENGER_RUNTIME,
         ]);
     }
 


### PR DESCRIPTION
Gate dynamic Zone execution fees and the public RPC fee policy at Tempo T13 instead of Z1. Before T13, blocks keep a zero base fee and the RPC keeps its legacy defaults; at T13, the existing T7 fee controller and zero-tip RPC policy activate together using the inherited Tempo schedule.

Update the Tempo pin to [346c22e](https://github.com/tempoxyz/tempo/commit/346c22eb4293ac1f5edd27d4afd1f99323bc527c), which introduces T13 and moves TIP-1096 to that boundary. This moves off the v1.14 release pin onto the mainline T13 commit; the lower package version labels in Cargo.lock reflect mainline's version metadata. Public-network T13 activation remains unscheduled. Update the reference ZoneFactory installer and its existing runtime validation tests to use the renamed T13 contract runtimes.

Targets the branch for [#1433](https://github.com/tempoxyz/zones/pull/1433). Tests cover the T13 boundary, inherited activation, Z1 remaining fee-free before T13, RPC redaction, and sponsored fee settlement. The existing public-RPC test follows the DEV schedule's T13-at-genesis behavior.

Validation: all four CI test partitions (929 tests), the Docker build, nightly formatting, Clippy, and dependency checks pass. The network-chaos test `test_incoming_leader_recovers_after_l1_disconnect` passed on CI's automatic retry. All 13 chainspec tests and both reference ZoneFactory installer tests also pass locally. Automated review and Cyclops audit checks remain pending.

Prompted by: @0xKitsune
